### PR TITLE
Deprecate schema module and CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Additional server flags:
 ### Command‑Line Interface
 
 See [README_CLI.md](README_CLI.md) for detailed CLI commands: loading schemas and folds, listing them, querying, mutating, and executing operations from JSON.
+Schema-related CLI commands (`load-schema`, `list-schemas`, `list-available-schemas`, and `unload-schema`) are deprecated and will be removed in a future release.
 
 ### Running a DataFold Node
 

--- a/README_CLI.md
+++ b/README_CLI.md
@@ -46,6 +46,8 @@ active). `list-available-schemas` displays all schemas with either state.
 
 ### Commands
 
+**Deprecated:** `load-schema`, `list-schemas`, `list-available-schemas`, and `unload-schema` will be removed in a future release. Use fold commands instead.
+
 #### Load Schema
 
 Load a schema from a JSON file:

--- a/fold_node/src/bin/datafold_cli.rs
+++ b/fold_node/src/bin/datafold_cli.rs
@@ -25,16 +25,20 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Load a schema from a JSON file
+    #[deprecated(note = "Schema commands are deprecated and will be removed")] 
     LoadSchema {
         /// Path to the schema JSON file
         #[arg(required = true)]
         path: PathBuf,
     },
     /// List all loaded schemas
+    #[deprecated(note = "Schema commands are deprecated and will be removed")]
     ListSchemas {},
     /// List all schemas available on disk
+    #[deprecated(note = "Schema commands are deprecated and will be removed")]
     ListAvailableSchemas {},
     /// Unload a schema
+    #[deprecated(note = "Schema commands are deprecated and will be removed")]
     UnloadSchema {
         /// Schema name to unload
         #[arg(long, short, required = true)]
@@ -103,6 +107,7 @@ enum Commands {
 }
 
 fn handle_load_schema(path: PathBuf, node: &mut DataFoldNode) -> Result<(), Box<dyn std::error::Error>> {
+    warn!("Schema commands are deprecated and will be removed");
     info!("Loading schema from: {}", path.display());
     load_schema_from_file(path, node)?;
     info!("Schema loaded successfully");
@@ -149,6 +154,7 @@ mod tests {
 }
 
 fn handle_list_schemas(node: &mut DataFoldNode) -> Result<(), Box<dyn std::error::Error>> {
+    warn!("Schema commands are deprecated and will be removed");
     let schemas = node.list_schemas()?;
     info!("Loaded schemas:");
     for schema in schemas {
@@ -158,6 +164,7 @@ fn handle_list_schemas(node: &mut DataFoldNode) -> Result<(), Box<dyn std::error
 }
 
 fn handle_list_available_schemas(node: &mut DataFoldNode) -> Result<(), Box<dyn std::error::Error>> {
+    warn!("Schema commands are deprecated and will be removed");
     let names = node.list_available_schemas()?;
     info!("Available schemas:");
     for name in names {
@@ -167,6 +174,7 @@ fn handle_list_available_schemas(node: &mut DataFoldNode) -> Result<(), Box<dyn 
 }
 
 fn handle_unload_schema(name: String, node: &mut DataFoldNode) -> Result<(), Box<dyn std::error::Error>> {
+    warn!("Schema commands are deprecated and will be removed");
     node.unload_schema(&name)?;
     info!("Schema '{}' unloaded", name);
     Ok(())

--- a/fold_node/src/lib.rs
+++ b/fold_node/src/lib.rs
@@ -34,7 +34,6 @@ pub mod fold_db_core;
 pub mod fold;
 pub mod network;
 pub mod permissions;
-#[deprecated(note = "schema module is deprecated, use fold definitions instead")]
 pub mod schema;
 pub mod transform;
 pub mod testing;

--- a/fold_node/src/schema/mod.rs
+++ b/fold_node/src/schema/mod.rs
@@ -21,6 +21,8 @@
 //! Schemas are loaded from JSON definitions, validated, and then used to process
 //! queries and mutations against the database.
 
+#![deprecated(note = "The schema module is deprecated and will be removed in a future release. Use fold definitions instead.")]
+
 // Internal modules
 pub(crate) mod core;
 pub mod types;

--- a/fold_node/src/schema/types/field.rs
+++ b/fold_node/src/schema/types/field.rs
@@ -116,6 +116,7 @@ macro_rules! impl_field {
 }
 
 /// Field storing a single value.
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SingleField {
     inner: FieldCommon,
@@ -137,6 +138,7 @@ impl SingleField {
 impl_field!(SingleField);
 
 /// Field storing a collection of values.
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CollectionField {
     inner: FieldCommon,
@@ -158,6 +160,7 @@ impl CollectionField {
 impl_field!(CollectionField);
 
 /// Field storing a range of values.
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RangeField {
     inner: FieldCommon,

--- a/fold_node/src/schema/types/fields.rs
+++ b/fold_node/src/schema/types/fields.rs
@@ -38,6 +38,7 @@ impl fmt::Display for FieldType {
 /// - Specific payment requirements for data access
 /// - Links to stored data through atom references
 /// - Transformation mappings for schema evolution
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize)] // Removed Deserialize
 pub struct SchemaField {
     /// Permission policy controlling read/write access to this field

--- a/fold_node/src/schema/types/fold.rs
+++ b/fold_node/src/schema/types/fold.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 /// A Fold mirrors the behaviour of a `Schema` but stores its
 /// fields using the `FieldVariant` type so that each field can
 /// be represented as a `SingleField`, `CollectionField` or `RangeField`.
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Fold {
     /// Unique name identifying this fold

--- a/fold_node/src/schema/types/json_fold.rs
+++ b/fold_node/src/schema/types/json_fold.rs
@@ -8,6 +8,7 @@ use crate::transform::parser::TransformParser;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonFoldDefinition {
     pub name: String,
@@ -15,6 +16,7 @@ pub struct JsonFoldDefinition {
     pub payment_config: SchemaPaymentConfig,
 }
 
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonFoldField {
     pub permission_policy: JsonPermissionPolicy,

--- a/fold_node/src/schema/types/json_schema.rs
+++ b/fold_node/src/schema/types/json_schema.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Represents a complete JSON schema definition
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonSchemaDefinition {
     pub name: String,
@@ -18,6 +19,7 @@ pub struct JsonSchemaDefinition {
 }
 
 /// Represents a field in the JSON schema
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonSchemaField {
     pub permission_policy: JsonPermissionPolicy,
@@ -36,6 +38,7 @@ pub struct JsonSchemaField {
 /// fields in the incoming JSON will cause a deserialization error so
 /// that stale attributes such as `reversible` or `signature` do not
 /// silently pass through the system.
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct JsonTransform {
@@ -51,6 +54,7 @@ pub struct JsonTransform {
 }
 
 /// JSON representation of permission policy
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonPermissionPolicy {
     #[serde(rename = "read_policy")]
@@ -64,6 +68,7 @@ pub struct JsonPermissionPolicy {
 }
 
 /// JSON representation of field payment config
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonFieldPaymentConfig {
     pub base_multiplier: f64,

--- a/fold_node/src/schema/types/operations.rs
+++ b/fold_node/src/schema/types/operations.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Query {
     pub schema_name: String,
@@ -68,6 +69,7 @@ impl<'de> Deserialize<'de> for MutationType {
     }
 }
 
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize)]
 pub struct Mutation {
     pub schema_name: String,

--- a/fold_node/src/schema/types/schema.rs
+++ b/fold_node/src/schema/types/schema.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 /// - Proper access control
 /// - Payment validation
 /// - Data transformation rules
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Schema {
     /// Unique name identifying this schema

--- a/fold_node/src/schema/types/transform.rs
+++ b/fold_node/src/schema/types/transform.rs
@@ -29,6 +29,7 @@ use crate::transform::ast::TransformDeclaration;
 /// ```
 /// Parameters for registering a transform
 #[derive(Debug, Clone)]
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Serialize, Deserialize)]
 pub struct TransformRegistration {
     /// The ID of the transform
@@ -50,6 +51,7 @@ pub struct TransformRegistration {
     pub field_name: String,
 }
 
+#[deprecated(note = "Schema system is deprecated and will be removed")]
 #[derive(Debug, Clone, Serialize)]
 pub struct Transform {
     /// Explicit input fields in `Schema.field` format


### PR DESCRIPTION
## Summary
- mark schema module and types as deprecated
- warn when using schema CLI commands
- document deprecation in README files

## Testing
- `cargo test --workspace`
- `cargo clippy` *(fails: 'cargo-clippy' not installed)*
- `npm test`