### PR TITLE
Update transform inputs handling

### DIFF
--- a/fold_node/src/datafold_node/samples/data/BlogPost.json
+++ b/fold_node/src/datafold_node/samples/data/BlogPost.json
@@ -81,7 +81,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["content"]
+      "inputs": ["content"]
     },
     "tag_count": {
       "name": "tag_count",
@@ -89,7 +89,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["tags"]
+      "inputs": ["tags"]
     },
     "reading_time": {
       "name": "reading_time",
@@ -97,7 +97,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["content"]
+      "inputs": ["content"]
     }
   },
   "payment_config": {

--- a/fold_node/src/datafold_node/samples/data/FinancialTransaction.json
+++ b/fold_node/src/datafold_node/samples/data/FinancialTransaction.json
@@ -87,7 +87,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["sender", "amount", "recipient"]
+      "inputs": ["sender", "amount", "recipient"]
     },
     "time_since_transaction": {
       "name": "time_since_transaction",
@@ -95,7 +95,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["timestamp"]
+      "inputs": ["timestamp"]
     },
     "transaction_category": {
       "name": "transaction_category",
@@ -103,7 +103,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["amount"]
+      "inputs": ["amount"]
     }
   },
   "payment_config": {

--- a/fold_node/src/datafold_node/samples/data/ProductCatalog.json
+++ b/fold_node/src/datafold_node/samples/data/ProductCatalog.json
@@ -81,7 +81,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["inventory_count"]
+      "inputs": ["inventory_count"]
     },
     "price_range": {
       "name": "price_range",
@@ -89,7 +89,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["price"]
+      "inputs": ["price"]
     },
     "product_preview": {
       "name": "product_preview",
@@ -97,7 +97,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["name", "category", "price"]
+      "inputs": ["name", "category", "price"]
     }
   },
   "payment_config": {

--- a/fold_node/src/datafold_node/samples/data/UserProfile.json
+++ b/fold_node/src/datafold_node/samples/data/UserProfile.json
@@ -81,7 +81,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["username", "full_name"]
+      "inputs": ["username", "full_name"]
     },
     "age_group": {
       "name": "age_group",
@@ -89,7 +89,7 @@
       "reversible": false,
       "signature": null,
       "payment_required": false,
-      "input_dependencies": ["age"]
+      "inputs": ["age"]
     }
   },
   "payment_config": {


### PR DESCRIPTION
## Summary
- rename `input_dependencies` to `inputs` in sample schema JSON files
- test provider input logic in executor tests

## Testing
- `cargo test --lib`
- `cargo test -p fold_node`