### PR TITLE
Implement schema removal and listing APIs

### DIFF
--- a/fold_node/src/datafold_node/README_TCP_SERVER.md
+++ b/fold_node/src/datafold_node/README_TCP_SERVER.md
@@ -98,9 +98,13 @@ The TCP server uses a simple protocol for communication:
 
 The TCP server supports the following operations:
 
-- `list_schemas`: List all available schemas
+- `list_schemas`: List schemas currently loaded
+- `list_available_schemas`: List all schemas stored on disk
 - `get_schema`: Get a schema by name
 - `create_schema`: Create a new schema
+- `update_schema`: Replace an existing schema
+- `unload_schema`: Unload a schema from memory
+- `remove_schema`: Delete a schema from disk
 - `query`: Query data from a schema
 - `mutation`: Mutate data in a schema
 - `discover_nodes`: Discover remote nodes


### PR DESCRIPTION
## Summary
- add ability to remove schemas from disk
- expose list of available schemas and remove schema via TCP server
- document new TCP operations
- test schema removal in `DataFoldNode`

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: `cargo-clippy` component not installed)*
- `npm test`