### PR TITLE
Remove dummy functions from Rust examples

### DIFF
--- a/fold_node/examples/auto_transform_demo.rs
+++ b/fold_node/examples/auto_transform_demo.rs
@@ -5,9 +5,6 @@
 use fold_node::transform::{TransformParser, Interpreter, Value};
 use std::collections::HashMap;
 
-// This is needed to ensure the main function is properly recognized
-#[allow(dead_code)]
-fn dummy() {}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("Automatic Transform Generation Demo");

--- a/fold_node/examples/transform_dsl_samples.rs
+++ b/fold_node/examples/transform_dsl_samples.rs
@@ -214,9 +214,6 @@ fn test_transform(id: usize, name: &str, transform_str: &str, parser: &Transform
                 _ => {}
             }
             
-            // This is needed to ensure the main function is properly recognized
-            #[allow(dead_code)]
-            fn dummy() {}
             
             variables.insert("input".to_string(), Value::Object(input));
             


### PR DESCRIPTION
## Summary
- clean up unused `dummy` functions from example code

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` in `fold_node/src/datafold_node/static-react`
