### PR TITLE
Abort network loop on stop

### DIFF
--- a/fold_node/src/datafold_node/node.rs
+++ b/fold_node/src/datafold_node/node.rs
@@ -558,11 +558,9 @@ impl DataFoldNode {
     /// Stop the network service
     pub async fn stop_network(&self) -> FoldDbResult<()> {
         if let Some(network) = &self.network {
-            let network_guard = network.lock().await;
-            // In a real implementation, this would stop the network service
-            // For now, just log that we're stopping
+            let mut network_guard = network.lock().await;
             println!("Stopping network service");
-            let _ = network_guard; // Acknowledge the guard to avoid unused variable warning
+            network_guard.stop();
             Ok(())
         } else {
             Err(FoldDbError::Network(NetworkErrorKind::Protocol(

--- a/fold_node/src/network/core.rs
+++ b/fold_node/src/network/core.rs
@@ -61,6 +61,8 @@ pub struct NetworkCore {
     /// Mock for testing - maps peer IDs to schema services
     #[cfg(test)]
     mock_peers: HashMap<PeerId, SchemaService>,
+    /// Handle for the background networking task
+    mdns_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl NetworkCore {
@@ -79,6 +81,7 @@ impl NetworkCore {
             peer_to_node_map: HashMap::new(),
             #[cfg(test)]
             mock_peers: HashMap::new(),
+            mdns_handle: None,
         })
     }
 
@@ -141,7 +144,7 @@ impl NetworkCore {
             // This is a placeholder for the actual implementation
             // In a real implementation, this would start a background task
             // that periodically announces this node via mDNS
-            tokio::spawn(async move {
+            let handle = tokio::spawn(async move {
                 println!(
                     "Starting mDNS announcements on port {} every {:?}",
                     discovery_port, announcement_interval
@@ -155,6 +158,8 @@ impl NetworkCore {
                     tokio::time::sleep(announcement_interval).await;
                 }
             });
+
+            self.mdns_handle = Some(handle);
 
             // For now, we'll simulate peer discovery
             if cfg!(feature = "simulate-peers") {
@@ -170,6 +175,13 @@ impl NetworkCore {
         }
 
         Ok(())
+    }
+
+    /// Stop the network service by aborting any background tasks
+    pub fn stop(&mut self) {
+        if let Some(handle) = self.mdns_handle.take() {
+            handle.abort();
+        }
     }
 
     /// Check which schemas are available on a remote peer.


### PR DESCRIPTION
## Summary
- store JoinHandle for network tasks in `NetworkCore`
- abort background task from `DataFoldNode::stop_network`

## Testing
- `cargo test --workspace`