### PR TITLE
Add mutation hash context to transform queue

### DIFF
--- a/fold_node/Cargo.toml
+++ b/fold_node/Cargo.toml
@@ -22,6 +22,7 @@ sled = "0.34"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
+sha2 = "0.10"
 async-trait = "0.1"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "sync", "time", "fs", "signal", "io-util"] }
 thiserror = "1.0"

--- a/fold_node/src/datafold_node/transform_queue.rs
+++ b/fold_node/src/datafold_node/transform_queue.rs
@@ -8,7 +8,7 @@ impl DataFoldNode {
             .db
             .lock()
             .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
-        db.transform_orchestrator.add_transform(transform_id)?;
+        db.transform_orchestrator.add_transform(transform_id, "manual")?;
         Ok(())
     }
 

--- a/fold_node/src/schema/types/operations.rs
+++ b/fold_node/src/schema/types/operations.rs
@@ -68,7 +68,7 @@ impl<'de> Deserialize<'de> for MutationType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Mutation {
     pub schema_name: String,
     pub fields_and_values: HashMap<String, Value>,


### PR DESCRIPTION
## Summary
- hash mutations and include the hash when queueing transforms
- skip transform execution if mutation hash + transform id already processed
- update tests for new orchestrator behavior

## Testing
- `cargo test --workspace`
- `npm test` *(fails: Missing script: "test")*