### PR TITLE
Set new schema default state to Unloaded

### DIFF
--- a/fold_node/src/schema/core.rs
+++ b/fold_node/src/schema/core.rs
@@ -262,7 +262,10 @@ impl SchemaCore {
                         if let Some(mut schema) = schema_opt {
                             self.fix_transform_outputs(&mut schema);
                             let name = schema.name.clone();
-                            let state = states.get(&name).copied().unwrap_or(SchemaState::Loaded);
+                            let state = states
+                                .get(&name)
+                                .copied()
+                                .unwrap_or(SchemaState::Unloaded);
                             {
                                 let mut available = self.available.lock().map_err(|_| SchemaError::InvalidData("Failed to acquire schema lock".to_string()))?;
                                 available.insert(name.clone(), (schema.clone(), state));

--- a/fold_node/tests/schema_tests.rs
+++ b/fold_node/tests/schema_tests.rs
@@ -200,6 +200,9 @@ fn test_transform_placeholder_output_on_disk_load() {
     // Load the schema from disk
     let manager = SchemaCore::new(test_dir.path().to_str().unwrap()).unwrap();
     manager.load_schemas_from_disk().unwrap();
+    manager
+        .load_schema_from_file(schema_path.to_str().unwrap())
+        .unwrap();
 
     // Verify the transform output was updated
     let schema = manager


### PR DESCRIPTION
## Summary
- mark schemas without saved state as `Unloaded` when loading from disk
- update tests for new behaviour
- ensure transform placeholder test loads schema explicitly

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `CI=true npm test --silent`