### PR TITLE
Persist transform output to designated field

### DIFF
--- a/fold_node/src/schema/types/transform.rs
+++ b/fold_node/src/schema/types/transform.rs
@@ -288,8 +288,10 @@ impl Transform {
         // Set payment requirement to false since it's been removed
         let payment_required = false;
 
-        // Derive output schema from declaration name
-        let output_schema = "test.test_transform".to_string();
+        // Derive output schema from the transform name using a placeholder
+        // schema name. When registered, this may be replaced with the actual
+        // schema field depending on where the transform is attached.
+        let output_schema = format!("test.{}", declaration.name);
         
         Self {
             name: declaration.name.clone(),


### PR DESCRIPTION
## Summary
- persist transform results to the field specified by the transform's `output_schema`
- add a test for persisting transform results to a different schema field
- derive placeholder output schema from transform name when parsing DSL

## Testing
- `cargo test --workspace`