### PR TITLE
Refresh transforms after schema changes

### DIFF
--- a/fold_node/src/datafold_node/static/components/__tests__/transforms-tab.test.js
+++ b/fold_node/src/datafold_node/static/components/__tests__/transforms-tab.test.js
@@ -1,0 +1,43 @@
+const { fireEvent } = require('@testing-library/dom');
+require('@testing-library/jest-dom');
+
+// Mock modules
+window.icons = {
+    refresh: () => '<svg>refresh</svg>'
+};
+
+window.transformsModule = {
+    loadTransforms: jest.fn()
+};
+
+// Mock utils to satisfy script though not used
+window.utils = {
+    displayResult: jest.fn()
+};
+
+describe('Transforms Tab Component', () => {
+    let container;
+
+    beforeEach(() => {
+        const html = require('../transforms-tab.html');
+        document.body.innerHTML = html;
+        container = document.getElementById('transformsTab');
+
+        const scriptContent = html.match(/<script>([\s\S]*?)<\/script>/)[1];
+        eval(scriptContent);
+        jest.clearAllMocks();
+        document.dispatchEvent(new Event('DOMContentLoaded'));
+    });
+
+    test('initializes and loads transforms on DOMContentLoaded', () => {
+        expect(window.transformsModule.loadTransforms).toHaveBeenCalledTimes(1);
+        const refreshIcon = document.getElementById('refreshTransformsIcon');
+        expect(refreshIcon.innerHTML).toBe('<svg>refresh</svg>');
+    });
+
+    test('refresh button triggers loadTransforms', () => {
+        const btn = container.querySelector('#refreshTransformsBtn');
+        fireEvent.click(btn);
+        expect(window.transformsModule.loadTransforms).toHaveBeenCalled();
+    });
+});

--- a/fold_node/src/datafold_node/static/js/__tests__/schema-module.test.js
+++ b/fold_node/src/datafold_node/static/js/__tests__/schema-module.test.js
@@ -1,0 +1,34 @@
+require('@testing-library/jest-dom');
+
+window.transformsModule = {
+    loadTransforms: jest.fn()
+};
+
+window.utils = {
+    isValidJSON: () => true,
+    apiRequest: jest.fn().mockResolvedValue({}),
+    displayResult: jest.fn()
+};
+
+document.body.innerHTML = '<textarea id="schemaInput"></textarea>';
+
+const fs = require('fs');
+const path = require('path');
+const schemaPath = path.join(__dirname, '..', 'schema.js');
+const schemaCode = fs.readFileSync(schemaPath, 'utf8');
+
+// Evaluate schema.js in this context
+Function(schemaCode)();
+
+describe('schemaModule.loadSchema', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('calls transformsModule.loadTransforms after loading schema', async () => {
+        document.getElementById('schemaInput').value = '{}';
+        await window.schemaModule.loadSchema();
+        expect(window.utils.apiRequest).toHaveBeenCalled();
+        expect(window.transformsModule.loadTransforms).toHaveBeenCalled();
+    });
+});

--- a/fold_node/src/datafold_node/static/js/schema.js
+++ b/fold_node/src/datafold_node/static/js/schema.js
@@ -132,6 +132,9 @@ async function removeSchema(schemaName, event) {
         utils.displayResult('Schema removed successfully');
         // Refresh schema list
         loadSchemaList();
+        if (window.transformsModule?.loadTransforms) {
+            window.transformsModule.loadTransforms();
+        }
     } catch (error) {
         utils.displayResult(error.message, true);
     }
@@ -160,6 +163,9 @@ async function loadSchema() {
         utils.displayResult('Schema loaded successfully');
         // Refresh schema list
         loadSchemaList();
+        if (window.transformsModule?.loadTransforms) {
+            window.transformsModule.loadTransforms();
+        }
     } catch (error) {
         utils.displayResult(error.message, true);
     }

--- a/fold_node/tests/transform_validation_tests.rs
+++ b/fold_node/tests/transform_validation_tests.rs
@@ -30,6 +30,7 @@ fn build_schema(transform_logic: &str) -> JsonSchemaDefinition {
             reversible: false,
             signature: None,
             payment_required: false,
+            inputs: Vec::new(),
         }),
     };
 


### PR DESCRIPTION
## Summary
- refresh transforms list when schemas are added or removed
- add unit tests for transforms tab component
- add unit tests for schema module
- update transform validation tests to include inputs

## Testing
- `npm test`
- `cargo test --workspace`
