### PR TITLE
Disable schema deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ See **datafold_api_examples/** for Python scripts that demonstrate:
 
 - Creating a user
 - Listing schemas
+- Unloading schemas
 - Querying data
 - Executing mutations
 - Updating records

--- a/fold_node/src/datafold_node/schema_routes.rs
+++ b/fold_node/src/datafold_node/schema_routes.rs
@@ -68,7 +68,7 @@ pub async fn unload_schema_route(path: web::Path<String>, state: web::Data<AppSt
 
     match node_guard.unload_schema(&name) {
         Ok(_) => HttpResponse::Ok().json(json!({"success": true})),
-        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to delete schema: {}", e)})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to unload schema: {}", e)})),
     }
 }
 

--- a/fold_node/tests/schema_tests.rs
+++ b/fold_node/tests/schema_tests.rs
@@ -111,8 +111,8 @@ fn test_schema_persistence() {
     let reloaded_schema = new_manager.get_schema("test_persistence").unwrap().unwrap();
     assert_eq!(reloaded_schema.name, "test_persistence");
 
-    // Test schema deletion
-    assert!(manager.delete_schema("test_persistence").unwrap());
+    // Unload the schema
+    assert!(manager.unload_schema("test_persistence").is_ok());
 
     // Verify schema was removed
     let removed_schema = manager.get_schema("test_persistence").unwrap();


### PR DESCRIPTION
## Summary
- remove `delete_schema` from the schema core
- update error text in schema routes
- adjust unit tests that expected deletion
- document how to unload schemas

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: clippy component missing)*
- `npm test`