### PR TITLE
Update transform registration to use new input/output API

### DIFF
--- a/fold_node/src/datafold_node/http_server.rs
+++ b/fold_node/src/datafold_node/http_server.rs
@@ -756,7 +756,7 @@ async fn add_to_transform_queue(path: web::Path<String>, state: web::Data<AppSta
                 error!("Transform not found: {}", transform_id);
                 info!("Transform details for each transform:");
                 for (id, transform) in &transforms {
-                    info!("ID: {}, Output: {}, Logic: {}", id, transform.output, transform.logic);
+                    info!("ID: {}, Output: {}, Logic: {}", id, transform.get_output(), transform.logic);
                 }
                 return HttpResponse::NotFound().json(json!({
                     "error": format!("Transform '{}' not found. Available transforms: {:?}",

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -209,8 +209,9 @@ impl FoldDB {
                 let mut trigger_fields = Vec::new();
                 let mut seen_cross = std::collections::HashSet::new();
 
-                if !transform.inputs.is_empty() {
-                    for input in &transform.inputs {
+                let inputs = transform.get_inputs();
+                if !inputs.is_empty() {
+                    for input in inputs {
                         if let Some((schema_name, field_dep)) = input.split_once('.') {
                             seen_cross.insert(field_dep.to_string());
                             trigger_fields.push(format!("{}.{}", schema_name, field_dep));

--- a/fold_node/src/fold_db_core/transform_manager.rs
+++ b/fold_node/src/fold_db_core/transform_manager.rs
@@ -387,8 +387,9 @@ impl TransformManager {
         let mut input_values = HashMap::new();
 
         // Fetch explicit inputs if provided
-        if !transform.inputs.is_empty() {
-            for input in &transform.inputs {
+        let inputs = transform.get_inputs();
+        if !inputs.is_empty() {
+            for input in inputs {
                 if let Some((schema, field)) = input.split_once('.') {
                     let val = (self.get_field_fn)(schema, field)?;
                     input_values.insert(input.clone(), val);

--- a/fold_node/src/transform/executor.rs
+++ b/fold_node/src/transform/executor.rs
@@ -54,7 +54,7 @@ impl TransformExecutor {
         let mut input_values = HashMap::new();
         
         // Use the transform's declared dependencies
-        for input_name in &transform.inputs {
+        for input_name in transform.get_inputs() {
             match input_provider(input_name) {
                 Ok(value) => {
                     input_values.insert(input_name.clone(), value);
@@ -64,9 +64,9 @@ impl TransformExecutor {
                 }
             }
         }
-        
+
         // If no dependencies are declared, try to analyze the transform logic
-        if transform.inputs.is_empty() {
+        if transform.get_inputs().is_empty() {
             let dependencies = transform.analyze_dependencies();
             for input_name in dependencies {
                 // Skip if we already have this input


### PR DESCRIPTION
## Summary
- use new `Transform` API methods when loading schemas
- update transform execution to access inputs via getters
- patch transform manager and HTTP server to use getters

## Testing
- `cargo test --no-run`
- `cargo test`