### PR TITLE
Refactor schema core into validator and storage modules

### DIFF
--- a/fold_node/src/schema/mod.rs
+++ b/fold_node/src/schema/mod.rs
@@ -23,11 +23,13 @@
 
 // Internal modules
 pub(crate) mod core;
+pub(crate) mod storage;
 pub mod types;
 
 
 // Public re-exports
 pub use core::SchemaCore;
+pub use storage::SchemaStorage;
 pub use types::{errors::SchemaError, schema::Schema, Transform};
 pub mod validator;
 pub use validator::SchemaValidator;

--- a/fold_node/src/schema/storage.rs
+++ b/fold_node/src/schema/storage.rs
@@ -1,0 +1,97 @@
+use crate::schema::types::{Schema, SchemaError};
+use super::core::SchemaState;
+use log::info;
+use serde_json;
+use sled::Tree;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+/// Handles persistence of schemas and their states on disk
+pub struct SchemaStorage {
+    pub(crate) schemas_dir: PathBuf,
+    pub(crate) schema_states_tree: Tree,
+}
+
+impl SchemaStorage {
+    /// Create a new storage helper ensuring the schema directory exists
+    pub fn new(schemas_dir: PathBuf, schema_states_tree: Tree) -> Result<Self, SchemaError> {
+        if let Err(e) = fs::create_dir_all(&schemas_dir) {
+            if e.kind() != std::io::ErrorKind::AlreadyExists {
+                return Err(SchemaError::InvalidData(format!(
+                    "Failed to create schemas directory: {}",
+                    e
+                )));
+            }
+        }
+        Ok(Self { schemas_dir, schema_states_tree })
+    }
+
+    /// Gets the path for a schema file
+    pub fn schema_path(&self, schema_name: &str) -> PathBuf {
+        self.schemas_dir.join(format!("{}.json", schema_name))
+    }
+
+    /// Persist all schema load states to the sled tree
+    pub fn persist_states(&self, available: &HashMap<String, (Schema, SchemaState)>) -> Result<(), SchemaError> {
+        info!("Persisting schema states to sled tree");
+        // Remove stale entries
+        for key in self.schema_states_tree.iter().keys() {
+            let k = key?;
+            if let Ok(name) = std::str::from_utf8(&k) {
+                if !available.contains_key(name) {
+                    self.schema_states_tree.remove(name)?;
+                }
+            }
+        }
+
+        for (name, (_, state)) in available.iter() {
+            let bytes = serde_json::to_vec(state)
+                .map_err(|e| SchemaError::InvalidData(format!("Failed to serialize state: {}", e)))?;
+            self.schema_states_tree.insert(name.as_bytes(), bytes)?;
+        }
+        self.schema_states_tree.flush()?;
+        info!("Schema states persisted successfully");
+        Ok(())
+    }
+
+    /// Load schema states from the sled tree
+    pub fn load_states(&self) -> HashMap<String, SchemaState> {
+        let mut map = HashMap::new();
+        for item in self.schema_states_tree.iter().flatten() {
+            if let Ok(name) = String::from_utf8(item.0.to_vec()) {
+                if let Ok(state) = serde_json::from_slice::<SchemaState>(&item.1) {
+                    map.insert(name, state);
+                }
+            }
+        }
+        map
+    }
+
+    /// Persists a schema to disk
+    pub fn persist_schema(&self, schema: &Schema) -> Result<(), SchemaError> {
+        let path = self.schema_path(&schema.name);
+
+        info!("Persisting schema '{}' to {}", schema.name, path.display());
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                SchemaError::InvalidData(format!("Failed to create schema directory: {}", e))
+            })?;
+        }
+
+        let json = serde_json::to_string_pretty(schema)
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to serialize schema: {}", e)))?;
+
+        fs::write(&path, json).map_err(|e| {
+            SchemaError::InvalidData(format!(
+                "Failed to write schema file: {}, path: {}",
+                e,
+                path.to_string_lossy()
+            ))
+        })?;
+
+        info!("Schema '{}' persisted to disk", schema.name);
+        Ok(())
+    }
+}
+

--- a/fold_node/tests/schema_core_tests.rs
+++ b/fold_node/tests/schema_core_tests.rs
@@ -1,0 +1,201 @@
+use fold_node::testing::{
+    Field, FieldPaymentConfig, PermissionsPolicy, Schema, SingleField, FieldVariant,
+    SchemaCore, SchemaValidator, TrustDistance, TrustDistanceScaling,
+};
+use fold_node::schema::types::{JsonSchemaDefinition, JsonSchemaField};
+use fold_node::schema::types::field::{FieldType};
+use fold_node::schema::types::json_schema::{JsonFieldPaymentConfig, JsonPermissionPolicy};
+use fold_node::fees::SchemaPaymentConfig;
+use tempfile::tempdir;
+use std::collections::HashMap;
+use std::fs;
+
+fn cleanup_test_schema(name: &str) {
+    let path = std::path::PathBuf::from("data/schemas").join(format!("{}.json", name));
+    let _ = fs::remove_file(path);
+}
+
+fn create_test_field(ref_atom_uuid: Option<String>, field_mappers: HashMap<String, String>) -> FieldVariant {
+    let mut single_field = SingleField::new(
+        PermissionsPolicy::default(),
+        FieldPaymentConfig::default(),
+        field_mappers,
+    );
+    if let Some(uuid) = ref_atom_uuid {
+        single_field.set_ref_atom_uuid(uuid);
+    }
+    FieldVariant::Single(single_field)
+}
+
+fn build_json_schema(name: &str) -> JsonSchemaDefinition {
+    let permission_policy = JsonPermissionPolicy {
+        read: TrustDistance::Distance(0),
+        write: TrustDistance::Distance(0),
+        explicit_read: None,
+        explicit_write: None,
+    };
+    let field = JsonSchemaField {
+        permission_policy,
+        ref_atom_uuid: Some("uuid".to_string()),
+        payment_config: JsonFieldPaymentConfig {
+            base_multiplier: 1.0,
+            trust_distance_scaling: TrustDistanceScaling::None,
+            min_payment: None,
+        },
+        field_mappers: HashMap::new(),
+        field_type: FieldType::Single,
+        transform: None,
+    };
+    let mut fields = HashMap::new();
+    fields.insert("field".to_string(), field);
+    JsonSchemaDefinition {
+        name: name.to_string(),
+        fields,
+        payment_config: SchemaPaymentConfig::default(),
+    }
+}
+
+#[test]
+fn test_schema_persistence() {
+    let test_schema_name = "test_persistence_schema";
+    cleanup_test_schema(test_schema_name);
+
+    let temp_dir = tempdir().unwrap();
+    let core = SchemaCore::new(temp_dir.path().to_str().unwrap()).unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert(
+        "test_field".to_string(),
+        create_test_field(Some("test_uuid".to_string()), HashMap::new()),
+    );
+    let schema = Schema::new(test_schema_name.to_string()).with_fields(fields);
+
+    core.load_schema(schema.clone()).unwrap();
+    let schema_path = core.schema_path(test_schema_name);
+    assert!(schema_path.exists());
+
+    let content = fs::read_to_string(&schema_path).unwrap();
+    let loaded_schema: Schema = serde_json::from_str(&content).unwrap();
+    assert_eq!(loaded_schema.name, test_schema_name);
+    assert_eq!(
+        loaded_schema
+            .fields
+            .get("test_field")
+            .unwrap()
+            .ref_atom_uuid(),
+        Some(&"test_uuid".to_string())
+    );
+
+    core.unload_schema(test_schema_name).unwrap();
+    assert!(schema_path.exists());
+
+    cleanup_test_schema(test_schema_name);
+}
+
+#[test]
+fn test_map_fields_success() {
+    let core = SchemaCore::new("data").unwrap();
+
+    let mut source_fields = HashMap::new();
+    source_fields.insert(
+        "source_field".to_string(),
+        create_test_field(Some("test_uuid".to_string()), HashMap::new()),
+    );
+    let source_schema = Schema::new("source_schema".to_string()).with_fields(source_fields);
+    core.load_schema(source_schema).unwrap();
+
+    let mut field_mappers = HashMap::new();
+    field_mappers.insert("source_schema".to_string(), "source_field".to_string());
+    let mut target_fields = HashMap::new();
+    target_fields.insert(
+        "target_field".to_string(),
+        create_test_field(None, field_mappers),
+    );
+    let target_schema = Schema::new("target_schema".to_string()).with_fields(target_fields);
+    core.load_schema(target_schema).unwrap();
+
+    core.map_fields("target_schema").unwrap();
+    let mapped_schema = core.get_schema("target_schema").unwrap().unwrap();
+    let mapped_field = mapped_schema.fields.get("target_field").unwrap();
+    assert_eq!(
+        mapped_field.ref_atom_uuid(),
+        Some(&"test_uuid".to_string())
+    );
+}
+
+#[test]
+fn test_validate_schema_valid() {
+    let temp_dir = tempdir().unwrap();
+    let core = SchemaCore::new(temp_dir.path().to_str().unwrap()).unwrap();
+    let schema = build_json_schema("valid");
+    let validator = SchemaValidator::new(&core);
+    assert!(validator.validate_json_schema(&schema).is_ok());
+}
+
+#[test]
+fn test_validate_schema_empty_name() {
+    let temp_dir = tempdir().unwrap();
+    let core = SchemaCore::new(temp_dir.path().to_str().unwrap()).unwrap();
+    let schema = build_json_schema("");
+    let validator = SchemaValidator::new(&core);
+    let result = validator.validate_json_schema(&schema);
+    assert!(matches!(result, Err(fold_node::schema::types::errors::SchemaError::InvalidField(msg)) if msg == "Schema name cannot be empty"));
+}
+
+#[test]
+fn test_validate_schema_empty_field_name() {
+    let temp_dir = tempdir().unwrap();
+    let core = SchemaCore::new(temp_dir.path().to_str().unwrap()).unwrap();
+    let mut schema = build_json_schema("valid");
+    let field = schema.fields.remove("field").unwrap();
+    schema.fields.insert("".to_string(), field);
+    let validator = SchemaValidator::new(&core);
+    let result = validator.validate_json_schema(&schema);
+    assert!(matches!(result, Err(fold_node::schema::types::errors::SchemaError::InvalidField(msg)) if msg == "Field name cannot be empty"));
+}
+
+#[test]
+fn test_validate_schema_invalid_mapper() {
+    let temp_dir = tempdir().unwrap();
+    let core = SchemaCore::new(temp_dir.path().to_str().unwrap()).unwrap();
+    let mut schema = build_json_schema("valid");
+    if let Some(field) = schema.fields.get_mut("field") {
+        field.field_mappers.insert(String::new(), "v".to_string());
+    }
+    let validator = SchemaValidator::new(&core);
+    let result = validator.validate_json_schema(&schema);
+    assert!(matches!(result, Err(fold_node::schema::types::errors::SchemaError::InvalidField(msg)) if msg.contains("invalid field mapper")));
+}
+
+#[test]
+fn test_validate_schema_min_payment_zero() {
+    let temp_dir = tempdir().unwrap();
+    let core = SchemaCore::new(temp_dir.path().to_str().unwrap()).unwrap();
+    let mut schema = build_json_schema("valid");
+    if let Some(field) = schema.fields.get_mut("field") {
+        field.payment_config.min_payment = Some(0);
+    }
+    let validator = SchemaValidator::new(&core);
+    let result = validator.validate_json_schema(&schema);
+    assert!(matches!(result, Err(fold_node::schema::types::errors::SchemaError::InvalidField(msg)) if msg.contains("min_payment cannot be zero")));
+}
+
+#[test]
+fn test_load_schemas_from_disk_persists_state() {
+    let dir = tempdir().unwrap();
+    let schema_dir = dir.path().join("schemas");
+    std::fs::create_dir_all(&schema_dir).unwrap();
+    let schema_path = schema_dir.join("disk.json");
+
+    let schema = Schema::new("disk".to_string());
+    std::fs::write(&schema_path, serde_json::to_string_pretty(&schema).unwrap()).unwrap();
+
+    let core = SchemaCore::new(dir.path().to_str().unwrap()).unwrap();
+    core.load_schemas_from_disk().unwrap();
+    drop(core);
+
+    let db = sled::open(dir.path()).unwrap();
+    let tree = db.open_tree("schema_states").unwrap();
+    assert!(tree.get("disk").unwrap().is_some());
+}
+


### PR DESCRIPTION
## Summary
- add new `schema/storage.rs` module for persistence helpers
- move validation logic into `schema/validator.rs`
- expose new modules in `schema/mod.rs`
- slim down `schema/core.rs` to delegate to helpers
- relocate schema core tests to `tests/schema_core_tests.rs`

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test`