### PR TITLE
Refactor HTTP server modules

### DIFF
--- a/fold_node/src/datafold_node/mod.rs
+++ b/fold_node/src/datafold_node/mod.rs
@@ -12,6 +12,10 @@
 pub mod config;
 pub mod error;
 pub mod http_server;
+pub mod sample_manager;
+pub mod schema_routes;
+pub mod query_routes;
+pub mod network_routes;
 pub mod loader;
 pub mod node;
 pub mod tcp_server;
@@ -21,6 +25,7 @@ pub mod tests;
 pub use config::NodeConfig;
 pub use config::load_node_config;
 pub use http_server::DataFoldHttpServer;
+pub use sample_manager::SampleManager;
 pub use loader::load_schema_from_file;
 pub use node::DataFoldNode;
 pub use tcp_server::TcpServer;

--- a/fold_node/src/datafold_node/network_routes.rs
+++ b/fold_node/src/datafold_node/network_routes.rs
@@ -1,0 +1,125 @@
+use super::http_server::AppState;
+use actix_web::{web, HttpResponse, Responder};
+use serde::Deserialize;
+use serde_json::json;
+use crate::network::NetworkConfig;
+
+#[derive(Deserialize)]
+pub(crate) struct NetworkConfigPayload {
+    listen_address: String,
+    discovery_port: Option<u16>,
+    max_connections: Option<usize>,
+    connection_timeout_secs: Option<u64>,
+    announcement_interval_secs: Option<u64>,
+    enable_discovery: Option<bool>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct ConnectRequest {
+    node_id: String,
+}
+
+pub async fn init_network(
+    config: web::Json<NetworkConfigPayload>,
+    state: web::Data<AppState>,
+) -> impl Responder {
+    let mut node = state.node.lock().await;
+
+    let mut network_config = NetworkConfig::new(&config.listen_address);
+    if let Some(port) = config.discovery_port {
+        network_config = network_config.with_discovery_port(port);
+    }
+    if let Some(max) = config.max_connections {
+        network_config = network_config.with_max_connections(max);
+    }
+    if let Some(timeout) = config.connection_timeout_secs {
+        network_config = network_config.with_connection_timeout(std::time::Duration::from_secs(timeout));
+    }
+    if let Some(interval) = config.announcement_interval_secs {
+        network_config = network_config.with_announcement_interval(std::time::Duration::from_secs(interval));
+    }
+    if let Some(enable) = config.enable_discovery {
+        network_config = network_config.with_mdns(enable);
+    }
+
+    match node.init_network(network_config).await {
+        Ok(_) => HttpResponse::Ok().json(json!({ "success": true })),
+        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to init network: {}", e) })),
+    }
+}
+
+pub async fn start_network(state: web::Data<AppState>) -> impl Responder {
+    let node = state.node.lock().await;
+    match node.start_network().await {
+        Ok(_) => HttpResponse::Ok().json(json!({ "success": true })),
+        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to start network: {}", e) })),
+    }
+}
+
+pub async fn stop_network(state: web::Data<AppState>) -> impl Responder {
+    let node = state.node.lock().await;
+    match node.stop_network().await {
+        Ok(_) => HttpResponse::Ok().json(json!({ "success": true })),
+        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to stop network: {}", e) })),
+    }
+}
+
+pub async fn get_network_status(state: web::Data<AppState>) -> impl Responder {
+    let node = state.node.lock().await;
+    match node.get_network_status().await {
+        Ok(status) => HttpResponse::Ok().json(json!({ "data": status })),
+        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to get network status: {}", e) })),
+    }
+}
+
+pub async fn connect_to_node(
+    req: web::Json<ConnectRequest>,
+    state: web::Data<AppState>,
+) -> impl Responder {
+    let mut node = state.node.lock().await;
+    match node.connect_to_node(&req.node_id).await {
+        Ok(_) => HttpResponse::Ok().json(json!({ "success": true })),
+        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to connect to node: {}", e) })),
+    }
+}
+
+pub async fn discover_nodes(state: web::Data<AppState>) -> impl Responder {
+    let node = state.node.lock().await;
+    match node.discover_nodes().await {
+        Ok(peers) => {
+            let peers: Vec<String> = peers.into_iter().map(|p| p.to_string()).collect();
+            HttpResponse::Ok().json(json!({ "data": peers }))
+        }
+        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to discover nodes: {}", e) })),
+    }
+}
+
+pub async fn list_nodes(state: web::Data<AppState>) -> impl Responder {
+    let node = state.node.lock().await;
+    match node.get_known_nodes().await {
+        Ok(nodes) => HttpResponse::Ok().json(json!({ "data": nodes })),
+        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to list nodes: {}", e) })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datafold_node::{DataFoldNode, config::NodeConfig};
+    use actix_web::web;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn list_nodes_empty() {
+        let dir = tempdir().unwrap();
+        let config = NodeConfig::new(dir.path().to_path_buf());
+        let node = DataFoldNode::new(config).unwrap();
+        let state = web::Data::new(super::super::http_server::AppState {
+            node: std::sync::Arc::new(tokio::sync::Mutex::new(node)),
+            sample_manager: super::super::sample_manager::SampleManager { schemas: Default::default(), queries: Default::default(), mutations: Default::default() }
+        });
+        let resp = list_nodes(state).await.respond_to(&actix_web::HttpRequest::default());
+        assert_eq!(resp.status(), 200);
+    }
+}
+

--- a/fold_node/src/datafold_node/query_routes.rs
+++ b/fold_node/src/datafold_node/query_routes.rs
@@ -1,0 +1,179 @@
+use super::http_server::AppState;
+use actix_web::{web, HttpResponse, Responder};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use crate::schema::types::Operation;
+
+/// Execute an operation (query or mutation).
+#[derive(Deserialize)]
+pub(crate) struct OperationRequest {
+    operation: String,
+}
+
+pub async fn execute_operation(
+    request: web::Json<OperationRequest>,
+    state: web::Data<AppState>,
+) -> impl Responder {
+    let operation_str = &request.operation;
+
+    let operation: Operation = match serde_json::from_str(operation_str) {
+        Ok(op) => op,
+        Err(e) => {
+            return HttpResponse::BadRequest().json(json!({"error": format!("Failed to parse operation: {}", e)}));
+        }
+    };
+
+    let mut node_guard = state.node.lock().await;
+
+    match node_guard.execute_operation(operation) {
+        Ok(result) => HttpResponse::Ok().json(json!({"data": result})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to execute operation: {}", e)})),
+    }
+}
+
+/// Execute a query.
+pub async fn execute_query(query: web::Json<Value>, state: web::Data<AppState>) -> impl Responder {
+    let operation = match serde_json::from_value::<Operation>(query.into_inner()) {
+        Ok(op) => match op {
+            Operation::Query { .. } => op,
+            _ => return HttpResponse::BadRequest().json(json!({"error": "Expected a query operation"})),
+        },
+        Err(e) => return HttpResponse::BadRequest().json(json!({"error": format!("Failed to parse query: {}", e)})),
+    };
+
+    let mut node_guard = state.node.lock().await;
+
+    match node_guard.execute_operation(operation) {
+        Ok(result) => HttpResponse::Ok().json(json!({"data": result})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to execute query: {}", e)})),
+    }
+}
+
+/// Execute a mutation.
+pub async fn execute_mutation(mutation: web::Json<Value>, state: web::Data<AppState>) -> impl Responder {
+    let operation = match serde_json::from_value::<Operation>(mutation.into_inner()) {
+        Ok(op) => match op {
+            Operation::Mutation { .. } => op,
+            _ => return HttpResponse::BadRequest().json(json!({"error": "Expected a mutation operation"})),
+        },
+        Err(e) => return HttpResponse::BadRequest().json(json!({"error": format!("Failed to parse mutation: {}", e)})),
+    };
+
+    let mut node_guard = state.node.lock().await;
+
+    match node_guard.execute_operation(operation) {
+        Ok(_) => HttpResponse::Ok().json(json!({"success": true})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to execute mutation: {}", e)})),
+    }
+}
+
+/// List all sample schemas.
+pub async fn list_schema_samples(state: web::Data<AppState>) -> impl Responder {
+    HttpResponse::Ok().json(json!({"data": state.sample_manager.list_schema_samples()}))
+}
+
+/// List all sample queries.
+pub async fn list_query_samples(state: web::Data<AppState>) -> impl Responder {
+    HttpResponse::Ok().json(json!({"data": state.sample_manager.list_query_samples()}))
+}
+
+/// List all sample mutations.
+pub async fn list_mutation_samples(state: web::Data<AppState>) -> impl Responder {
+    HttpResponse::Ok().json(json!({"data": state.sample_manager.list_mutation_samples()}))
+}
+
+/// Get a sample schema by name.
+pub async fn get_schema_sample(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
+    let name = path.into_inner();
+
+    match state.sample_manager.get_schema_sample(&name) {
+        Some(schema) => HttpResponse::Ok().json(schema),
+        None => HttpResponse::NotFound().json(json!({"error": format!("Sample schema '{}' not found", name)})),
+    }
+}
+
+/// Get a sample query by name.
+pub async fn get_query_sample(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
+    let name = path.into_inner();
+
+    match state.sample_manager.get_query_sample(&name) {
+        Some(query) => HttpResponse::Ok().json(query),
+        None => HttpResponse::NotFound().json(json!({"error": format!("Sample query '{}' not found", name)})),
+    }
+}
+
+/// Get a sample mutation by name.
+pub async fn get_mutation_sample(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
+    let name = path.into_inner();
+
+    match state.sample_manager.get_mutation_sample(&name) {
+        Some(mutation) => HttpResponse::Ok().json(mutation),
+        None => HttpResponse::NotFound().json(json!({"error": format!("Sample mutation '{}' not found", name)})),
+    }
+}
+
+pub async fn list_transforms(state: web::Data<AppState>) -> impl Responder {
+    let node = state.node.lock().await;
+    match node.list_transforms() {
+        Ok(map) => HttpResponse::Ok().json(json!({ "data": map })),
+        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to list transforms: {}", e) })),
+    }
+}
+
+pub async fn run_transform(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
+    let id = path.into_inner();
+    let mut node = state.node.lock().await;
+    match node.run_transform(&id) {
+        Ok(val) => HttpResponse::Ok().json(json!({ "data": val })),
+        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to run transform: {}", e) })),
+    }
+}
+
+pub async fn add_to_transform_queue(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
+    let transform_id = path.into_inner();
+    let node = state.node.lock().await;
+
+    match node.list_transforms() {
+        Ok(transforms) => {
+            if !transforms.contains_key(&transform_id) {
+                return HttpResponse::NotFound().json(json!({"error": format!("Transform '{}' not found. Available transforms: {:?}", transform_id, transforms.keys().collect::<Vec<_>>())}));
+            }
+        }
+        Err(e) => return HttpResponse::InternalServerError().json(json!({"error": format!("Failed to verify transform: {}", e)})),
+    }
+
+    match node.add_transform_to_queue(&transform_id) {
+        Ok(_) => HttpResponse::Ok().json(json!({"success": true, "message": format!("Transform '{}' added to queue", transform_id)})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to add transform to queue: {}", e)})),
+    }
+}
+
+pub async fn get_transform_queue(state: web::Data<AppState>) -> impl Responder {
+    let node = state.node.lock().await;
+    match node.get_transform_queue_info() {
+        Ok(info) => HttpResponse::Ok().json(info),
+        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to get transform queue info: {}", e) })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datafold_node::{DataFoldNode, config::NodeConfig};
+    use actix_web::web;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn list_sample_schemas_empty() {
+        let dir = tempdir().unwrap();
+        let config = NodeConfig::new(dir.path().to_path_buf());
+        let node = DataFoldNode::new(config).unwrap();
+        let state = web::Data::new(super::super::http_server::AppState {
+            node: std::sync::Arc::new(tokio::sync::Mutex::new(node)),
+            sample_manager: super::super::sample_manager::SampleManager { schemas: Default::default(), queries: Default::default(), mutations: Default::default() }
+        });
+        let resp = list_schema_samples(state).await.respond_to(&actix_web::HttpRequest::default());
+        assert_eq!(resp.status(), 200);
+    }
+}
+

--- a/fold_node/src/datafold_node/sample_manager.rs
+++ b/fold_node/src/datafold_node/sample_manager.rs
@@ -1,0 +1,130 @@
+use crate::error::{FoldDbError, FoldDbResult};
+use log::error;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::Path;
+use tokio::fs;
+
+/// Sample data manager for the HTTP server.
+///
+/// `SampleManager` provides access to sample schemas, queries, and mutations
+/// for one-click loading in the UI.
+#[derive(Clone)]
+pub struct SampleManager {
+    /// Sample schemas
+    pub(crate) schemas: HashMap<String, Value>,
+    /// Sample queries
+    pub(crate) queries: HashMap<String, Value>,
+    /// Sample mutations
+    pub(crate) mutations: HashMap<String, Value>,
+}
+
+impl SampleManager {
+    /// Create a new sample manager and load samples from disk.
+    pub async fn new() -> FoldDbResult<Self> {
+        let mut manager = Self {
+            schemas: HashMap::new(),
+            queries: HashMap::new(),
+            mutations: HashMap::new(),
+        };
+
+        // Load sample data
+        manager.load_samples().await?;
+
+        Ok(manager)
+    }
+
+    /// Load sample data from files.
+    async fn load_samples(&mut self) -> FoldDbResult<()> {
+        let samples_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/datafold_node/samples/data");
+
+        let mut entries = match fs::read_dir(&samples_dir).await {
+            Ok(e) => e,
+            Err(e) => {
+                error!(
+                    "Failed to read samples directory {}: {}",
+                    samples_dir.display(),
+                    e
+                );
+                return Err(FoldDbError::Io(e));
+            }
+        };
+
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            if let Ok(ft) = entry.file_type().await {
+                if !ft.is_file() {
+                    continue;
+                }
+            }
+
+            if let Ok(content) = fs::read_to_string(entry.path()).await {
+                if let Ok(value) = serde_json::from_str::<Value>(&content) {
+                    let name = entry
+                        .file_name()
+                        .to_string_lossy()
+                        .trim_end_matches(".json")
+                        .to_string();
+
+                    match value.get("type").and_then(|v| v.as_str()) {
+                        Some("query") => {
+                            self.queries.insert(name, value);
+                        }
+                        Some("mutation") => {
+                            self.mutations.insert(name, value);
+                        }
+                        _ => {
+                            self.schemas.insert(name, value);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get a sample schema by name.
+    pub fn get_schema_sample(&self, name: &str) -> Option<&Value> {
+        self.schemas.get(name)
+    }
+
+    /// Get a sample query by name.
+    pub fn get_query_sample(&self, name: &str) -> Option<&Value> {
+        self.queries.get(name)
+    }
+
+    /// Get a sample mutation by name.
+    pub fn get_mutation_sample(&self, name: &str) -> Option<&Value> {
+        self.mutations.get(name)
+    }
+
+    /// List all sample schemas.
+    pub fn list_schema_samples(&self) -> Vec<String> {
+        self.schemas.keys().cloned().collect()
+    }
+
+    /// List all sample queries.
+    pub fn list_query_samples(&self) -> Vec<String> {
+        self.queries.keys().cloned().collect()
+    }
+
+    /// List all sample mutations.
+    pub fn list_mutation_samples(&self) -> Vec<String> {
+        self.mutations.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SampleManager;
+
+    #[tokio::test]
+    async fn sample_manager_loads_schemas() {
+        let manager = SampleManager::new().await.expect("failed to load samples");
+        let schemas = manager.list_schema_samples();
+        assert!(schemas.contains(&"UserProfile".to_string()));
+        assert!(schemas.contains(&"ProductCatalog".to_string()));
+    }
+}
+

--- a/fold_node/src/datafold_node/schema_routes.rs
+++ b/fold_node/src/datafold_node/schema_routes.rs
@@ -1,0 +1,95 @@
+#[cfg(test)]
+use super::sample_manager::SampleManager;
+use super::http_server::AppState;
+use crate::schema::Schema;
+use actix_web::{web, HttpResponse, Responder};
+use serde_json::json;
+use log::{info, error};
+
+/// List all schemas.
+pub async fn list_schemas(state: web::Data<AppState>) -> impl Responder {
+    info!("Received request to list schemas");
+    let node_guard = state.node.lock().await;
+
+    match node_guard.list_schemas() {
+        Ok(schemas) => HttpResponse::Ok().json(json!({"data": schemas})),
+        Err(e) => {
+            error!("Failed to list schemas: {}", e);
+            HttpResponse::InternalServerError().json(json!({"error": format!("Failed to list schemas: {}", e)}))
+        }
+    }
+}
+
+/// Get a schema by name.
+pub async fn get_schema(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
+    let name = path.into_inner();
+    let node_guard = state.node.lock().await;
+
+    match node_guard.get_schema(&name) {
+        Ok(Some(schema)) => HttpResponse::Ok().json(schema),
+        Ok(None) => HttpResponse::NotFound().json(json!({"error": format!("Schema '{}' not found", name)})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to get schema: {}", e)})),
+    }
+}
+
+/// Create a new schema.
+pub async fn create_schema(schema: web::Json<Schema>, state: web::Data<AppState>) -> impl Responder {
+    let mut node_guard = state.node.lock().await;
+
+    match node_guard.load_schema(schema.into_inner()) {
+        Ok(_) => HttpResponse::Created().json(json!({"success": true})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to create schema: {}", e)})),
+    }
+}
+
+/// Update an existing schema.
+pub async fn update_schema(path: web::Path<String>, schema: web::Json<Schema>, state: web::Data<AppState>) -> impl Responder {
+    let name = path.into_inner();
+    let schema_data = schema.into_inner();
+
+    if schema_data.name != name {
+        return HttpResponse::BadRequest().json(json!({"error": format!("Schema name '{}' does not match path '{}'", schema_data.name, name)}));
+    }
+
+    let mut node_guard = state.node.lock().await;
+
+    let _ = node_guard.remove_schema(&name);
+
+    match node_guard.load_schema(schema_data) {
+        Ok(_) => HttpResponse::Ok().json(json!({"success": true})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to update schema: {}", e)})),
+    }
+}
+
+/// Delete a schema.
+pub async fn delete_schema(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
+    let name = path.into_inner();
+    let mut node_guard = state.node.lock().await;
+
+    match node_guard.remove_schema(&name) {
+        Ok(_) => HttpResponse::Ok().json(json!({"success": true})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to delete schema: {}", e)})),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datafold_node::{DataFoldNode, config::NodeConfig};
+    use actix_web::web;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn list_schemas_empty() {
+        let dir = tempdir().unwrap();
+        let config = NodeConfig::new(dir.path().to_path_buf());
+        let node = DataFoldNode::new(config).unwrap();
+        let state = web::Data::new(super::super::http_server::AppState {
+            node: std::sync::Arc::new(tokio::sync::Mutex::new(node)),
+            sample_manager: SampleManager { schemas: Default::default(), queries: Default::default(), mutations: Default::default() }
+        });
+        let resp = list_schemas(state).await.respond_to(&actix_web::HttpRequest::default());
+        assert_eq!(resp.status(), 200);
+    }
+}
+


### PR DESCRIPTION
## Summary
- extract `SampleManager` into its own module
- split REST endpoints into `schema_routes`, `query_routes` and `network_routes`
- expose new modules from `datafold_node`
- update http server to use extracted logic
- add unit tests for the new modules

## Testing
- `cargo test`