### PR TITLE
Remove unused builtin registration method

### DIFF
--- a/fold_node/src/transform/interpreter.rs
+++ b/fold_node/src/transform/interpreter.rs
@@ -42,11 +42,6 @@ impl Interpreter {
         interpreter
     }
     
-    /// Registers built-in functions.
-    #[allow(dead_code)]
-    fn register_builtin_functions(&mut self) {
-        self.functions.extend(builtin_functions());
-    }
     
     /// Evaluates an expression.
     pub fn evaluate(&mut self, expr: &Expression) -> Result<Value, SchemaError> {


### PR DESCRIPTION
## Summary
- remove unused `register_builtin_functions` method from Interpreter

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` in `fold_node/src/datafold_node/static-react`