### PR TITLE
Add transform orchestrator

### DIFF
--- a/fold_node/src/fold_db_core/collection_manager.rs
+++ b/fold_node/src/fold_db_core/collection_manager.rs
@@ -32,8 +32,8 @@ impl CollectionManager {
         ctx.validate_field_type(FieldType::Collection)?;
         ctx.create_and_update_collection_atom(None, content.clone(), None, id.clone())?;
 
-        if let Some(tm) = self.field_manager.get_transform_manager() {
-            tm.execute_field_transforms(&schema.name, field, &content)?;
+        if let Some(orc) = self.field_manager.get_orchestrator() {
+            orc.add_task(&schema.name, field);
         }
 
         Ok(())
@@ -60,8 +60,8 @@ impl CollectionManager {
 
         ctx.create_and_update_collection_atom(Some(prev_atom_uuid), content.clone(), None, id.clone())?;
 
-        if let Some(tm) = self.field_manager.get_transform_manager() {
-            tm.execute_field_transforms(&schema.name, field, &content)?;
+        if let Some(orc) = self.field_manager.get_orchestrator() {
+            orc.add_task(&schema.name, field);
         }
 
         Ok(())
@@ -92,8 +92,8 @@ impl CollectionManager {
             id.clone(),
         )?;
 
-        if let Some(tm) = self.field_manager.get_transform_manager() {
-            tm.execute_field_transforms(&schema.name, field, &Value::Null)?;
+        if let Some(orc) = self.field_manager.get_orchestrator() {
+            orc.add_task(&schema.name, field);
         }
 
         Ok(())

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -3,6 +3,7 @@ pub mod collection_manager;
 pub mod context;
 pub mod field_manager;
 pub mod transform_manager;
+pub mod transform_orchestrator;
 
 use std::sync::Arc;
 use crate::atom::{Atom, AtomRefBehavior};
@@ -20,6 +21,7 @@ use self::atom_manager::AtomManager;
 use self::collection_manager::CollectionManager;
 use self::field_manager::FieldManager;
 use self::transform_manager::TransformManager;
+use self::transform_orchestrator::TransformOrchestrator;
 
 /// The main database coordinator that manages schemas, permissions, and data storage.
 pub struct FoldDB {
@@ -28,6 +30,7 @@ pub struct FoldDB {
     pub(crate) collection_manager: CollectionManager,
     pub(crate) schema_manager: SchemaCore,
     pub(crate) transform_manager: Arc<TransformManager>,
+    pub(crate) transform_orchestrator: Arc<TransformOrchestrator>,
     permission_wrapper: PermissionWrapper,
     /// Tree for storing metadata such as node_id
     metadata_tree: sled::Tree,
@@ -116,6 +119,8 @@ impl FoldDB {
         ));
 
         field_manager.set_transform_manager(Arc::clone(&transform_manager));
+        let orchestrator = Arc::new(TransformOrchestrator::new(transform_manager.clone()));
+        field_manager.set_orchestrator(Arc::clone(&orchestrator));
         let _ = schema_manager.load_schemas_from_disk();
 
         Ok(Self {
@@ -124,6 +129,7 @@ impl FoldDB {
             collection_manager,
             schema_manager,
             transform_manager,
+            transform_orchestrator: orchestrator,
             permission_wrapper: PermissionWrapper::new(),
             metadata_tree,
             permissions_tree,

--- a/fold_node/src/fold_db_core/transform_manager.rs
+++ b/fold_node/src/fold_db_core/transform_manager.rs
@@ -1,6 +1,7 @@
 use crate::atom::{Atom, AtomRef};
 use crate::schema::types::{Transform, SchemaError};
 use crate::transform::TransformExecutor;
+use super::transform_orchestrator::TransformRunner;
 use serde_json::Value as JsonValue;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
@@ -282,6 +283,12 @@ impl TransformManager {
         self.execute_transform(transform_id)
     }
 
+    /// Returns true if a transform with the given id is registered.
+    pub fn transform_exists(&self, transform_id: &str) -> bool {
+        let registered_transforms = self.registered_transforms.read().unwrap();
+        registered_transforms.contains_key(transform_id)
+    }
+
     /// Gets all transforms that depend on the specified atom reference.
     pub fn get_dependent_transforms(&self, aref_uuid: &str) -> HashSet<String> {
         let aref_to_transforms = self.aref_to_transforms.read().unwrap();
@@ -307,7 +314,7 @@ impl TransformManager {
     }
 
     /// Execute transforms for a specific schema field
-    pub fn execute_field_transforms(
+pub fn execute_field_transforms(
         &self,
         schema_name: &str,
         field_name: &str,
@@ -327,5 +334,15 @@ impl TransformManager {
         }
 
         Ok(())
+    }
+}
+
+impl TransformRunner for TransformManager {
+    fn execute_transform_now(&self, transform_id: &str) -> Result<JsonValue, SchemaError> {
+        TransformManager::execute_transform_now(self, transform_id)
+    }
+
+    fn transform_exists(&self, transform_id: &str) -> bool {
+        TransformManager::transform_exists(self, transform_id)
     }
 }

--- a/fold_node/src/fold_db_core/transform_orchestrator.rs
+++ b/fold_node/src/fold_db_core/transform_orchestrator.rs
@@ -1,0 +1,55 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value as JsonValue;
+
+use crate::schema::SchemaError;
+
+/// Trait abstraction over transform execution for easier testing.
+pub trait TransformRunner: Send + Sync {
+    fn execute_transform_now(&self, transform_id: &str) -> Result<JsonValue, SchemaError>;
+    fn transform_exists(&self, transform_id: &str) -> bool;
+}
+
+/// Orchestrates execution of transforms sequentially.
+pub struct TransformOrchestrator {
+    queue: Mutex<VecDeque<String>>,
+    manager: Arc<dyn TransformRunner>,
+}
+
+impl TransformOrchestrator {
+    pub fn new(manager: Arc<dyn TransformRunner>) -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+            manager,
+        }
+    }
+
+    /// Add a task for the given schema and field.
+    pub fn add_task(&self, schema_name: &str, field_name: &str) {
+        let transform_id = format!("{}.{}", schema_name, field_name);
+        if self.manager.transform_exists(&transform_id) {
+            let mut q = self.queue.lock().unwrap();
+            q.push_back(transform_id);
+        }
+    }
+
+    /// Process a single task from the queue.
+    pub fn process_one(&self) -> Option<Result<JsonValue, SchemaError>> {
+        let transform_id = {
+            let mut q = self.queue.lock().unwrap();
+            q.pop_front()
+        }?;
+        Some(self.manager.execute_transform_now(&transform_id))
+    }
+
+    /// Process all queued tasks sequentially.
+    pub fn process_queue(&self) {
+        while self.process_one().is_some() {}
+    }
+
+    /// Queue length, useful for tests.
+    pub fn len(&self) -> usize {
+        self.queue.lock().unwrap().len()
+    }
+}

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -3,3 +3,4 @@ pub mod schema_field_mapping_tests;
 pub mod versioning_tests;
 pub mod cross_schema_transform_tests;
 pub mod persistence_tests;
+pub mod transform_orchestrator_tests;

--- a/tests/integration_tests/transform_orchestrator_tests.rs
+++ b/tests/integration_tests/transform_orchestrator_tests.rs
@@ -1,0 +1,64 @@
+use std::sync::{Arc, Mutex};
+
+use fold_node::fold_db_core::transform_orchestrator::{TransformOrchestrator, TransformRunner};
+use fold_node::schema::SchemaError;
+use serde_json::json;
+
+struct MockTransformManager {
+    executed: Arc<Mutex<Vec<String>>>,
+    exists: Arc<Mutex<Vec<String>>>,
+}
+
+impl MockTransformManager {
+    fn new() -> Self {
+        Self {
+            executed: Arc::new(Mutex::new(Vec::new())),
+            exists: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl TransformRunner for MockTransformManager {
+    fn execute_transform_now(&self, transform_id: &str) -> Result<serde_json::Value, SchemaError> {
+        self.executed.lock().unwrap().push(transform_id.to_string());
+        Ok(json!(null))
+    }
+
+    fn transform_exists(&self, transform_id: &str) -> bool {
+        self.exists.lock().unwrap().push(transform_id.to_string());
+        true
+    }
+}
+
+#[test]
+fn field_update_adds_to_queue() {
+    let manager = Arc::new(MockTransformManager::new());
+    let orchestrator = TransformOrchestrator::new(manager.clone());
+
+    orchestrator.add_task("SchemaA", "field1");
+
+    assert_eq!(orchestrator.len(), 1);
+    // transform_exists should have been called
+    let calls = manager.exists.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0], "SchemaA.field1");
+}
+
+#[test]
+fn sequential_processing_of_tasks() {
+    let manager = Arc::new(MockTransformManager::new());
+    let orchestrator = TransformOrchestrator::new(manager.clone());
+
+    orchestrator.add_task("Schema", "a");
+    orchestrator.add_task("Schema", "b");
+    orchestrator.add_task("Schema", "c");
+
+    orchestrator.process_queue();
+
+    let exec = manager.executed.lock().unwrap();
+    assert_eq!(exec.len(), 3);
+    assert_eq!(exec[0], "Schema.a");
+    assert_eq!(exec[1], "Schema.b");
+    assert_eq!(exec[2], "Schema.c");
+    assert_eq!(orchestrator.len(), 0);
+}


### PR DESCRIPTION
## Summary
- add `TransformOrchestrator` for sequential transform execution
- hook orchestrator into `FoldDB` startup
- queue transform tasks from field and collection managers
- expose transform existence check on `TransformManager`
- provide unit tests for orchestrator behavior

## Testing
- `cargo test --no-run`
- `cargo build -p fold_node --bin datafold_cli`
- `cargo test`