### PR TITLE
Refactor TCP server structure

### DIFF
--- a/fold_node/src/datafold_node/mod.rs
+++ b/fold_node/src/datafold_node/mod.rs
@@ -15,6 +15,8 @@ pub mod http_server;
 pub mod loader;
 pub mod node;
 pub mod tcp_server;
+pub mod tcp_protocol;
+pub mod tcp_connections;
 pub mod tests;
 
 // Re-export the DataFoldNode struct for easier imports

--- a/fold_node/src/datafold_node/tcp_connections.rs
+++ b/fold_node/src/datafold_node/tcp_connections.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use log::{error, info};
+use tokio::net::TcpStream;
+use tokio::sync::Mutex;
+
+use super::{DataFoldNode, TcpServer};
+use crate::datafold_node::tcp_protocol::{read_request, send_response};
+use crate::error::{FoldDbError, FoldDbResult};
+use serde_json::json;
+
+impl TcpServer {
+    /// Handle a single client connection.
+    ///
+    /// This method reads requests using the protocol utilities and delegates
+    /// processing to [`TcpServer::process_request`]. It will continue handling
+    /// messages until the client disconnects or an error occurs.
+    pub(crate) async fn handle_connection(
+        mut socket: TcpStream,
+        node: Arc<Mutex<DataFoldNode>>,
+    ) -> FoldDbResult<()> {
+        while let Some(request) = read_request(&mut socket).await? {
+            let response = match Self::process_request(&request, node.clone()).await {
+                Ok(resp) => resp,
+                Err(e) => {
+                    error!("Error processing request: {}", e);
+                    json!({ "error": format!("Error processing request: {}", e) })
+                }
+            };
+
+            if let Err(e) = send_response(&mut socket, &response).await {
+                match &e {
+                    FoldDbError::Io(io_err) if io_err.kind() == std::io::ErrorKind::BrokenPipe => {
+                        info!("Client disconnected while sending response");
+                        return Ok(());
+                    }
+                    _ => return Err(e),
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/fold_node/src/datafold_node/tcp_protocol.rs
+++ b/fold_node/src/datafold_node/tcp_protocol.rs
@@ -1,0 +1,76 @@
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use log::{error, info, warn};
+
+use crate::error::FoldDbResult;
+
+/// Maximum allowed request size in bytes.
+const MAX_REQUEST_SIZE: usize = 10_000_000;
+
+/// Read a JSON request from the given TCP stream.
+///
+/// The function reads a length-prefixed JSON message and deserializes it into
+/// a [`serde_json::Value`]. If the peer disconnects while reading, `Ok(None)`
+/// is returned.
+pub async fn read_request(socket: &mut TcpStream) -> FoldDbResult<Option<Value>> {
+    let request_len = match socket.read_u32().await {
+        Ok(len) => len as usize,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                info!("Client disconnected");
+                return Ok(None);
+            }
+            error!("Error reading request length: {}", e);
+            return Err(e.into());
+        }
+    };
+
+    if request_len > MAX_REQUEST_SIZE {
+        warn!("Request too large: {} bytes", request_len);
+        let error_response = json!({
+            "error": "Request too large",
+            "max_size": MAX_REQUEST_SIZE,
+        });
+        send_response(socket, &error_response).await?;
+        return Ok(None);
+    }
+
+    let mut request_bytes = vec![0u8; request_len];
+    match socket.read_exact(&mut request_bytes).await {
+        Ok(_) => {},
+        Err(e) => {
+            error!("Error reading request: {}", e);
+            if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                info!("Client disconnected while reading request");
+                return Ok(None);
+            }
+            let error_response = json!({
+                "error": format!("Error reading request: {}", e),
+            });
+            let _ = send_response(socket, &error_response).await;
+            return Err(e.into());
+        }
+    };
+
+    match serde_json::from_slice(&request_bytes) {
+        Ok(req) => Ok(Some(req)),
+        Err(e) => {
+            error!("Error deserializing request: {}", e);
+            let error_response = json!({
+                "error": format!("Error deserializing request: {}", e),
+            });
+            let _ = send_response(socket, &error_response).await;
+            Ok(None)
+        }
+    }
+}
+
+/// Send a JSON response using the length-prefixed protocol.
+pub async fn send_response(socket: &mut TcpStream, value: &Value) -> FoldDbResult<()> {
+    let bytes = serde_json::to_vec(value)?;
+    socket.write_u32(bytes.len() as u32).await?;
+    socket.write_all(&bytes).await?;
+    socket.flush().await?;
+    Ok(())
+}

--- a/fold_node/src/datafold_node/tests.rs
+++ b/fold_node/src/datafold_node/tests.rs
@@ -36,3 +36,35 @@ fn test_node_config_default() {
     assert_eq!(config.default_trust_distance, 1);
     assert_eq!(config.network_listen_address, "/ip4/0.0.0.0/tcp/0".to_string());
 }
+
+#[tokio::test]
+async fn test_tcp_protocol_roundtrip() {
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use crate::datafold_node::tcp_protocol::{read_request, send_response};
+    use serde_json::json;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let req = read_request(&mut socket).await.unwrap().unwrap();
+        assert_eq!(req["foo"], "bar");
+        send_response(&mut socket, &json!({"ok": true})).await.unwrap();
+    });
+
+    let mut client = TcpStream::connect(addr).await.unwrap();
+    let request = json!({"foo": "bar"});
+    let bytes = serde_json::to_vec(&request).unwrap();
+    client.write_u32(bytes.len() as u32).await.unwrap();
+    client.write_all(&bytes).await.unwrap();
+
+    let resp_len = client.read_u32().await.unwrap();
+    let mut resp_bytes = vec![0u8; resp_len as usize];
+    client.read_exact(&mut resp_bytes).await.unwrap();
+    let resp: serde_json::Value = serde_json::from_slice(&resp_bytes).unwrap();
+    assert_eq!(resp, json!({"ok": true}));
+
+    server.await.unwrap();
+}


### PR DESCRIPTION
## Summary
- split request/response utilities into `tcp_protocol.rs`
- move connection management to `tcp_connections.rs`
- keep server startup logic in `tcp_server.rs`
- test message round‑trip via the new protocol helper

## Testing
- `cargo test --workspace --quiet`