### PR TITLE
Add transforms UI tab

### DIFF
--- a/fold_node/src/datafold_node/node.rs
+++ b/fold_node/src/datafold_node/node.rs
@@ -8,7 +8,7 @@ use crate::datafold_node::config::NodeInfo;
 use crate::error::{FoldDbError, FoldDbResult, NetworkErrorKind};
 use crate::fold_db_core::FoldDB;
 use crate::network::{NetworkConfig, NetworkCore, PeerId};
-use crate::schema::types::{Mutation, Operation, Query};
+use crate::schema::types::{Mutation, Operation, Query, Transform};
 use crate::schema::{Schema, SchemaError};
 
 /// A node in the DataFold distributed database system.
@@ -713,6 +713,24 @@ impl DataFoldNode {
             initialized,
             connected_nodes_count,
         })
+    }
+
+    /// List all registered transforms.
+    pub fn list_transforms(&self) -> FoldDbResult<HashMap<String, Transform>> {
+        let db = self
+            .db
+            .lock()
+            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
+        Ok(db.list_transforms())
+    }
+
+    /// Execute a transform by id and return the result.
+    pub fn run_transform(&mut self, transform_id: &str) -> FoldDbResult<Value> {
+        let db = self
+            .db
+            .lock()
+            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
+        Ok(db.run_transform(transform_id)?)
     }
 
     /// Gets the unique identifier for this node.

--- a/fold_node/src/datafold_node/static/components/transforms-tab.html
+++ b/fold_node/src/datafold_node/static/components/transforms-tab.html
@@ -1,0 +1,24 @@
+<div id="transformsTab" class="tab-content">
+    <div id="transformsList" class="mt-3">
+        <div class="status info">
+            <span class="loading"></span>
+            <span>Loading transforms...</span>
+        </div>
+    </div>
+    <div class="btn-group mt-3">
+        <button id="refreshTransformsBtn" class="btn btn-primary">
+            <span id="refreshTransformsIcon"></span> Refresh
+        </button>
+    </div>
+</div>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        if(window.icons){
+            document.getElementById('refreshTransformsIcon').innerHTML = icons.refresh();
+        }
+        document.getElementById('refreshTransformsBtn')?.addEventListener('click', () => {
+            transformsModule.loadTransforms();
+        });
+        transformsModule.loadTransforms();
+    });
+</script>

--- a/fold_node/src/datafold_node/static/index.html
+++ b/fold_node/src/datafold_node/static/index.html
@@ -54,6 +54,9 @@
                         <button class="tab-button" data-tab="samples">
                             <span id="samplesTabIcon"></span> Samples
                         </button>
+                        <button class="tab-button" data-tab="transforms">
+                            <span id="transformsTabIcon"></span> Transforms
+                        </button>
                         <button class="tab-button" data-tab="network">
                             <span id="networkTabIcon"></span> Network
                         </button>
@@ -80,7 +83,18 @@
                                 });
                         </script>
                     </div>
-                    
+
+                    <!-- Include Transforms Tab Component -->
+                    <div id="transformsTabContainer">
+                        <script>
+                            fetch('/static/components/transforms-tab.html')
+                                .then(response => response.text())
+                                .then(html => {
+                                    document.getElementById('transformsTabContainer').innerHTML = html;
+                                });
+                        </script>
+                    </div>
+
                     <!-- Include Network Tab Component -->
                     <div id="networkTabContainer">
                         <script>
@@ -137,6 +151,7 @@
     <script src="/static/js/operations.js"></script>
     <script src="/static/js/network.js"></script>
     <script src="/static/js/samples.js"></script>
+    <script src="/static/js/transforms.js"></script>
     <script src="/static/js/app.js"></script>
 
     <!-- Initialize icons -->
@@ -151,6 +166,7 @@
             document.getElementById('queryTabIcon').innerHTML = icons.search();
             document.getElementById('mutationTabIcon').innerHTML = icons.code();
             document.getElementById('samplesTabIcon').innerHTML = icons.library();
+            document.getElementById('transformsTabIcon').innerHTML = icons.gear();
             document.getElementById('networkTabIcon').innerHTML = icons.network();
             
             // Set status icon

--- a/fold_node/src/datafold_node/static/js/transforms.js
+++ b/fold_node/src/datafold_node/static/js/transforms.js
@@ -1,0 +1,41 @@
+/**
+ * Transform management for the DataFold Node UI
+ */
+
+async function loadTransforms() {
+    const container = document.getElementById('transformsList');
+    if (!container) return;
+    utils.showLoading(container, 'Loading transforms...');
+    try {
+        const resp = await utils.apiRequest('/api/transforms');
+        const map = resp.data || {};
+        container.innerHTML = '';
+        Object.entries(map).forEach(([id, t]) => {
+            const div = document.createElement('div');
+            div.className = 'transform-item';
+            const pre = document.createElement('pre');
+            pre.textContent = JSON.stringify(t, null, 2);
+            const btn = document.createElement('button');
+            btn.className = 'btn btn-sm btn-primary mt-2';
+            btn.innerHTML = `${window.icons ? icons.play() + ' ' : ''}Run`;
+            btn.addEventListener('click', () => runTransform(id));
+            div.appendChild(document.createTextNode(id));
+            div.appendChild(btn);
+            div.appendChild(pre);
+            container.appendChild(div);
+        });
+    } catch (e) {
+        container.innerHTML = 'Failed to load transforms';
+    }
+}
+
+async function runTransform(id) {
+    try {
+        const resp = await utils.apiRequest(`/api/transform/${id}/run`, {method: 'POST'});
+        utils.displayResult(resp.data);
+    } catch (e) {
+        utils.displayResult(e.message, true);
+    }
+}
+
+window.transformsModule = { loadTransforms, runTransform };

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -6,6 +6,7 @@ pub mod transform_manager;
 pub mod transform_orchestrator;
 
 use std::sync::Arc;
+use std::collections::HashMap;
 use crate::atom::{Atom, AtomRefBehavior};
 use crate::db_operations::DbOperations;
 use crate::permissions::PermissionWrapper;
@@ -386,5 +387,15 @@ impl FoldDB {
     /// Returns the number of queued transform tasks.
     pub fn orchestrator_len(&self) -> usize {
         self.transform_orchestrator.len()
+    }
+
+    /// List all registered transforms.
+    pub fn list_transforms(&self) -> HashMap<String, Transform> {
+        self.transform_manager.list_transforms()
+    }
+
+    /// Execute a transform immediately and return the result.
+    pub fn run_transform(&self, transform_id: &str) -> Result<Value, SchemaError> {
+        self.transform_manager.execute_transform_now(transform_id)
     }
 }

--- a/fold_node/src/fold_db_core/transform_manager.rs
+++ b/fold_node/src/fold_db_core/transform_manager.rs
@@ -330,6 +330,12 @@ impl TransformManager {
         registered_transforms.contains_key(transform_id)
     }
 
+    /// List all registered transforms.
+    pub fn list_transforms(&self) -> HashMap<String, Transform> {
+        let registered_transforms = self.registered_transforms.read().unwrap();
+        registered_transforms.clone()
+    }
+
     /// Gets all transforms that depend on the specified atom reference.
     pub fn get_dependent_transforms(&self, aref_uuid: &str) -> HashSet<String> {
         let aref_to_transforms = self.aref_to_transforms.read().unwrap();

--- a/tests/integration_tests/http_server_tests.rs
+++ b/tests/integration_tests/http_server_tests.rs
@@ -184,3 +184,61 @@ async fn test_network_endpoints() {
     handle.abort();
 }
 
+#[tokio::test]
+async fn test_transform_endpoints() {
+    let (handle, addr, _tmp) = start_server().await;
+    let client = Client::new();
+
+    let schema_json = serde_json::json!({
+        "name": "transform_schema",
+        "fields": {
+            "computed": {
+                "permission_policy": {
+                    "read_policy": { "Distance": 0 },
+                    "write_policy": { "Distance": 0 },
+                    "explicit_read_policy": null,
+                    "explicit_write_policy": null
+                },
+                "ref_atom_uuid": "calc_uuid",
+                "payment_config": {
+                    "base_multiplier": 1.0,
+                    "trust_distance_scaling": { "None": null },
+                    "min_payment": null
+                },
+                "field_mappers": {},
+                "field_type": "Single",
+                "transform": "transform calc { logic: { 4 + 5; } }"
+            }
+        },
+        "payment_config": { "base_multiplier": 1.0, "min_payment_threshold": 0 }
+    });
+
+    let resp = client
+        .post(format!("http://{}/api/schema", addr))
+        .json(&schema_json)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "{}", resp.text().await.unwrap());
+
+    let resp = client
+        .get(format!("http://{}/api/transforms", addr))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["data"].as_object().unwrap().contains_key("transform_schema.computed"));
+
+    let resp = client
+        .post(format!("http://{}/api/transform/transform_schema.computed/run", addr))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["data"], serde_json::json!(9.0));
+
+    handle.abort();
+}
+


### PR DESCRIPTION
## Summary
- expose APIs to list and run transforms
- provide Node helpers for transform APIs
- create Transform tab in UI
- add JS for transform actions
- support transform endpoints in HTTP server
- test transform endpoints via http server integration test

## Testing
- `cargo test --test mod integration_tests::http_server_tests::test_transform_endpoints -- --nocapture`
- `cargo test --workspace`