### PR TITLE
Refactor network config cleanup

### DIFF
--- a/fold_node/src/bin/datafold_node.rs
+++ b/fold_node/src/bin/datafold_node.rs
@@ -70,7 +70,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listen_address = format!("/ip4/0.0.0.0/tcp/{}", port);
     let network_config = NetworkConfig::new(&listen_address)
         .with_mdns(true)
-        .with_request_timeout(30)
         .with_max_connections(50)
         .with_keep_alive_interval(20)
         .with_max_message_size(1_000_000);

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -49,9 +49,6 @@ pub struct FoldDB {
     metadata_tree: sled::Tree,
     /// Tree for storing per-node schema permissions
     permissions_tree: sled::Tree,
-    /// Tree storing schema states
-    #[allow(dead_code)]
-    schema_states_tree: sled::Tree,
 }
 
 impl FoldDB {
@@ -110,7 +107,7 @@ impl FoldDB {
         let field_manager = FieldManager::new(atom_manager.clone());
         let collection_manager = CollectionManager::new(field_manager.clone());
         let schema_manager = Arc::new(
-            SchemaCore::new_with_tree(path, schema_states_tree.clone())
+            SchemaCore::new_with_tree(path, schema_states_tree)
                 .map_err(|e| sled::Error::Unsupported(e.to_string()))?,
         );
         let atom_manager_clone = atom_manager.clone();
@@ -169,7 +166,6 @@ impl FoldDB {
             permission_wrapper: PermissionWrapper::new(),
             metadata_tree,
             permissions_tree,
-            schema_states_tree,
         })
     }
 

--- a/fold_node/src/network/config.rs
+++ b/fold_node/src/network/config.rs
@@ -3,8 +3,6 @@
 pub struct NetworkConfig {
     /// Local listening address
     pub listen_address: String,
-    /// Request timeout in seconds
-    pub request_timeout: u64,
     /// Enable mDNS discovery
     pub enable_mdns: bool,
     /// Maximum number of concurrent connections
@@ -25,7 +23,6 @@ impl Default for NetworkConfig {
     fn default() -> Self {
         Self {
             listen_address: "/ip4/0.0.0.0/tcp/0".to_string(),
-            request_timeout: 30,
             enable_mdns: true,
             max_connections: 50,
             keep_alive_interval: 20,
@@ -44,12 +41,6 @@ impl NetworkConfig {
             listen_address: listen_address.to_string(),
             ..Default::default()
         }
-    }
-
-    /// Set the request timeout in seconds
-    pub fn with_request_timeout(mut self, timeout: u64) -> Self {
-        self.request_timeout = timeout;
-        self
     }
 
     /// Enable or disable mDNS discovery

--- a/fold_node/src/network/core.rs
+++ b/fold_node/src/network/core.rs
@@ -28,8 +28,7 @@ use log::info;
 /// #[tokio::main]
 /// async fn main() -> NetworkResult<()> {
 ///     let config = NetworkConfig::new("/ip4/0.0.0.0/tcp/9000")
-///         .with_mdns(true)
-///         .with_request_timeout(30);
+///         .with_mdns(true);
 ///
 ///     let mut network = NetworkCore::new(config).await?;
 ///     network.run("/ip4/0.0.0.0/tcp/9000").await?;
@@ -47,9 +46,6 @@ pub struct NetworkCore {
     pub(crate) local_peer_id: PeerId,
     /// Known peers
     pub(crate) known_peers: HashSet<PeerId>,
-    /// Request timeout in seconds
-    #[allow(dead_code)]
-    pub(crate) request_timeout: u64,
     /// Network configuration
     pub(crate) config: NetworkConfig,
     /// Mapping from node IDs (UUIDs) to peer IDs
@@ -75,7 +71,6 @@ impl NetworkCore {
             schema_service: SchemaService::new(),
             local_peer_id,
             known_peers: HashSet::new(),
-            request_timeout: config.request_timeout,
             config,
             node_to_peer_map: HashMap::new(),
             peer_to_node_map: HashMap::new(),

--- a/fold_node/tests/network_discovery_tests.rs
+++ b/fold_node/tests/network_discovery_tests.rs
@@ -20,7 +20,6 @@ fn create_test_network_config(enable_discovery: bool) -> NetworkConfig {
 
     NetworkConfig {
         listen_address: format!("/ip4/127.0.0.1/tcp/{}", tcp_port),
-        request_timeout: 30,
         enable_mdns: enable_discovery,
         max_connections: 10,
         keep_alive_interval: 20,

--- a/fold_node/tests/network_tests.rs
+++ b/fold_node/tests/network_tests.rs
@@ -20,7 +20,6 @@ fn create_test_network_config() -> NetworkConfig {
 
     NetworkConfig {
         listen_address: format!("127.0.0.1:{}", tcp_port).parse().unwrap(),
-        request_timeout: 1,
         enable_mdns: false,
         max_connections: 10,
         keep_alive_interval: 1,


### PR DESCRIPTION
## Summary
- remove unused `schema_states_tree` from FoldDB
- drop `request_timeout` from NetworkConfig and NetworkCore
- update binary and tests

## Testing
- `cargo test --workspace -- --test-threads=1`
- `cargo clippy`
- `npm test` in `fold_node/src/datafold_node/static-react`