### PR TITLE
Add coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ rust-project.json
 
 # Coverage reports
 coverage/
+target/llvm-cov/
 *.profraw
 *.profdata
 vendor/

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ Run tests for a specific crate (e.g., fold_node):
 cargo test --package fold_node
 ```
 
+## Generating Coverage Reports
+
+DataFold uses [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) to produce code coverage information. Install the tool if it is not already available:
+
+```bash
+cargo install cargo-llvm-cov
+```
+
+Then run the helper script to create an HTML report for the entire workspace:
+
+```bash
+./generate_coverage.sh
+```
+
+The report will be generated at `target/llvm-cov/html/index.html`.
+
 ## Examples
 
 See **datafold_api_examples/** for Python scripts that demonstrate:

--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Generate code coverage using cargo-llvm-cov
+# Installs cargo-llvm-cov if not already available and runs coverage
+
+set -e
+
+if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+    echo "cargo-llvm-cov not found. Installing..."
+    cargo install cargo-llvm-cov
+fi
+
+# Run coverage for the entire workspace and output HTML report
+cargo llvm-cov --workspace --html
+


### PR DESCRIPTION
## Summary
- add helper script `generate_coverage.sh` for running `cargo llvm-cov`
- document coverage generation in README
- ignore llvm-cov output directory in `.gitignore`

## Testing
- `cargo test --all --quiet`
