### PR TITLE
Add npm tests to pre-commit hook

### DIFF
--- a/HOOKS_README.md
+++ b/HOOKS_README.md
@@ -16,6 +16,7 @@ The pre-commit hook runs before each commit and performs the following checks:
 6. Runs SDK integration tests
 7. Runs real integration tests
 8. Runs all tests across the entire workspace with `cargo test --workspace`
+9. Runs `npm test` for UI components when JavaScript or TypeScript files are committed
 
 If any of these checks fail, the commit will be aborted.
 

--- a/pre-commit
+++ b/pre-commit
@@ -43,8 +43,20 @@ if git diff --cached --name-only | grep -q '\.rs$'; then
     cargo run --manifest-path fold_node/Cargo.toml --example transform_dsl_samples || { echo "transform_dsl_samples example failed!"; exit 1; }
     cargo run --manifest-path fold_node/Cargo.toml --example transform_logic_test || { echo "transform_logic_test example failed!"; exit 1; }
     echo "Fold_node examples passed!"
+
 else
     echo "No Rust files in commit, skipping tests."
 fi
 
+# Check if there are any JavaScript or TypeScript files being committed
+if git diff --cached --name-only | grep -Eq '\.(js|jsx|ts|tsx)$'; then
+    echo "JavaScript/TypeScript files detected in commit, running npm tests..."
+    pushd fold_node/src/datafold_node/static > /dev/null
+    npm test || { echo "npm tests failed!"; popd > /dev/null; exit 1; }
+    popd > /dev/null
+else
+    echo "No JavaScript/TypeScript files in commit, skipping npm tests."
+fi
+
 exit 0
+

--- a/tests/precommit_hook.rs
+++ b/tests/precommit_hook.rs
@@ -1,0 +1,5 @@
+#[test]
+fn precommit_contains_npm_test() {
+    let script = std::fs::read_to_string("pre-commit").expect("read pre-commit");
+    assert!(script.contains("npm test"), "pre-commit hook should run npm tests");
+}


### PR DESCRIPTION
## Summary
- run npm tests in pre-commit when JS/TS files change
- document npm tests in hook readme
- test that the pre-commit hook contains npm test

## Testing
- `cargo test --workspace`
- `cd fold_node/src/datafold_node/static && npm test`