### PR TITLE
Update TransformSchema inputs and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Sample JSON files live under
 `fold_node/src/datafold_node/samples/data/`. Add your own files to this
 directory to make them available in the Samples tab.
 
+The `TransformSchema` example relies on values from the accompanying
+`TransformBase` schema. Populate `value1` and `value2` on `TransformBase`
+before running the `TransformSchema.result` transform.
+
 ### Network Features
 
 The **Network** tab exposes new peer‑to‑peer features:

--- a/fold_node/src/datafold_node/samples/data/TransformSchema.json
+++ b/fold_node/src/datafold_node/samples/data/TransformSchema.json
@@ -20,7 +20,7 @@
       "field_mappers": {},
       "transform": {
         "logic": "TransformBase.value1 + TransformBase.value2",
-        "inputs": [],
+        "inputs": ["TransformBase.value1", "TransformBase.value2"],
         "output": "TransformSchema.result"
       }
     }

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -8,3 +8,4 @@ pub mod transform_enqueue_tests;
 pub mod http_server_tests;
 pub mod schema_unload_transform_tests;
 pub mod transform_output_schema_tests;
+pub mod transform_sample_execution_tests;

--- a/tests/integration_tests/transform_sample_execution_tests.rs
+++ b/tests/integration_tests/transform_sample_execution_tests.rs
@@ -1,0 +1,43 @@
+use crate::test_data::test_helpers::create_test_node;
+use fold_node::testing::{Mutation, MutationType};
+use fold_node::datafold_node::loader::load_schema_from_file;
+use serde_json::json;
+
+#[test]
+fn test_sample_transform_execution() {
+    let mut node = create_test_node();
+
+    // Load sample schemas
+    load_schema_from_file(
+        "fold_node/src/datafold_node/samples/data/TransformBase.json",
+        &mut node,
+    )
+    .unwrap();
+    load_schema_from_file(
+        "fold_node/src/datafold_node/samples/data/TransformSchema.json",
+        &mut node,
+    )
+    .unwrap();
+
+    node.allow_schema("TransformBase").unwrap();
+    node.allow_schema("TransformSchema").unwrap();
+
+    // Populate inputs
+    for (field, val) in [("value1", json!(2)), ("value2", json!(3))] {
+        let mut fields = std::collections::HashMap::new();
+        fields.insert(field.to_string(), val);
+        let mutation = Mutation {
+            mutation_type: MutationType::Create,
+            schema_name: "TransformBase".to_string(),
+            pub_key: "test_key".to_string(),
+            trust_distance: 0,
+            fields_and_values: fields,
+        };
+        node.mutate(mutation).unwrap();
+    }
+
+    // Execute transform and verify result
+    let result = node.run_transform("TransformSchema.result").unwrap();
+    assert_eq!(result, json!(5.0));
+}
+


### PR DESCRIPTION
## Summary
- specify required inputs in `TransformSchema.json`
- note required inputs in README documentation
- test TransformSchema execution using sample schemas

## Testing
- `cargo test --workspace`
- `npm test` *(fails: Missing script)*