### PR TITLE
Add schema load/unload UI

### DIFF
--- a/fold_node/src/datafold_node/db.rs
+++ b/fold_node/src/datafold_node/db.rs
@@ -166,6 +166,20 @@ impl DataFoldNode {
         db.unload_schema(schema_name).map_err(|e| e.into())
     }
 
+    /// Load an available schema by name.
+    pub fn load_available_schema(&mut self, schema_name: &str) -> FoldDbResult<()> {
+        let mut db = self
+            .db
+            .lock()
+            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
+        db.schema_manager
+            .load_available_schema(schema_name)
+            .map_err(FoldDbError::from)?;
+        drop(db);
+        self.grant_schema_permission(schema_name)?;
+        Ok(())
+    }
+
 
     /// List all registered transforms.
     pub fn list_transforms(&self) -> FoldDbResult<HashMap<String, Transform>> {

--- a/fold_node/src/datafold_node/http_server.rs
+++ b/fold_node/src/datafold_node/http_server.rs
@@ -127,10 +127,12 @@ impl DataFoldHttpServer {
                     web::scope("/api")
                         // Schema endpoints
                         .route("/schemas", web::get().to(schema_routes::list_schemas))
+                        .route("/schemas/available", web::get().to(schema_routes::list_available_schemas_route))
                         .route("/schema/{name}", web::get().to(schema_routes::get_schema))
                         .route("/schema", web::post().to(schema_routes::create_schema))
                         .route("/schema/{name}", web::put().to(schema_routes::update_schema))
                         .route("/schema/{name}", web::delete().to(schema_routes::unload_schema_route))
+                        .route("/schema/load/{name}", web::post().to(schema_routes::load_available_schema_route))
                         // Operation endpoints
                         .route("/execute", web::post().to(query_routes::execute_operation))
                         .route("/query", web::post().to(query_routes::execute_query))

--- a/fold_node/src/datafold_node/schema_routes.rs
+++ b/fold_node/src/datafold_node/schema_routes.rs
@@ -20,6 +20,20 @@ pub async fn list_schemas(state: web::Data<AppState>) -> impl Responder {
     }
 }
 
+/// List schemas available on disk.
+pub async fn list_available_schemas_route(state: web::Data<AppState>) -> impl Responder {
+    info!("Received request to list available schemas");
+    let node_guard = state.node.lock().await;
+
+    match node_guard.list_available_schemas() {
+        Ok(names) => HttpResponse::Ok().json(json!({"data": names})),
+        Err(e) => {
+            error!("Failed to list available schemas: {}", e);
+            HttpResponse::InternalServerError().json(json!({"error": format!("Failed to list available schemas: {}", e)}))
+        }
+    }
+}
+
 /// Get a schema by name.
 pub async fn get_schema(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
     let name = path.into_inner();
@@ -69,6 +83,17 @@ pub async fn unload_schema_route(path: web::Path<String>, state: web::Data<AppSt
     match node_guard.unload_schema(&name) {
         Ok(_) => HttpResponse::Ok().json(json!({"success": true})),
         Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to unload schema: {}", e)})),
+    }
+}
+
+/// Load a schema from disk by name.
+pub async fn load_available_schema_route(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
+    let name = path.into_inner();
+    let mut node_guard = state.node.lock().await;
+
+    match node_guard.load_available_schema(&name) {
+        Ok(_) => HttpResponse::Ok().json(json!({"success": true})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": format!("Failed to load schema: {}", e)})),
     }
 }
 

--- a/fold_node/src/datafold_node/static-react/src/test/components/tabs/SchemasTab.test.jsx
+++ b/fold_node/src/datafold_node/static-react/src/test/components/tabs/SchemasTab.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import SchemasTab from '../../../components/tabs/SchemasTab'
+
+describe('SchemasTab Component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ name: 'User' }] })
+    }).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: ['User', 'Blog'] })
+    })
+  })
+
+  it('fetches loaded and available schemas on mount', async () => {
+    render(<SchemasTab />)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/schemas')
+      expect(fetch).toHaveBeenCalledWith('/api/schemas/available')
+    })
+  })
+
+  it('unloads schema on button click', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ name: 'User' }] })
+    }).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [] })
+    }).mockResolvedValueOnce({ ok: true })
+
+    render(<SchemasTab />)
+
+    await waitFor(() => {
+      expect(screen.getByText('User')).toBeInTheDocument()
+    })
+
+    const btn = screen.getByText('Unload')
+    fireEvent.click(btn)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/schema/User', { method: 'DELETE' })
+    })
+  })
+})

--- a/fold_node/src/schema/core.rs
+++ b/fold_node/src/schema/core.rs
@@ -177,6 +177,23 @@ impl SchemaCore {
         Ok(schemas.contains_key(schema_name))
     }
 
+    /// Load a schema from the available list by name.
+    pub fn load_available_schema(&self, schema_name: &str) -> Result<(), SchemaError> {
+        let schema = {
+            let available = self
+                .available
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("Failed to acquire schema lock".to_string()))?;
+            if let Some((schema, _)) = available.get(schema_name) {
+                schema.clone()
+            } else {
+                return Err(SchemaError::NotFound(format!("Schema {schema_name} not found")));
+            }
+        };
+
+        self.load_schema(schema)
+    }
+
     /// Mark a schema as unloaded but keep it available in memory
     pub fn set_unloaded(&self, schema_name: &str) -> Result<(), SchemaError> {
         let mut schemas = self


### PR DESCRIPTION
## Summary
- add ability to load available schemas and unload loaded schemas
- expose new API routes for listing and loading schemas
- show dropdown of available schemas in UI
- add tests for new UI

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test`