### PR TITLE
Add fold API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,42 @@ The **Network** tab exposes new peer‑to‑peer features:
 These operations map to the `/api/network/*` endpoints served by
 `datafold_http_server`.
 
+### Fold HTTP API
+
+The HTTP server also exposes endpoints for managing **folds**. The basic
+routes mirror the schema API but operate on fold definitions:
+
+```
+GET    /api/folds              # list loaded folds
+POST   /api/fold               # create a fold from JSON
+GET    /api/fold/<NAME>        # retrieve a fold by name
+PUT    /api/fold/<NAME>        # update an existing fold
+DELETE /api/fold/<NAME>        # unload a fold
+```
+
+Example `curl` usage:
+
+```bash
+# Create a fold from fold.json
+curl -X POST http://localhost:9001/api/fold \
+  -H 'Content-Type: application/json' \
+  -d @fold.json
+
+# List all folds
+curl http://localhost:9001/api/folds
+
+# Retrieve the newly created fold
+curl http://localhost:9001/api/fold/my_fold
+
+# Update the fold
+curl -X PUT http://localhost:9001/api/fold/my_fold \
+  -H 'Content-Type: application/json' \
+  -d @fold.json
+
+# Unload the fold
+curl -X DELETE http://localhost:9001/api/fold/my_fold
+```
+
 ## Running Tests
 
 Run all unit and integration tests across the workspace:

--- a/README_CLI.md
+++ b/README_CLI.md
@@ -124,6 +124,32 @@ Unload a fold so it is no longer active:
 datafold_cli unload-fold --name <FOLD>
 ```
 
+### HTTP Fold API
+
+The fold commands correspond to `/api/fold` HTTP endpoints. You can
+manage folds directly with `curl` when the HTTP server is running.
+
+```bash
+# Add a fold from fold.json
+curl -X POST http://localhost:9001/api/fold \
+  -H 'Content-Type: application/json' \
+  -d @fold.json
+
+# List folds
+curl http://localhost:9001/api/folds
+
+# Get a fold
+curl http://localhost:9001/api/fold/my_fold
+
+# Update a fold
+curl -X PUT http://localhost:9001/api/fold/my_fold \
+  -H 'Content-Type: application/json' \
+  -d @fold.json
+
+# Unload a fold
+curl -X DELETE http://localhost:9001/api/fold/my_fold
+```
+
 #### Query
 
 Execute a query operation:


### PR DESCRIPTION
## Summary
- document fold-based HTTP API usage
- show example curl calls for creating, listing and deleting folds

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: `'cargo-clippy' is not installed`)*
- `npm test`