### PR TITLE
Simplify Transform struct

### DIFF
--- a/fold_node/src/datafold_node/http_server.rs
+++ b/fold_node/src/datafold_node/http_server.rs
@@ -756,7 +756,7 @@ async fn add_to_transform_queue(path: web::Path<String>, state: web::Data<AppSta
                 error!("Transform not found: {}", transform_id);
                 info!("Transform details for each transform:");
                 for (id, transform) in &transforms {
-                    info!("ID: {}, Name: {}, Logic: {}", id, transform.name, transform.logic);
+                    info!("ID: {}, Output: {}, Logic: {}", id, transform.output, transform.logic);
                 }
                 return HttpResponse::NotFound().json(json!({
                     "error": format!("Transform '{}' not found. Available transforms: {:?}",

--- a/fold_node/src/datafold_node/loader.rs
+++ b/fold_node/src/datafold_node/loader.rs
@@ -124,10 +124,8 @@ mod tests {
                     "field_type": "Single",
                     "transform": {
                         "logic": "4 + 5",
-                        "reversible": false,
-                        "signature": null,
-                        "payment_required": false,
-                        "output_schema": "transform_schema.computed"
+                        "inputs": [],
+                        "output": "transform_schema.computed"
                     }
                 }
             },

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -167,7 +167,7 @@ impl FoldDB {
             if let Some(transform) = field.get_transform() {
                 // Determine the actual output field for this transform
                 let (out_schema_name, out_field_name) = match transform
-                    .get_output_schema()
+                    .get_output()
                     .split_once('.')
                 {
                     Some((s, f)) => (s.to_string(), f.to_string()),

--- a/fold_node/src/fold_db_core/transform_manager.rs
+++ b/fold_node/src/fold_db_core/transform_manager.rs
@@ -93,12 +93,8 @@ impl TransformManager {
         // Validate the transform
         TransformExecutor::validate_transform(&transform)?;
 
-        // Set transform output schema
-        transform.set_output_schema(schema_name, field_name);
-        
-        // Set the transform's input dependencies and output reference
-        transform.set_input_dependencies(input_arefs.clone());
-        transform.set_output_reference(output_aref.clone());
+        // Set transform output field
+        transform.set_output(format!("{}.{}", schema_name, field_name));
         
         // Store the transform
         let transform_json = serde_json::to_vec(&transform)

--- a/fold_node/src/schema/core.rs
+++ b/fold_node/src/schema/core.rs
@@ -94,9 +94,9 @@ impl SchemaCore {
         // Ensure any transforms on fields have the correct output schema
         for (field_name, field) in schema.fields.iter_mut() {
             if let Some(transform) = field.transform.as_mut() {
-                let out_schema = transform.get_output_schema();
+                let out_schema = transform.get_output();
                 if out_schema.starts_with("test.") {
-                    transform.set_output_schema(schema.name.clone(), field_name.clone());
+                    transform.set_output(format!("{}.{}", schema.name, field_name));
                 }
             }
         }

--- a/fold_node/src/schema/types/fields.rs
+++ b/fold_node/src/schema/types/fields.rs
@@ -92,7 +92,7 @@ impl<'de> Deserialize<'de> for SchemaField {
                     let transform = Transform::from_declaration(declaration);
                     let transform = if let (Some(schema_name), Some(field_name)) = (&helper.schema_name, &helper.field_name) {
                         Transform {
-                            output_schema: format!("{}.{}", schema_name, field_name),
+                            output: format!("{}.{}", schema_name, field_name),
                             ..transform
                         }
                     } else {
@@ -114,11 +114,7 @@ impl<'de> Deserialize<'de> for SchemaField {
             writable: helper.writable.unwrap_or(true),
         };
 
-        if let Some(t) = &field.transform {
-            if !t.reversible {
-                field.writable = false;
-            }
-        }
+
 
         Ok(field)
     }
@@ -236,7 +232,6 @@ impl SchemaField {
     ///
     /// The field instance with the transform set
     pub fn with_transform(mut self, transform: Transform) -> Self {
-        self.writable = transform.reversible;
         self.transform = Some(transform);
         self
     }
@@ -262,7 +257,6 @@ impl SchemaField {
     ///
     /// * `transform` - The transform to apply to this field
     pub fn set_transform(&mut self, transform: Transform) {
-        self.writable = transform.reversible;
         self.transform = Some(transform);
     }
 }
@@ -343,10 +337,7 @@ mod tests {
     fn test_field_with_transform() {
         let transform = Transform::new(
             "return field1 + field2;".to_string(),
-            false,
-            None,
-            false,
-            "test.calc".to_string()
+            "test.calc".to_string(),
         );
         let field = SchemaField::new(
             PermissionsPolicy::default(),
@@ -381,7 +372,7 @@ mod tests {
         assert!(field.transform.is_some());
         let transform = field.transform.unwrap();
         assert_eq!(transform.logic, "return (field1 * 2)".to_string());
-        assert_eq!(transform.output_schema, "test.temp");  // Default output_schema from Transform::from_declaration
+        assert_eq!(transform.output, "test.temp");  // Default output from Transform::from_declaration
     }
 
     #[test]

--- a/fold_node/src/schema/types/json_schema.rs
+++ b/fold_node/src/schema/types/json_schema.rs
@@ -35,23 +35,13 @@ pub struct JsonSchemaField {
 pub struct JsonTransform {
     /// The transform logic expressed in the DSL
     pub logic: String,
-    
-    /// Whether this transform is reversible
-    pub reversible: bool,
-    
-    /// Optional signature for verification
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub signature: Option<String>,
-    
-    /// Whether payment is required for this transform
-    pub payment_required: bool,
 
     /// Explicit list of input fields in `Schema.field` format
     #[serde(default)]
     pub inputs: Vec<String>,
 
-    /// Output schema for this transform in `Schema.field` format
-    pub output_schema: String,
+    /// Output field for this transform in `Schema.field` format
+    pub output: String,
 }
 
 /// JSON representation of permission policy
@@ -99,17 +89,10 @@ impl From<JsonFieldPaymentConfig> for FieldPaymentConfig {
 impl From<JsonTransform> for Transform {
     fn from(json: JsonTransform) -> Self {
         Self {
-            name: String::new(),
-            logic: json.logic,
-            reversible: json.reversible,
-            signature: json.signature,
-            payment_required: json.payment_required,
             inputs: json.inputs,
-            input_dependencies: Vec::new(),
-            output_reference: None,
-            output_schema: json.output_schema,
-            parsed_expr: None,
-            parsed_declaration: None,
+            logic: json.logic,
+            output: json.output,
+            parsed_expression: None,
         }
     }
 }

--- a/fold_node/tests/permissions_tests.rs
+++ b/fold_node/tests/permissions_tests.rs
@@ -20,10 +20,7 @@ fn test_non_reversible_transform_not_writable() {
 
     let transform = Transform::new(
         "1 + 1".to_string(),
-        false,
-        None,
-        false,
-        "test_schema.calc".to_string()
+        "test_schema.calc".to_string(),
     );
     let field = SchemaField::new(
         PermissionsPolicy::default(),

--- a/fold_node/tests/transform_validation_tests.rs
+++ b/fold_node/tests/transform_validation_tests.rs
@@ -27,11 +27,8 @@ fn build_schema(transform_logic: &str) -> JsonSchemaDefinition {
         field_type: FieldType::Single,
         transform: Some(JsonTransform {
             logic: transform_logic.to_string(),
-            reversible: false,
-            signature: None,
-            payment_required: false,
             inputs: Vec::new(),
-            output_schema: "test.calc".to_string(),
+            output: "test.calc".to_string(),
         }),
     };
 

--- a/tests/integration_tests/cross_schema_transform_tests.rs
+++ b/tests/integration_tests/cross_schema_transform_tests.rs
@@ -68,9 +68,6 @@ fn test_cross_schema_transform_manual_execution() {
     let transform = Transform::new_with_expr(
         "SchemaA.a_test_field + 5".to_string(),
         expr,
-        false,
-        None,
-        false,
         "SchemaB.b_test_field".to_string()
     );
     let schema_b = create_schema_b(transform.clone());
@@ -109,9 +106,6 @@ fn test_cross_schema_transform_with_inputs() {
     let mut transform = Transform::new_with_expr(
         "SchemaA.a_test_field + 5".to_string(),
         expr,
-        false,
-        None,
-        false,
         "SchemaB.b_test_field".to_string()
     );
     transform.set_inputs(vec!["SchemaA.a_test_field".to_string()]);
@@ -154,9 +148,6 @@ fn test_transform_persists_to_output_field() {
     let mut transform = Transform::new_with_expr(
         "a_in + 2".to_string(),
         expr,
-        false,
-        None,
-        false,
         "SchemaB.b_out".to_string(),
     );
     transform.set_inputs(vec!["SchemaA.a_in".to_string()]);

--- a/tests/integration_tests/persistence_tests.rs
+++ b/tests/integration_tests/persistence_tests.rs
@@ -25,10 +25,7 @@ fn create_persistence_schema() -> Schema {
     let transform = Transform::new_with_expr(
         "input_field + 1".to_string(),
         expr,
-        false,
-        None,
-        false,
-        "PersistSchema.transform_field".to_string()
+        "PersistSchema.transform_field".to_string(),
     );
     let transform_field = SchemaField::new(
         PermissionsPolicy::new(TrustDistance::Distance(1), TrustDistance::Distance(1)),

--- a/tests/integration_tests/schema_unload_transform_tests.rs
+++ b/tests/integration_tests/schema_unload_transform_tests.rs
@@ -16,9 +16,6 @@ fn unload_schema_removes_transforms() {
     let transform = Transform::new_with_expr(
         "1 + 2".to_string(),
         expr,
-        false,
-        None,
-        false,
         "UnloadSchema.calc".to_string(),
     );
     let field = SchemaField::new(

--- a/tests/integration_tests/transform_enqueue_tests.rs
+++ b/tests/integration_tests/transform_enqueue_tests.rs
@@ -17,9 +17,6 @@ fn mutation_enqueues_transform() {
     let transform = Transform::new_with_expr(
         "1 + 1".to_string(),
         expr,
-        false,
-        None,
-        false,
         "EnqueueSchema.calc".to_string()
     );
     let field = SchemaField::new(

--- a/tests/integration_tests/transform_output_schema_tests.rs
+++ b/tests/integration_tests/transform_output_schema_tests.rs
@@ -13,9 +13,6 @@ fn create_schema_with_transform() -> Schema {
     let transform = Transform::new_with_expr(
         "1 + 2".to_string(),
         expr,
-        false,
-        None,
-        false,
         "test.calc".to_string(),
     );
     let field = SchemaField::new(
@@ -30,7 +27,7 @@ fn create_schema_with_transform() -> Schema {
 }
 
 #[test]
-fn transform_output_schema_updated_on_load() {
+fn transform_output_updated_on_load() {
     let mut node = create_test_node();
     let schema = create_schema_with_transform();
     node.load_schema(schema).unwrap();
@@ -38,5 +35,5 @@ fn transform_output_schema_updated_on_load() {
     let loaded_schema = node.get_schema("OutputSchemaTest").unwrap().unwrap();
     let field = loaded_schema.fields.get("calc").unwrap();
     let transform = field.get_transform().unwrap();
-    assert_eq!(transform.get_output_schema(), "OutputSchemaTest.calc");
+    assert_eq!(transform.get_output(), "OutputSchemaTest.calc");
 }


### PR DESCRIPTION
## Summary
- simplify the `Transform` definition
- update constructors and methods
- adjust schema loading and transform manager
- fix executor and field helpers
- update tests for new API

## Testing
- `cargo test --all`