### PR TITLE
Add dependency graph

### DIFF
--- a/fold_node/src/datafold_node/static-react/package.json
+++ b/fold_node/src/datafold_node/static-react/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/fold_node/src/datafold_node/static-react/src/App.jsx
+++ b/fold_node/src/datafold_node/static-react/src/App.jsx
@@ -7,6 +7,7 @@ import SchemaTab from './components/tabs/SchemaTab'
 import QueryTab from './components/tabs/QueryTab'
 import MutationTab from './components/tabs/MutationTab'
 import TransformsTab from './components/tabs/TransformsTab'
+import SchemaDependenciesTab from './components/tabs/SchemaDependenciesTab'
 import LogSidebar from './components/LogSidebar'
 
 function App() {
@@ -57,6 +58,8 @@ function App() {
         return <MutationTab schemas={schemas} onResult={handleOperationResult} />
       case 'transforms':
         return <TransformsTab schemas={schemas} onResult={handleOperationResult} />
+      case 'dependencies':
+        return <SchemaDependenciesTab schemas={schemas} />
       default:
         return null
     }
@@ -110,6 +113,16 @@ function App() {
               onClick={() => handleTabChange('transforms')}
             >
               Transforms
+            </button>
+            <button
+              className={`px-4 py-2 text-sm font-medium ${
+                activeTab === 'dependencies'
+                  ? 'text-primary border-b-2 border-primary'
+                  : 'text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              }`}
+              onClick={() => handleTabChange('dependencies')}
+            >
+              Dependencies
             </button>
             </div>
 

--- a/fold_node/src/datafold_node/static-react/src/components/tabs/SchemaDependenciesTab.jsx
+++ b/fold_node/src/datafold_node/static-react/src/components/tabs/SchemaDependenciesTab.jsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react'
+import { getDependencyGraph } from '../../utils/dependencyUtils'
+
+function SchemaDependenciesTab({ schemas }) {
+  const { nodes, edges } = useMemo(() => getDependencyGraph(schemas), [schemas])
+
+  const nodeWidth = 120
+  const nodeHeight = 40
+  const vSpacing = 60
+  const positions = {}
+  nodes.forEach((name, idx) => {
+    positions[name] = { x: 160, y: idx * (nodeHeight + vSpacing) + 20 }
+  })
+  const svgHeight = nodes.length * (nodeHeight + vSpacing) + 40
+
+  return (
+    <div className="p-6">
+      <svg className="w-full" height={svgHeight}>
+        <defs>
+          <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto" markerUnits="strokeWidth">
+            <path d="M0 0 L10 5 L0 10 Z" fill="currentColor" />
+          </marker>
+        </defs>
+        {edges.map((edge, idx) => {
+          const src = positions[edge.source]
+          const tgt = positions[edge.target]
+          const x1 = src.x + nodeWidth / 2
+          const y1 = src.y + nodeHeight / 2
+          const x2 = tgt.x - nodeWidth / 2
+          const y2 = tgt.y + nodeHeight / 2
+          const midX = (x1 + x2) / 2
+          const midY = (y1 + y2) / 2
+          const color = edge.type === 'transform' ? '#2563eb' : '#16a34a'
+          return (
+            <g key={idx} className="text-xs">
+              <line x1={x1} y1={y1} x2={x2} y2={y2} stroke={color} strokeWidth="2" markerEnd="url(#arrow)" />
+              <text x={midX} y={midY - 4} textAnchor="middle" fill={color}>{edge.type}</text>
+            </g>
+          )
+        })}
+
+        {nodes.map(name => {
+          const pos = positions[name]
+          return (
+            <g key={name} transform={`translate(${pos.x - nodeWidth / 2}, ${pos.y})`}>
+              <rect width={nodeWidth} height={nodeHeight} rx="4" fill="#f9fafb" stroke="#4b5563" />
+              <text x={nodeWidth / 2} y={nodeHeight / 2 + 4} textAnchor="middle" className="text-sm" fill="#111827">
+                {name}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+export default SchemaDependenciesTab

--- a/fold_node/src/datafold_node/static-react/src/utils/dependencyUtils.js
+++ b/fold_node/src/datafold_node/static-react/src/utils/dependencyUtils.js
@@ -1,0 +1,59 @@
+export function getSchemaDependencies(schemas) {
+  const deps = {}
+  schemas.forEach(schema => {
+    deps[schema.name] = new Map()
+  })
+
+  schemas.forEach(schema => {
+    if (!schema.fields) return
+    Object.values(schema.fields).forEach(field => {
+      if (field.field_mappers) {
+        Object.keys(field.field_mappers).forEach(srcSchema => {
+          if (srcSchema && srcSchema !== schema.name) {
+            if (!deps[schema.name].has(srcSchema)) {
+              deps[schema.name].set(srcSchema, new Set())
+            }
+            deps[schema.name].get(srcSchema).add('field_mapper')
+          }
+        })
+      }
+      if (field.transform && Array.isArray(field.transform.inputs)) {
+        field.transform.inputs.forEach(input => {
+          const [schemaName] = input.split('.')
+          if (schemaName && schemaName !== schema.name) {
+            if (!deps[schema.name].has(schemaName)) {
+              deps[schema.name].set(schemaName, new Set())
+            }
+            deps[schema.name].get(schemaName).add('transform')
+          }
+        })
+      }
+    })
+  })
+
+  return Object.fromEntries(
+    Object.entries(deps).map(([schema, map]) => [
+      schema,
+      Array.from(map.entries()).map(([depSchema, types]) => ({
+        schema: depSchema,
+        types: Array.from(types)
+      }))
+    ])
+  )
+}
+
+export function getDependencyGraph(schemas) {
+  const deps = getSchemaDependencies(schemas)
+  const nodes = schemas.map(s => s.name)
+  const edges = []
+
+  Object.entries(deps).forEach(([target, arr]) => {
+    arr.forEach(dep => {
+      dep.types.forEach(type => {
+        edges.push({ source: dep.schema, target, type })
+      })
+    })
+  })
+
+  return { nodes, edges }
+}

--- a/fold_node/src/datafold_node/static-react/tests/dependencyUtils.test.js
+++ b/fold_node/src/datafold_node/static-react/tests/dependencyUtils.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+import { getSchemaDependencies } from '../src/utils/dependencyUtils.js'
+
+test('getSchemaDependencies computes dependencies with types', () => {
+  const schemas = [
+    { name: 'A', fields: { a1: { field_mappers: {}, transform: null } } },
+    { name: 'B', fields: { b1: { field_mappers: { A: 'a1' } } } },
+    { name: 'C', fields: { c1: { transform: { inputs: ['B.b1', 'A.a1'] } } } }
+  ]
+  const deps = getSchemaDependencies(schemas)
+  assert.deepStrictEqual(deps.A, [])
+  assert.deepStrictEqual(deps.B, [
+    { schema: 'A', types: ['field_mapper'] }
+  ])
+  assert.deepStrictEqual(
+    deps.C.sort((a, b) => a.schema.localeCompare(b.schema)),
+    [
+      { schema: 'A', types: ['transform'] },
+      { schema: 'B', types: ['transform'] }
+    ]
+  )
+})


### PR DESCRIPTION
## Summary
- compute schema dependencies with dependency type information
- visualize schema dependencies as a simple SVG graph
- update dependency helper tests

## Testing
- `npm test --silent --prefix fold_node/src/datafold_node/static-react`
- `cargo test --workspace --quiet`
