### PR TITLE
Add fold state tracking

### DIFF
--- a/fold_node/src/bin/datafold_cli.rs
+++ b/fold_node/src/bin/datafold_cli.rs
@@ -48,6 +48,8 @@ enum Commands {
     },
     /// List all loaded folds
     ListFolds {},
+    /// List all folds available on disk
+    ListAvailableFolds {},
     /// Get a fold by name
     GetFold {
         /// Fold name to retrieve
@@ -131,6 +133,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_list_available_folds() {
+        let cli = Cli::parse_from(["test", "list-available-folds"]);
+        matches!(cli.command, Commands::ListAvailableFolds {});
+    }
+
+    #[test]
     fn parse_get_fold() {
         let cli = Cli::parse_from(["test", "get-fold", "--name", "foo"]);
         match cli.command {
@@ -183,6 +191,15 @@ fn handle_list_folds(node: &mut DataFoldNode) -> Result<(), Box<dyn std::error::
     let folds = node.list_folds()?;
     info!("Loaded folds:");
     for name in folds {
+        info!("  - {}", name);
+    }
+    Ok(())
+}
+
+fn handle_list_available_folds(node: &mut DataFoldNode) -> Result<(), Box<dyn std::error::Error>> {
+    let names = node.list_available_folds()?;
+    info!("Available folds:");
+    for name in names {
         info!("  - {}", name);
     }
     Ok(())
@@ -338,6 +355,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::UnloadSchema { name } => handle_unload_schema(name, &mut node)?,
         Commands::LoadFold { path } => handle_load_fold(path, &mut node)?,
         Commands::ListFolds {} => handle_list_folds(&mut node)?,
+        Commands::ListAvailableFolds {} => handle_list_available_folds(&mut node)?,
         Commands::GetFold { name } => handle_get_fold(name, &mut node)?,
         Commands::UnloadFold { name } => handle_unload_fold(name, &mut node)?,
         Commands::Execute { path } => handle_execute(path, &mut node)?,

--- a/fold_node/src/datafold_node/db.rs
+++ b/fold_node/src/datafold_node/db.rs
@@ -191,6 +191,24 @@ impl DataFoldNode {
         Ok(db.list_folds()?)
     }
 
+    /// List all loaded folds.
+    pub fn list_loaded_folds(&self) -> FoldDbResult<Vec<String>> {
+        let db = self
+            .db
+            .lock()
+            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
+        Ok(db.list_loaded_folds()?)
+    }
+
+    /// List all folds available on disk.
+    pub fn list_available_folds(&self) -> FoldDbResult<Vec<String>> {
+        let db = self
+            .db
+            .lock()
+            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
+        Ok(db.list_available_folds()?)
+    }
+
     /// Unload a fold from memory.
     pub fn unload_fold(&self, name: &str) -> FoldDbResult<()> {
         let db = self

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -541,6 +541,16 @@ impl FoldDB {
         self.fold_manager.list_folds()
     }
 
+    /// List names of all loaded folds.
+    pub fn list_loaded_folds(&self) -> Result<Vec<String>, SchemaError> {
+        self.fold_manager.list_loaded_folds()
+    }
+
+    /// List names of all folds stored on disk.
+    pub fn list_available_folds(&self) -> Result<Vec<String>, SchemaError> {
+        self.fold_manager.list_available_folds()
+    }
+
     /// Unload a fold from memory without removing it from disk.
     pub fn unload_fold(&self, name: &str) -> Result<(), SchemaError> {
         self.fold_manager.unload_fold(name)


### PR DESCRIPTION
## Summary
- add `FoldState` and track loaded/unloaded folds
- expose fold state queries in FoldDB core and DataFoldNode
- support listing available folds in CLI
- test fold manager state tracking

## Testing
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings` *(fails: `cargo-clippy` component not installed)*
- `npm test`