### PR TITLE
Add reusable test node helper

### DIFF
--- a/fold_node/tests/transform_validation_tests.rs
+++ b/fold_node/tests/transform_validation_tests.rs
@@ -30,6 +30,7 @@ fn build_schema(transform_logic: &str) -> JsonSchemaDefinition {
             reversible: false,
             signature: None,
             payment_required: false,
+            inputs: Vec::new(),
         }),
     };
 

--- a/tests/integration_tests/cross_schema_transform_tests.rs
+++ b/tests/integration_tests/cross_schema_transform_tests.rs
@@ -2,20 +2,10 @@ use fold_node::testing::{
     FieldPaymentConfig, FieldType, Mutation, MutationType, PermissionsPolicy, Query, Schema, SchemaField, TrustDistance, TrustDistanceScaling,
 };
 use fold_node::transform::{Transform, TransformExecutor, TransformParser};
-use fold_node::{DataFoldNode, NodeConfig};
+use crate::test_data::test_helpers::create_test_node;
 use serde_json::json;
 use std::collections::HashMap;
-use tempfile::tempdir;
 
-fn create_test_node() -> DataFoldNode {
-    let dir = tempdir().unwrap();
-    let config = NodeConfig {
-        storage_path: dir.path().to_path_buf(),
-        default_trust_distance: 1,
-        network_listen_address: "/ip4/127.0.0.1/tcp/0".to_string(),
-    };
-    DataFoldNode::new(config).unwrap()
-}
 
 fn create_schema_a() -> Schema {
     let mut schema = Schema::new("SchemaA".to_string());

--- a/tests/integration_tests/datafold_node_tests.rs
+++ b/tests/integration_tests/datafold_node_tests.rs
@@ -1,50 +1,12 @@
-use fold_node::testing::{
-    FieldPaymentConfig, FieldType, Mutation, MutationType, PermissionsPolicy, Query, Schema,
-    SchemaField, TrustDistance, TrustDistanceScaling,
-};
-use fold_node::{DataFoldNode, NodeConfig};
+use fold_node::testing::{Mutation, MutationType, Query};
 use serde_json::json;
-use std::collections::HashMap;
-use tempfile::tempdir;
-
-fn create_test_node() -> DataFoldNode {
-    let dir = tempdir().unwrap();
-    let config = NodeConfig {
-        storage_path: dir.path().to_path_buf(),
-        default_trust_distance: 1,
-        network_listen_address: "/ip4/127.0.0.1/tcp/0".to_string(),
-    };
-    DataFoldNode::new(config).unwrap()
-}
-
-fn create_test_schema() -> Schema {
-    let mut schema = Schema::new("user_profile".to_string());
-
-    // Add name field
-    let name_field = SchemaField::new(
-        PermissionsPolicy::new(TrustDistance::Distance(1), TrustDistance::Distance(1)),
-        FieldPaymentConfig::new(1.0, TrustDistanceScaling::None, None).unwrap(),
-        HashMap::new(),
-        Some(FieldType::Single),
-    );
-    schema.add_field("name".to_string(), name_field);
-
-    // Add email field
-    let email_field = SchemaField::new(
-        PermissionsPolicy::new(TrustDistance::Distance(1), TrustDistance::Distance(1)),
-        FieldPaymentConfig::new(1.0, TrustDistanceScaling::None, None).unwrap(),
-        HashMap::new(),
-        Some(FieldType::Single),
-    );
-    schema.add_field("email".to_string(), email_field);
-
-    schema
-}
+use crate::test_data::test_helpers::create_test_node;
+use crate::test_data::schema_test_data::create_basic_user_profile_schema;
 
 #[test]
 fn test_node_schema_operations() {
     let mut node = create_test_node();
-    let schema = create_test_schema();
+    let schema = create_basic_user_profile_schema();
 
     // Test schema loading
     assert!(node.load_schema(schema.clone()).is_ok());
@@ -58,7 +20,7 @@ fn test_node_schema_operations() {
 #[test]
 fn test_node_data_operations() {
     let mut node = create_test_node();
-    let schema = create_test_schema();
+    let schema = create_basic_user_profile_schema();
 
     // Load schema
     node.load_schema(schema).unwrap();
@@ -107,7 +69,7 @@ fn test_trust_distance_handling() {
     assert!(node.add_trusted_node("test_node").is_ok());
 
     // Verify default trust distance is applied to queries
-    let schema = create_test_schema();
+    let schema = create_basic_user_profile_schema();
     node.load_schema(schema).unwrap();
     node.allow_schema("user_profile").unwrap();
 
@@ -125,7 +87,7 @@ fn test_trust_distance_handling() {
 #[test]
 fn test_version_history() {
     let mut node = create_test_node();
-    let schema = create_test_schema();
+    let schema = create_basic_user_profile_schema();
 
     // Load schema
     node.load_schema(schema).unwrap();

--- a/tests/integration_tests/schema_field_mapping_tests.rs
+++ b/tests/integration_tests/schema_field_mapping_tests.rs
@@ -1,20 +1,11 @@
 use fold_node::schema::Schema;
-use fold_node::{DataFoldNode, NodeConfig};
+use crate::test_data::test_helpers::create_test_node;
 use serde_json::json;
-use tempfile::tempdir;
 
 #[test]
 fn test_field_mappers_share_aref_uuid() {
-    // Create a temporary directory for the test
-    let dir = tempdir().unwrap();
-    let config = NodeConfig {
-        storage_path: dir.path().to_path_buf(),
-        default_trust_distance: 1,
-        network_listen_address: "/ip4/127.0.0.1/tcp/0".to_string(),
-    };
-
     // Create a new DataFoldNode
-    let mut node = DataFoldNode::new(config).unwrap();
+    let mut node = create_test_node();
 
     // Create source schema (UserProfile)
     let source_schema_json = r#"{

--- a/tests/network_tests.rs
+++ b/tests/network_tests.rs
@@ -1,7 +1,8 @@
-use fold_node::datafold_node::{config::NodeConfig, DataFoldNode};
+#[path = "test_data/test_helpers/mod.rs"]
+mod test_helpers;
+use test_helpers::create_test_node;
 use fold_node::network::{NetworkConfig, NetworkCore, SchemaService};
 use fold_node::schema::Schema;
-use tempfile::tempdir;
 
 #[tokio::test]
 async fn test_schema_service() {
@@ -44,26 +45,9 @@ async fn test_network_core_creation() {
 
 #[tokio::test]
 async fn test_datafold_node_network_integration() {
-    // Create temporary directories for the nodes
-    let node1_dir = tempdir().unwrap();
-    let node2_dir = tempdir().unwrap();
-
-    // Create node configs
-    let node1_config = NodeConfig {
-        storage_path: node1_dir.path().to_path_buf(),
-        default_trust_distance: 1,
-        network_listen_address: "/ip4/127.0.0.1/tcp/0".to_string(),
-    };
-
-    let node2_config = NodeConfig {
-        storage_path: node2_dir.path().to_path_buf(),
-        default_trust_distance: 1,
-        network_listen_address: "/ip4/127.0.0.1/tcp/0".to_string(),
-    };
-
     // Create the nodes
-    let mut node1 = DataFoldNode::new(node1_config).unwrap();
-    let mut node2 = DataFoldNode::new(node2_config).unwrap();
+    let mut node1 = create_test_node();
+    let mut node2 = create_test_node();
 
     // Create network configs
     let network1_config = NetworkConfig::new("/ip4/127.0.0.1/tcp/0").with_mdns(false); // Disable mDNS for testing

--- a/tests/test_data/schema_test_data.rs
+++ b/tests/test_data/schema_test_data.rs
@@ -27,6 +27,29 @@ pub fn create_test_schema(name: &str) -> Schema {
 }
 
 #[allow(dead_code)]
+pub fn create_basic_user_profile_schema() -> Schema {
+    let mut schema = Schema::new("user_profile".to_string());
+
+    let name_field = SchemaField::new(
+        PermissionsPolicy::new(TrustDistance::Distance(1), TrustDistance::Distance(1)),
+        create_default_payment_config(),
+        HashMap::new(),
+        Some(FieldType::Single),
+    );
+    schema.add_field("name".to_string(), name_field);
+
+    let email_field = SchemaField::new(
+        PermissionsPolicy::new(TrustDistance::Distance(1), TrustDistance::Distance(1)),
+        create_default_payment_config(),
+        HashMap::new(),
+        Some(FieldType::Single),
+    );
+    schema.add_field("email".to_string(), email_field);
+
+    schema
+}
+
+#[allow(dead_code)]
 pub fn create_user_profile_schema() -> Schema {
     let mut schema = Schema::new("user_profile".to_string());
 


### PR DESCRIPTION
## Summary
- add `create_test_node` helper
- consolidate simple user profile schema
- use helper across integration tests
- update transform validation test struct usage
- test the helper itself

## Testing
- `cargo test --all --quiet`