### PR TITLE
Refactor TransformManager types

### DIFF
--- a/fold_node/src/fold_db_core/transform_manager/manager.rs
+++ b/fold_node/src/fold_db_core/transform_manager/manager.rs
@@ -1,23 +1,10 @@
-use crate::atom::{Atom, AtomRef};
 use crate::schema::types::{Transform, SchemaError, TransformRegistration};
 use crate::transform::TransformExecutor;
-use super::transform_orchestrator::TransformRunner;
+use super::types::{CreateAtomFn, GetAtomFn, GetFieldFn, UpdateAtomRefFn, TransformRunner};
 use serde_json::Value as JsonValue;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 use log::error;
-
-/// Callback function type for getting an atom by its reference UUID
-pub type GetAtomFn = Arc<dyn Fn(&str) -> Result<Atom, Box<dyn std::error::Error>> + Send + Sync>;
-
-/// Callback function type for creating a new atom
-pub type CreateAtomFn = Arc<dyn Fn(&str, String, Option<String>, JsonValue, Option<crate::atom::AtomStatus>) -> Result<Atom, Box<dyn std::error::Error>> + Send + Sync>;
-
-/// Callback function type for updating an atom reference
-pub type UpdateAtomRefFn = Arc<dyn Fn(&str, String, String) -> Result<AtomRef, Box<dyn std::error::Error>> + Send + Sync>;
-
-/// Callback function type for getting a field value by schema and field name
-pub type GetFieldFn = Arc<dyn Fn(&str, &str) -> Result<JsonValue, SchemaError> + Send + Sync>;
 
 pub struct TransformManager {
     /// Tree for storing transforms

--- a/fold_node/src/fold_db_core/transform_manager/mod.rs
+++ b/fold_node/src/fold_db_core/transform_manager/mod.rs
@@ -1,0 +1,5 @@
+pub mod manager;
+pub mod types;
+
+pub use manager::TransformManager;
+pub use types::*;

--- a/fold_node/src/fold_db_core/transform_manager/types.rs
+++ b/fold_node/src/fold_db_core/transform_manager/types.rs
@@ -1,0 +1,28 @@
+use crate::atom::{Atom, AtomRef};
+use crate::schema::SchemaError;
+use serde_json::Value as JsonValue;
+use std::sync::Arc;
+use std::collections::HashSet;
+
+/// Callback function type for getting an atom by its reference UUID
+pub type GetAtomFn = Arc<dyn Fn(&str) -> Result<Atom, Box<dyn std::error::Error>> + Send + Sync>;
+
+/// Callback function type for creating a new atom
+pub type CreateAtomFn = Arc<dyn Fn(&str, String, Option<String>, JsonValue, Option<crate::atom::AtomStatus>) -> Result<Atom, Box<dyn std::error::Error>> + Send + Sync>;
+
+/// Callback function type for updating an atom reference
+pub type UpdateAtomRefFn = Arc<dyn Fn(&str, String, String) -> Result<AtomRef, Box<dyn std::error::Error>> + Send + Sync>;
+
+/// Callback function type for getting a field value by schema and field name
+pub type GetFieldFn = Arc<dyn Fn(&str, &str) -> Result<JsonValue, SchemaError> + Send + Sync>;
+
+/// Trait abstraction over transform execution for easier testing.
+pub trait TransformRunner: Send + Sync {
+    fn execute_transform_now(&self, transform_id: &str) -> Result<JsonValue, SchemaError>;
+    fn transform_exists(&self, transform_id: &str) -> Result<bool, SchemaError>;
+    fn get_transforms_for_field(
+        &self,
+        schema_name: &str,
+        field_name: &str,
+    ) -> Result<HashSet<String>, SchemaError>;
+}

--- a/fold_node/src/fold_db_core/transform_orchestrator.rs
+++ b/fold_node/src/fold_db_core/transform_orchestrator.rs
@@ -1,21 +1,11 @@
-use std::collections::{VecDeque, HashSet};
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use serde_json::Value as JsonValue;
 use log::{info, error};
 
 use crate::schema::SchemaError;
-
-/// Trait abstraction over transform execution for easier testing.
-pub trait TransformRunner: Send + Sync {
-    fn execute_transform_now(&self, transform_id: &str) -> Result<JsonValue, SchemaError>;
-    fn transform_exists(&self, transform_id: &str) -> Result<bool, SchemaError>;
-    fn get_transforms_for_field(
-        &self,
-        schema_name: &str,
-        field_name: &str,
-    ) -> Result<HashSet<String>, SchemaError>;
-}
+use super::transform_manager::types::TransformRunner;
 
 /// Orchestrates execution of transforms sequentially.
 pub struct TransformOrchestrator {

--- a/tests/integration_tests/transform_orchestrator_tests.rs
+++ b/tests/integration_tests/transform_orchestrator_tests.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
-use fold_node::fold_db_core::transform_orchestrator::{TransformOrchestrator, TransformRunner};
+use fold_node::fold_db_core::transform_manager::types::TransformRunner;
+use fold_node::fold_db_core::transform_orchestrator::TransformOrchestrator;
 use fold_node::schema::SchemaError;
 use serde_json::json;
 


### PR DESCRIPTION
## Summary
- move callback type aliases and `TransformRunner` trait into `transform_manager/types.rs`
- re-export new modules through `transform_manager/mod.rs`
- update `TransformManager` and orchestrator to use new module
- adjust tests for new imports

## Testing
- `cargo test --quiet`