### PR TITLE
Deprecate schema module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 DataFold is a Rust-based distributed data platform providing a core library, a node server, and a command‑line interface to load schemas, run queries, and execute mutations across connected nodes.
 
+**Note:** The legacy schema system is now deprecated. New development should use fold definitions in place of schemas.
+
 ## Repository Structure
 
 - **src/**  

--- a/README_CLI.md
+++ b/README_CLI.md
@@ -2,6 +2,8 @@
 
 A command-line interface for interacting with the DataFold node, allowing you to load schemas, run queries, and execute mutations.
 
+**Note:** The schema commands are deprecated and will be removed in favor of fold-based workflows.
+
 ## Installation
 
 The CLI is built as part of the main project. To build it, run:

--- a/fold_node/src/lib.rs
+++ b/fold_node/src/lib.rs
@@ -34,6 +34,7 @@ pub mod fold_db_core;
 pub mod fold;
 pub mod network;
 pub mod permissions;
+#[deprecated(note = "schema module is deprecated, use fold definitions instead")]
 pub mod schema;
 pub mod transform;
 pub mod testing;
@@ -49,9 +50,13 @@ pub use fold_db_core::FoldDB;
 pub use network::{NetworkConfig, NetworkCore, NetworkError, NetworkResult, PeerId, SchemaService};
 
 // Re-export schema types needed for CLI
+#[allow(deprecated)]
 pub use schema::types::operation::Operation;
+#[allow(deprecated)]
 pub use schema::types::operations::MutationType;
+#[allow(deprecated)]
 pub use schema::Schema;
+#[allow(deprecated)]
 pub use schema::types::Fold;
 pub use fold::FoldManager;
 pub use fold::FoldError;


### PR DESCRIPTION
## Summary
- mark `schema` module deprecated in library
- mention the deprecation in docs

## Testing
- `cargo test --workspace`
- `npm test` in `fold_node/src/datafold_node/static-react`
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails: `cargo-clippy` not installed)*