### PR TITLE
Add field mapper sample schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ Run all unit and integration tests across the workspace:
 cargo test --workspace
 ```
 
+If you encounter `cargo: command not found`, install Rust with `rustup` first:
+
+```bash
+curl https://sh.rustup.rs -sSf | sh
+rustup component add clippy
+```
+
 Run only integration tests:
 
 ```bash

--- a/fold_node/src/datafold_node/sample_manager.rs
+++ b/fold_node/src/datafold_node/sample_manager.rs
@@ -125,6 +125,8 @@ mod tests {
         let schemas = manager.list_schema_samples();
         assert!(schemas.contains(&"UserProfile".to_string()));
         assert!(schemas.contains(&"ProductCatalog".to_string()));
+        assert!(schemas.contains(&"UserProfileView".to_string()));
+        assert!(schemas.contains(&"BlogPostSummary".to_string()));
     }
 }
 

--- a/fold_node/src/datafold_node/samples/data/BlogPostSummary.json
+++ b/fold_node/src/datafold_node/samples/data/BlogPostSummary.json
@@ -1,0 +1,57 @@
+{
+  "name": "BlogPostSummary",
+  "fields": {
+    "post_title": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": { "NoRequirement": null },
+        "write_policy": { "Distance": 0 }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": { "None": null }
+      },
+      "field_mappers": { "BlogPost": "title" }
+    },
+    "summary_content": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": { "NoRequirement": null },
+        "write_policy": { "Distance": 0 }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": { "None": null }
+      },
+      "field_mappers": { "BlogPost": "content" }
+    },
+    "writer": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": { "NoRequirement": null },
+        "write_policy": { "Distance": 0 }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": { "None": null }
+      },
+      "field_mappers": { "BlogPost": "author" }
+    },
+    "posted_on": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": { "NoRequirement": null },
+        "write_policy": { "Distance": 0 }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": { "None": null }
+      },
+      "field_mappers": { "BlogPost": "publish_date" }
+    }
+  },
+  "payment_config": {
+    "base_multiplier": 1.0,
+    "min_payment_threshold": 0
+  }
+}

--- a/fold_node/src/datafold_node/samples/data/UserProfileView.json
+++ b/fold_node/src/datafold_node/samples/data/UserProfileView.json
@@ -1,0 +1,69 @@
+{
+  "name": "UserProfileView",
+  "fields": {
+    "user_name": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": { "NoRequirement": null },
+        "write_policy": { "Distance": 0 }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": { "None": null }
+      },
+      "field_mappers": { "UserProfile": "username" }
+    },
+    "contact_email": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": { "Distance": 1 },
+        "write_policy": { "Distance": 0 }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": { "None": null }
+      },
+      "field_mappers": { "UserProfile": "email" }
+    },
+    "display_name": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": { "Distance": 1 },
+        "write_policy": { "Distance": 0 }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": { "None": null }
+      },
+      "field_mappers": { "UserProfile": "full_name" }
+    },
+    "profile_description": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": { "NoRequirement": null },
+        "write_policy": { "Distance": 0 }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": { "None": null }
+      },
+      "field_mappers": { "UserProfile": "bio" }
+    },
+    "user_location": {
+      "field_type": "Single",
+      "permission_policy": {
+        "read_policy": { "Distance": 2 },
+        "write_policy": { "Distance": 0 }
+      },
+      "payment_config": {
+        "base_multiplier": 1.0,
+        "trust_distance_scaling": { "None": null }
+      },
+      "field_mappers": { "UserProfile": "location" }
+    }
+  },
+  "payment_config": {
+    "base_multiplier": 1.0,
+    "min_payment_threshold": 0
+  }
+}

--- a/tests/integration_tests/http_server_tests.rs
+++ b/tests/integration_tests/http_server_tests.rs
@@ -89,6 +89,8 @@ async fn test_sample_endpoints() {
     assert!(schemas_arr.contains(&Value::String("ProductCatalog".to_string())));
     assert!(schemas_arr.contains(&Value::String("TransformBase".to_string())));
     assert!(schemas_arr.contains(&Value::String("TransformSchema".to_string())));
+    assert!(schemas_arr.contains(&Value::String("UserProfileView".to_string())));
+    assert!(schemas_arr.contains(&Value::String("BlogPostSummary".to_string())));
     let resp = client
         .get(format!("http://{}/api/samples/schema/UserProfile", addr))
         .send()
@@ -126,6 +128,25 @@ async fn test_sample_endpoints() {
     assert!(resp.status().is_success());
     let schema: Value = resp.json().await.unwrap();
     assert_eq!(schema["name"], "TransformSchema");
+
+    // Verify new schema samples with field mappers
+    let resp = client
+        .get(format!("http://{}/api/samples/schema/UserProfileView", addr))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let schema: Value = resp.json().await.unwrap();
+    assert_eq!(schema["name"], "UserProfileView");
+
+    let resp = client
+        .get(format!("http://{}/api/samples/schema/BlogPostSummary", addr))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let schema: Value = resp.json().await.unwrap();
+    assert_eq!(schema["name"], "BlogPostSummary");
 
     // Query samples
     let resp = client


### PR DESCRIPTION
## Summary
- add `UserProfileView` and `BlogPostSummary` schemas demonstrating field mappers
- assert new samples in the SampleManager tests
- extend HTTP server tests to verify the new schemas
- document how to install rust and clippy if `cargo` isn't found

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: `cargo-clippy` not installed)*
- `npm test`