### PR TITLE
Fix transforms tab loading

### DIFF
--- a/fold_node/src/datafold_node/static/index.html
+++ b/fold_node/src/datafold_node/static/index.html
@@ -65,59 +65,48 @@
                     <!-- Include Schema Tab Components -->
                     <div id="schemaTabsContainer">
                         <script>
-                            fetch('/static/components/schema-tab.html')
-                                .then(response => response.text())
-                                .then(html => {
-                                    document.getElementById('schemaTabsContainer').innerHTML = html;
-                                });
+                            utils.loadHtmlIntoContainer('/static/components/schema-tab.html', 'schemaTabsContainer');
                         </script>
                     </div>
                     
                     <!-- Include Operations Tab Components -->
                     <div id="operationsTabsContainer">
                         <script>
-                            fetch('/static/components/operations-tab.html')
-                                .then(response => response.text())
-                                .then(html => {
-                                    document.getElementById('operationsTabsContainer').innerHTML = html;
-                                });
+                            utils.loadHtmlIntoContainer('/static/components/operations-tab.html', 'operationsTabsContainer');
                         </script>
                     </div>
 
                     <!-- Include Transforms Tab Component -->
                     <div id="transformsTabContainer">
                         <script>
-                            fetch('/static/components/transforms-tab.html')
-                                .then(response => response.text())
-                                .then(html => {
-                                    document.getElementById('transformsTabContainer').innerHTML = html;
+                            utils.loadHtmlIntoContainer('/static/components/transforms-tab.html', 'transformsTabContainer', () => {
+                                const refreshIcon = document.getElementById('refreshTransformsIcon');
+                                if (window.icons && refreshIcon) {
+                                    refreshIcon.innerHTML = icons.refresh();
+                                }
+                                document.getElementById('refreshTransformsBtn')?.addEventListener('click', () => {
+                                    transformsModule.loadTransforms();
                                 });
+                                transformsModule.loadTransforms();
+                            });
                         </script>
                     </div>
 
                     <!-- Include Network Tab Component -->
                     <div id="networkTabContainer">
                         <script>
-                            fetch('/static/components/network-tab.html')
-                                .then(response => response.text())
-                                .then(html => {
-                                    document.getElementById('networkTabContainer').innerHTML = html;
-                                });
+                            utils.loadHtmlIntoContainer('/static/components/network-tab.html', 'networkTabContainer');
                         </script>
                     </div>
                     
                     <!-- Include Samples Tab Component -->
                     <div id="samplesTabContainer">
                         <script>
-                            fetch('/static/components/samples-tab.html')
-                                .then(response => response.text())
-                                .then(html => {
-                                    document.getElementById('samplesTabContainer').innerHTML = html;
-                                    // Initialize samples tab after loading
-                                    if (window.samplesModule && window.samplesModule.initSamplesTab) {
-                                        window.samplesModule.initSamplesTab();
-                                    }
-                                });
+                            utils.loadHtmlIntoContainer('/static/components/samples-tab.html', 'samplesTabContainer', () => {
+                                if (window.samplesModule && window.samplesModule.initSamplesTab) {
+                                    window.samplesModule.initSamplesTab();
+                                }
+                            });
                         </script>
                     </div>
                 </div>

--- a/fold_node/src/datafold_node/static/js/utils.js
+++ b/fold_node/src/datafold_node/static/js/utils.js
@@ -249,6 +249,47 @@ function toggleSchema(element) {
     }
 }
 
+/**
+ * Load an HTML snippet into a container and execute any embedded scripts.
+ * @param {string} url - The URL to fetch the HTML from
+ * @param {string} containerId - The id of the container element
+ * @param {Function} callback - Optional callback after loading
+ */
+async function loadHtmlIntoContainer(url, containerId, callback) {
+    try {
+        const response = await fetch(url);
+        const html = await response.text();
+        const container = document.getElementById(containerId);
+        if (!container) {
+            console.error(`Container ${containerId} not found`);
+            return;
+        }
+
+        container.innerHTML = html;
+
+        // Execute any inline scripts within the loaded HTML
+        container.querySelectorAll('script').forEach(script => {
+            const newScript = document.createElement('script');
+            if (script.src) {
+                newScript.src = script.src;
+            } else {
+                newScript.textContent = script.textContent;
+            }
+            document.body.appendChild(newScript);
+            document.body.removeChild(newScript);
+        });
+
+        // Dispatch DOMContentLoaded for handlers registered in the snippet
+        document.dispatchEvent(new Event('DOMContentLoaded'));
+
+        if (typeof callback === 'function') {
+            callback(container);
+        }
+    } catch (e) {
+        console.error('Failed to load HTML component', e);
+    }
+}
+
 // Export functions for use in other modules
 window.utils = {
     displayResult,
@@ -258,5 +299,6 @@ window.utils = {
     apiRequest,
     switchTab,
     toggleSchema,
-    showNotification
+    showNotification,
+    loadHtmlIntoContainer
 };

--- a/tests/ui/load_component_test.js
+++ b/tests/ui/load_component_test.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+class Element {
+  constructor(tag) {
+    this.tag = tag;
+    this.innerHTML = '';
+    this.id = '';
+    this.children = [];
+  }
+  appendChild(c) {
+    this.children.push(c);
+    if (c.tag === 'script' && c.textContent) {
+      Function(c.textContent)();
+    }
+  }
+  removeChild(c) { this.children = this.children.filter(x => x !== c); }
+  querySelectorAll(selector) {
+    if (selector === 'script') {
+      const regex = /<script[^>]*>([\s\S]*?)<\/script>/gi;
+      const matches = [...this.innerHTML.matchAll(regex)];
+      return matches.map(m => ({ textContent: m[1], src: '' }));
+    }
+    return [];
+  }
+}
+class Document {
+  constructor() {
+    this.elements = { container: new Element('div') };
+    this.body = new Element('body');
+  }
+  getElementById(id) { return this.elements[id]; }
+  createElement(tag) { return new Element(tag); }
+  dispatchEvent() {}
+}
+
+global.document = new Document();
+global.window = { icons: { refresh: () => '[refresh]' } };
+
+const utilsPath = path.join(__dirname, '..', '..', 'fold_node', 'src', 'datafold_node', 'static', 'js', 'utils.js');
+const utilsCode = fs.readFileSync(utilsPath, 'utf8');
+
+// Evaluate utils.js in this context
+Function(utilsCode)();
+
+// Mock fetch
+global.fetch = async () => ({
+  text: async () => '<div id="inner">Content</div><script>window.testVar=42;</script>'
+});
+
+(async () => {
+  await window.utils.loadHtmlIntoContainer('dummy', 'container');
+  assert.strictEqual(document.getElementById('container').innerHTML.includes('Content'), true);
+  assert.strictEqual(window.testVar, 42);
+  console.log('loadHtmlIntoContainer test passed');
+})();


### PR DESCRIPTION
## Summary
- load HTML snippets via utility function
- execute embedded scripts when components are inserted
- refresh and load transforms after component injection
- add unit test for new loader helper

## Testing
- `node tests/ui/load_component_test.js`
- `cargo test --workspace --quiet`