### PR TITLE
Fix BlogPost sample initial state

### DIFF
--- a/fold_node/src/datafold_node/db.rs
+++ b/fold_node/src/datafold_node/db.rs
@@ -66,6 +66,15 @@ impl DataFoldNode {
         Ok(())
     }
 
+    /// Persist a schema without loading it into memory.
+    pub fn add_schema_unloaded(&mut self, schema: Schema) -> FoldDbResult<()> {
+        let mut db = self
+            .db
+            .lock()
+            .map_err(|_| FoldDbError::Config("Cannot lock database mutex".into()))?;
+        db.add_schema_unloaded(schema).map_err(|e| e.into())
+    }
+
     /// Executes an operation (query or mutation) on the database.
     pub fn execute_operation(&mut self, operation: Operation) -> FoldDbResult<Value> {
         match operation {

--- a/fold_node/src/datafold_node/http_server.rs
+++ b/fold_node/src/datafold_node/http_server.rs
@@ -75,8 +75,8 @@ impl DataFoldHttpServer {
         for schema_value in sample_schemas {
             let schema: Schema = serde_json::from_value(schema_value)
                 .map_err(|e| FoldDbError::Config(format!("Failed to deserialize sample schema: {}", e)))?;
-            info!("Loading sample schema into node: {}", schema.name);
-            node.load_schema(schema)?;
+            info!("Adding sample schema to node as unloaded: {}", schema.name);
+            node.add_schema_unloaded(schema)?;
         }
 
         Ok(Self {
@@ -279,6 +279,29 @@ mod tests {
 
         handle.abort();
         let _ = handle.await;
+    }
+
+    /// Ensure sample schemas start unloaded
+    #[tokio::test]
+    async fn samples_start_unloaded() {
+        let temp_dir = tempdir().unwrap();
+        let config = NodeConfig::new(temp_dir.path().to_path_buf());
+        let node = DataFoldNode::new(config).unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let bind_addr = format!("127.0.0.1:{}", addr.port());
+
+        let server = DataFoldHttpServer::new(node, &bind_addr)
+            .await
+            .expect("server init");
+
+        let node_guard = server.node.lock().await;
+        let loaded = node_guard.list_schemas().unwrap();
+        assert!(!loaded.iter().any(|s| s.name == "BlogPost"));
+        let available = node_guard.list_available_schemas().unwrap();
+        assert!(available.iter().any(|n| n == "BlogPost"));
     }
 }
 

--- a/fold_node/src/fold_db_core/mod.rs
+++ b/fold_node/src/fold_db_core/mod.rs
@@ -185,6 +185,11 @@ impl FoldDB {
         Ok(())
     }
 
+    /// Persist a schema but keep it unloaded.
+    pub fn add_schema_unloaded(&mut self, schema: Schema) -> Result<(), SchemaError> {
+        self.schema_manager.add_schema_unloaded(schema)
+    }
+
     pub fn allow_schema(&mut self, schema_name: &str) -> Result<(), SchemaError> {
         let exists = self.schema_manager.schema_exists(schema_name)?;
         if !exists {


### PR DESCRIPTION
## Summary
- add `add_schema_unloaded` to `SchemaCore` and expose through `FoldDB` and `DataFoldNode`
- ensure HTTP server persists sample schemas without loading them
- update integration tests to load samples over HTTP
- add unit test verifying samples start unloaded

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` in `fold_node/src/datafold_node/static-react`
