### PR TITLE
Add fold management HTTP API and tests

### DIFF
--- a/fold_node/src/datafold_node/fold_routes.rs
+++ b/fold_node/src/datafold_node/fold_routes.rs
@@ -1,0 +1,94 @@
+use super::http_server::AppState;
+use crate::schema::types::Fold;
+use actix_web::{web, HttpResponse, Responder};
+use serde_json::json;
+use log::{info, error};
+
+/// List all folds.
+pub async fn list_folds(state: web::Data<AppState>) -> impl Responder {
+    info!("Received request to list folds");
+    let node_guard = state.node.lock().await;
+
+    match node_guard.list_folds() {
+        Ok(folds) => HttpResponse::Ok().json(json!({"data": folds})),
+        Err(e) => {
+            error!("Failed to list folds: {}", e);
+            HttpResponse::InternalServerError().json(json!({"error": format!("Failed to list folds: {}", e)}))
+        }
+    }
+}
+
+/// Get a fold by name.
+pub async fn get_fold(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
+    let name = path.into_inner();
+    let node_guard = state.node.lock().await;
+
+    match node_guard.get_fold(&name) {
+        Ok(Some(fold)) => HttpResponse::Ok().json(fold),
+        Ok(None) => HttpResponse::NotFound().json(json!({"error": format!("Fold '{}' not found", name)})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to get fold: {}", e)})),
+    }
+}
+
+/// Create a new fold.
+pub async fn load_fold(fold: web::Json<Fold>, state: web::Data<AppState>) -> impl Responder {
+    let mut node_guard = state.node.lock().await;
+
+    match node_guard.load_fold(fold.into_inner()) {
+        Ok(_) => HttpResponse::Created().json(json!({"success": true})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to create fold: {}", e)})),
+    }
+}
+
+/// Update an existing fold.
+pub async fn update_fold(path: web::Path<String>, fold: web::Json<Fold>, state: web::Data<AppState>) -> impl Responder {
+    let name = path.into_inner();
+    let fold_data = fold.into_inner();
+
+    if fold_data.name != name {
+        return HttpResponse::BadRequest().json(json!({"error": format!("Fold name '{}' does not match path '{}'", fold_data.name, name)}));
+    }
+
+    let mut node_guard = state.node.lock().await;
+
+    let _ = node_guard.unload_fold(&name);
+
+    match node_guard.load_fold(fold_data) {
+        Ok(_) => HttpResponse::Ok().json(json!({"success": true})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to update fold: {}", e)})),
+    }
+}
+
+/// Unload a fold so it is no longer active.
+pub async fn unload_fold_route(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
+    let name = path.into_inner();
+    let mut node_guard = state.node.lock().await;
+
+    match node_guard.unload_fold(&name) {
+        Ok(_) => HttpResponse::Ok().json(json!({"success": true})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to unload fold: {}", e)})),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datafold_node::{DataFoldNode, config::NodeConfig};
+    use actix_web::web;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn list_folds_empty() {
+        let dir = tempdir().unwrap();
+        let config = NodeConfig::new(dir.path().to_path_buf());
+        let node = DataFoldNode::new(config).unwrap();
+        let state = web::Data::new(super::super::http_server::AppState {
+            node: std::sync::Arc::new(tokio::sync::Mutex::new(node)),
+            sample_manager: super::super::sample_manager::SampleManager { schemas: Default::default(), queries: Default::default(), mutations: Default::default() }
+        });
+        use actix_web::test;
+        let req = test::TestRequest::default().to_http_request();
+        let resp = list_folds(state).await.respond_to(&req);
+        assert_eq!(resp.status(), 200);
+    }
+}

--- a/fold_node/src/datafold_node/http_server.rs
+++ b/fold_node/src/datafold_node/http_server.rs
@@ -2,7 +2,7 @@ use crate::datafold_node::DataFoldNode;
 use crate::error::{FoldDbError, FoldDbResult};
 use crate::schema::Schema;
 use super::sample_manager::SampleManager;
-use super::{schema_routes, query_routes, network_routes};
+use super::{schema_routes, query_routes, network_routes, fold_routes};
 use super::log_routes;
 
 use actix_cors::Cors;
@@ -131,6 +131,12 @@ impl DataFoldHttpServer {
                         .route("/schema", web::post().to(schema_routes::create_schema))
                         .route("/schema/{name}", web::put().to(schema_routes::update_schema))
                         .route("/schema/{name}", web::delete().to(schema_routes::unload_schema_route))
+                        // Fold endpoints
+                        .route("/folds", web::get().to(fold_routes::list_folds))
+                        .route("/fold/{name}", web::get().to(fold_routes::get_fold))
+                        .route("/fold", web::post().to(fold_routes::load_fold))
+                        .route("/fold/{name}", web::put().to(fold_routes::update_fold))
+                        .route("/fold/{name}", web::delete().to(fold_routes::unload_fold_route))
                         // Operation endpoints
                         .route("/execute", web::post().to(query_routes::execute_operation))
                         .route("/query", web::post().to(query_routes::execute_query))

--- a/fold_node/src/datafold_node/mod.rs
+++ b/fold_node/src/datafold_node/mod.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub mod http_server;
 pub mod sample_manager;
 pub mod schema_routes;
+pub mod fold_routes;
 pub mod query_routes;
 pub mod network_routes;
 pub mod loader;


### PR DESCRIPTION
## Summary
- implement new fold HTTP routes mirroring schema routes
- register fold routes in the HTTP server
- cover fold API endpoints with integration tests

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: component not installed)*
- `npm test`