### PR TITLE
Support schema unload state

### DIFF
--- a/fold_node/src/datafold_node/db.rs
+++ b/fold_node/src/datafold_node/db.rs
@@ -89,7 +89,7 @@ impl DataFoldNode {
             .db
             .lock()
             .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
-        let schema_names = db.schema_manager.list_schemas()?;
+        let schema_names = db.schema_manager.list_loaded_schemas()?;
         let mut schemas = Vec::new();
         for name in schema_names {
             if let Some(schema) = db.schema_manager.get_schema(&name)? {
@@ -97,6 +97,15 @@ impl DataFoldNode {
             }
         }
         Ok(schemas)
+    }
+
+    /// List the names of all schemas available on disk.
+    pub fn list_available_schemas(&self) -> FoldDbResult<Vec<String>> {
+        let db = self
+            .db
+            .lock()
+            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
+        Ok(db.schema_manager.list_available_schemas()?)
     }
 
     /// Executes a query against the database.
@@ -153,6 +162,15 @@ impl DataFoldNode {
             .lock()
             .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
         db.remove_schema(schema_name).map_err(|e| e.into())
+    }
+
+    /// Mark a schema as unloaded without removing its transforms.
+    pub fn set_schema_unloaded(&mut self, schema_name: &str) -> FoldDbResult<()> {
+        let db = self
+            .db
+            .lock()
+            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
+        db.set_schema_unloaded(schema_name).map_err(|e| e.into())
     }
 
     /// List all registered transforms.

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -538,4 +538,9 @@ impl FoldDB {
             ))),
         }
     }
+
+    /// Mark a schema as unloaded without removing transforms.
+    pub fn set_schema_unloaded(&self, schema_name: &str) -> Result<(), SchemaError> {
+        self.schema_manager.set_unloaded(schema_name)
+    }
 }

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -7,6 +7,7 @@ pub mod transform_orchestrator_tests;
 pub mod transform_enqueue_tests;
 pub mod http_server_tests;
 pub mod schema_unload_transform_tests;
+pub mod schema_set_unloaded_tests;
 pub mod transform_output_schema_tests;
 pub mod transform_sample_execution_tests;
 pub mod transform_manager_persistence_tests;

--- a/tests/integration_tests/schema_set_unloaded_tests.rs
+++ b/tests/integration_tests/schema_set_unloaded_tests.rs
@@ -1,0 +1,38 @@
+use fold_node::testing::{
+    PermissionsPolicy, FieldPaymentConfig, FieldType, Schema, SchemaField,
+    TrustDistance, TrustDistanceScaling,
+};
+use fold_node::transform::{Transform, TransformParser};
+use crate::test_data::test_helpers::create_test_node;
+
+#[test]
+fn set_unloaded_keeps_transforms() {
+    let mut node = create_test_node();
+
+    let mut schema = Schema::new("UnloadSchema".to_string());
+    let parser = TransformParser::new();
+    let expr = parser.parse_expression("1 + 2").unwrap();
+    let transform = Transform::new_with_expr(
+        "1 + 2".to_string(),
+        expr,
+        "UnloadSchema.calc".to_string(),
+    );
+    let field = SchemaField::new(
+        PermissionsPolicy::new(TrustDistance::Distance(0), TrustDistance::Distance(0)),
+        FieldPaymentConfig::new(1.0, TrustDistanceScaling::None, None).unwrap(),
+        std::collections::HashMap::new(),
+        Some(FieldType::Single),
+    )
+    .with_transform(transform);
+    schema.add_field("calc".to_string(), field);
+
+    node.load_schema(schema).unwrap();
+    node.allow_schema("UnloadSchema").unwrap();
+
+    assert!(node.list_transforms().unwrap().contains_key("UnloadSchema.calc"));
+
+    node.set_schema_unloaded("UnloadSchema").unwrap();
+
+    assert!(node.list_transforms().unwrap().contains_key("UnloadSchema.calc"));
+    assert!(node.get_schema("UnloadSchema").unwrap().is_none());
+}


### PR DESCRIPTION
## Summary
- add `SchemaState` enum for loaded/unloaded schemas
- track all schemas in `SchemaCore::available`
- expose schema state management through `set_schema_unloaded`
- update DataFoldNode and FoldDB APIs
- test that transforms persist after unloading

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: `cargo-clippy` is not installed)*
- `npm test` in `fold_node/src/datafold_node/static-react`