### PR TITLE
Add AtomRefRange type

### DIFF
--- a/fold_node/src/atom/mod.rs
+++ b/fold_node/src/atom/mod.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 use uuid::Uuid;
 
 mod atom_ref;
-pub use atom_ref::{AtomRef, AtomRefBehavior, AtomRefCollection, AtomRefStatus};
+pub use atom_ref::{
+    AtomRef, AtomRefBehavior, AtomRefCollection, AtomRefRange, AtomRefStatus,
+};
 
 /// An immutable data container that represents a single version of content in the database.
 ///

--- a/fold_node/src/testing.rs
+++ b/fold_node/src/testing.rs
@@ -11,7 +11,9 @@ pub use crate::permissions::PermissionWrapper;
 
 pub use crate::fees::{FieldPaymentConfig, SchemaPaymentConfig, TrustDistanceScaling};
 
-pub use crate::atom::{Atom, AtomRef, AtomRefBehavior, AtomRefCollection, AtomStatus};
+pub use crate::atom::{
+    Atom, AtomRef, AtomRefBehavior, AtomRefCollection, AtomRefRange, AtomStatus,
+};
 
 use serde_json::Value;
 use std::collections::HashMap;

--- a/fold_node/tests/atom_manager_tests.rs
+++ b/fold_node/tests/atom_manager_tests.rs
@@ -202,5 +202,30 @@ fn test_reference_updates() {
             .unwrap(),
         &col_atom2.uuid().to_string()
     );
+
+    // range update
+    let range_uuid = Uuid::new_v4().to_string();
+    let range_atom1 = manager
+        .create_atom("schema", "key".to_string(), None, json!("r1"), None)
+        .unwrap();
+    manager
+        .update_atom_ref_range(
+            &range_uuid,
+            range_atom1.uuid().to_string(),
+            "a".to_string(),
+            "key".to_string(),
+        )
+        .unwrap();
+    let range_map = manager.get_ref_ranges();
+    assert_eq!(
+        range_map
+            .lock()
+            .unwrap()
+            .get(&range_uuid)
+            .unwrap()
+            .get_atom_uuid("a")
+            .unwrap(),
+        &range_atom1.uuid().to_string()
+    );
 }
 


### PR DESCRIPTION
## Summary
- implement `AtomRefRange` backed by `BTreeMap`
- expose the new type in public modules and testing utilities
- support persisting range refs via `DbOperations` and `AtomManager`
- test the range reference logic and persistence

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: `cargo-clippy` not installed)*
- `npm test` in `fold_node/src/datafold_node/static-react`