### PR TITLE
Add field mapping to TransformManager

### DIFF
--- a/tests/integration_tests/transform_orchestrator_tests.rs
+++ b/tests/integration_tests/transform_orchestrator_tests.rs
@@ -4,16 +4,20 @@ use fold_node::fold_db_core::transform_orchestrator::{TransformOrchestrator, Tra
 use fold_node::schema::SchemaError;
 use serde_json::json;
 
+use std::collections::{HashMap, HashSet};
+
 struct MockTransformManager {
     executed: Arc<Mutex<Vec<String>>>,
-    exists: Arc<Mutex<Vec<String>>>,
+    lookup: Arc<Mutex<Vec<(String, String)>>>,
+    field_map: HashMap<String, Vec<String>>,
 }
 
 impl MockTransformManager {
     fn new() -> Self {
         Self {
             executed: Arc::new(Mutex::new(Vec::new())),
-            exists: Arc::new(Mutex::new(Vec::new())),
+            lookup: Arc::new(Mutex::new(Vec::new())),
+            field_map: HashMap::new(),
         }
     }
 }
@@ -24,29 +28,41 @@ impl TransformRunner for MockTransformManager {
         Ok(json!(null))
     }
 
-    fn transform_exists(&self, transform_id: &str) -> bool {
-        self.exists.lock().unwrap().push(transform_id.to_string());
-        true
+    fn transform_exists(&self, _transform_id: &str) -> bool { true }
+
+    fn get_transforms_for_field(&self, schema_name: &str, field_name: &str) -> HashSet<String> {
+        self.lookup.lock().unwrap().push((schema_name.to_string(), field_name.to_string()));
+        self.field_map
+            .get(&format!("{}.{}", schema_name, field_name))
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect()
     }
 }
 
 #[test]
 fn field_update_adds_to_queue() {
-    let manager = Arc::new(MockTransformManager::new());
+    let mut mgr = MockTransformManager::new();
+    mgr.field_map.insert("SchemaA.field1".to_string(), vec!["SchemaA.field1".to_string()]);
+    let manager = Arc::new(mgr);
     let orchestrator = TransformOrchestrator::new(manager.clone());
 
     orchestrator.add_task("SchemaA", "field1");
 
     assert_eq!(orchestrator.len(), 1);
-    // transform_exists should have been called
-    let calls = manager.exists.lock().unwrap();
+    let calls = manager.lookup.lock().unwrap();
     assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0], "SchemaA.field1");
+    assert_eq!(calls[0], ("SchemaA".to_string(), "field1".to_string()));
 }
 
 #[test]
 fn sequential_processing_of_tasks() {
-    let manager = Arc::new(MockTransformManager::new());
+    let mut mgr = MockTransformManager::new();
+    mgr.field_map.insert("Schema.a".to_string(), vec!["Schema.a".to_string()]);
+    mgr.field_map.insert("Schema.b".to_string(), vec!["Schema.b".to_string()]);
+    mgr.field_map.insert("Schema.c".to_string(), vec!["Schema.c".to_string()]);
+    let manager = Arc::new(mgr);
     let orchestrator = TransformOrchestrator::new(manager.clone());
 
     orchestrator.add_task("Schema", "a");
@@ -61,4 +77,21 @@ fn sequential_processing_of_tasks() {
     assert_eq!(exec[1], "Schema.b");
     assert_eq!(exec[2], "Schema.c");
     assert_eq!(orchestrator.len(), 0);
+}
+
+#[test]
+fn mapping_adds_specific_transform() {
+    let mut mgr = MockTransformManager::new();
+    mgr.field_map.insert("SchemaA.field".to_string(), vec!["SchemaB.other".to_string()]);
+    let manager = Arc::new(mgr);
+    let orchestrator = TransformOrchestrator::new(manager.clone());
+
+    orchestrator.add_task("SchemaA", "field");
+    assert_eq!(orchestrator.len(), 1);
+
+    orchestrator.process_queue();
+
+    let exec = manager.executed.lock().unwrap();
+    assert_eq!(exec.len(), 1);
+    assert_eq!(exec[0], "SchemaB.other");
 }


### PR DESCRIPTION
## Summary
- add field-to-transform mapping to `TransformManager`
- allow lookups for transforms triggered by schema fields
- update orchestrator to use new mapping
- revise orchestrator tests for new API

## Testing
- `cargo test --quiet`
