### PR TITLE
Fix AtomRef uuid usage and mapping

### DIFF
--- a/fold_node/src/atom/atom_ref.rs
+++ b/fold_node/src/atom/atom_ref.rs
@@ -37,6 +37,13 @@ pub trait AtomRefBehavior {
     fn update_history(&self) -> &Vec<AtomRefUpdate>;
 }
 
+/// Wrapper enum for either a single [`AtomRef`] or an [`AtomRefCollection`].
+#[derive(Debug, Clone)]
+pub enum AtomRefWrapper {
+    Single(AtomRef),
+    Collection(AtomRefCollection),
+}
+
 /// A reference to a single atom version.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AtomRef {
@@ -53,6 +60,22 @@ impl AtomRef {
     pub fn new(atom_uuid: String, source_pub_key: String) -> Self {
         Self {
             uuid: Uuid::new_v4().to_string(),
+            atom_uuid,
+            updated_at: Utc::now(),
+            status: AtomRefStatus::Active,
+            update_history: vec![AtomRefUpdate {
+                timestamp: Utc::now(),
+                status: AtomRefStatus::Active,
+                source_pub_key,
+            }],
+        }
+    }
+
+    /// Creates a new AtomRef with a provided UUID.
+    #[must_use]
+    pub fn new_with_uuid(atom_uuid: String, source_pub_key: String, uuid: String) -> Self {
+        Self {
+            uuid,
             atom_uuid,
             updated_at: Utc::now(),
             status: AtomRefStatus::Active,
@@ -122,6 +145,22 @@ impl AtomRefCollection {
     pub fn new(source_pub_key: String) -> Self {
         Self {
             uuid: Uuid::new_v4().to_string(),
+            atom_uuids: HashMap::new(),
+            updated_at: Utc::now(),
+            status: AtomRefStatus::Active,
+            update_history: vec![AtomRefUpdate {
+                timestamp: Utc::now(),
+                status: AtomRefStatus::Active,
+                source_pub_key,
+            }],
+        }
+    }
+
+    /// Creates a new AtomRefCollection with the specified UUID.
+    #[must_use]
+    pub fn new_with_uuid(source_pub_key: String, uuid: String) -> Self {
+        Self {
+            uuid,
             atom_uuids: HashMap::new(),
             updated_at: Utc::now(),
             status: AtomRefStatus::Active,

--- a/fold_node/src/atom/mod.rs
+++ b/fold_node/src/atom/mod.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 use uuid::Uuid;
 
 mod atom_ref;
-pub use atom_ref::{AtomRef, AtomRefBehavior, AtomRefCollection, AtomRefStatus};
+pub use atom_ref::{
+    AtomRef, AtomRefBehavior, AtomRefCollection, AtomRefStatus, AtomRefWrapper,
+};
 
 /// An immutable data container that represents a single version of content in the database.
 ///

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -7,7 +7,7 @@ pub mod transform_orchestrator;
 
 use std::sync::Arc;
 use std::collections::HashMap;
-use crate::atom::{Atom, AtomRefBehavior};
+use crate::atom::{Atom, AtomRefBehavior, AtomRefWrapper};
 use crate::db_operations::DbOperations;
 use crate::permissions::PermissionWrapper;
 use crate::schema::types::{Mutation, MutationType, Query, Transform, TransformRegistration};
@@ -323,17 +323,28 @@ impl FoldDB {
         // Get the atom refs that need to be persisted
         let atom_refs = self.schema_manager.map_fields(&name)?;
 
-        // Persist each atom ref
-        for atom_ref in atom_refs {
-            let aref_uuid = atom_ref.uuid().to_string();
-            let atom_uuid = atom_ref.get_atom_uuid().clone();
-
-            // Store the atom ref in the database
-            self.atom_manager
-                .update_atom_ref(&aref_uuid, atom_uuid, "system".to_string())
-                .map_err(|e| {
-                    SchemaError::InvalidData(format!("Failed to persist atom ref: {}", e))
-                })?;
+        for aref in atom_refs {
+            match aref {
+                AtomRefWrapper::Single(atom_ref) => {
+                    let aref_uuid = atom_ref.uuid().to_string();
+                    let atom_uuid = atom_ref.get_atom_uuid().clone();
+                    self.atom_manager
+                        .update_atom_ref(&aref_uuid, atom_uuid, "system".to_string())
+                        .map_err(|e| {
+                            SchemaError::InvalidData(format!("Failed to persist atom ref: {}", e))
+                        })?;
+                }
+                AtomRefWrapper::Collection(collection) => {
+                    self.atom_manager
+                        .create_atom_ref_collection(collection)
+                        .map_err(|e| {
+                            SchemaError::InvalidData(format!(
+                                "Failed to persist atom ref collection: {}",
+                                e
+                            ))
+                        })?;
+                }
+            }
         }
 
         if let Some(loaded_schema) = self.schema_manager.get_schema(&name)? {

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -9,3 +9,4 @@ pub mod http_server_tests;
 pub mod schema_unload_transform_tests;
 pub mod transform_output_schema_tests;
 pub mod transform_sample_execution_tests;
+pub mod transform_no_value_tests;

--- a/tests/integration_tests/transform_no_value_tests.rs
+++ b/tests/integration_tests/transform_no_value_tests.rs
@@ -1,0 +1,32 @@
+use crate::test_data::test_helpers::create_test_node;
+use fold_node::datafold_node::loader::load_schema_from_file;
+
+#[test]
+fn transform_without_values_does_not_error_on_missing_refs() {
+    let mut node = create_test_node();
+
+    // Load sample schemas with a transform
+    load_schema_from_file(
+        "fold_node/src/datafold_node/samples/data/TransformBase.json",
+        &mut node,
+    )
+    .unwrap();
+    load_schema_from_file(
+        "fold_node/src/datafold_node/samples/data/TransformSchema.json",
+        &mut node,
+    )
+    .unwrap();
+
+    node.allow_schema("TransformBase").unwrap();
+    node.allow_schema("TransformSchema").unwrap();
+
+    let result = node.run_transform("TransformSchema.result");
+    if let Err(e) = result {
+        let msg = format!("{e:?}");
+        assert!(
+            !msg.contains("AtomRef not found"),
+            "Transform failed with unexpected error: {}",
+            msg
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- implement `new_with_uuid` constructors for atom refs and collections
- create `AtomRefWrapper` enum
- assign consistent ref UUIDs in `map_fields`
- persist collections on schema load
- add integration test for transforms with empty inputs

## Testing
- `cargo test --workspace` *(fails: some tests hang over 60s)*
- `npm test` *(fails: Missing script: "test")*