### PR TITLE
Add schema dependency type info

### DIFF
--- a/fold_node/src/datafold_node/static-react/package.json
+++ b/fold_node/src/datafold_node/static-react/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/fold_node/src/datafold_node/static-react/src/App.jsx
+++ b/fold_node/src/datafold_node/static-react/src/App.jsx
@@ -7,6 +7,7 @@ import SchemaTab from './components/tabs/SchemaTab'
 import QueryTab from './components/tabs/QueryTab'
 import MutationTab from './components/tabs/MutationTab'
 import TransformsTab from './components/tabs/TransformsTab'
+import SchemaDependenciesTab from './components/tabs/SchemaDependenciesTab'
 import LogSidebar from './components/LogSidebar'
 
 function App() {
@@ -57,6 +58,8 @@ function App() {
         return <MutationTab schemas={schemas} onResult={handleOperationResult} />
       case 'transforms':
         return <TransformsTab schemas={schemas} onResult={handleOperationResult} />
+      case 'dependencies':
+        return <SchemaDependenciesTab schemas={schemas} />
       default:
         return null
     }
@@ -110,6 +113,16 @@ function App() {
               onClick={() => handleTabChange('transforms')}
             >
               Transforms
+            </button>
+            <button
+              className={`px-4 py-2 text-sm font-medium ${
+                activeTab === 'dependencies'
+                  ? 'text-primary border-b-2 border-primary'
+                  : 'text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              }`}
+              onClick={() => handleTabChange('dependencies')}
+            >
+              Dependencies
             </button>
             </div>
 

--- a/fold_node/src/datafold_node/static-react/src/components/tabs/SchemaDependenciesTab.jsx
+++ b/fold_node/src/datafold_node/static-react/src/components/tabs/SchemaDependenciesTab.jsx
@@ -1,0 +1,30 @@
+import { useMemo } from 'react'
+import { getSchemaDependencies } from '../../utils/dependencyUtils'
+
+function SchemaDependenciesTab({ schemas }) {
+  const dependencies = useMemo(() => getSchemaDependencies(schemas), [schemas])
+
+  return (
+    <div className="p-6 space-y-4">
+      {Object.entries(dependencies).map(([schema, deps]) => (
+        <div key={schema} className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
+          <h3 className="font-medium text-gray-900 mb-2">{schema}</h3>
+          {deps.length === 0 ? (
+            <p className="text-sm text-gray-500">No dependencies</p>
+          ) : (
+            <ul className="list-disc list-inside space-y-1">
+              {deps.map(dep => (
+                <li key={dep.schema} className="text-sm text-gray-700">
+                  {dep.schema}{' '}
+                  <span className="text-gray-500">({dep.types.join(', ')})</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default SchemaDependenciesTab

--- a/fold_node/src/datafold_node/static-react/src/utils/dependencyUtils.js
+++ b/fold_node/src/datafold_node/static-react/src/utils/dependencyUtils.js
@@ -1,0 +1,34 @@
+export function getSchemaDependencies(schemas) {
+  const deps = {}
+  schemas.forEach(schema => {
+    deps[schema.name] = {}
+    if (!schema.fields) return
+    Object.values(schema.fields).forEach(field => {
+      if (field.field_mappers) {
+        Object.keys(field.field_mappers).forEach(srcSchema => {
+          if (srcSchema && srcSchema !== schema.name) {
+            if (!deps[schema.name][srcSchema]) deps[schema.name][srcSchema] = new Set()
+            deps[schema.name][srcSchema].add('field mapper')
+          }
+        })
+      }
+      if (field.transform && Array.isArray(field.transform.inputs)) {
+        field.transform.inputs.forEach(input => {
+          const [schemaName] = input.split('.')
+          if (schemaName && schemaName !== schema.name) {
+            if (!deps[schema.name][schemaName]) deps[schema.name][schemaName] = new Set()
+            deps[schema.name][schemaName].add('transform')
+          }
+        })
+      }
+    })
+  })
+  const result = {}
+  Object.entries(deps).forEach(([schemaName, map]) => {
+    result[schemaName] = Object.entries(map).map(([dep, kinds]) => ({
+      schema: dep,
+      types: Array.from(kinds)
+    }))
+  })
+  return result
+}

--- a/fold_node/src/datafold_node/static-react/tests/dependencyUtils.test.js
+++ b/fold_node/src/datafold_node/static-react/tests/dependencyUtils.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+import { getSchemaDependencies } from '../src/utils/dependencyUtils.js'
+
+test('getSchemaDependencies computes dependencies', () => {
+  const schemas = [
+    { name: 'A', fields: { a1: { field_mappers: {}, transform: null } } },
+    { name: 'B', fields: { b1: { field_mappers: { A: 'a1' } } } },
+    { name: 'C', fields: { c1: { transform: { inputs: ['B.b1', 'A.a1'] } } } }
+  ]
+  const deps = getSchemaDependencies(schemas)
+  assert.deepStrictEqual(deps.A, [])
+  assert.deepStrictEqual(deps.B, [
+    { schema: 'A', types: ['field mapper'] }
+  ])
+  assert.deepStrictEqual(deps.C, [
+    { schema: 'B', types: ['transform'] },
+    { schema: 'A', types: ['transform'] }
+  ])
+})


### PR DESCRIPTION
## Summary
- show dependency kind (transform or field mapper) in new tab
- return dependency type information from the helper
- update unit test for dependency utility

## Testing
- `npm test --silent --prefix fold_node/src/datafold_node/static-react`
- `cargo test --workspace --quiet`