### PR TITLE
Add unified API response struct

### DIFF
--- a/cline_docs/datafold_node_api.md
+++ b/cline_docs/datafold_node_api.md
@@ -22,6 +22,16 @@ All HTTP routes are prefixed with `/api`.
 | `DELETE` | `/schema/{name}` | Unload a schema without deleting it from disk. |
 | `POST` | `/execute` | Execute a query or mutation operation. |
 
+All responses share the same JSON structure:
+
+```json
+{
+  "success": true,
+  "data": {},
+  "error": null
+}
+```
+
 The TCP protocol accepts the same operations. Additional operation `list_available_schemas` returns all schemas stored on disk with their state.
 
 ### Example: Unload a Schema via HTTP

--- a/fold_node/src/datafold_node/mod.rs
+++ b/fold_node/src/datafold_node/mod.rs
@@ -26,6 +26,7 @@ pub mod tcp_server;
 pub mod tcp_protocol;
 pub mod tcp_connections;
 pub mod tests;
+pub mod unified_response;
 
 // Re-export the DataFoldNode struct for easier imports
 pub use config::NodeConfig;
@@ -35,3 +36,4 @@ pub use sample_manager::SampleManager;
 pub use loader::load_schema_from_file;
 pub use node::DataFoldNode;
 pub use tcp_server::TcpServer;
+pub use unified_response::UnifiedResponse;

--- a/fold_node/src/datafold_node/query_routes.rs
+++ b/fold_node/src/datafold_node/query_routes.rs
@@ -2,6 +2,7 @@ use super::http_server::AppState;
 use actix_web::{web, HttpResponse, Responder};
 use serde::Deserialize;
 use serde_json::{json, Value};
+use super::unified_response::UnifiedResponse;
 use crate::schema::types::Operation;
 
 /// Execute an operation (query or mutation).
@@ -19,15 +20,21 @@ pub async fn execute_operation(
     let operation: Operation = match serde_json::from_str(operation_str) {
         Ok(op) => op,
         Err(e) => {
-            return HttpResponse::BadRequest().json(json!({"error": format!("Failed to parse operation: {}", e)}));
+            return HttpResponse::Ok().json(UnifiedResponse::error(format!(
+                "Failed to parse operation: {}",
+                e
+            )));
         }
     };
 
     let mut node_guard = state.node.lock().await;
 
     match node_guard.execute_operation(operation) {
-        Ok(result) => HttpResponse::Ok().json(json!({"data": result})),
-        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to execute operation: {}", e)})),
+        Ok(result) => HttpResponse::Ok().json(UnifiedResponse::success(Some(result))),
+        Err(e) => HttpResponse::Ok().json(UnifiedResponse::error(format!(
+            "Failed to execute operation: {}",
+            e
+        ))),
     }
 }
 
@@ -36,50 +43,68 @@ pub async fn execute_query(query: web::Json<Value>, state: web::Data<AppState>) 
     let operation = match serde_json::from_value::<Operation>(query.into_inner()) {
         Ok(op) => match op {
             Operation::Query { .. } => op,
-            _ => return HttpResponse::BadRequest().json(json!({"error": "Expected a query operation"})),
+            _ => return HttpResponse::Ok().json(UnifiedResponse::error("Expected a query operation")),
         },
-        Err(e) => return HttpResponse::BadRequest().json(json!({"error": format!("Failed to parse query: {}", e)})),
+        Err(e) => return HttpResponse::Ok().json(UnifiedResponse::error(format!("Failed to parse query: {}", e))),
     };
 
     let mut node_guard = state.node.lock().await;
 
     match node_guard.execute_operation(operation) {
-        Ok(result) => HttpResponse::Ok().json(json!({"data": result})),
-        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to execute query: {}", e)})),
+        Ok(result) => HttpResponse::Ok().json(UnifiedResponse::success(Some(result))),
+        Err(e) => HttpResponse::Ok().json(UnifiedResponse::error(format!("Failed to execute query: {}", e))),
     }
 }
 
 /// Execute a mutation.
-pub async fn execute_mutation(mutation: web::Json<Value>, state: web::Data<AppState>) -> impl Responder {
+pub async fn execute_mutation(
+    mutation: web::Json<Value>,
+    state: web::Data<AppState>,
+) -> impl Responder {
     let operation = match serde_json::from_value::<Operation>(mutation.into_inner()) {
         Ok(op) => match op {
             Operation::Mutation { .. } => op,
-            _ => return HttpResponse::BadRequest().json(json!({"error": "Expected a mutation operation"})),
+            _ => {
+                return HttpResponse::Ok()
+                    .json(UnifiedResponse::error("Expected a mutation operation"));
+            }
         },
-        Err(e) => return HttpResponse::BadRequest().json(json!({"error": format!("Failed to parse mutation: {}", e)})),
+        Err(e) => {
+            return HttpResponse::Ok()
+                .json(UnifiedResponse::error(format!("Failed to parse mutation: {}", e)));
+        }
     };
 
     let mut node_guard = state.node.lock().await;
 
     match node_guard.execute_operation(operation) {
-        Ok(_) => HttpResponse::Ok().json(json!({"success": true})),
-        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to execute mutation: {}", e)})),
+        Ok(_) => HttpResponse::Ok().json(UnifiedResponse::success(None)),
+        Err(e) => HttpResponse::Ok().json(UnifiedResponse::error(format!(
+            "Failed to execute mutation: {}",
+            e
+        ))),
     }
 }
 
 /// List all sample schemas.
 pub async fn list_schema_samples(state: web::Data<AppState>) -> impl Responder {
-    HttpResponse::Ok().json(json!({"data": state.sample_manager.list_schema_samples()}))
+    HttpResponse::Ok().json(UnifiedResponse::success(Some(json!(
+        state.sample_manager.list_schema_samples()
+    ))) )
 }
 
 /// List all sample queries.
 pub async fn list_query_samples(state: web::Data<AppState>) -> impl Responder {
-    HttpResponse::Ok().json(json!({"data": state.sample_manager.list_query_samples()}))
+    HttpResponse::Ok().json(UnifiedResponse::success(Some(json!(
+        state.sample_manager.list_query_samples()
+    ))) )
 }
 
 /// List all sample mutations.
 pub async fn list_mutation_samples(state: web::Data<AppState>) -> impl Responder {
-    HttpResponse::Ok().json(json!({"data": state.sample_manager.list_mutation_samples()}))
+    HttpResponse::Ok().json(UnifiedResponse::success(Some(json!(
+        state.sample_manager.list_mutation_samples()
+    ))) )
 }
 
 /// Get a sample schema by name.
@@ -87,8 +112,11 @@ pub async fn get_schema_sample(path: web::Path<String>, state: web::Data<AppStat
     let name = path.into_inner();
 
     match state.sample_manager.get_schema_sample(&name) {
-        Some(schema) => HttpResponse::Ok().json(schema),
-        None => HttpResponse::NotFound().json(json!({"error": format!("Sample schema '{}' not found", name)})),
+        Some(schema) => HttpResponse::Ok().json(UnifiedResponse::success(Some(schema.clone()))),
+        None => HttpResponse::Ok().json(UnifiedResponse::error(format!(
+            "Sample schema '{}' not found",
+            name
+        ))),
     }
 }
 
@@ -97,8 +125,11 @@ pub async fn get_query_sample(path: web::Path<String>, state: web::Data<AppState
     let name = path.into_inner();
 
     match state.sample_manager.get_query_sample(&name) {
-        Some(query) => HttpResponse::Ok().json(query),
-        None => HttpResponse::NotFound().json(json!({"error": format!("Sample query '{}' not found", name)})),
+        Some(query) => HttpResponse::Ok().json(UnifiedResponse::success(Some(query.clone()))),
+        None => HttpResponse::Ok().json(UnifiedResponse::error(format!(
+            "Sample query '{}' not found",
+            name
+        ))),
     }
 }
 
@@ -107,16 +138,19 @@ pub async fn get_mutation_sample(path: web::Path<String>, state: web::Data<AppSt
     let name = path.into_inner();
 
     match state.sample_manager.get_mutation_sample(&name) {
-        Some(mutation) => HttpResponse::Ok().json(mutation),
-        None => HttpResponse::NotFound().json(json!({"error": format!("Sample mutation '{}' not found", name)})),
+        Some(mutation) => HttpResponse::Ok().json(UnifiedResponse::success(Some(mutation.clone()))),
+        None => HttpResponse::Ok().json(UnifiedResponse::error(format!(
+            "Sample mutation '{}' not found",
+            name
+        ))),
     }
 }
 
 pub async fn list_transforms(state: web::Data<AppState>) -> impl Responder {
     let node = state.node.lock().await;
     match node.list_transforms() {
-        Ok(map) => HttpResponse::Ok().json(json!({ "data": map })),
-        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to list transforms: {}", e) })),
+        Ok(map) => HttpResponse::Ok().json(UnifiedResponse::success(Some(json!(map)))),
+        Err(e) => HttpResponse::Ok().json(UnifiedResponse::error(format!("Failed to list transforms: {}", e))),
     }
 }
 
@@ -124,8 +158,8 @@ pub async fn run_transform(path: web::Path<String>, state: web::Data<AppState>) 
     let id = path.into_inner();
     let mut node = state.node.lock().await;
     match node.run_transform(&id) {
-        Ok(val) => HttpResponse::Ok().json(json!({ "data": val })),
-        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to run transform: {}", e) })),
+        Ok(val) => HttpResponse::Ok().json(UnifiedResponse::success(Some(json!(val)))),
+        Err(e) => HttpResponse::Ok().json(UnifiedResponse::error(format!("Failed to run transform: {}", e))),
     }
 }
 
@@ -136,23 +170,32 @@ pub async fn add_to_transform_queue(path: web::Path<String>, state: web::Data<Ap
     match node.list_transforms() {
         Ok(transforms) => {
             if !transforms.contains_key(&transform_id) {
-                return HttpResponse::NotFound().json(json!({"error": format!("Transform '{}' not found. Available transforms: {:?}", transform_id, transforms.keys().collect::<Vec<_>>())}));
+                return HttpResponse::Ok().json(UnifiedResponse::error(format!(
+                    "Transform '{}' not found. Available transforms: {:?}",
+                    transform_id,
+                    transforms.keys().collect::<Vec<_>>()
+                )));
             }
         }
-        Err(e) => return HttpResponse::InternalServerError().json(json!({"error": format!("Failed to verify transform: {}", e)})),
+        Err(e) => {
+            return HttpResponse::Ok()
+                .json(UnifiedResponse::error(format!("Failed to verify transform: {}", e)));
+        }
     }
 
     match node.add_transform_to_queue(&transform_id) {
-        Ok(_) => HttpResponse::Ok().json(json!({"success": true, "message": format!("Transform '{}' added to queue", transform_id)})),
-        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to add transform to queue: {}", e)})),
+        Ok(_) => HttpResponse::Ok().json(UnifiedResponse::success(Some(json!({
+            "message": format!("Transform '{}' added to queue", transform_id)
+        })))),
+        Err(e) => HttpResponse::Ok().json(UnifiedResponse::error(format!("Failed to add transform to queue: {}", e))),
     }
 }
 
 pub async fn get_transform_queue(state: web::Data<AppState>) -> impl Responder {
     let node = state.node.lock().await;
     match node.get_transform_queue_info() {
-        Ok(info) => HttpResponse::Ok().json(info),
-        Err(e) => HttpResponse::InternalServerError().json(json!({ "error": format!("Failed to get transform queue info: {}", e) })),
+        Ok(info) => HttpResponse::Ok().json(UnifiedResponse::success(Some(json!(info)))),
+        Err(e) => HttpResponse::Ok().json(UnifiedResponse::error(format!("Failed to get transform queue info: {}", e))),
     }
 }
 

--- a/fold_node/src/datafold_node/tcp_connections.rs
+++ b/fold_node/src/datafold_node/tcp_connections.rs
@@ -4,10 +4,10 @@ use log::{error, info};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 
-use super::{DataFoldNode, TcpServer};
+use super::{DataFoldNode, TcpServer, unified_response::UnifiedResponse};
 use crate::datafold_node::tcp_protocol::{read_request, send_response};
 use crate::error::{FoldDbError, FoldDbResult};
-use serde_json::json;
+use serde_json::to_value;
 
 impl TcpServer {
     /// Handle a single client connection.
@@ -24,7 +24,10 @@ impl TcpServer {
                 Ok(resp) => resp,
                 Err(e) => {
                     error!("Error processing request: {}", e);
-                    json!({ "error": format!("Error processing request: {}", e) })
+                    to_value(UnifiedResponse::error(format!(
+                        "Error processing request: {}",
+                        e
+                    )))?
                 }
             };
 

--- a/fold_node/src/datafold_node/unified_response.rs
+++ b/fold_node/src/datafold_node/unified_response.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+use serde_json::Value;
+
+/// Unified response type for HTTP and TCP APIs
+#[derive(Serialize)]
+pub struct UnifiedResponse {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl UnifiedResponse {
+    /// Create a success response with optional data
+    pub fn success(data: Option<Value>) -> Self {
+        Self { success: true, data, error: None }
+    }
+
+    /// Create an error response
+    pub fn error<E: ToString>(msg: E) -> Self {
+        Self { success: false, data: None, error: Some(msg.to_string()) }
+    }
+}

--- a/tests/integration_tests/http_server_tests.rs
+++ b/tests/integration_tests/http_server_tests.rs
@@ -45,7 +45,7 @@ async fn test_get_schema_route() {
         .unwrap();
     assert!(resp.status().is_success());
     let body: Value = resp.json().await.unwrap();
-    assert_eq!(body["name"], "UserProfile");
+    assert_eq!(body["data"]["name"], "UserProfile");
     handle.abort();
 }
 
@@ -98,7 +98,7 @@ async fn test_sample_endpoints() {
         .unwrap();
     assert!(resp.status().is_success());
     let schema: Value = resp.json().await.unwrap();
-    assert_eq!(schema["name"], "UserProfile");
+    assert_eq!(schema["data"]["name"], "UserProfile");
 
     // Verify second sample as well
     let resp = client
@@ -108,7 +108,7 @@ async fn test_sample_endpoints() {
         .unwrap();
     assert!(resp.status().is_success());
     let schema: Value = resp.json().await.unwrap();
-    assert_eq!(schema["name"], "ProductCatalog");
+    assert_eq!(schema["data"]["name"], "ProductCatalog");
 
     // Verify transform sample schemas
     let resp = client
@@ -118,7 +118,7 @@ async fn test_sample_endpoints() {
         .unwrap();
     assert!(resp.status().is_success());
     let schema: Value = resp.json().await.unwrap();
-    assert_eq!(schema["name"], "TransformBase");
+    assert_eq!(schema["data"]["name"], "TransformBase");
 
     let resp = client
         .get(format!("http://{}/api/samples/schema/TransformSchema", addr))
@@ -127,7 +127,7 @@ async fn test_sample_endpoints() {
         .unwrap();
     assert!(resp.status().is_success());
     let schema: Value = resp.json().await.unwrap();
-    assert_eq!(schema["name"], "TransformSchema");
+    assert_eq!(schema["data"]["name"], "TransformSchema");
 
     // Verify new schema samples with field mappers
     let resp = client
@@ -137,7 +137,7 @@ async fn test_sample_endpoints() {
         .unwrap();
     assert!(resp.status().is_success());
     let schema: Value = resp.json().await.unwrap();
-    assert_eq!(schema["name"], "UserProfileView");
+    assert_eq!(schema["data"]["name"], "UserProfileView");
 
     let resp = client
         .get(format!("http://{}/api/samples/schema/BlogPostSummary", addr))
@@ -146,7 +146,7 @@ async fn test_sample_endpoints() {
         .unwrap();
     assert!(resp.status().is_success());
     let schema: Value = resp.json().await.unwrap();
-    assert_eq!(schema["name"], "BlogPostSummary");
+    assert_eq!(schema["data"]["name"], "BlogPostSummary");
 
     // Query samples
     let resp = client
@@ -400,7 +400,9 @@ async fn test_unload_schema_keeps_transforms() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+    assert!(resp.status().is_success());
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["success"], false);
 
     let resp = client
         .get(format!("http://{}/api/transforms", addr))


### PR DESCRIPTION
## Summary
- introduce `UnifiedResponse` and re-export it
- update query, schema and network routes to respond with unified JSON
- adapt TCP server and connections to emit the same structure
- update docs and integration tests for new layout

## Testing
- `cargo test --workspace`
- `npm test`