### PR TITLE
Fix clippy lint warning

### DIFF
--- a/fold_node/tests/test_data/test_helpers/mod.rs
+++ b/fold_node/tests/test_data/test_helpers/mod.rs
@@ -107,10 +107,7 @@ pub fn cleanup_tmp_dir() {
             if entries.count() == 0 {
                 Ok(())
             } else {
-                Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Directory not empty",
-                ))
+                Err(std::io::Error::other("Directory not empty"))
             }
         } else {
             Ok(())

--- a/tests/test_data/test_helpers/mod.rs
+++ b/tests/test_data/test_helpers/mod.rs
@@ -106,10 +106,7 @@ pub fn cleanup_tmp_dir() {
             if entries.count() == 0 {
                 Ok(())
             } else {
-                Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Directory not empty",
-                ))
+                Err(std::io::Error::other("Directory not empty"))
             }
         } else {
             Ok(())


### PR DESCRIPTION
## Summary
- resolve clippy `io_other_error` warning in test helpers

## Testing
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm test` (in `fold_node/src/datafold_node/static-react`, interrupted after completion)
