### PR TITLE
Centralize transform queueing

### DIFF
--- a/fold_node/src/fold_db_core/collection_manager.rs
+++ b/fold_node/src/fold_db_core/collection_manager.rs
@@ -32,10 +32,6 @@ impl CollectionManager {
         ctx.validate_field_type(FieldType::Collection)?;
         ctx.create_and_update_collection_atom(None, content.clone(), None, id.clone())?;
 
-        if let Some(orc) = self.field_manager.get_orchestrator() {
-            orc.add_task(&schema.name, field);
-        }
-
         Ok(())
     }
 
@@ -59,10 +55,6 @@ impl CollectionManager {
         let prev_atom_uuid = ctx.get_prev_collection_atom_uuid(&aref_uuid, &id)?;
 
         ctx.create_and_update_collection_atom(Some(prev_atom_uuid), content.clone(), None, id.clone())?;
-
-        if let Some(orc) = self.field_manager.get_orchestrator() {
-            orc.add_task(&schema.name, field);
-        }
 
         Ok(())
     }
@@ -91,10 +83,6 @@ impl CollectionManager {
             Some(AtomStatus::Deleted),
             id.clone(),
         )?;
-
-        if let Some(orc) = self.field_manager.get_orchestrator() {
-            orc.add_task(&schema.name, field);
-        }
 
         Ok(())
     }

--- a/fold_node/src/fold_db_core/field_manager.rs
+++ b/fold_node/src/fold_db_core/field_manager.rs
@@ -133,10 +133,6 @@ impl FieldManager {
 
         ctx.create_and_update_atom(prev_atom_uuid, content.clone(), None)?;
 
-        if let Some(orc) = self.get_orchestrator() {
-            orc.add_task(&schema.name, field);
-        }
-
         Ok(())
     }
 
@@ -161,10 +157,6 @@ impl FieldManager {
 
         ctx.create_and_update_atom(Some(prev_atom_uuid), content.clone(), None)?;
 
-        if let Some(orc) = self.get_orchestrator() {
-            orc.add_task(&schema.name, field);
-        }
-
         Ok(())
     }
 
@@ -187,10 +179,6 @@ impl FieldManager {
         let prev_atom_uuid = ctx.get_prev_atom_uuid(&aref_uuid)?;
 
         ctx.create_and_update_atom(Some(prev_atom_uuid), Value::Null, Some(AtomStatus::Deleted))?;
-
-        if let Some(orc) = self.get_orchestrator() {
-            orc.add_task(&schema.name, field);
-        }
 
         Ok(())
     }

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -363,6 +363,8 @@ impl FoldDB {
                     )?;
                 }
             }
+
+            self.transform_orchestrator.add_task(&schema.name, field_name);
         }
         Ok(())
     }
@@ -372,5 +374,10 @@ impl FoldDB {
         aref_uuid: &str,
     ) -> Result<Vec<Atom>, Box<dyn std::error::Error>> {
         self.atom_manager.get_atom_history(aref_uuid)
+    }
+
+    /// Returns the number of queued transform tasks.
+    pub fn orchestrator_len(&self) -> usize {
+        self.transform_orchestrator.len()
     }
 }

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -4,3 +4,4 @@ pub mod versioning_tests;
 pub mod cross_schema_transform_tests;
 pub mod persistence_tests;
 pub mod transform_orchestrator_tests;
+pub mod transform_enqueue_tests;

--- a/tests/integration_tests/transform_enqueue_tests.rs
+++ b/tests/integration_tests/transform_enqueue_tests.rs
@@ -1,0 +1,45 @@
+use crate::test_data::test_helpers::{setup_test_db, cleanup_test_db};
+use fold_node::testing::{
+    PermissionsPolicy, FieldPaymentConfig, FieldType, Schema, SchemaField,
+    TrustDistance, TrustDistanceScaling, Mutation, MutationType,
+};
+use fold_node::transform::{Transform, TransformParser};
+use serde_json::json;
+
+#[test]
+fn mutation_enqueues_transform() {
+    let (mut db, path) = setup_test_db();
+
+    // Build schema with a field that has a simple transform
+    let mut schema = Schema::new("EnqueueSchema".to_string());
+    let parser = TransformParser::new();
+    let expr = parser.parse_expression("1 + 1").unwrap();
+    let transform = Transform::new_with_expr("1 + 1".to_string(), expr, false, None, false);
+    let field = SchemaField::new(
+        PermissionsPolicy::new(TrustDistance::Distance(0), TrustDistance::Distance(0)),
+        FieldPaymentConfig::new(1.0, TrustDistanceScaling::None, None).unwrap(),
+        std::collections::HashMap::new(),
+        Some(FieldType::Single),
+    ).with_transform(transform);
+    schema.add_field("calc".to_string(), field);
+
+    db.load_schema(schema).unwrap();
+    db.allow_schema("EnqueueSchema").unwrap();
+
+    let mutation = Mutation {
+        mutation_type: MutationType::Create,
+        schema_name: "EnqueueSchema".to_string(),
+        pub_key: "test_key".to_string(),
+        trust_distance: 0,
+        fields_and_values: vec![("calc".to_string(), json!(123))]
+            .into_iter()
+            .collect(),
+    };
+
+    db.write_schema(mutation).unwrap();
+
+    // Verify that a transform task was queued
+    assert_eq!(db.orchestrator_len(), 1);
+
+    cleanup_test_db(&path);
+}


### PR DESCRIPTION
## Summary
- move transform enqueue logic from collection/field managers to FoldDB
- expose orchestrator queue length
- add integration test for new enqueue behavior

## Testing
- `cargo test --quiet`