### PR TITLE
Fix schema field display

### DIFF
--- a/fold_node/src/datafold_node/static-react/src/components/tabs/SchemaTab.jsx
+++ b/fold_node/src/datafold_node/static-react/src/components/tabs/SchemaTab.jsx
@@ -363,10 +363,19 @@ function SchemaTab({ schemas, onResult, onSchemaUpdated }) {
     return String(state || '').toLowerCase()
   }
   
-  const availableSchemas = allSchemas.filter(schema => getStateString(schema.state) === 'available')
-  // Use the schemas prop from App.jsx for approved schemas (these have field details)
-  const approvedSchemas = schemas || []
-  const blockedSchemas = allSchemas.filter(schema => getStateString(schema.state) === 'blocked')
+  const availableSchemas = allSchemas.filter(
+    (schema) => getStateString(schema.state) === 'available'
+  )
+
+  // Derive approved schemas from the full schema list so newly fetched field
+  // details are reflected when a schema is expanded.
+  const approvedSchemas = allSchemas.filter(
+    (schema) => getStateString(schema.state) === 'approved'
+  )
+
+  const blockedSchemas = allSchemas.filter(
+    (schema) => getStateString(schema.state) === 'blocked'
+  )
 
   return (
     <div className="p-6 space-y-6">

--- a/fold_node/src/datafold_node/static-react/src/test/components/tabs/SchemaTab.test.jsx
+++ b/fold_node/src/datafold_node/static-react/src/test/components/tabs/SchemaTab.test.jsx
@@ -252,4 +252,40 @@ describe('SchemaTab Component', () => {
       expect(fetch).toHaveBeenCalledWith('/api/schema/ApprovedSchema', { method: 'DELETE' })
     })
   })
+
+  it('fetches and displays fields when expanding an approved schema', async () => {
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [] })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            ApprovedSchema: 'Approved'
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          name: 'ApprovedSchema',
+          fields: {
+            id: { field_type: 'string', writable: true }
+          }
+        })
+      })
+
+    render(<SchemaTab {...mockProps} />)
+
+    // Expand the approved schema to trigger field fetch
+    await waitFor(() => {
+      fireEvent.click(screen.getByText('ApprovedSchema'))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('id')).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- use full schema list to keep field info updated
- test field display when expanding schema

## Testing
- `cargo test --workspace` *(fails: could not compile fold_db tests)*
- `cargo clippy`
- `npm test`