### PR TITLE
Fix transform orchestrator test deadlock

### DIFF
--- a/tests/integration_tests/transform_orchestrator_tests.rs
+++ b/tests/integration_tests/transform_orchestrator_tests.rs
@@ -132,6 +132,7 @@ fn processed_prevents_rerun() {
 
     let exec = manager.executed.lock().unwrap();
     assert_eq!(exec.len(), 1);
+    drop(exec);
 
     // New hash should trigger execution
     orchestrator.add_transform("T2", "h6").unwrap();


### PR DESCRIPTION
## Summary
- drop the lock on `executed` before queueing another transform in the `processed_prevents_rerun` test

## Testing
- `cargo test --workspace -- --test-threads=1`
- `npm test` *(fails: Missing script)*