### PR TITLE
Add RangeField mutation and query handling

### DIFF
--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -10,3 +10,4 @@ pub mod schema_set_unloaded_tests;
 pub mod transform_output_schema_tests;
 pub mod transform_sample_execution_tests;
 pub mod transform_manager_persistence_tests;
+pub mod range_field_node_tests;

--- a/tests/integration_tests/range_field_node_tests.rs
+++ b/tests/integration_tests/range_field_node_tests.rs
@@ -1,0 +1,40 @@
+use fold_node::testing::{Mutation, MutationType};
+use serde_json::json;
+use crate::test_data::schema_test_data::create_range_field_schema;
+use crate::test_data::test_helpers::create_test_node;
+
+#[test]
+fn test_range_field_mutations_and_queries() {
+    let mut node = create_test_node();
+    let schema = create_range_field_schema();
+    crate::test_data::test_helpers::node_operations::load_and_allow(&mut node, schema).unwrap();
+
+    // insert first value
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("numbers".to_string(), json!({"key": "a", "value": 1}));
+    let mut1 = Mutation::new("range_schema".to_string(), fields, String::new(), 0, MutationType::Create);
+    node.mutate(mut1).unwrap();
+
+    let val = crate::test_data::test_helpers::node_operations::query_value(&mut node, "range_schema", "numbers").unwrap();
+    assert_eq!(val, json!({"a": 1}));
+
+    // update existing key
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("numbers".to_string(), json!({"key": "a", "value": 2}));
+    let mut2 = Mutation::new("range_schema".to_string(), fields, String::new(), 0, MutationType::Update);
+    node.mutate(mut2).unwrap();
+
+    let val = crate::test_data::test_helpers::node_operations::query_value(&mut node, "range_schema", "numbers").unwrap();
+    assert_eq!(val, json!({"a": 2}));
+
+    // add second key
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("numbers".to_string(), json!({"key": "b", "value": 3}));
+    let mut3 = Mutation::new("range_schema".to_string(), fields, String::new(), 0, MutationType::Create);
+    node.mutate(mut3).unwrap();
+
+    let val = crate::test_data::test_helpers::node_operations::query_value(&mut node, "range_schema", "numbers").unwrap();
+    assert_eq!(val, json!({"a": 2, "b": 3}));
+
+}
+

--- a/tests/test_data/schema_test_data.rs
+++ b/tests/test_data/schema_test_data.rs
@@ -1,5 +1,6 @@
 use fold_node::testing::{
-    FieldPaymentConfig, PermissionsPolicy, Schema, FieldVariant, SingleField, TrustDistance, TrustDistanceScaling,
+    FieldPaymentConfig, PermissionsPolicy, Schema, FieldVariant, SingleField, RangeField,
+    TrustDistance, TrustDistanceScaling,
 };
 use std::collections::HashMap;
 
@@ -116,5 +117,18 @@ pub fn create_multi_field_schema() -> Schema {
         );
     }
 
+    schema
+}
+
+#[allow(dead_code)]
+pub fn create_range_field_schema() -> Schema {
+    let mut schema = Schema::new("range_schema".to_string());
+    let range_field = RangeField::new_with_range(
+        PermissionsPolicy::new(TrustDistance::Distance(1), TrustDistance::Distance(1)),
+        create_default_payment_config(),
+        HashMap::new(),
+        "test_key".to_string(),
+    );
+    schema.add_field("numbers".to_string(), FieldVariant::Range(range_field));
     schema
 }


### PR DESCRIPTION
## Summary
- implement `create_range_field_schema` for tests
- support range key operations via `create_and_update_range_atom`
- extend field manager logic for `RangeField`
- add integration test covering range field mutations and queries

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test`