### PR TITLE
Add transform input field tracking

### DIFF
--- a/fold_node/src/schema/types/transform.rs
+++ b/fold_node/src/schema/types/transform.rs
@@ -37,6 +37,9 @@ pub struct TransformRegistration {
     pub transform: Transform,
     /// Input atom reference UUIDs
     pub input_arefs: Vec<String>,
+    /// Names of input fields corresponding to the atom references
+    #[serde(default)]
+    pub input_names: Vec<String>,
     /// Fields that trigger the transform
     pub trigger_fields: Vec<String>,
     /// Output atom reference UUID


### PR DESCRIPTION
## Summary
- track names of input fields for registered transforms
- include new mapping for field names in TransformManager
- use stored names when gathering input values
- test cross-schema transform without explicit inputs

## Testing
- `cargo test --workspace`
- `npm test` *(fails: Missing script)*