### PR TITLE
Remove stray comment from DataFold Node library

### DIFF
--- a/fold_node/src/lib.rs
+++ b/fold_node/src/lib.rs
@@ -51,4 +51,3 @@ pub use network::{NetworkConfig, NetworkCore, NetworkError, NetworkResult, PeerI
 pub use schema::types::operation::Operation;
 pub use schema::types::operations::MutationType;
 pub use schema::Schema;
-// Test comment


### PR DESCRIPTION
## Summary
- remove trailing comment in `fold_node/src/lib.rs`

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: `'cargo-clippy' is not installed`)*
- `npm test` in `fold_node/src/datafold_node/static-react`