### PR TITLE
Update sample transforms to new input syntax

### DIFF
--- a/fold_node/src/datafold_node/samples/data/BlogPost.json
+++ b/fold_node/src/datafold_node/samples/data/BlogPost.json
@@ -81,7 +81,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["content"]
+      "inputs": ["content"]
     },
     "tag_count": {
       "name": "tag_count",
@@ -89,7 +89,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["tags"]
+      "inputs": ["tags"]
     },
     "reading_time": {
       "name": "reading_time",
@@ -97,7 +97,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["content"]
+      "inputs": ["content"]
     }
   },
   "payment_config": {

--- a/fold_node/src/datafold_node/samples/data/FinancialTransaction.json
+++ b/fold_node/src/datafold_node/samples/data/FinancialTransaction.json
@@ -87,7 +87,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["sender", "amount", "recipient"]
+      "inputs": ["sender", "amount", "recipient"]
     },
     "time_since_transaction": {
       "name": "time_since_transaction",
@@ -95,7 +95,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["timestamp"]
+      "inputs": ["timestamp"]
     },
     "transaction_category": {
       "name": "transaction_category",
@@ -103,7 +103,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["amount"]
+      "inputs": ["amount"]
     }
   },
   "payment_config": {

--- a/fold_node/src/datafold_node/samples/data/ProductCatalog.json
+++ b/fold_node/src/datafold_node/samples/data/ProductCatalog.json
@@ -81,7 +81,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["inventory_count"]
+      "inputs": ["inventory_count"]
     },
     "price_range": {
       "name": "price_range",
@@ -89,7 +89,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["price"]
+      "inputs": ["price"]
     },
     "product_preview": {
       "name": "product_preview",
@@ -97,7 +97,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["name", "category", "price"]
+      "inputs": ["name", "category", "price"]
     }
   },
   "payment_config": {

--- a/fold_node/src/datafold_node/samples/data/UserProfile.json
+++ b/fold_node/src/datafold_node/samples/data/UserProfile.json
@@ -81,7 +81,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["username", "full_name"]
+      "inputs": ["username", "full_name"]
     },
     "age_group": {
       "name": "age_group",
@@ -89,7 +89,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["age"]
+      "inputs": ["age"]
     }
   },
   "payment_config": {

--- a/fold_node/src/fold_db_core/transform_manager.rs
+++ b/fold_node/src/fold_db_core/transform_manager.rs
@@ -79,7 +79,9 @@ impl TransformManager {
         }
     }
 
-    /// Registers a transform with its input and output atom references.
+    /// Registers a transform and tracks its input and output atom references
+    /// internally.  The provided `input_arefs` are used only for dependency
+    /// tracking and are not persisted on the [`Transform`] itself.
     pub fn register_transform(&self, registration: TransformRegistration) -> Result<(), SchemaError> {
         let TransformRegistration {
             transform_id,


### PR DESCRIPTION
## Summary
- update sample JSON transforms to use `inputs` field instead of legacy `input_dependencies`

## Testing
- `cargo test -q`
