### PR TITLE
Move schema service tests

### DIFF
--- a/fold_node/src/network/core.rs
+++ b/fold_node/src/network/core.rs
@@ -58,9 +58,6 @@ pub struct NetworkCore {
     pub(crate) peer_to_node_map: HashMap<PeerId, String>,
     /// Mapping from node IDs to their listening addresses
     pub(crate) node_to_address_map: HashMap<String, String>,
-    /// Mock for testing - maps peer IDs to schema services
-    #[cfg(test)]
-    pub(crate) mock_peers: HashMap<PeerId, SchemaService>,
     /// Handle for the background networking task
     pub(crate) mdns_handle: Option<tokio::task::JoinHandle<()>>,
 }
@@ -80,8 +77,6 @@ impl NetworkCore {
             node_to_peer_map: HashMap::new(),
             peer_to_node_map: HashMap::new(),
             node_to_address_map: HashMap::new(),
-            #[cfg(test)]
-            mock_peers: HashMap::new(),
             mdns_handle: None,
         })
     }

--- a/fold_node/src/network/discovery.rs
+++ b/fold_node/src/network/discovery.rs
@@ -46,12 +46,6 @@ impl NetworkCore {
         peer_id: PeerId,
         schema_names: Vec<String>,
     ) -> NetworkResult<Vec<String>> {
-        #[cfg(test)]
-        {
-            if let Some(peer_service) = self.mock_peers.get(&peer_id) {
-                return Ok(peer_service.check_schemas(&schema_names));
-            }
-        }
 
         if !self.known_peers.contains(&peer_id) {
             return Err(NetworkError::ConnectionError(format!(

--- a/fold_node/src/network/schema_service.rs
+++ b/fold_node/src/network/schema_service.rs
@@ -144,34 +144,3 @@ impl SchemaService {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_schema_service() {
-        let mut service = SchemaService::new();
-
-        // Default callback should return empty list
-        let result = service.check_schemas(&["schema1".to_string(), "schema2".to_string()]);
-        assert!(result.is_empty());
-
-        // Set custom callback
-        service.set_schema_check_callback(|names| {
-            names
-                .iter()
-                .filter(|name| name.contains("1"))
-                .cloned()
-                .collect()
-        });
-
-        // Should now return only schemas containing "1"
-        let result = service.check_schemas(&[
-            "schema1".to_string(),
-            "schema2".to_string(),
-            "test1".to_string(),
-        ]);
-
-        assert_eq!(result, vec!["schema1".to_string(), "test1".to_string()]);
-    }
-}

--- a/fold_node/tests/network_schema_service_tests.rs
+++ b/fold_node/tests/network_schema_service_tests.rs
@@ -1,0 +1,28 @@
+use fold_node::network::schema_service::SchemaService;
+
+#[test]
+fn test_schema_service() {
+    let mut service = SchemaService::new();
+
+    // Default callback should return empty list
+    let result = service.check_schemas(&["schema1".to_string(), "schema2".to_string()]);
+    assert!(result.is_empty());
+
+    // Set custom callback
+    service.set_schema_check_callback(|names| {
+        names
+            .iter()
+            .filter(|name| name.contains("1"))
+            .cloned()
+            .collect()
+    });
+
+    // Should now return only schemas containing "1"
+    let result = service.check_schemas(&[
+        "schema1".to_string(),
+        "schema2".to_string(),
+        "test1".to_string(),
+    ]);
+
+    assert_eq!(result, vec!["schema1".to_string(), "test1".to_string()]);
+}


### PR DESCRIPTION
## Summary
- relocate tests out of src/network/schema_service.rs
- drop mock peer test stubs
- place schema service tests in dedicated network_schema_service_tests.rs

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test`