### PR TITLE
Filter loaded schemas only

### DIFF
--- a/fold_node/src/datafold_node/static-react/src/App.jsx
+++ b/fold_node/src/datafold_node/static-react/src/App.jsx
@@ -23,7 +23,11 @@ function App() {
     try {
       const response = await fetch('/api/schemas')
       const data = await response.json()
-      setSchemas(data.data || [])
+      const schemas = Array.isArray(data.data) ? data.data : []
+      const loadedSchemas = schemas.filter(
+        (s) => s.state && s.state.toLowerCase() === 'loaded'
+      )
+      setSchemas(loadedSchemas)
     } catch (error) {
       console.error('Failed to fetch schemas:', error)
     }

--- a/fold_node/src/datafold_node/static-react/src/test/App.test.jsx
+++ b/fold_node/src/datafold_node/static-react/src/test/App.test.jsx
@@ -79,8 +79,8 @@ describe('App Component', () => {
       ok: true,
       json: async () => ({
         data: [
-          { name: 'TestSchema1', fields: {} },
-          { name: 'TestSchema2', fields: {} }
+          { name: 'TestSchema1', state: 'Loaded', fields: {} },
+          { name: 'TestSchema2', state: 'Loaded', fields: {} }
         ]
       })
     })
@@ -304,5 +304,23 @@ describe('App Component', () => {
     
     fireEvent.click(screen.getByText('Execute Transform'))
     expect(screen.getByText('Results: {"transform":"test"}')).toBeInTheDocument()
+  })
+
+  it('filters schemas by loaded state', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [
+          { name: 'LoadedSchema', state: 'Loaded', fields: {} },
+          { name: 'OtherSchema', state: 'Unloaded', fields: {} }
+        ]
+      })
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Schema Tab - 1 schemas')).toBeInTheDocument()
+    })
   })
 })

--- a/fold_node/src/datafold_node/static-react/src/test/integration/AppIntegration.test.jsx
+++ b/fold_node/src/datafold_node/static-react/src/test/integration/AppIntegration.test.jsx
@@ -18,6 +18,7 @@ describe('App Integration Tests', () => {
             data: [
               {
                 name: 'UserProfile',
+                state: 'Loaded',
                 fields: {
                   id: { field_type: 'string', writable: false },
                   name: { field_type: 'string', writable: true },
@@ -26,6 +27,7 @@ describe('App Integration Tests', () => {
               },
               {
                 name: 'BlogPost',
+                state: 'Loaded',
                 fields: {
                   title: { field_type: 'string', writable: true },
                   content: { field_type: 'text', writable: true }


### PR DESCRIPTION
## Summary
- filter schemas by `state` when fetching in the React app
- adjust tests to include schema `state` and verify loaded filter

## Testing
- `cargo test --workspace` *(fails: Database error: Could not acquire lock)*
- `cargo clippy`
- `npm test` in `fold_node/src/datafold_node/static-react`
