### PR TITLE
Add unload_schema wrapper

### DIFF
--- a/fold_node/src/datafold_node/db.rs
+++ b/fold_node/src/datafold_node/db.rs
@@ -165,12 +165,18 @@ impl DataFoldNode {
     }
 
     /// Mark a schema as unloaded without removing its transforms.
-    pub fn set_schema_unloaded(&mut self, schema_name: &str) -> FoldDbResult<()> {
+    pub fn unload_schema(&mut self, schema_name: &str) -> FoldDbResult<()> {
         let db = self
             .db
             .lock()
             .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
-        db.set_schema_unloaded(schema_name).map_err(|e| e.into())
+        db.unload_schema(schema_name).map_err(|e| e.into())
+    }
+
+    /// Deprecated alias for [`unload_schema`].
+    #[allow(dead_code)]
+    pub fn set_schema_unloaded(&mut self, schema_name: &str) -> FoldDbResult<()> {
+        self.unload_schema(schema_name)
     }
 
     /// List all registered transforms.

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -540,7 +540,13 @@ impl FoldDB {
     }
 
     /// Mark a schema as unloaded without removing transforms.
-    pub fn set_schema_unloaded(&self, schema_name: &str) -> Result<(), SchemaError> {
+    pub fn unload_schema(&self, schema_name: &str) -> Result<(), SchemaError> {
         self.schema_manager.set_unloaded(schema_name)
+    }
+
+    /// Deprecated alias for [`unload_schema`].
+    #[allow(dead_code)]
+    pub fn set_schema_unloaded(&self, schema_name: &str) -> Result<(), SchemaError> {
+        self.unload_schema(schema_name)
     }
 }

--- a/tests/integration_tests/schema_set_unloaded_tests.rs
+++ b/tests/integration_tests/schema_set_unloaded_tests.rs
@@ -6,7 +6,7 @@ use fold_node::transform::{Transform, TransformParser};
 use crate::test_data::test_helpers::create_test_node;
 
 #[test]
-fn set_unloaded_keeps_transforms() {
+fn unload_schema_keeps_transforms() {
     let mut node = create_test_node();
 
     let mut schema = Schema::new("UnloadSchema".to_string());
@@ -31,7 +31,7 @@ fn set_unloaded_keeps_transforms() {
 
     assert!(node.list_transforms().unwrap().contains_key("UnloadSchema.calc"));
 
-    node.set_schema_unloaded("UnloadSchema").unwrap();
+    node.unload_schema("UnloadSchema").unwrap();
 
     assert!(node.list_transforms().unwrap().contains_key("UnloadSchema.calc"));
     assert!(node.get_schema("UnloadSchema").unwrap().is_none());


### PR DESCRIPTION
## Summary
- add `unload_schema` helper that keeps transforms
- update integration tests to use new method

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: `cargo-clippy` is not installed)*
- `npm test` in `fold_node/src/datafold_node/static-react`