### PR TITLE
Load schemas lazily from saved state

### DIFF
--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -152,7 +152,8 @@ impl FoldDB {
         field_manager
             .set_orchestrator(Arc::clone(&orchestrator))
             .map_err(|e| sled::Error::Unsupported(e.to_string()))?;
-        let _ = schema_manager.load_schemas_from_disk();
+
+        let _ = schema_manager.load_schema_states_from_disk();
 
         Ok(Self {
             atom_manager,

--- a/tests/cli/cli_tests.rs
+++ b/tests/cli/cli_tests.rs
@@ -87,7 +87,7 @@ fn load_and_list_schemas() {
     assert!(status.success());
 
     let output = Command::new(&exe)
-        .args(["-c", config.to_str().unwrap(), "list-schemas"])
+        .args(["-c", config.to_str().unwrap(), "list-available-schemas"])
         .output()
         .expect("list-schemas command failed");
     assert!(output.status.success());


### PR DESCRIPTION
## Summary
- avoid loading schemas on startup
- expose schema state lookup
- load required schemas lazily when querying or mutating
- adjust CLI tests for new behaviour

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` in `fold_node/src/datafold_node/static-react`