### PR TITLE
Update TransformsTab to match new transform schema

### DIFF
--- a/fold_node/src/datafold_node/static-react/src/components/tabs/TransformsTab.jsx
+++ b/fold_node/src/datafold_node/static-react/src/components/tabs/TransformsTab.jsx
@@ -17,7 +17,7 @@ const TransformsTab = ({ schemas, onResult }) => {
     ).map(schema => {
       // Deep clone the schema to avoid modifying the original
       const processedSchema = JSON.parse(JSON.stringify(schema))
-      
+
       // Process each field's transform
       Object.entries(processedSchema.fields).forEach(([fieldName, field]) => {
         if (typeof field.transform === 'string') {
@@ -25,9 +25,9 @@ const TransformsTab = ({ schemas, onResult }) => {
           const match = field.transform.match(/transform\s+(\w+)\s*{\s*logic:\s*{\s*([^}]+);\s*}\s*}/)
           if (match) {
             field.transform = {
-              name: match[1],
               logic: match[2].trim(),
-              reversible: false // Default value
+              output: `${schema.name}.${fieldName}`,
+              inputs: []
             }
           }
         }
@@ -120,26 +120,22 @@ const TransformsTab = ({ schemas, onResult }) => {
                     <div key={fieldName} className="border-l-4 border-primary pl-4">
                       <h4 className="font-medium text-gray-700">{fieldName}</h4>
                       <div className="mt-2 space-y-2">
-                        <div className="text-sm">
+                      <div className="text-sm">
                           <div className="flex items-center gap-2">
-                            <span className="font-medium">Transform Name:</span>
-                            <span className="text-gray-600">{field.transform.name}</span>
-                          </div>
-                          <div className="flex items-center gap-2 mt-1">
-                            <span className="font-medium">Output Schema:</span>
-                            <span className="text-blue-600">{field.transform.output_schema}</span>
+                            <span className="font-medium">Output:</span>
+                            <span className="text-blue-600">{field.transform.output}</span>
                           </div>
                           <div className="flex items-center">
                             <button
                               onClick={() => handleAddToQueue(schema.name, fieldName, field.transform)}
-                              disabled={loading[field.transform.name]}
+                              disabled={loading[`${schema.name}.${fieldName}`]}
                               className="ml-4 px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-blue-300"
                             >
-                              {loading[field.transform.name] ? 'Adding...' : 'Add to Queue'}
+                              {loading[`${schema.name}.${fieldName}`] ? 'Adding...' : 'Add to Queue'}
                             </button>
-                            {error[field.transform.name] && (
+                            {error[`${schema.name}.${fieldName}`] && (
                               <span className="ml-2 text-sm text-red-600">
-                                Error: {error[field.transform.name]}
+                                Error: {error[`${schema.name}.${fieldName}`]}
                               </span>
                             )}
                           </div>
@@ -150,18 +146,10 @@ const TransformsTab = ({ schemas, onResult }) => {
                             {field.transform.logic}
                           </code>
                         </div>
-                        <div className="text-sm">
-                          <span className="font-medium">Reversible:</span>{' '}
-                          <span className="text-gray-600">
-                            {field.transform.reversible ? 'Yes' : 'No'}
-                          </span>
-                        </div>
                         {field.transform.output && (
                           <div className="text-sm mt-2 bg-blue-50 p-3 rounded-md border-l-4 border-blue-500">
                             <span className="font-medium text-blue-700">Output:</span>{' '}
-                            <pre className="mt-1 whitespace-pre-wrap text-gray-800 font-mono text-xs bg-white p-2 rounded">
-                              {JSON.stringify(field.transform.output, null, 2)}
-                            </pre>
+                            <code className="ml-1">{field.transform.output}</code>
                           </div>
                         )}
                       </div>


### PR DESCRIPTION
## Summary
- update frontend logic for transforms to parse simplified transform objects
- display transform `output` instead of old `name`, `reversible`, and `output_schema` fields

## Testing
- `bash pre-commit`