### PR TITLE
Add shared config loader

### DIFF
--- a/fold_node/src/bin/datafold_cli.rs
+++ b/fold_node/src/bin/datafold_cli.rs
@@ -1,5 +1,8 @@
 use clap::{Parser, Subcommand};
-use fold_node::{load_schema_from_file, DataFoldNode, MutationType, NodeConfig, Operation};
+use fold_node::{
+    load_schema_from_file, DataFoldNode, MutationType, NodeConfig, Operation,
+    load_node_config,
+};
 use serde_json::Value;
 use std::fs;
 use std::path::PathBuf;
@@ -100,8 +103,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Load node configuration
     info!("Loading config from: {}", cli.config);
-    let config_str = fs::read_to_string(&cli.config)?;
-    let config: NodeConfig = serde_json::from_str(&config_str)?;
+    let config = load_node_config(Some(&cli.config), None);
 
     // Initialize node
     info!("Initializing DataFold Node...");

--- a/fold_node/src/bin/datafold_http_server.rs
+++ b/fold_node/src/bin/datafold_http_server.rs
@@ -1,8 +1,7 @@
 use fold_node::{
-    datafold_node::{config::NodeConfig, DataFoldNode, DataFoldHttpServer},
+    datafold_node::{load_node_config, NodeConfig, DataFoldNode, DataFoldHttpServer},
 };
 use std::env;
-use std::fs;
 use std::path::PathBuf;
 use env_logger;
 use log::{info, warn, error};
@@ -56,18 +55,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Read node config from environment variable or default path
-    let config_path =
-        std::env::var("NODE_CONFIG").unwrap_or_else(|_| "config/node_config.json".to_string());
-    info!("Loading config from: {}", config_path);
-
-    // Create a default config if the file doesn't exist
-    let config: NodeConfig = if let Ok(config_str) = fs::read_to_string(&config_path) {
-        serde_json::from_str(&config_str)?
-    } else {
-        println!("Config file not found, using default config");
-        NodeConfig::default()
-    };
+    // Load node configuration
+    let config = load_node_config(None, None);
     info!("Config loaded successfully");
 
     // Load or initialize node

--- a/fold_node/src/bin/datafold_node.rs
+++ b/fold_node/src/bin/datafold_node.rs
@@ -1,9 +1,8 @@
 use fold_node::{
-    datafold_node::{config::NodeConfig, DataFoldNode, TcpServer},
+    datafold_node::{load_node_config, NodeConfig, DataFoldNode, TcpServer},
     network::NetworkConfig,
 };
 use std::env;
-use std::fs;
 use std::path::PathBuf;
 use env_logger;
 use log::{info, warn, error};
@@ -68,19 +67,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Read node config from environment variable or default path
-    let config_path =
-        std::env::var("NODE_CONFIG").unwrap_or_else(|_| "config/node_config.json".to_string());
-    info!("Loading config from: {}", config_path);
-
-    // Create a default config if the file doesn't exist
-    let config: NodeConfig = if let Ok(config_str) = fs::read_to_string(&config_path) {
-        serde_json::from_str(&config_str)?
-    } else {
-        println!("Config file not found, using default config");
-        NodeConfig::default()
-            .with_network_listen_address(&format!("/ip4/0.0.0.0/tcp/{}", port))
-    };
+    // Load node configuration
+    let config = load_node_config(None, Some(port));
     info!("Config loaded successfully");
 
     // Load or initialize node

--- a/fold_node/src/datafold_node/mod.rs
+++ b/fold_node/src/datafold_node/mod.rs
@@ -19,6 +19,7 @@ pub mod tests;
 
 // Re-export the DataFoldNode struct for easier imports
 pub use config::NodeConfig;
+pub use config::load_node_config;
 pub use http_server::DataFoldHttpServer;
 pub use loader::load_schema_from_file;
 pub use node::DataFoldNode;

--- a/fold_node/src/lib.rs
+++ b/fold_node/src/lib.rs
@@ -39,6 +39,7 @@ pub mod testing;
 
 // Re-export main types for convenience
 pub use datafold_node::config::NodeConfig;
+pub use datafold_node::config::load_node_config;
 pub use datafold_node::loader::load_schema_from_file;
 pub use datafold_node::DataFoldNode;
 pub use error::{FoldDbError, FoldDbResult};

--- a/fold_node/tests/node_config_tests.rs
+++ b/fold_node/tests/node_config_tests.rs
@@ -1,0 +1,20 @@
+use fold_node::datafold_node::load_node_config;
+use std::env;
+
+#[test]
+fn default_when_file_missing_with_port() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("missing.json");
+    let config = load_node_config(Some(missing.to_str().unwrap()), Some(1234));
+    assert_eq!(config.network_listen_address, "/ip4/0.0.0.0/tcp/1234");
+}
+
+#[test]
+fn default_when_env_missing_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("missing2.json");
+    env::set_var("NODE_CONFIG", missing.to_str().unwrap());
+    let config = load_node_config(None, None);
+    env::remove_var("NODE_CONFIG");
+    assert_eq!(config.storage_path, std::path::PathBuf::from("data"));
+}

--- a/fold_node/tests/transform_validation_tests.rs
+++ b/fold_node/tests/transform_validation_tests.rs
@@ -30,6 +30,7 @@ fn build_schema(transform_logic: &str) -> JsonSchemaDefinition {
             reversible: false,
             signature: None,
             payment_required: false,
+            inputs: Vec::new(),
         }),
     };
 

--- a/tests/cli/cli_tests.rs
+++ b/tests/cli/cli_tests.rs
@@ -171,11 +171,11 @@ fn help_and_version() {
 }
 
 #[test]
-fn missing_config_fails() {
+fn missing_config_uses_default() {
     let exe = cli_path();
     let status = Command::new(&exe)
         .args(["-c", "nonexistent.json", "list-schemas"])
         .status()
         .expect("command failed");
-    assert!(!status.success());
+    assert!(status.success());
 }


### PR DESCRIPTION
## Summary
- add `load_node_config` utility for defaulting to NODE_CONFIG
- update DataFold node bins and CLI to use the shared loader
- test loading fallback behaviour when config file is missing
- adjust CLI test to expect success without config

## Testing
- `cargo test --workspace`