### PR TITLE
Remove transforms on schema unload

### DIFF
--- a/fold_node/src/datafold_node/node.rs
+++ b/fold_node/src/datafold_node/node.rs
@@ -441,14 +441,7 @@ impl DataFoldNode {
             .lock()
             .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
 
-        match db.schema_manager.unload_schema(schema_name) {
-            Ok(true) => Ok(()),
-            Ok(false) => Err(FoldDbError::Config(format!(
-                "Schema {} not found",
-                schema_name
-            ))),
-            Err(e) => Err(e.into()),
-        }
+        db.remove_schema(schema_name).map_err(|e| e.into())
     }
 
     /// Initialize the network layer

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -6,3 +6,4 @@ pub mod persistence_tests;
 pub mod transform_orchestrator_tests;
 pub mod transform_enqueue_tests;
 pub mod http_server_tests;
+pub mod schema_unload_transform_tests;

--- a/tests/integration_tests/schema_unload_transform_tests.rs
+++ b/tests/integration_tests/schema_unload_transform_tests.rs
@@ -1,0 +1,46 @@
+use fold_node::testing::{
+    PermissionsPolicy, FieldPaymentConfig, FieldType, Schema, SchemaField,
+    TrustDistance, TrustDistanceScaling,
+};
+use fold_node::transform::{Transform, TransformParser};
+use crate::test_data::test_helpers::create_test_node;
+
+#[test]
+fn unload_schema_removes_transforms() {
+    let mut node = create_test_node();
+
+    // Build schema with a simple transform
+    let mut schema = Schema::new("UnloadSchema".to_string());
+    let parser = TransformParser::new();
+    let expr = parser.parse_expression("1 + 2").unwrap();
+    let transform = Transform::new_with_expr(
+        "1 + 2".to_string(),
+        expr,
+        false,
+        None,
+        false,
+        "UnloadSchema.calc".to_string(),
+    );
+    let field = SchemaField::new(
+        PermissionsPolicy::new(TrustDistance::Distance(0), TrustDistance::Distance(0)),
+        FieldPaymentConfig::new(1.0, TrustDistanceScaling::None, None).unwrap(),
+        std::collections::HashMap::new(),
+        Some(FieldType::Single),
+    )
+    .with_transform(transform);
+    schema.add_field("calc".to_string(), field);
+
+    node.load_schema(schema).unwrap();
+    node.allow_schema("UnloadSchema").unwrap();
+
+    // Ensure transform exists
+    let transforms = node.list_transforms().unwrap();
+    assert!(transforms.contains_key("UnloadSchema.calc"));
+
+    node.remove_schema("UnloadSchema").unwrap();
+
+    // Transform should be gone
+    let transforms = node.list_transforms().unwrap();
+    assert!(!transforms.contains_key("UnloadSchema.calc"));
+    assert!(node.get_schema("UnloadSchema").unwrap().is_none());
+}


### PR DESCRIPTION
## Summary
- ensure removing a schema also unregisters its transforms
- update `DataFoldNode` to call the new database method
- cover schema unload behaviour with a new integration test

## Testing
- `cargo test --workspace --quiet`