### PR TITLE
Remove local env_logger patch from fold_node

### DIFF
--- a/fold_node/Cargo.toml
+++ b/fold_node/Cargo.toml
@@ -89,5 +89,3 @@ path = "examples/transform_logic_test.rs"
 name = "complex_transform_dsl"
 path = "examples/complex_transform_dsl.rs"
 
-[patch.crates-io]
-env_logger = { path = "../vendor/env_logger" }


### PR DESCRIPTION
## Summary
- remove the `[patch.crates-io]` section from `fold_node/Cargo.toml`

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: component not installed)*
- `npm test` in `fold_node/src/datafold_node/static-react`