### PR TITLE
Add structured logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ futures = "0.3"
 rand = "0.8"
 tempfile = "3.8"
 clap = { version = "4.4", features = ["derive"] }
+log = "0.4"
+env_logger = "0.10"
 # P2P Networking
 libp2p = { version = "0.53", features = [
     "mdns",
@@ -66,3 +68,6 @@ reqwest = { version = "0.11", features = ["json"] }
 [lib]
 name = "fold_db"
 path = "src/lib.rs"
+
+[patch.crates-io]
+env_logger = { path = "vendor/env_logger" }

--- a/fold_node/Cargo.toml
+++ b/fold_node/Cargo.toml
@@ -31,6 +31,8 @@ tempfile = "3.8"
 clap = { version = "4.4", features = ["derive"] }
 pest = "2.7"
 pest_derive = "2.7"
+log = "0.4"
+env_logger = "0.10"
 # P2P Networking
 libp2p = { version = "0.53", features = [
     "mdns",
@@ -82,3 +84,6 @@ path = "examples/transform_logic_test.rs"
 [[example]]
 name = "complex_transform_dsl"
 path = "examples/complex_transform_dsl.rs"
+
+[patch.crates-io]
+env_logger = { path = "../vendor/env_logger" }

--- a/fold_node/src/bin/datafold_http_server.rs
+++ b/fold_node/src/bin/datafold_http_server.rs
@@ -4,6 +4,8 @@ use fold_node::{
 use std::env;
 use std::fs;
 use std::path::PathBuf;
+use env_logger;
+use log::{info, warn, error};
 
 /// Main entry point for the DataFold HTTP server.
 ///
@@ -31,7 +33,8 @@ use std::path::PathBuf;
 /// * The HTTP server cannot be started
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Starting DataFold HTTP Server...");
+    env_logger::init();
+    info!("Starting DataFold HTTP Server...");
 
     // Parse command-line arguments
     let args: Vec<String> = env::args().collect();
@@ -56,27 +59,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Read node config from environment variable or default path
     let config_path =
         std::env::var("NODE_CONFIG").unwrap_or_else(|_| "config/node_config.json".to_string());
-    println!("Loading config from: {}", config_path);
+    info!("Loading config from: {}", config_path);
 
     // Create a default config if the file doesn't exist
     let config: NodeConfig = if let Ok(config_str) = fs::read_to_string(&config_path) {
         serde_json::from_str(&config_str)?
     } else {
-        println!("Config file not found, using default config");
+        warn!("Config file not found, using default config");
         NodeConfig::new(PathBuf::from("data"))
     };
-    println!("Config loaded successfully");
+    info!("Config loaded successfully");
 
     // Load or initialize node
-    println!("Loading DataFold Node...");
+    info!("Loading DataFold Node...");
     let node = DataFoldNode::load(config)?;
-    println!("Node loaded successfully");
+    info!("Node loaded successfully");
 
     // Print node ID for connecting
-    println!("Node ID: {}", node.get_node_id());
+    info!("Node ID: {}", node.get_node_id());
 
     // Start the HTTP server
-    println!("Starting HTTP server on port {}...", http_port);
+    info!("Starting HTTP server on port {}...", http_port);
     let bind_address = format!("127.0.0.1:{}", http_port);
     let http_server = DataFoldHttpServer::new(node, &bind_address).await?;
 

--- a/fold_node/src/bin/datafold_node.rs
+++ b/fold_node/src/bin/datafold_node.rs
@@ -5,6 +5,8 @@ use fold_node::{
 use std::env;
 use std::fs;
 use std::path::PathBuf;
+use env_logger;
+use log::{info, warn, error};
 
 /// Main entry point for the DataFold Node server.
 ///
@@ -34,7 +36,8 @@ use std::path::PathBuf;
 /// * The TCP server cannot be started
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Starting DataFold Node...");
+    env_logger::init();
+    info!("Starting DataFold Node...");
 
     // Parse command-line arguments
     let args: Vec<String> = env::args().collect();
@@ -68,28 +71,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Read node config from environment variable or default path
     let config_path =
         std::env::var("NODE_CONFIG").unwrap_or_else(|_| "config/node_config.json".to_string());
-    println!("Loading config from: {}", config_path);
+    info!("Loading config from: {}", config_path);
 
     // Create a default config if the file doesn't exist
     let config: NodeConfig = if let Ok(config_str) = fs::read_to_string(&config_path) {
         serde_json::from_str(&config_str)?
     } else {
-        println!("Config file not found, using default config");
+        warn!("Config file not found, using default config");
         NodeConfig::new(PathBuf::from("data"))
             .with_network_listen_address(&format!("/ip4/0.0.0.0/tcp/{}", port))
     };
-    println!("Config loaded successfully");
+    info!("Config loaded successfully");
 
     // Load or initialize node
-    println!("Loading DataFold Node...");
+    info!("Loading DataFold Node...");
     let mut node = DataFoldNode::load(config)?;
-    println!("Node loaded successfully");
+    info!("Node loaded successfully");
 
     // Schemas are loaded from disk during node initialization
-    println!("Previously loaded schemas are available");
+    info!("Previously loaded schemas are available");
 
     // Initialize network layer
-    println!("Initializing network layer...");
+    info!("Initializing network layer...");
     let listen_address = format!("/ip4/0.0.0.0/tcp/{}", port);
     let network_config = NetworkConfig::new(&listen_address)
         .with_mdns(true)
@@ -99,25 +102,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_max_message_size(1_000_000);
 
     node.init_network(network_config).await?;
-    println!("Network layer initialized");
+    info!("Network layer initialized");
 
     // Start the network service
-    println!("Starting network service on port {}...", port);
+    info!("Starting network service on port {}...", port);
     node.start_network_with_address(&listen_address).await?;
-    println!("Network service started");
+    info!("Network service started");
 
     // Print node ID for connecting
-    println!("Node ID: {}", node.get_node_id());
-    println!("Other nodes can connect to this node using the Node ID above");
+    info!("Node ID: {}", node.get_node_id());
+    info!("Other nodes can connect to this node using the Node ID above");
 
     // Start the TCP server
-    println!("Starting TCP server on port {}...", tcp_port);
+    info!("Starting TCP server on port {}...", tcp_port);
     let tcp_server = TcpServer::new(node.clone(), tcp_port).await?;
 
     // Run the TCP server in a separate task
     let tcp_server_handle = tokio::spawn(async move {
         if let Err(e) = tcp_server.run().await {
-            eprintln!("TCP server error: {}", e);
+            error!("TCP server error: {}", e);
         }
     });
 

--- a/fold_node/src/datafold_node/http_server.rs
+++ b/fold_node/src/datafold_node/http_server.rs
@@ -8,6 +8,7 @@ use actix_cors::Cors;
 use actix_files::Files;
 use actix_web::{web, App, HttpResponse, HttpServer as ActixHttpServer, Responder};
 use serde::Deserialize;
+use log::{info, warn, error};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::Path;
@@ -73,7 +74,7 @@ impl SampleManager {
         let mut entries = match fs::read_dir(&samples_dir).await {
             Ok(e) => e,
             Err(e) => {
-                eprintln!(
+                error!(
                     "Failed to read samples directory {}: {}",
                     samples_dir.display(),
                     e
@@ -181,7 +182,7 @@ impl DataFoldHttpServer {
         for (_, schema_value) in sample_manager.schemas.iter() {
             let schema: Schema = serde_json::from_value(schema_value.clone())
                 .map_err(|e| FoldDbError::Config(format!("Failed to deserialize sample schema: {}", e)))?;
-            println!("Loading sample schema into node: {}", schema.name);
+            info!("Loading sample schema into node: {}", schema.name);
             node.load_schema(schema)?;
         }
 
@@ -208,7 +209,7 @@ impl DataFoldHttpServer {
     /// * There is an error binding to the specified address
     /// * There is an error starting the server
     pub async fn run(&self) -> FoldDbResult<()> {
-        println!("HTTP server running on {}", self.bind_address);
+        info!("HTTP server running on {}", self.bind_address);
 
         // Create shared application state
         let app_state = web::Data::new(AppState {
@@ -283,19 +284,19 @@ impl DataFoldHttpServer {
 
 /// List all schemas.
 async fn list_schemas(state: web::Data<AppState>) -> impl Responder {
-    println!("Received request to list schemas");
+    info!("Received request to list schemas");
     let node_guard = state.node.lock().await;
 
     match node_guard.list_schemas() {
         Ok(schemas) => {
-            println!("Successfully listed schemas: {:?}", schemas);
+            info!("Successfully listed schemas: {:?}", schemas);
             // Wrap the schemas in a data field to match frontend expectations
             HttpResponse::Ok().json(json!({
                 "data": schemas
             }))
         },
         Err(e) => {
-            println!("Failed to list schemas: {}", e);
+            error!("Failed to list schemas: {}", e);
             HttpResponse::InternalServerError().json(json!({
                 "error": format!("Failed to list schemas: {}", e)
             }))

--- a/fold_node/src/datafold_node/node.rs
+++ b/fold_node/src/datafold_node/node.rs
@@ -2,6 +2,7 @@ use serde_json::Value;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use log::{info, warn, error};
 
 use crate::datafold_node::config::NodeConfig;
 use crate::datafold_node::config::NodeInfo;
@@ -223,7 +224,7 @@ impl DataFoldNode {
     /// }
     /// ```
     pub fn execute_operation(&mut self, operation: Operation) -> FoldDbResult<Value> {
-        println!("Executing operation: {:?}", operation);
+        info!("Executing operation: {:?}", operation);
         match operation {
             Operation::Query {
                 schema,
@@ -285,7 +286,7 @@ impl DataFoldNode {
                     }
                 };
 
-                println!("Mutation type: {:?}", mutation_type);
+                info!("Mutation type: {:?}", mutation_type);
 
                 let mutation = Mutation {
                     schema_name: schema,
@@ -322,7 +323,7 @@ impl DataFoldNode {
             .lock()
             .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
         let schema_names = db.schema_manager.list_schemas()?;
-        println!("Schema names from schema_manager: {:?}", schema_names);
+        info!("Schema names from schema_manager: {:?}", schema_names);
         let mut schemas = Vec::new();
         for name in schema_names {
             if let Some(schema) = db.schema_manager.get_schema(&name)? {
@@ -508,7 +509,7 @@ impl DataFoldNode {
         // Register the node ID with the network core
         let local_peer_id = network_core.local_peer_id();
         network_core.register_node_id(&self.node_id, local_peer_id);
-        println!(
+        info!(
             "Registered node ID {} with peer ID {}",
             self.node_id, local_peer_id
         );
@@ -559,7 +560,7 @@ impl DataFoldNode {
     pub async fn stop_network(&self) -> FoldDbResult<()> {
         if let Some(network) = &self.network {
             let mut network_guard = network.lock().await;
-            println!("Stopping network service");
+            info!("Stopping network service");
             network_guard.stop();
             Ok(())
         } else {
@@ -587,7 +588,7 @@ impl DataFoldNode {
 
             // Trigger mDNS discovery
             // This will update the known_peers list in the NetworkCore
-            println!("Triggering mDNS discovery...");
+            info!("Triggering mDNS discovery...");
 
             // In a real implementation, this would actively scan for peers
             // For now, we'll just return the current known peers
@@ -674,7 +675,7 @@ impl DataFoldNode {
                 .get_node_id_for_peer(&peer_id)
                 .unwrap_or_else(|| peer_id.to_string());
 
-            println!("Forwarding request to node {} (peer {})", node_id, peer_id);
+            info!("Forwarding request to node {} (peer {})", node_id, peer_id);
 
             // Use the network layer to forward the request
             let response = network
@@ -682,7 +683,7 @@ impl DataFoldNode {
                 .await
                 .map_err(|e| FoldDbError::Network(e.into()))?;
 
-            println!("Received response from node {} (peer {})", node_id, peer_id);
+            info!("Received response from node {} (peer {})", node_id, peer_id);
 
             Ok(response)
         } else {

--- a/fold_node/src/fees/payment_manager.rs
+++ b/fold_node/src/fees/payment_manager.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
+use log::{info, warn, error};
 
 use crate::fees::lightning::LightningClient;
 use crate::fees::{
@@ -309,7 +310,7 @@ impl PaymentManager {
                 .cancel_invoice(&format!("mock_invoice_{payment_hash}"))
                 .await
             {
-                eprintln!("Failed to cancel expired invoice {payment_hash}: {e}");
+                warn!("Failed to cancel expired invoice {payment_hash}: {e}");
             }
             if let Some(state) = states.get_mut(&payment_hash) {
                 state.status = PaymentStatus::Expired;

--- a/fold_node/src/fold_db_core/transform_manager.rs
+++ b/fold_node/src/fold_db_core/transform_manager.rs
@@ -5,6 +5,7 @@ use super::transform_orchestrator::TransformRunner;
 use serde_json::Value as JsonValue;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
+use log::{info, warn, error};
 
 /// Callback function type for getting an atom by its reference UUID
 pub type GetAtomFn = Arc<dyn Fn(&str) -> Result<Atom, Box<dyn std::error::Error>> + Send + Sync>;
@@ -539,7 +540,7 @@ pub fn execute_field_transforms(
             input_values.insert("field_key".to_string(), serde_json::Value::String(transform_id.clone()));
 
             if let Err(e) = TransformExecutor::execute_transform(transform, input_values) {
-                eprintln!("Failed to execute transform for field {}: {}", transform_id, e);
+                error!("Failed to execute transform for field {}: {}", transform_id, e);
             }
         }
 

--- a/fold_node/src/network/core.rs
+++ b/fold_node/src/network/core.rs
@@ -6,6 +6,7 @@ use libp2p::PeerId;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
+use log::{info, warn, error};
 
 /// Core network component for P2P communication between DataFold nodes.
 ///
@@ -131,14 +132,14 @@ impl NetworkCore {
 
     /// Start the network service
     pub async fn run(&mut self, listen_address: &str) -> NetworkResult<()> {
-        println!("Network service started on {}", listen_address);
-        println!("Using protocol: {}", SCHEMA_PROTOCOL_NAME);
+        info!("Network service started on {}", listen_address);
+        info!("Using protocol: {}", SCHEMA_PROTOCOL_NAME);
 
         // Set up mDNS discovery if enabled
         if self.config.enable_mdns {
-            println!("mDNS discovery enabled");
-            println!("Discovery port: {}", self.config.discovery_port);
-            println!(
+            info!("mDNS discovery enabled");
+            info!("Discovery port: {}", self.config.discovery_port);
+            info!(
                 "Announcement interval: {:?}",
                 self.config.announcement_interval
             );
@@ -158,14 +159,14 @@ impl NetworkCore {
             // In a real implementation, this would start a background task
             // that periodically announces this node via mDNS
             let handle = tokio::spawn(async move {
-                println!(
+                info!(
                     "Starting mDNS announcements on port {} every {:?}",
                     discovery_port, announcement_interval
                 );
 
                 loop {
                     // Simulate mDNS announcement
-                    println!("SIMULATION: Announcing peer {} via mDNS", local_peer_id);
+                    info!("SIMULATION: Announcing peer {} via mDNS", local_peer_id);
 
                     // Wait for the next announcement
                     tokio::time::sleep(announcement_interval).await;
@@ -176,15 +177,15 @@ impl NetworkCore {
 
             // For now, we'll simulate peer discovery
             if cfg!(feature = "simulate-peers") {
-                println!("SIMULATION: Generating random peers for demonstration");
+                info!("SIMULATION: Generating random peers for demonstration");
                 for _ in 0..3 {
                     let peer_id = PeerId::random();
                     self.known_peers.insert(peer_id);
-                    println!("SIMULATION: Discovered peer: {}", peer_id);
+                    info!("SIMULATION: Discovered peer: {}", peer_id);
                 }
             }
         } else {
-            println!("mDNS discovery disabled");
+            info!("mDNS discovery disabled");
         }
 
         Ok(())
@@ -360,7 +361,7 @@ impl NetworkCore {
             .get_node_id_for_peer(&peer_id)
             .unwrap_or_else(|| peer_id.to_string());
 
-        println!(
+        info!(
             "Forwarding {} request to node {} (peer {})",
             operation, node_id, peer_id
         );
@@ -379,7 +380,7 @@ impl NetworkCore {
             }
         };
 
-        println!("Connecting to target node at {}", target_address);
+        info!("Connecting to target node at {}", target_address);
 
         // Connect to the target node
         let stream = match tokio::net::TcpStream::connect(&target_address).await {
@@ -397,14 +398,14 @@ impl NetworkCore {
 
         match result {
             Ok(response) => {
-                println!("Received response from target node");
+                info!("Received response from target node");
                 Ok(response)
             }
             Err(e) => {
-                println!("Error forwarding request to target node: {}", e);
+                error!("Error forwarding request to target node: {}", e);
 
                 // If we can't connect to the target node, fall back to simulated responses
-                println!("Falling back to simulated response");
+                warn!("Falling back to simulated response");
 
                 match operation {
                     "query" => {
@@ -537,11 +538,11 @@ impl NetworkCore {
     /// Actively scan for peers using mDNS
     pub async fn discover_nodes(&mut self) -> NetworkResult<Vec<PeerId>> {
         if !self.config.enable_mdns {
-            println!("mDNS discovery is disabled, no peers will be discovered");
+            info!("mDNS discovery is disabled, no peers will be discovered");
             return Ok(Vec::new());
         }
 
-        println!(
+        info!(
             "Scanning for peers using mDNS on port {}",
             self.config.discovery_port
         );
@@ -554,14 +555,14 @@ impl NetworkCore {
 
         // For now, we'll simulate peer discovery
         if cfg!(feature = "simulate-peers") {
-            println!("SIMULATION: Generating random peers for demonstration");
+            info!("SIMULATION: Generating random peers for demonstration");
 
             // Generate 0-3 random peers
             let num_peers = rand::random::<u8>() % 4;
             for _ in 0..num_peers {
                 let peer_id = PeerId::random();
                 self.known_peers.insert(peer_id);
-                println!("SIMULATION: Discovered peer: {}", peer_id);
+                info!("SIMULATION: Discovered peer: {}", peer_id);
             }
         }
 

--- a/fold_node/src/permissions/permission_manager.rs
+++ b/fold_node/src/permissions/permission_manager.rs
@@ -1,4 +1,5 @@
 use crate::permissions::types::policy::{PermissionsPolicy, TrustDistance};
+use log::{info, warn, error};
 
 /// Manages and enforces access control policies in the database.
 ///
@@ -61,12 +62,12 @@ impl PermissionManager {
         // If trust distance check fails, check explicit permissions
         permissions_policy.explicit_read_policy.as_ref().map_or_else(
             || {
-                eprintln!("Trust distance failed and no explicit permissions for {pub_key}");
+                warn!("Trust distance failed and no explicit permissions for {pub_key}");
                 false
             },
             |explicit_policy| {
                 let allowed = explicit_policy.counts_by_pub_key.contains_key(pub_key);
-                eprintln!("Trust distance failed checking explicit permission for {pub_key}: {allowed}");
+                warn!("Trust distance failed checking explicit permission for {pub_key}: {allowed}");
                 allowed
             }
         )
@@ -109,7 +110,7 @@ impl PermissionManager {
             TrustDistance::Distance(required_distance) => {
                 // Calculate result and print it before returning
                 let result = trust_distance <= required_distance;
-                eprintln!("Trust distance check for {pub_key}: {trust_distance} <= {required_distance} = {result}");
+                info!("Trust distance check for {pub_key}: {trust_distance} <= {required_distance} = {result}");
                 result
             }
         };
@@ -122,12 +123,12 @@ impl PermissionManager {
         // If trust distance check fails, check explicit permissions
         permissions_policy.explicit_write_policy.as_ref().map_or_else(
             || {
-                eprintln!("Trust distance failed and no explicit permissions for {pub_key}");
+                warn!("Trust distance failed and no explicit permissions for {pub_key}");
                 false
             },
             |explicit_policy| {
                 let allowed = explicit_policy.counts_by_pub_key.contains_key(pub_key);
-                eprintln!("Trust distance failed checking explicit permission for {pub_key}: {allowed}");
+                warn!("Trust distance failed checking explicit permission for {pub_key}: {allowed}");
                 allowed
             }
         )

--- a/fold_node/tests/network_discovery_tests.rs
+++ b/fold_node/tests/network_discovery_tests.rs
@@ -3,6 +3,7 @@ use std::thread;
 use std::time::Duration;
 
 use fold_node::{datafold_node::config::NodeConfig, network::NetworkConfig, DataFoldNode};
+use env_logger;
 
 // Helper function to create a test network config with random ports
 fn create_test_network_config(enable_discovery: bool) -> NetworkConfig {
@@ -33,6 +34,7 @@ fn create_test_network_config(enable_discovery: bool) -> NetworkConfig {
 
 #[tokio::test]
 async fn test_discovery_initialization() {
+    let _ = env_logger::builder().is_test(true).try_init();
     // Create a temporary directory for test data
     let temp_dir = tempfile::tempdir().unwrap();
     let storage_path = temp_dir.path().to_path_buf();
@@ -73,6 +75,7 @@ async fn test_discovery_initialization() {
 
 #[tokio::test]
 async fn test_node_discovery_enabled() {
+    let _ = env_logger::builder().is_test(true).try_init();
     // Create temporary directories for test data
     let temp_dir1 = tempfile::tempdir().unwrap();
     let temp_dir2 = tempfile::tempdir().unwrap();
@@ -183,6 +186,7 @@ async fn test_node_discovery_enabled() {
 
 #[tokio::test]
 async fn test_node_discovery_disabled() {
+    let _ = env_logger::builder().is_test(true).try_init();
     // Create temporary directories for test data
     let temp_dir1 = tempfile::tempdir().unwrap();
     let temp_dir2 = tempfile::tempdir().unwrap();
@@ -256,6 +260,7 @@ async fn test_node_discovery_disabled() {
 
 #[tokio::test]
 async fn test_manual_node_connection() {
+    let _ = env_logger::builder().is_test(true).try_init();
     // Create temporary directories for test data
     let temp_dir1 = tempfile::tempdir().unwrap();
     let temp_dir2 = tempfile::tempdir().unwrap();
@@ -331,6 +336,7 @@ async fn test_manual_node_connection() {
 
 #[tokio::test]
 async fn test_discovery_with_multiple_nodes() {
+    let _ = env_logger::builder().is_test(true).try_init();
     const NUM_NODES: usize = 3;
 
     // Create temporary directories and nodes

--- a/fold_node/tests/permissions_tests.rs
+++ b/fold_node/tests/permissions_tests.rs
@@ -5,6 +5,7 @@ use fold_node::testing::{
 };
 use serde_json::Value;
 use std::collections::HashMap;
+use env_logger;
 
 fn create_default_payment_config() -> FieldPaymentConfig {
     FieldPaymentConfig::new(1.0, TrustDistanceScaling::None, None).unwrap()
@@ -12,6 +13,7 @@ fn create_default_payment_config() -> FieldPaymentConfig {
 
 #[test]
 fn test_permission_wrapper_query() {
+    let _ = env_logger::builder().is_test(true).try_init();
     // Setup
     let wrapper = PermissionWrapper::new();
     let schema_manager = SchemaCore::new("data");
@@ -71,6 +73,7 @@ fn test_permission_wrapper_query() {
 
 #[test]
 fn test_permission_wrapper_no_requirement() {
+    let _ = env_logger::builder().is_test(true).try_init();
     // Setup
     let wrapper = PermissionWrapper::new();
     let schema_manager = SchemaCore::new("data");
@@ -120,6 +123,7 @@ fn test_permission_wrapper_no_requirement() {
 
 #[test]
 fn test_permission_wrapper_mutation() {
+    let _ = env_logger::builder().is_test(true).try_init();
     // Setup
     let wrapper = PermissionWrapper::new();
     let schema_manager = SchemaCore::new("data");

--- a/fold_node/tests/request_forwarding_tests.rs
+++ b/fold_node/tests/request_forwarding_tests.rs
@@ -4,9 +4,11 @@ use serde_json::json;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::time::sleep;
+use env_logger;
 
 #[tokio::test]
 async fn test_request_forwarding() {
+    let _ = env_logger::builder().is_test(true).try_init();
     // Create temporary directories for the nodes
     let node1_dir = PathBuf::from("test_data/request_forwarding/node1/db");
     let node2_dir = PathBuf::from("test_data/request_forwarding/node2/db");
@@ -237,6 +239,7 @@ async fn test_request_forwarding() {
 
 #[tokio::test]
 async fn test_request_forwarding_address_resolution() {
+    let _ = env_logger::builder().is_test(true).try_init();
     let node1_dir = PathBuf::from("test_data/request_forwarding_addr/node1/db");
     let node2_dir = PathBuf::from("test_data/request_forwarding_addr/node2/db");
 

--- a/vendor/env_logger/Cargo.toml
+++ b/vendor/env_logger/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "env_logger"
+version = "0.10.0"
+edition = "2021"
+
+[dependencies]
+log = "0.4"

--- a/vendor/env_logger/src/lib.rs
+++ b/vendor/env_logger/src/lib.rs
@@ -1,0 +1,39 @@
+use log::{Record, LevelFilter, Metadata, SetLoggerError};
+use std::sync::Once;
+
+struct SimpleLogger;
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= log::max_level()
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            println!("{} - {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: SimpleLogger = SimpleLogger;
+static INIT: Once = Once::new();
+
+pub fn init() -> Result<(), SetLoggerError> {
+    INIT.call_once(|| {
+        let _ = log::set_logger(&LOGGER);
+        log::set_max_level(LevelFilter::Info);
+    });
+    Ok(())
+}
+
+pub fn builder() -> Builder {
+    Builder
+}
+
+pub struct Builder;
+impl Builder {
+    pub fn is_test(self, _is_test: bool) -> Self { self }
+    pub fn try_init(self) -> Result<(), SetLoggerError> { init() }
+}


### PR DESCRIPTION
## Summary
- add `log` + `env_logger` to the workspace
- create a small vendored `env_logger` implementation for offline builds
- convert many `println!`/`eprintln!` calls to `info!`, `warn!`, and `error!`
- initialize logging in binaries and tests
- patch tests to initialize logging

## Testing
- `cargo test --workspace --offline`