### PR TITLE
Remove reversible-based writability

### DIFF
--- a/fold_node/src/datafold_node/samples/data/TransformSchema.json
+++ b/fold_node/src/datafold_node/samples/data/TransformSchema.json
@@ -18,7 +18,11 @@
         }
       },
       "field_mappers": {},
-      "transform": "transform sum_values { logic: { TransformBase.value1 + TransformBase.value2; } }"
+      "transform": {
+        "logic": "TransformBase.value1 + TransformBase.value2",
+        "inputs": [],
+        "output": "TransformSchema.result"
+      }
     }
   },
   "payment_config": {

--- a/tests/integration_tests/http_server_tests.rs
+++ b/tests/integration_tests/http_server_tests.rs
@@ -223,7 +223,11 @@ async fn test_transform_endpoints() {
                 },
                 "field_mappers": {},
                 "field_type": "Single",
-                "transform": "transform calc { logic: { 4 + 5; } }"
+                "transform": {
+                    "logic": "4 + 5",
+                    "inputs": [],
+                    "output": "transform_schema.computed"
+                }
             }
         },
         "payment_config": { "base_multiplier": 1.0, "min_payment_threshold": 0 }
@@ -298,7 +302,11 @@ async fn test_delete_schema_removes_transforms() {
                 },
                 "field_mappers": {},
                 "field_type": "Single",
-                "transform": "transform calc { logic: { 1 + 1; } }"
+                "transform": {
+                    "logic": "1 + 1",
+                    "inputs": [],
+                    "output": "delete_schema.calc"
+                }
             }
         },
         "payment_config": { "base_multiplier": 1.0, "min_payment_threshold": 0 }


### PR DESCRIPTION
## Summary
- simplify `SchemaField` transform handling
- parse new JSON transform representation
- update sample transform schema
- adjust HTTP server tests for new format

## Testing
- `cargo test --quiet`