### PR TITLE
Expose schema loaded status in API

### DIFF
--- a/fold_node/src/datafold_node/schema_routes.rs
+++ b/fold_node/src/datafold_node/schema_routes.rs
@@ -11,7 +11,7 @@ pub async fn list_schemas(state: web::Data<AppState>) -> impl Responder {
     info!("Received request to list schemas");
     let node_guard = state.node.lock().await;
 
-    match node_guard.list_schemas() {
+    match node_guard.list_schemas_with_state() {
         Ok(schemas) => HttpResponse::Ok().json(json!({"data": schemas})),
         Err(e) => {
             error!("Failed to list schemas: {}", e);

--- a/tests/integration_tests/http_server_tests.rs
+++ b/tests/integration_tests/http_server_tests.rs
@@ -30,7 +30,9 @@ async fn test_list_schemas_route() {
         .unwrap();
     assert!(resp.status().is_success());
     let body: Value = resp.json().await.unwrap();
-    assert!(body["data"].as_array().map(|a| !a.is_empty()).unwrap_or(false));
+    let arr = body["data"].as_array().expect("data array");
+    assert!(!arr.is_empty());
+    assert_eq!(arr[0]["state"], "Loaded");
     handle.abort();
 }
 


### PR DESCRIPTION
## Summary
- include schema load state when listing schemas
- fetch schemas with state in the HTTP route
- verify route output includes state

## Testing
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `npm test --silent`