### PR TITLE
Add unload_schema wrapper

### DIFF
--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -515,6 +515,6 @@ impl FoldDB {
 
     /// Mark a schema as unloaded without removing transforms.
     pub fn unload_schema(&self, schema_name: &str) -> Result<(), SchemaError> {
-        self.schema_manager.set_unloaded(schema_name)
+        self.schema_manager.unload_schema(schema_name)
     }
 }

--- a/fold_node/src/schema/core.rs
+++ b/fold_node/src/schema/core.rs
@@ -134,8 +134,8 @@ impl SchemaCore {
         Ok(())
     }
 
-    /// Unloads a schema from the manager and removes its persistent storage.
-    pub fn unload_schema(&self, schema_name: &str) -> Result<bool, SchemaError> {
+    /// Removes a schema from the manager and deletes its persistent storage.
+    pub fn delete_schema(&self, schema_name: &str) -> Result<bool, SchemaError> {
         let mut schemas = self
             .schemas
             .lock()
@@ -221,6 +221,11 @@ impl SchemaCore {
         } else {
             Err(SchemaError::NotFound(format!("Schema {schema_name} not found")))
         }
+    }
+
+    /// Unload a schema from memory without deleting its persisted file.
+    pub fn unload_schema(&self, schema_name: &str) -> Result<(), SchemaError> {
+        self.set_unloaded(schema_name)
     }
 
     /// Loads all schema files from the schemas directory.
@@ -518,8 +523,8 @@ mod tests {
             Some("test_uuid".to_string())
         );
 
-        // Test unload removes file
-        core.unload_schema(test_schema_name).unwrap();
+        // Test delete removes file
+        core.delete_schema(test_schema_name).unwrap();
         assert!(!schema_path.exists());
 
         cleanup_test_schema(test_schema_name);

--- a/fold_node/tests/schema_tests.rs
+++ b/fold_node/tests/schema_tests.rs
@@ -111,8 +111,8 @@ fn test_schema_persistence() {
     let reloaded_schema = new_manager.get_schema("test_persistence").unwrap().unwrap();
     assert_eq!(reloaded_schema.name, "test_persistence");
 
-    // Test schema unloading
-    assert!(manager.unload_schema("test_persistence").unwrap());
+    // Test schema deletion
+    assert!(manager.delete_schema("test_persistence").unwrap());
 
     // Verify schema was removed
     let removed_schema = manager.get_schema("test_persistence").unwrap();


### PR DESCRIPTION
## Summary
- introduce `unload_schema` method in `SchemaCore`
- rename destructive `unload_schema` to `delete_schema`
- update `FoldDB` to use new method
- adjust tests

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: component not installed)*
- `npm test` in `fold_node/src/datafold_node/static-react`