### PR TITLE
Fix preview modal event setup

### DIFF
--- a/fold_node/src/datafold_node/static/components/__tests__/samples-tab.test.js
+++ b/fold_node/src/datafold_node/static/components/__tests__/samples-tab.test.js
@@ -1,0 +1,26 @@
+const { fireEvent } = require('@testing-library/dom');
+require('@testing-library/jest-dom');
+
+describe('Samples Tab Preview Modal', () => {
+    let modal;
+    beforeEach(() => {
+        const html = require('../samples-tab.html');
+        document.body.innerHTML = html;
+        modal = document.getElementById('samplePreviewModal');
+        const scriptContent = html.match(/<script>([\s\S]*?)<\/script>/)[1];
+        eval(scriptContent);
+    });
+
+    test('close button hides the modal', () => {
+        modal.style.display = 'block';
+        const closeButton = modal.querySelector('.close-modal');
+        fireEvent.click(closeButton);
+        expect(modal.style.display).toBe('none');
+    });
+
+    test('clicking outside hides the modal', () => {
+        modal.style.display = 'block';
+        fireEvent.click(modal);
+        expect(modal.style.display).toBe('none');
+    });
+});

--- a/fold_node/src/datafold_node/static/components/samples-tab.html
+++ b/fold_node/src/datafold_node/static/components/samples-tab.html
@@ -67,25 +67,25 @@
 
 <script>
     // Add icons to buttons
-    document.addEventListener('DOMContentLoaded', () => {
+    (() => {
         // Make sure sample tabs are properly set up
         const schemaSamples = document.getElementById('schemaSamples');
         const querySamples = document.getElementById('querySamples');
         const mutationSamples = document.getElementById('mutationSamples');
-        
+
         if (schemaSamples && querySamples && mutationSamples) {
             schemaSamples.classList.add('active');
             querySamples.classList.remove('active');
             mutationSamples.classList.remove('active');
         }
-        
+
         // Set up modal close buttons
         document.querySelectorAll('.close-modal').forEach(button => {
             button.addEventListener('click', () => {
                 document.getElementById('samplePreviewModal').style.display = 'none';
             });
         });
-        
+
         // Close modal when clicking outside of it
         window.addEventListener('click', (event) => {
             const modal = document.getElementById('samplePreviewModal');
@@ -93,5 +93,5 @@
                 modal.style.display = 'none';
             }
         });
-    });
+    })();
 </script>


### PR DESCRIPTION
## Summary
- fix preview modal initialization so event handlers run when component loads
- add tests covering preview modal close behavior

## Testing
- `npm test`
- `cargo test --workspace` *(fails: missing field `inputs` in `JsonTransform`)*