### PR TITLE
Refactor DataFoldNode database locking

### DIFF
--- a/fold_node/src/datafold_node/node.rs
+++ b/fold_node/src/datafold_node/node.rs
@@ -353,4 +353,26 @@ impl DataFoldNode {
         &self.node_id
     }
 
+    pub(super) fn with_db<F, R>(&self, f: F) -> FoldDbResult<R>
+    where
+        F: FnOnce(&FoldDB) -> FoldDbResult<R>,
+    {
+        let db = self
+            .db
+            .lock()
+            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
+        f(&db)
+    }
+
+    pub(super) fn with_db_mut<F, R>(&self, f: F) -> FoldDbResult<R>
+    where
+        F: FnOnce(&mut FoldDB) -> FoldDbResult<R>,
+    {
+        let mut db = self
+            .db
+            .lock()
+            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
+        f(&mut db)
+    }
+
 }

--- a/fold_node/src/datafold_node/permissions.rs
+++ b/fold_node/src/datafold_node/permissions.rs
@@ -31,52 +31,44 @@ impl DataFoldNode {
 
     /// Allows operations on a schema and persists permission for this node.
     pub fn allow_schema(&mut self, schema_name: &str) -> FoldDbResult<()> {
-        let mut db = self
-            .db
-            .lock()
-            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
-        db.allow_schema(schema_name)?;
-        drop(db);
+        self.with_db_mut(|db| {
+            db.allow_schema(schema_name)?;
+            Ok(())
+        })?;
         self.grant_schema_permission(schema_name)?;
         Ok(())
     }
 
     /// Grants schema permission for this node.
     pub fn grant_schema_permission(&mut self, schema_name: &str) -> FoldDbResult<()> {
-        let db = self
-            .db
-            .lock()
-            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
-        let mut perms = db.get_schema_permissions(&self.node_id);
-        if !perms.contains(&schema_name.to_string()) {
-            perms.push(schema_name.to_string());
-            db.set_schema_permissions(&self.node_id, &perms)
-                .map_err(|e| FoldDbError::Config(format!("Failed to set permissions: {}", e)))?;
-        }
-        Ok(())
+        self.with_db(|db| {
+            let mut perms = db.get_schema_permissions(&self.node_id);
+            if !perms.contains(&schema_name.to_string()) {
+                perms.push(schema_name.to_string());
+                db.set_schema_permissions(&self.node_id, &perms)
+                    .map_err(|e| FoldDbError::Config(format!("Failed to set permissions: {}", e)))?;
+            }
+            Ok(())
+        })
     }
 
     /// Revokes schema permission for this node.
     pub fn revoke_schema_permission(&mut self, schema_name: &str) -> FoldDbResult<()> {
-        let db = self
-            .db
-            .lock()
-            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
-        let mut perms = db.get_schema_permissions(&self.node_id);
-        perms.retain(|s| s != schema_name);
-        db.set_schema_permissions(&self.node_id, &perms)
-            .map_err(|e| FoldDbError::Config(format!("Failed to set permissions: {}", e)))?;
-        Ok(())
+        self.with_db(|db| {
+            let mut perms = db.get_schema_permissions(&self.node_id);
+            perms.retain(|s| s != schema_name);
+            db.set_schema_permissions(&self.node_id, &perms)
+                .map_err(|e| FoldDbError::Config(format!("Failed to set permissions: {}", e)))?;
+            Ok(())
+        })
     }
 
     /// Checks if this node has permission to access the given schema.
     pub fn check_schema_permission(&self, schema_name: &str) -> FoldDbResult<bool> {
-        let db = self
-            .db
-            .lock()
-            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
-        let perms = db.get_schema_permissions(&self.node_id);
-        Ok(perms.contains(&schema_name.to_string()))
+        self.with_db(|db| {
+            let perms = db.get_schema_permissions(&self.node_id);
+            Ok(perms.contains(&schema_name.to_string()))
+        })
     }
 }
 

--- a/fold_node/src/datafold_node/transform_queue.rs
+++ b/fold_node/src/datafold_node/transform_queue.rs
@@ -4,35 +4,31 @@ use super::DataFoldNode;
 impl DataFoldNode {
     /// Add a transform to the queue
     pub fn add_transform_to_queue(&self, transform_id: &str) -> FoldDbResult<()> {
-        let db = self
-            .db
-            .lock()
-            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
-        db.transform_orchestrator.add_transform(transform_id, "manual")?;
-        Ok(())
+        self.with_db(|db| {
+            db.transform_orchestrator.add_transform(transform_id, "manual")?;
+            Ok(())
+        })
     }
 
     /// Get information about the transform queue
     pub fn get_transform_queue_info(&self) -> FoldDbResult<serde_json::Value> {
-        let db = self
-            .db
-            .lock()
-            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
-        let queue_length = db.transform_orchestrator.len()?;
-        let is_empty = db.transform_orchestrator.is_empty()?;
-        let mut queue = Vec::new();
-        let mut current = queue_length;
-        while current > 0 {
-            if let Some(Ok(id)) = db.transform_orchestrator.process_one() {
-                queue.push(id.to_string());
+        self.with_db(|db| {
+            let queue_length = db.transform_orchestrator.len()?;
+            let is_empty = db.transform_orchestrator.is_empty()?;
+            let mut queue = Vec::new();
+            let mut current = queue_length;
+            while current > 0 {
+                if let Some(Ok(id)) = db.transform_orchestrator.process_one() {
+                    queue.push(id.to_string());
+                }
+                current -= 1;
             }
-            current -= 1;
-        }
-        Ok(serde_json::json!({
-            "queue": queue,
-            "length": queue_length,
-            "isEmpty": is_empty
-        }))
+            Ok(serde_json::json!({
+                "queue": queue,
+                "length": queue_length,
+                "isEmpty": is_empty
+            }))
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- add `with_db` and `with_db_mut` helpers
- use these helpers for DB operations in submodules
- remove explicit mutex drops

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test --silent` in `fold_node/src/datafold_node/static-react`