### PR TITLE
Clean up dead_code allowances

### DIFF
--- a/fold_node/src/datafold_node/tests.rs
+++ b/fold_node/src/datafold_node/tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use tempfile::tempdir;
 
-#[allow(dead_code)]
 fn create_test_config() -> NodeConfig {
     let dir = tempdir().unwrap();
     NodeConfig {

--- a/tests/test_data/test_helpers/mod.rs
+++ b/tests/test_data/test_helpers/mod.rs
@@ -13,10 +13,8 @@ use std::thread;
 use std::time::Duration;
 use uuid::Uuid;
 
-#[allow(dead_code)]
 static CLEANUP_LOCK: Mutex<()> = Mutex::new(());
 
-#[allow(dead_code)]
 fn retry_with_backoff<F, T, E>(mut f: F, retries: u32) -> Result<T, E>
 where
     F: FnMut() -> Result<T, E>,
@@ -35,7 +33,6 @@ where
     }
 }
 
-#[allow(dead_code)]
 pub fn get_test_db_path() -> String {
     let current_dir = std::env::current_dir().expect("Failed to get current directory");
     let tmp_dir = current_dir.join("tmp");
@@ -66,7 +63,6 @@ pub fn get_test_db_path() -> String {
     db_path.to_string_lossy().into_owned()
 }
 
-#[allow(dead_code)]
 pub fn cleanup_test_db(path: &str) {
     let _lock = CLEANUP_LOCK.lock().unwrap();
     let path = Path::new(path);
@@ -81,7 +77,6 @@ pub fn cleanup_test_db(path: &str) {
     }
 }
 
-#[allow(dead_code)]
 pub fn cleanup_tmp_dir() {
     let _lock = CLEANUP_LOCK.lock().unwrap();
     let current_dir = std::env::current_dir().expect("Failed to get current directory");
@@ -125,14 +120,12 @@ pub fn cleanup_tmp_dir() {
     }
 }
 
-#[allow(dead_code)]
 pub fn setup_test_db() -> (FoldDB, String) {
     let db_path = get_test_db_path();
     let db = FoldDB::new(&db_path).expect("Failed to create test database");
     (db, db_path)
 }
 
-#[allow(dead_code)]
 pub fn setup_and_allow_schema(
     db: &mut FoldDB,
     schema_name: &str,
@@ -140,7 +133,6 @@ pub fn setup_and_allow_schema(
     db.allow_schema(schema_name)
 }
 
-#[allow(dead_code)]
 pub fn create_test_node() -> DataFoldNode {
     let dir = tempdir().expect("temp dir");
     let config = NodeConfig {

--- a/tests/test_data/test_helpers/node_operations.rs
+++ b/tests/test_data/test_helpers/node_operations.rs
@@ -4,7 +4,6 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /// Load a schema into the node and allow access.
-#[allow(dead_code)]
 pub fn load_and_allow(node: &mut DataFoldNode, schema: Schema) -> FoldDbResult<()> {
     let name = schema.name.clone();
     node.load_schema(schema)?;
@@ -12,16 +11,7 @@ pub fn load_and_allow(node: &mut DataFoldNode, schema: Schema) -> FoldDbResult<(
     Ok(())
 }
 
-/// Create a new node with the given schema loaded and allowed.
-#[allow(dead_code)]
-pub fn create_node_with_schema(schema: Schema) -> DataFoldNode {
-    let mut node = super::create_test_node();
-    load_and_allow(&mut node, schema).expect("failed to load schema");
-    node
-}
-
 /// Execute a single field create mutation on the node.
-#[allow(dead_code)]
 pub fn insert_value(
     node: &mut DataFoldNode,
     schema: &str,
@@ -41,7 +31,6 @@ pub fn insert_value(
 }
 
 /// Query a single field from the node and return the value.
-#[allow(dead_code)]
 pub fn query_value(
     node: &mut DataFoldNode,
     schema: &str,

--- a/tests/test_data/test_helpers/operation_builder.rs
+++ b/tests/test_data/test_helpers/operation_builder.rs
@@ -2,7 +2,6 @@ use fold_node::testing::{Mutation, MutationType, Query};
 use serde_json::Value;
 use std::collections::HashMap;
 
-#[allow(dead_code)]
 pub fn create_query(
     schema_name: String,
     fields: Vec<String>,
@@ -18,7 +17,6 @@ pub fn create_query(
     }
 }
 
-#[allow(dead_code)]
 pub fn create_mutation(
     schema_name: String,
     fields_and_values: HashMap<String, Value>,
@@ -34,7 +32,6 @@ pub fn create_mutation(
     }
 }
 
-#[allow(dead_code)]
 pub fn create_single_field_mutation(
     schema_name: String,
     field: String,

--- a/tests/test_data/test_helpers/schema_builder.rs
+++ b/tests/test_data/test_helpers/schema_builder.rs
@@ -4,7 +4,6 @@ use fold_node::testing::{
 };
 use std::collections::HashMap;
 
-#[allow(dead_code)]
 pub fn create_field_with_permissions(
     ref_atom_uuid: String,
     read_distance: u32,
@@ -36,7 +35,6 @@ pub fn create_field_with_permissions(
     field
 }
 
-#[allow(dead_code)]
 pub fn create_schema_with_fields(name: String, fields: HashMap<String, FieldVariant>) -> Schema {
     Schema::new(name)
         .with_fields(fields)


### PR DESCRIPTION
## Summary
- remove `allow(dead_code)` from test helpers and node tests
- delete unused `create_node_with_schema`

## Testing
- `npm test`
- `cargo test --workspace`
- `cargo clippy`