### PR TITLE
Return Result from SchemaCore constructors

### DIFF
--- a/fold_node/src/datafold_node/loader.rs
+++ b/fold_node/src/datafold_node/loader.rs
@@ -55,7 +55,7 @@ pub fn load_schema_from_file<P: AsRef<Path>>(
         }
         Err(_) => {
             let json_schema: JsonSchemaDefinition = serde_json::from_str(&schema_str)?;
-            let core = SchemaCore::default();
+            let core = SchemaCore::default()?;
             let schema = core.interpret_schema(json_schema)?;
             node.load_schema(schema)?;
         }

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -92,7 +92,8 @@ impl FoldDB {
         let atom_manager = AtomManager::new(db_ops);
         let field_manager = FieldManager::new(atom_manager.clone());
         let collection_manager = CollectionManager::new(field_manager.clone());
-        let schema_manager = SchemaCore::new(path);
+        let schema_manager = SchemaCore::new(path)
+            .map_err(|e| sled::Error::Unsupported(e.to_string()))?;
         let atom_manager_clone = atom_manager.clone();
         let get_atom_fn = Arc::new(move |aref_uuid: &str| {
             atom_manager_clone.get_latest_atom(aref_uuid)

--- a/fold_node/tests/permissions_tests.rs
+++ b/fold_node/tests/permissions_tests.rs
@@ -14,7 +14,7 @@ fn create_default_payment_config() -> FieldPaymentConfig {
 fn test_permission_wrapper_query() {
     // Setup
     let wrapper = PermissionWrapper::new();
-    let schema_manager = SchemaCore::new("data");
+    let schema_manager = SchemaCore::new("data").unwrap();
 
     // Create a test schema
     let mut fields = HashMap::new();
@@ -73,7 +73,7 @@ fn test_permission_wrapper_query() {
 fn test_permission_wrapper_no_requirement() {
     // Setup
     let wrapper = PermissionWrapper::new();
-    let schema_manager = SchemaCore::new("data");
+    let schema_manager = SchemaCore::new("data").unwrap();
 
     // Create a test schema with no distance requirement
     let mut fields = HashMap::new();
@@ -122,7 +122,7 @@ fn test_permission_wrapper_no_requirement() {
 fn test_permission_wrapper_mutation() {
     // Setup
     let wrapper = PermissionWrapper::new();
-    let schema_manager = SchemaCore::new("data");
+    let schema_manager = SchemaCore::new("data").unwrap();
 
     // Create a test schema with both explicit write permissions and trust distance
     let mut fields = HashMap::new();

--- a/fold_node/tests/schema_core_init_tests.rs
+++ b/fold_node/tests/schema_core_init_tests.rs
@@ -1,0 +1,14 @@
+use fold_node::testing::SchemaCore;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_default_initialization() {
+    SchemaCore::default().expect("default initialization failed");
+}
+
+#[test]
+fn test_new_invalid_path() {
+    let file = NamedTempFile::new().unwrap();
+    let result = SchemaCore::new(file.path().to_str().unwrap());
+    assert!(result.is_err());
+}

--- a/fold_node/tests/schema_interpreter_tests.rs
+++ b/fold_node/tests/schema_interpreter_tests.rs
@@ -33,7 +33,7 @@ fn test_invalid_schema_validation() {
         }
     }"#;
 
-    let core = SchemaCore::new("data");
+    let core = SchemaCore::new("data").unwrap();
     let result = core.load_schema_from_json(invalid_json_str);
     assert!(result.is_err());
 }

--- a/fold_node/tests/schema_tests.rs
+++ b/fold_node/tests/schema_tests.rs
@@ -87,7 +87,7 @@ fn test_user_profile_schema() {
 fn test_schema_persistence() {
     // Create a temporary directory for test
     let test_dir = tempdir().unwrap();
-    let manager = SchemaCore::new(test_dir.path().to_str().unwrap());
+    let manager = SchemaCore::new(test_dir.path().to_str().unwrap()).unwrap();
 
     // Create and load a test schema
     let schema = create_test_schema("test_persistence");
@@ -106,7 +106,7 @@ fn test_schema_persistence() {
     );
 
     // Create a new manager instance to verify disk persistence
-    let new_manager = SchemaCore::new(test_dir.path().to_str().unwrap());
+    let new_manager = SchemaCore::new(test_dir.path().to_str().unwrap()).unwrap();
     new_manager.load_schemas_from_disk().unwrap();
     let reloaded_schema = new_manager.get_schema("test_persistence").unwrap().unwrap();
     assert_eq!(reloaded_schema.name, "test_persistence");
@@ -123,7 +123,7 @@ fn test_schema_persistence() {
 fn test_schema_disk_loading() {
     // Create a temporary directory for test
     let test_dir = tempdir().unwrap();
-    let manager = SchemaCore::new(test_dir.path().to_str().unwrap());
+    let manager = SchemaCore::new(test_dir.path().to_str().unwrap()).unwrap();
 
     // Create and save multiple schemas
     let schemas = vec![
@@ -138,7 +138,7 @@ fn test_schema_disk_loading() {
     }
 
     // Create a new manager instance and load schemas from disk
-    let new_manager = SchemaCore::new(test_dir.path().to_str().unwrap());
+    let new_manager = SchemaCore::new(test_dir.path().to_str().unwrap()).unwrap();
     new_manager.load_schemas_from_disk().unwrap();
 
     // Verify all schemas were loaded


### PR DESCRIPTION
## Summary
- make SchemaCore::default and SchemaCore::new fallible
- propagate errors when initializing SchemaCore
- update call sites and tests
- add tests for SchemaCore initialization

## Testing
- `cargo test --quiet`