### PR TITLE
Enable dynamic address lookup for request forwarding

### DIFF
--- a/fold_node/src/datafold_node/tcp_server.rs
+++ b/fold_node/src/datafold_node/tcp_server.rs
@@ -102,6 +102,11 @@ impl TcpServer {
         let listener = TcpListener::bind(&addr).await?;
         println!("TCP server listening on {}", addr);
 
+        // Register this node's address with the network if available
+        if let Ok(mut net) = node.get_network_mut().await {
+            net.register_node_address(node.get_node_id(), addr.clone());
+        }
+
         Ok(Self {
             node: Arc::new(Mutex::new(node)),
             listener,


### PR DESCRIPTION
## Summary
- map node IDs to listening addresses in `NetworkCore`
- use mapped address when forwarding requests
- register node address when creating `TcpServer`
- update forwarding tests and add new test for address resolution

## Testing
- `cargo test --workspace --quiet`