### PR TITLE
Add default NodeConfig implementation

### DIFF
--- a/fold_node/src/bin/datafold_http_server.rs
+++ b/fold_node/src/bin/datafold_http_server.rs
@@ -3,7 +3,6 @@ use fold_node::{
 };
 use std::env;
 use std::fs;
-use std::path::PathBuf;
 
 /// Main entry point for the DataFold HTTP server.
 ///
@@ -63,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         serde_json::from_str(&config_str)?
     } else {
         println!("Config file not found, using default config");
-        NodeConfig::new(PathBuf::from("data"))
+        NodeConfig::default()
     };
     println!("Config loaded successfully");
 

--- a/fold_node/src/bin/datafold_node.rs
+++ b/fold_node/src/bin/datafold_node.rs
@@ -4,7 +4,6 @@ use fold_node::{
 };
 use std::env;
 use std::fs;
-use std::path::PathBuf;
 
 /// Main entry point for the DataFold Node server.
 ///
@@ -75,7 +74,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         serde_json::from_str(&config_str)?
     } else {
         println!("Config file not found, using default config");
-        NodeConfig::new(PathBuf::from("data"))
+        NodeConfig::default()
             .with_network_listen_address(&format!("/ip4/0.0.0.0/tcp/{}", port))
     };
     println!("Config loaded successfully");

--- a/fold_node/src/datafold_node/config.rs
+++ b/fold_node/src/datafold_node/config.rs
@@ -18,13 +18,22 @@ fn default_network_listen_address() -> String {
     "/ip4/0.0.0.0/tcp/0".to_string()
 }
 
+impl Default for NodeConfig {
+    fn default() -> Self {
+        Self {
+            storage_path: PathBuf::from("data"),
+            default_trust_distance: 1,
+            network_listen_address: default_network_listen_address(),
+        }
+    }
+}
+
 impl NodeConfig {
     /// Create a new node configuration with the specified storage path
     pub fn new(storage_path: PathBuf) -> Self {
         Self {
             storage_path,
-            default_trust_distance: 1,
-            network_listen_address: default_network_listen_address(),
+            ..Default::default()
         }
     }
 

--- a/fold_node/src/datafold_node/tests.rs
+++ b/fold_node/src/datafold_node/tests.rs
@@ -28,3 +28,11 @@ fn test_add_trusted_node() {
     assert!(node.remove_trusted_node("test_node").is_ok());
     assert!(!node.get_trusted_nodes().contains_key("test_node"));
 }
+
+#[test]
+fn test_node_config_default() {
+    let config = NodeConfig::default();
+    assert_eq!(config.storage_path, std::path::PathBuf::from("data"));
+    assert_eq!(config.default_trust_distance, 1);
+    assert_eq!(config.network_listen_address, "/ip4/0.0.0.0/tcp/0".to_string());
+}


### PR DESCRIPTION
## Summary
- implement `Default` for `NodeConfig`
- delegate `NodeConfig::new` to `Default`
- use `NodeConfig::default()` in CLI binaries
- add a unit test for the default configuration

## Testing
- `cargo test --workspace`