### PR TITLE
Add Range field type

### DIFF
--- a/fold_node/tests/manager_tests.rs
+++ b/fold_node/tests/manager_tests.rs
@@ -160,5 +160,6 @@ fn test_atom_context_type_validation() {
     let mut ctx = AtomContext::new(&schema, "single", "key".to_string(), &mut atom_manager);
     assert!(ctx.validate_field_type(FieldType::Single).is_ok());
     assert!(ctx.validate_field_type(FieldType::Collection).is_err());
+    assert!(ctx.validate_field_type(FieldType::Range).is_err());
 }
 


### PR DESCRIPTION
## Summary
- add `Range` variant to `FieldType`
- expose `is_range` on `SchemaField`
- support `FieldType::Range` in `AtomContext`
- test `Range` parsing and behavior

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: `cargo-clippy` is not installed)*
- `npm test` in `fold_node/src/datafold_node/static-react`