### PR TITLE
Handle transform output in disk-loaded schemas

### DIFF
--- a/fold_node/src/schema/core.rs
+++ b/fold_node/src/schema/core.rs
@@ -169,8 +169,12 @@ impl SchemaCore {
                 if let Some(ext) = entry.path().extension() {
                     if ext == "json" {
                         if let Ok(contents) = std::fs::read_to_string(entry.path()) {
-                            if let Ok(schema) = serde_json::from_str(&contents) {
+                            if let Ok(schema) = serde_json::from_str::<Schema>(&contents) {
                                 let _ = self.load_schema(schema);
+                            } else if let Ok(json_schema) = serde_json::from_str::<JsonSchemaDefinition>(&contents) {
+                                if let Ok(schema) = self.interpret_schema(json_schema) {
+                                    let _ = self.load_schema(schema);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- ensure transforms from disk set output using new Transform API
- support JsonSchemaDefinition fallback when loading schemas
- test transform output correction when loading from disk

## Testing
- `cargo test -p fold_node --test schema_tests test_transform_placeholder_output_on_disk_load -- --quiet`
- `cargo test --quiet`