### PR TITLE
Remove unused annotation

### DIFF
--- a/fold_node/src/datafold_node/http_server.rs
+++ b/fold_node/src/datafold_node/http_server.rs
@@ -31,7 +31,6 @@ pub struct DataFoldHttpServer {
     /// The HTTP server bind address
     bind_address: String,
     /// The sample data manager
-    #[allow(dead_code)]
     sample_manager: SampleManager,
 }
 


### PR DESCRIPTION
## Summary
- remove the `#[allow(dead_code)]` from `sample_manager`

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(in `static-react` folder, cancelled watch mode)*