### PR TITLE
Use 'Unload' for schema actions

### DIFF
--- a/fold_node/src/datafold_node/static-react/src/components/tabs/SchemaTab.jsx
+++ b/fold_node/src/datafold_node/static-react/src/components/tabs/SchemaTab.jsx
@@ -34,13 +34,13 @@ function SchemaTab({ schemas, onResult, onSchemaUpdated }) {
     try {
       const resp = await fetch(`/api/schema/${schemaName}`, { method: 'DELETE' })
       if (!resp.ok) {
-        throw new Error(`Failed to remove schema: ${resp.status}`)
+        throw new Error(`Failed to unload schema: ${resp.status}`)
       }
       if (onSchemaUpdated) {
         onSchemaUpdated()
       }
     } catch (err) {
-      console.error('Failed to remove schema:', err)
+      console.error('Failed to unload schema:', err)
     }
   }
 
@@ -154,7 +154,7 @@ function SchemaTab({ schemas, onResult, onSchemaUpdated }) {
                 removeSchema(schema.name)
               }}
             >
-              Remove
+              Unload
             </button>
           </div>
         </div>

--- a/fold_node/src/datafold_node/static-react/src/components/tabs/SchemasTab.jsx
+++ b/fold_node/src/datafold_node/static-react/src/components/tabs/SchemasTab.jsx
@@ -63,12 +63,12 @@ function SchemasTab() {
         method: 'DELETE'
       })
       if (!resp.ok) {
-        throw new Error(`Failed to remove schema: ${resp.status}`)
+        throw new Error(`Failed to unload schema: ${resp.status}`)
       }
       await loadSchemas()
     } catch (err) {
-      console.error('Failed to remove schema:', err)
-      setError('Failed to remove schema. Please try again.')
+      console.error('Failed to unload schema:', err)
+      setError('Failed to unload schema. Please try again.')
     }
   }
 
@@ -138,7 +138,7 @@ function SchemasTab() {
                   }}
                 >
                   <TrashIcon className="icon icon-xs mr-1.5 text-white" />
-                  Remove
+                  Unload
                 </button>
               </div>
             </div>

--- a/fold_node/src/datafold_node/static-react/src/test/components/tabs/SchemaTab.test.jsx
+++ b/fold_node/src/datafold_node/static-react/src/test/components/tabs/SchemaTab.test.jsx
@@ -173,8 +173,8 @@ describe('SchemaTab Component', () => {
       expect(screen.getByText('UserProfile')).toBeInTheDocument()
     })
     
-    // Find and click the first remove button
-    const removeButtons = screen.getAllByText('Remove')
+    // Find and click the first unload button
+    const removeButtons = screen.getAllByText('Unload')
     fireEvent.click(removeButtons[0])
     
     await waitFor(() => {
@@ -217,8 +217,8 @@ describe('SchemaTab Component', () => {
     // Schema should be collapsed initially
     expect(screen.queryByText('id')).not.toBeInTheDocument()
     
-    // Click remove button (should not expand schema)
-    const removeButtons = screen.getAllByText('Remove')
+    // Click unload button (should not expand schema)
+    const removeButtons = screen.getAllByText('Unload')
     fireEvent.click(removeButtons[0])
     
     // Schema should still be collapsed

--- a/fold_node/src/datafold_node/static-react/src/test/integration/AppIntegration.test.jsx
+++ b/fold_node/src/datafold_node/static-react/src/test/integration/AppIntegration.test.jsx
@@ -152,8 +152,8 @@ describe('App Integration Tests', () => {
       expect(screen.getByText('UserProfile')).toBeInTheDocument()
     })
     
-    // Find and click remove button for UserProfile
-    const removeButtons = screen.getAllByText('Remove')
+    // Find and click unload button for UserProfile
+    const removeButtons = screen.getAllByText('Unload')
     await user.click(removeButtons[0])
     
     // Verify delete API call was made


### PR DESCRIPTION
## Summary
- switch schema buttons from `Remove` to `Unload`
- update error messages for unloading schemas
- adjust unit and integration tests to use new wording

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test --silent`