### PR TITLE
Configure Node test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ cargo test --package fold_node
 
 ### UI Tests
 
-The React UI can include its own test suite. If a `test` script exists in the
+The React UI uses Node's built-in test runner. If a `test` script exists in the
 package configuration, run the tests with:
 
 1. Install Node.js dependencies:

--- a/fold_node/src/datafold_node/static-react/package.json
+++ b/fold_node/src/datafold_node/static-react/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"No frontend tests configured\""
+    "test": "node --test tests/dependencyUtils.test.js"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
## Summary
- enable Node test runner for UI
- document updated frontend test command

## Testing
- `npm test` in `fold_node/src/datafold_node/static-react`
- `cargo test --workspace`
- `cargo clippy` *(fails: 'cargo-clippy' is not installed)*