### PR TITLE
Fix cargo test by initializing logger

### DIFF
--- a/fold_node/Cargo.toml
+++ b/fold_node/Cargo.toml
@@ -26,8 +26,9 @@ async-trait = "0.1"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "sync", "time", "fs", "signal", "io-util"] }
 thiserror = "1.0"
 futures = "0.3"
+futures-util = "0.3"
 once_cell = "1"
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["sync"] }
 rand = "0.8"
 tempfile = "3.8"
 clap = { version = "4.4", features = ["derive"] }

--- a/fold_node/src/datafold_node/http_server.rs
+++ b/fold_node/src/datafold_node/http_server.rs
@@ -64,6 +64,9 @@ impl DataFoldHttpServer {
     /// Returns a `FoldDbError` if:
     /// * There is an error creating the sample manager
     pub async fn new(mut node: DataFoldNode, bind_address: &str) -> FoldDbResult<Self> {
+        // Ensure the web logger is initialized so log routes have data
+        crate::web_logger::init().ok();
+
         // Create sample manager
         let sample_manager = SampleManager::new().await?;
 

--- a/fold_node/src/datafold_node/log_routes.rs
+++ b/fold_node/src/datafold_node/log_routes.rs
@@ -14,7 +14,9 @@ pub async fn stream_logs() -> impl Responder {
     };
     let stream = BroadcastStream::new(rx).filter_map(|msg| async move {
         match msg {
-            Ok(line) => Some(Ok(web::Bytes::from(format!("data: {}\n\n", line)))),
+            Ok(line) => Some(Ok::<web::Bytes, actix_web::Error>(
+                web::Bytes::from(format!("data: {}\n\n", line)),
+            )),
             Err(_) => None,
         }
     });


### PR DESCRIPTION
## Summary
- add futures-util dependency and enable sync feature for tokio-stream
- initialize logger inside `DataFoldHttpServer::new`
- clarify error type in log stream closure

## Testing
- `cargo test --workspace`
- `npm test` *(fails: Missing script)*