### PR TITLE
Handle empty ref_atom_uuid

### DIFF
--- a/fold_node/src/fold_db_core/field_manager.rs
+++ b/fold_node/src/fold_db_core/field_manager.rs
@@ -128,7 +128,12 @@ impl FieldManager {
         info!("📋 Field definition found for {}.{}, type: {:?}",
               schema.name, field, std::mem::discriminant(field_def));
         
-        let ref_atom_uuid = field_def.ref_atom_uuid();
+        // If the ref_atom_uuid hasn't been set yet, treat it as missing so
+        // queries return `null` for this field until a value is written.
+        let ref_atom_uuid = match field_def.ref_atom_uuid() {
+            Some(id) if id.is_empty() => None,
+            other => other,
+        };
         info!("🆔 ref_atom_uuid for {}.{}: {:?}", schema.name, field, ref_atom_uuid);
 
         let result = match field_def {

--- a/tests/integration_tests/datafold_node_tests.rs
+++ b/tests/integration_tests/datafold_node_tests.rs
@@ -134,3 +134,20 @@ fn test_version_history() {
     assert_eq!(history[0], json!("Jane Doe")); // Most recent first
     assert_eq!(history[1], json!("John Doe"));
 }
+
+#[test]
+fn test_query_returns_null_for_unwritten_field() {
+    let mut node = create_test_node();
+    let schema = create_basic_user_profile_schema();
+    load_and_allow(&mut node, schema).unwrap();
+
+    // Query a field that has never been written to
+    let value = query_value(&mut node, "user_profile", "name").unwrap();
+    assert_eq!(value, serde_json::Value::Null);
+
+    // Ensure the field has a ref_atom_uuid even though no data exists yet
+    let schema_after = node.get_schema("user_profile").unwrap().unwrap();
+    let name_field = schema_after.fields.get("name").unwrap();
+    assert!(name_field.ref_atom_uuid().is_some());
+    assert!(!name_field.ref_atom_uuid().unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary
- handle empty `ref_atom_uuid` in `FieldManager::get_field_value`
- ensure query returns null for unwritten field

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test --silent -- --run` *(fails: switches between tabs correctly)*

------
https://chatgpt.com/codex/tasks/task_e_6838f13dfe84832793ebfb1124b5f2ad