### PR TITLE
Trigger field transforms on field updates

### DIFF
--- a/fold_node/src/fold_db_core/collection_manager.rs
+++ b/fold_node/src/fold_db_core/collection_manager.rs
@@ -30,7 +30,13 @@ impl CollectionManager {
             &mut self.field_manager.atom_manager,
         );
         ctx.validate_field_type(FieldType::Collection)?;
-        ctx.create_and_update_collection_atom(None, content, None, id)
+        ctx.create_and_update_collection_atom(None, content.clone(), None, id.clone())?;
+
+        if let Some(tm) = self.field_manager.get_transform_manager() {
+            tm.execute_field_transforms(&schema.name, field, &content)?;
+        }
+
+        Ok(())
     }
 
     pub fn update_collection_field_value(
@@ -52,7 +58,13 @@ impl CollectionManager {
         let aref_uuid = ctx.get_or_create_atom_ref()?;
         let prev_atom_uuid = ctx.get_prev_collection_atom_uuid(&aref_uuid, &id)?;
 
-        ctx.create_and_update_collection_atom(Some(prev_atom_uuid), content, None, id)
+        ctx.create_and_update_collection_atom(Some(prev_atom_uuid), content.clone(), None, id.clone())?;
+
+        if let Some(tm) = self.field_manager.get_transform_manager() {
+            tm.execute_field_transforms(&schema.name, field, &content)?;
+        }
+
+        Ok(())
     }
 
     pub fn delete_collection_field_value(
@@ -77,8 +89,14 @@ impl CollectionManager {
             Some(prev_atom_uuid),
             Value::Null,
             Some(AtomStatus::Deleted),
-            id,
-        )
+            id.clone(),
+        )?;
+
+        if let Some(tm) = self.field_manager.get_transform_manager() {
+            tm.execute_field_transforms(&schema.name, field, &Value::Null)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/fold_node/src/fold_db_core/transform_manager.rs
+++ b/fold_node/src/fold_db_core/transform_manager.rs
@@ -83,8 +83,12 @@ impl TransformManager {
         let transform_json = serde_json::to_vec(&transform)
             .map_err(|e| SchemaError::InvalidData(format!("Failed to serialize transform: {}", e)))?;
         
-        self.transforms_tree.insert(transform_id.as_bytes(), transform_json)?;
-        self.transforms_tree.flush()?;
+        self.transforms_tree
+            .insert(transform_id.as_bytes(), transform_json)
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to store transform: {}", e)))?;
+        self.transforms_tree
+            .flush()
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to flush transform tree: {}", e)))?;
         
         // Update in-memory cache
         {

--- a/fold_node/src/transform.rs
+++ b/fold_node/src/transform.rs
@@ -1,0 +1,2 @@
+pub use crate::schema::transform::*;
+

--- a/tests/test_data/mod.rs
+++ b/tests/test_data/mod.rs
@@ -1,0 +1,2 @@
+pub mod schema_test_data;
+pub mod test_helpers;

--- a/tests/test_data/schema_test_data.rs
+++ b/tests/test_data/schema_test_data.rs
@@ -1,0 +1,108 @@
+use fold_node::testing::FieldType;
+use fold_node::testing::{
+    FieldPaymentConfig, PermissionsPolicy, Schema, SchemaField, TrustDistance, TrustDistanceScaling,
+};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+#[allow(dead_code)]
+pub fn create_default_payment_config() -> FieldPaymentConfig {
+    FieldPaymentConfig::new(1.0, TrustDistanceScaling::None, None).unwrap()
+}
+
+#[allow(dead_code)]
+pub fn create_test_schema(name: &str) -> Schema {
+    let mut schema = Schema::new(name.to_string());
+    let field_name = "test_field".to_string();
+    let field = SchemaField::new(
+        PermissionsPolicy::default(),
+        create_default_payment_config(),
+        HashMap::new(),
+        Some(FieldType::Single),
+    )
+    .with_ref_atom_uuid("test-uuid".to_string());
+
+    schema.add_field(field_name, field);
+    schema
+}
+
+#[allow(dead_code)]
+pub fn create_user_profile_schema() -> Schema {
+    let mut schema = Schema::new("user_profile".to_string());
+
+    // Public fields - basic profile info
+    schema.add_field(
+        "username".to_string(),
+        SchemaField::new(
+            PermissionsPolicy::default(), // Public read access
+            create_default_payment_config(),
+            HashMap::new(),
+            Some(FieldType::Single),
+        )
+        .with_ref_atom_uuid(Uuid::new_v4().to_string()),
+    );
+
+    // Protected fields - contact info
+    schema.add_field(
+        "email".to_string(),
+        SchemaField::new(
+            PermissionsPolicy::new(
+                TrustDistance::Distance(1), // Limited read access
+                TrustDistance::Distance(1), // Limited write access
+            ),
+            create_default_payment_config(),
+            HashMap::new(),
+            Some(FieldType::Single),
+        )
+        .with_ref_atom_uuid(Uuid::new_v4().to_string()),
+    );
+
+    // Private fields - sensitive info
+    schema.add_field(
+        "payment_info".to_string(),
+        SchemaField::new(
+            PermissionsPolicy::new(
+                TrustDistance::Distance(3), // Restricted read access
+                TrustDistance::Distance(3), // Restricted write access
+            ),
+            create_default_payment_config(),
+            HashMap::new(),
+            Some(FieldType::Single),
+        )
+        .with_ref_atom_uuid(Uuid::new_v4().to_string()),
+    );
+
+    schema
+}
+
+#[allow(dead_code)]
+pub fn create_multi_field_schema() -> Schema {
+    let mut schema = Schema::new("test_schema".to_string());
+
+    let fields = vec![
+        ("public_field", PermissionsPolicy::default()),
+        (
+            "protected_field",
+            PermissionsPolicy::new(TrustDistance::Distance(1), TrustDistance::Distance(2)),
+        ),
+        (
+            "private_field",
+            PermissionsPolicy::new(TrustDistance::Distance(3), TrustDistance::Distance(3)),
+        ),
+    ];
+
+    for (name, policy) in fields {
+        schema.add_field(
+            name.to_string(),
+            SchemaField::new(
+                policy,
+                create_default_payment_config(),
+                HashMap::new(),
+                Some(FieldType::Single),
+            )
+            .with_ref_atom_uuid(Uuid::new_v4().to_string()),
+        );
+    }
+
+    schema
+}

--- a/tests/test_data/test_helpers/mod.rs
+++ b/tests/test_data/test_helpers/mod.rs
@@ -1,0 +1,140 @@
+pub mod operation_builder;
+pub mod schema_builder;
+
+// Re-export testing utilities for all tests
+use fold_node::FoldDB;
+use std::fs;
+use std::path::Path;
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+use uuid::Uuid;
+
+#[allow(dead_code)]
+static CLEANUP_LOCK: Mutex<()> = Mutex::new(());
+
+#[allow(dead_code)]
+fn retry_with_backoff<F, T, E>(mut f: F, retries: u32) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+{
+    let mut attempt = 0;
+    loop {
+        match f() {
+            ok @ Ok(_) => return ok,
+            Err(_) if attempt < retries => {
+                attempt += 1;
+                thread::sleep(Duration::from_millis(100 * attempt as u64));
+                continue;
+            }
+            err => return err,
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn get_test_db_path() -> String {
+    let current_dir = std::env::current_dir().expect("Failed to get current directory");
+    let tmp_dir = current_dir.join("tmp");
+
+    // Create tmp directory and ensure it exists
+    fs::create_dir_all(&tmp_dir).expect("Failed to create tmp directory");
+
+    // Replace any potentially problematic characters in the UUID
+    let safe_uuid = Uuid::new_v4().to_string().replace("-", "_");
+    let db_path = tmp_dir.join(format!("test_db_{}", safe_uuid));
+
+    // Create the database directory
+    fs::create_dir_all(&db_path).expect("Failed to create database directory");
+
+    // Create schemas subdirectory with proper error handling
+    let schemas_dir = db_path.join("schemas");
+    match fs::create_dir_all(&schemas_dir) {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("Warning: Failed to create schemas directory: {}", e);
+            // Try an alternative approach
+            let schemas_path = db_path.to_string_lossy().into_owned() + "/schemas";
+            fs::create_dir_all(schemas_path)
+                .expect("Failed to create schemas directory with alternative method");
+        }
+    }
+
+    db_path.to_string_lossy().into_owned()
+}
+
+#[allow(dead_code)]
+pub fn cleanup_test_db(path: &str) {
+    let _lock = CLEANUP_LOCK.lock().unwrap();
+    let path = Path::new(path);
+    if path.exists() {
+        for _ in 0..3 {
+            // Try up to 3 times
+            if fs::remove_dir_all(path).is_ok() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn cleanup_tmp_dir() {
+    let _lock = CLEANUP_LOCK.lock().unwrap();
+    let current_dir = std::env::current_dir().expect("Failed to get current directory");
+    let tmp_dir = current_dir.join("tmp");
+
+    // First ensure the directory exists
+    let _ = fs::create_dir_all(&tmp_dir);
+
+    // Remove all contents with retries
+    let cleanup_contents = || -> std::io::Result<()> {
+        if let Ok(entries) = fs::read_dir(&tmp_dir) {
+            for entry in entries {
+                if let Ok(entry) = entry {
+                    let _ = fs::remove_dir_all(entry.path());
+                }
+            }
+        }
+        Ok(())
+    };
+
+    if let Err(e) = retry_with_backoff(cleanup_contents, 5) {
+        eprintln!("Warning: Failed to clean contents: {}", e);
+    }
+
+    // Verify the directory is empty
+    let verify_empty = || -> std::io::Result<()> {
+        if let Ok(entries) = fs::read_dir(&tmp_dir) {
+            if entries.count() == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Directory not empty",
+                ))
+            }
+        } else {
+            Ok(())
+        }
+    };
+
+    if let Err(e) = retry_with_backoff(verify_empty, 5) {
+        eprintln!("Warning: Directory may not be empty: {}", e);
+    }
+}
+
+#[allow(dead_code)]
+pub fn setup_test_db() -> (FoldDB, String) {
+    let db_path = get_test_db_path();
+    let db = FoldDB::new(&db_path).expect("Failed to create test database");
+    (db, db_path)
+}
+
+#[allow(dead_code)]
+pub fn setup_and_allow_schema(
+    db: &mut FoldDB,
+    schema_name: &str,
+) -> Result<(), fold_node::testing::SchemaError> {
+    db.allow_schema(schema_name)
+}

--- a/tests/test_data/test_helpers/operation_builder.rs
+++ b/tests/test_data/test_helpers/operation_builder.rs
@@ -1,0 +1,54 @@
+use fold_node::testing::{Mutation, MutationType, Query};
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[allow(dead_code)]
+pub fn create_query(
+    schema_name: String,
+    fields: Vec<String>,
+    pub_key: String,
+    trust_distance: u32,
+) -> Query {
+    Query {
+        schema_name,
+        fields,
+        pub_key,
+        trust_distance,
+    }
+}
+
+#[allow(dead_code)]
+pub fn create_mutation(
+    schema_name: String,
+    fields_and_values: HashMap<String, Value>,
+    pub_key: String,
+    trust_distance: u32,
+) -> Mutation {
+    Mutation {
+        schema_name,
+        fields_and_values,
+        pub_key,
+        trust_distance,
+        mutation_type: MutationType::Create,
+    }
+}
+
+#[allow(dead_code)]
+pub fn create_single_field_mutation(
+    schema_name: String,
+    field: String,
+    value: Value,
+    pub_key: String,
+    trust_distance: u32,
+) -> Mutation {
+    let mut fields_and_values = HashMap::new();
+    fields_and_values.insert(field, value);
+
+    Mutation {
+        schema_name,
+        fields_and_values,
+        pub_key,
+        trust_distance,
+        mutation_type: MutationType::Create,
+    }
+}

--- a/tests/test_data/test_helpers/schema_builder.rs
+++ b/tests/test_data/test_helpers/schema_builder.rs
@@ -1,0 +1,38 @@
+use fold_node::testing::{
+    ExplicitCounts, FieldPaymentConfig, FieldType, PermissionsPolicy, Schema, SchemaField,
+    SchemaPaymentConfig, TrustDistance,
+};
+use std::collections::HashMap;
+
+#[allow(dead_code)]
+pub fn create_field_with_permissions(
+    ref_atom_uuid: String,
+    read_distance: u32,
+    write_distance: u32,
+    explicit_read_keys: Option<HashMap<String, u8>>,
+    explicit_write_keys: Option<HashMap<String, u8>>,
+) -> SchemaField {
+    SchemaField::new(
+        PermissionsPolicy {
+            read_policy: TrustDistance::Distance(read_distance),
+            write_policy: TrustDistance::Distance(write_distance),
+            explicit_read_policy: explicit_read_keys.map(|counts| ExplicitCounts {
+                counts_by_pub_key: counts,
+            }),
+            explicit_write_policy: explicit_write_keys.map(|counts| ExplicitCounts {
+                counts_by_pub_key: counts,
+            }),
+        },
+        FieldPaymentConfig::default(),
+        HashMap::new(),
+        Some(FieldType::Single),
+    )
+    .with_ref_atom_uuid(ref_atom_uuid)
+}
+
+#[allow(dead_code)]
+pub fn create_schema_with_fields(name: String, fields: HashMap<String, SchemaField>) -> Schema {
+    Schema::new(name)
+        .with_fields(fields)
+        .with_payment_config(SchemaPaymentConfig::default())
+}


### PR DESCRIPTION
## Summary
- wire transform manager into field and collection managers
- execute registered field transforms automatically when fields are changed
- share transform manager via `Arc`
- provide missing `transform` module re-export
- copy test helper data for integration tests

## Testing
- `cargo test --quiet`