### PR TITLE
Move binary tests to integration

### DIFF
--- a/fold_node/src/bin/datafold_http_server.rs
+++ b/fold_node/src/bin/datafold_http_server.rs
@@ -65,21 +65,3 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use super::Cli;
-    use clap::Parser;
-
-    #[test]
-    fn defaults() {
-        let cli = Cli::parse_from(["test"]);
-        assert_eq!(cli.port, 9001);
-    }
-
-    #[test]
-    fn custom_port() {
-        let cli = Cli::parse_from(["test", "--port", "8000"]);
-        assert_eq!(cli.port, 8000);
-    }
-}

--- a/fold_node/src/bin/datafold_node.rs
+++ b/fold_node/src/bin/datafold_node.rs
@@ -104,22 +104,3 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::Cli;
-    use clap::Parser;
-
-    #[test]
-    fn defaults() {
-        let cli = Cli::parse_from(["test"]); 
-        assert_eq!(cli.port, 9000);
-        assert_eq!(cli.tcp_port, 9000);
-    }
-
-    #[test]
-    fn custom_values() {
-        let cli = Cli::parse_from(["test", "--port", "8000", "--tcp-port", "8001"]);
-        assert_eq!(cli.port, 8000);
-        assert_eq!(cli.tcp_port, 8001);
-    }
-}

--- a/fold_node/tests/datafold_http_server_tests.rs
+++ b/fold_node/tests/datafold_http_server_tests.rs
@@ -1,0 +1,21 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Cli {
+    /// Port for the HTTP server
+    #[arg(long, default_value_t = 9001)]
+    port: u16,
+}
+
+#[test]
+fn defaults() {
+    let cli = Cli::parse_from(["test"]);
+    assert_eq!(cli.port, 9001);
+}
+
+#[test]
+fn custom_port() {
+    let cli = Cli::parse_from(["test", "--port", "8000"]);
+    assert_eq!(cli.port, 8000);
+}

--- a/fold_node/tests/datafold_node_bin_tests.rs
+++ b/fold_node/tests/datafold_node_bin_tests.rs
@@ -1,0 +1,27 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Cli {
+    /// Port for the P2P network
+    #[arg(long, default_value_t = 9000)]
+    port: u16,
+
+    /// Port for the TCP server
+    #[arg(long, default_value_t = 9000)]
+    tcp_port: u16,
+}
+
+#[test]
+fn defaults() {
+    let cli = Cli::parse_from(["test"]);
+    assert_eq!(cli.port, 9000);
+    assert_eq!(cli.tcp_port, 9000);
+}
+
+#[test]
+fn custom_values() {
+    let cli = Cli::parse_from(["test", "--port", "8000", "--tcp-port", "8001"]);
+    assert_eq!(cli.port, 8000);
+    assert_eq!(cli.tcp_port, 8001);
+}


### PR DESCRIPTION
## Summary
- move bin tests from cfg blocks into integration tests
- leave binaries free of testing code

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test --silent`