### PR TITLE
Handle non-reversible transforms

### DIFF
--- a/fold_node/src/permissions/permission_wrapper.rs
+++ b/fold_node/src/permissions/permission_wrapper.rs
@@ -179,6 +179,16 @@ impl PermissionWrapper {
                 ))),
             },
             |field| {
+                if !field.is_writable() {
+                    return FieldPermissionResult {
+                        field_name: field_name.to_string(),
+                        allowed: false,
+                        error: Some(SchemaError::InvalidPermission(format!(
+                            "Field {field_name} is not writable"
+                        ))),
+                    };
+                }
+
                 let allowed = self.permission_manager.has_write_permission(
                     &mutation.pub_key,
                     &field.permission_policy,


### PR DESCRIPTION
## Summary
- mark schema fields as non-writable when transform isn't reversible
- enforce new writable flag in permission checks
- test that non-reversible transform fields reject mutations

## Testing
- `cargo test --no-run`
- `cargo test`