### PR TITLE
Add cross-schema transform sample

### DIFF
--- a/fold_node/src/datafold_node/samples/data/TransformBase.json
+++ b/fold_node/src/datafold_node/samples/data/TransformBase.json
@@ -1,0 +1,45 @@
+{
+  "name": "TransformBase",
+  "fields": {
+    "value1": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": {
+          "NoRequirement": null
+        },
+        "write_policy": {
+          "Distance": 0
+        }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": {
+          "None": null
+        }
+      },
+      "field_mappers": {}
+    },
+    "value2": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": {
+          "NoRequirement": null
+        },
+        "write_policy": {
+          "Distance": 0
+        }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": {
+          "None": null
+        }
+      },
+      "field_mappers": {}
+    }
+  },
+  "payment_config": {
+    "base_multiplier": 1.0,
+    "min_payment_threshold": 0
+  }
+}

--- a/fold_node/src/datafold_node/samples/data/TransformSchema.json
+++ b/fold_node/src/datafold_node/samples/data/TransformSchema.json
@@ -1,0 +1,40 @@
+{
+  "name": "TransformSchema",
+  "fields": {
+    "result": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": {
+          "NoRequirement": null
+        },
+        "write_policy": {
+          "Distance": 0
+        }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": {
+          "None": null
+        }
+      },
+      "field_mappers": {}
+    }
+  },
+  "transforms": {
+    "sum_values": {
+      "name": "sum_values",
+      "logic": "return TransformBase.value1 + TransformBase.value2;",
+      "reversible": false,
+      "signature": null,
+      "payment_required": false,
+      "input_dependencies": [
+        "TransformBase.value1",
+        "TransformBase.value2"
+      ]
+    }
+  },
+  "payment_config": {
+    "base_multiplier": 1.0,
+    "min_payment_threshold": 0
+  }
+}

--- a/fold_node/src/datafold_node/static/js/samples.js
+++ b/fold_node/src/datafold_node/static/js/samples.js
@@ -10,6 +10,8 @@ const sampleDescriptions = {
     'BlogPost': 'A blog post schema demonstrating collection fields for tags and comments.',
     'SocialMediaPost': 'A social media post schema with permissions on likes and comments.',
     'FinancialTransaction': 'A financial transaction schema with strict payment policies.',
+    'TransformBase': 'Base schema providing values for cross-schema transforms.',
+    'TransformSchema': 'Schema demonstrating a transform that reads data from TransformBase.',
     
     // Query descriptions
     'BasicUserQuery': 'A simple query to retrieve basic user information without any filtering.',

--- a/fold_node/tests/transform_validation_tests.rs
+++ b/fold_node/tests/transform_validation_tests.rs
@@ -30,6 +30,7 @@ fn build_schema(transform_logic: &str) -> JsonSchemaDefinition {
             reversible: false,
             signature: None,
             payment_required: false,
+            inputs: Vec::new(),
         }),
     };
 

--- a/tests/integration_tests/http_server_tests.rs
+++ b/tests/integration_tests/http_server_tests.rs
@@ -93,6 +93,8 @@ async fn test_sample_endpoints() {
     let schemas_arr = schemas["data"].as_array().unwrap();
     assert!(schemas_arr.contains(&Value::String("UserProfile".to_string())));
     assert!(schemas_arr.contains(&Value::String("ProductCatalog".to_string())));
+    assert!(schemas_arr.contains(&Value::String("TransformBase".to_string())));
+    assert!(schemas_arr.contains(&Value::String("TransformSchema".to_string())));
     let resp = client
         .get(format!("http://{}/api/samples/schema/UserProfile", addr))
         .send()
@@ -111,6 +113,25 @@ async fn test_sample_endpoints() {
     assert!(resp.status().is_success());
     let schema: Value = resp.json().await.unwrap();
     assert_eq!(schema["name"], "ProductCatalog");
+
+    // Verify transform sample schemas
+    let resp = client
+        .get(format!("http://{}/api/samples/schema/TransformBase", addr))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let schema: Value = resp.json().await.unwrap();
+    assert_eq!(schema["name"], "TransformBase");
+
+    let resp = client
+        .get(format!("http://{}/api/samples/schema/TransformSchema", addr))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let schema: Value = resp.json().await.unwrap();
+    assert_eq!(schema["name"], "TransformSchema");
     handle.abort();
 }
 


### PR DESCRIPTION
## Summary
- add `TransformBase` and `TransformSchema` samples demonstrating cross-schema transform
- document new samples in UI description table
- update tests for new `inputs` field and verify sample endpoints return new schemas

## Testing
- `cargo test --workspace`
- `npm test`