### PR TITLE
Fix dependencies graph edges

### DIFF
--- a/fold_node/src/datafold_node/static-react/src/utils/dependencyUtils.js
+++ b/fold_node/src/datafold_node/static-react/src/utils/dependencyUtils.js
@@ -50,7 +50,9 @@ export function getDependencyGraph(schemas) {
   Object.entries(deps).forEach(([target, arr]) => {
     arr.forEach(dep => {
       dep.types.forEach(type => {
-        edges.push({ source: dep.schema, target, type })
+        if (nodes.includes(dep.schema) && nodes.includes(target)) {
+          edges.push({ source: dep.schema, target, type })
+        }
       })
     })
   })


### PR DESCRIPTION
## Summary
- filter dependency graph edges to loaded schemas

## Testing
- `CI=1 npm test --prefix fold_node/src/datafold_node/static-react --silent`
- `cargo test --workspace --quiet`
- `cargo clippy --workspace -- -D warnings`
