### PR TITLE
Enable CLI folds for query/mutate

### DIFF
--- a/README_CLI.md
+++ b/README_CLI.md
@@ -155,11 +155,11 @@ curl -X DELETE http://localhost:9001/api/fold/my_fold
 Execute a query operation:
 
 ```bash
-datafold_cli query --schema <SCHEMA> --fields <FIELDS> [--filter <FILTER>] [--output <OUTPUT>]
+datafold_cli query --fold <FOLD> --fields <FIELDS> [--filter <FILTER>] [--output <OUTPUT>]
 ```
 
 Options:
-- `-s, --schema <SCHEMA>`: Schema name to query
+- `-s, --fold <FOLD>`: Fold name to query
 - `-f, --fields <FIELDS>`: Fields to retrieve (comma-separated)
 - `-i, --filter <FILTER>`: Optional filter in JSON format
 - `-o, --output <OUTPUT>`: Output format (json or pretty, default: pretty)
@@ -167,13 +167,13 @@ Options:
 Example:
 
 ```bash
-datafold_cli query --schema UserProfile --fields username,email
+datafold_cli query --fold UserProfile --fields username,email
 ```
 
 With filter:
 
 ```bash
-datafold_cli query --schema UserProfile --fields username,email --filter '{"username": "johndoe"}'
+datafold_cli query --fold UserProfile --fields username,email --filter '{"username": "johndoe"}'
 ```
 
 #### Mutate
@@ -181,11 +181,11 @@ datafold_cli query --schema UserProfile --fields username,email --filter '{"user
 Execute a mutation operation:
 
 ```bash
-datafold_cli mutate --schema <SCHEMA> --mutation-type <MUTATION_TYPE> --data <DATA>
+datafold_cli mutate --fold <FOLD> --mutation-type <MUTATION_TYPE> --data <DATA>
 ```
 
 Options:
-- `-s, --schema <SCHEMA>`: Schema name to mutate
+- `-s, --fold <FOLD>`: Fold name to mutate
 - `-m, --mutation-type <MUTATION_TYPE>`: Mutation type (see `--help` for allowed values)
 - `-d, --data <DATA>`: Data in JSON format
 
@@ -197,25 +197,25 @@ Mutation types:
 Example:
 
 ```bash
-datafold_cli mutate --schema UserProfile --mutation-type create --data '{"username": "johndoe", "email": "john@example.com"}'
+datafold_cli mutate --fold UserProfile --mutation-type create --data '{"username": "johndoe", "email": "john@example.com"}'
 ```
 
 Add to collection:
 
 ```bash
-datafold_cli mutate --schema UserProfile --mutation-type add_to_collection:friends --data '{"id": "friend42"}'
+datafold_cli mutate --fold UserProfile --mutation-type add_to_collection:friends --data '{"id": "friend42"}'
 ```
 
 Update in collection:
 
 ```bash
-datafold_cli mutate --schema UserProfile --mutation-type update_to_collection:friends --data '{"id": "friend42", "nickname": "JD"}'
+datafold_cli mutate --fold UserProfile --mutation-type update_to_collection:friends --data '{"id": "friend42", "nickname": "JD"}'
 ```
 
 Delete from collection:
 
 ```bash
-datafold_cli mutate --schema UserProfile --mutation-type delete_from_collection:friends --data '{"id": "friend42"}'
+datafold_cli mutate --fold UserProfile --mutation-type delete_from_collection:friends --data '{"id": "friend42"}'
 ```
 
 #### Execute

--- a/fold_node/src/bin/datafold_cli.rs
+++ b/fold_node/src/bin/datafold_cli.rs
@@ -68,9 +68,9 @@ enum Commands {
     },
     /// Execute a query operation
     Query {
-        /// Schema name to query
-        #[arg(short, long, required = true)]
-        schema: String,
+        /// Fold name to query
+        #[arg(short = 'n', long, required = true)]
+        fold: String,
 
         /// Fields to retrieve (comma-separated)
         #[arg(short, long, required = true, value_delimiter = ',')]
@@ -86,9 +86,9 @@ enum Commands {
     },
     /// Execute a mutation operation
     Mutate {
-        /// Schema name to mutate
-        #[arg(short, long, required = true)]
-        schema: String,
+        /// Fold name to mutate
+        #[arg(short = 'n', long, required = true)]
+        fold: String,
 
         /// Mutation type
         #[arg(short, long, required = true, value_enum)]
@@ -230,12 +230,12 @@ fn handle_unload_fold(name: String, node: &mut DataFoldNode) -> Result<(), Box<d
 
 fn handle_query(
     node: &mut DataFoldNode,
-    schema: String,
+    fold: String,
     fields: Vec<String>,
     filter: Option<String>,
     output: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Executing query on schema: {}", schema);
+    info!("Executing query on fold: {}", fold);
 
     let filter_value = if let Some(filter_str) = filter {
         Some(serde_json::from_str(&filter_str)?)
@@ -244,7 +244,7 @@ fn handle_query(
     };
 
     let operation = Operation::Query {
-        schema,
+        schema: fold,
         fields,
         filter: filter_value,
     };
@@ -262,16 +262,16 @@ fn handle_query(
 
 fn handle_mutate(
     node: &mut DataFoldNode,
-    schema: String,
+    fold: String,
     mutation_type: MutationType,
     data: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Executing mutation on schema: {}", schema);
+    info!("Executing mutation on fold: {}", fold);
 
     let data_value: Value = serde_json::from_str(&data)?;
 
     let operation = Operation::Mutation {
-        schema,
+        schema: fold,
         data: data_value,
         mutation_type,
     };
@@ -350,16 +350,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::ListSchemas {} => handle_list_schemas(&mut node)?,
         Commands::ListAvailableSchemas {} => handle_list_available_schemas(&mut node)?,
         Commands::Query {
-            schema,
+            fold,
             fields,
             filter,
             output,
-        } => handle_query(&mut node, schema, fields, filter, output)?,
+        } => handle_query(&mut node, fold, fields, filter, output)?,
         Commands::Mutate {
-            schema,
+            fold,
             mutation_type,
             data,
-        } => handle_mutate(&mut node, schema, mutation_type, data)?,
+        } => handle_mutate(&mut node, fold, mutation_type, data)?,
         Commands::UnloadSchema { name } => handle_unload_schema(name, &mut node)?,
         Commands::LoadFold { path } => handle_load_fold(path, &mut node)?,
         Commands::ListFolds {} => handle_list_folds(&mut node)?,

--- a/tests/cli/cli_tests.rs
+++ b/tests/cli/cli_tests.rs
@@ -57,20 +57,18 @@ fn cli_path() -> PathBuf {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let exe = manifest_dir.join("target/debug/datafold_cli");
 
-    if !exe.exists() {
-        // Build the CLI binary if it hasn't been compiled yet
-        let status = Command::new("cargo")
-            .args([
-                "build",
-                "--manifest-path",
-                "fold_node/Cargo.toml",
-                "--bin",
-                "datafold_cli",
-            ])
-            .status()
-            .expect("failed to build datafold_cli");
-        assert!(status.success());
-    }
+    // Build the CLI binary to ensure it is up to date
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "--manifest-path",
+            "fold_node/Cargo.toml",
+            "--bin",
+            "datafold_cli",
+        ])
+        .status()
+        .expect("failed to build datafold_cli");
+    assert!(status.success());
 
     exe
 }
@@ -111,7 +109,7 @@ fn mutate_query_execute() {
             "-c",
             config.to_str().unwrap(),
             "mutate",
-            "--schema",
+            "--fold",
             "TestSchema",
             "--mutation-type",
             "create",
@@ -127,7 +125,7 @@ fn mutate_query_execute() {
             "-c",
             config.to_str().unwrap(),
             "query",
-            "--schema",
+            "--fold",
             "TestSchema",
             "--fields",
             "username",


### PR DESCRIPTION
## Summary
- allow CLI query/mutate commands to target folds
- adjust tests to use `--fold`
- document `--fold` flag usage

## Testing
- `cargo test --workspace` *(fails: long build; output truncated)*
- `cargo clippy`
- `npm test`