### PR TITLE
Improve node config loading

### DIFF
--- a/fold_node/src/bin/datafold_cli.rs
+++ b/fold_node/src/bin/datafold_cli.rs
@@ -291,7 +291,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Load node configuration
     info!("Loading config from: {}", cli.config);
-    let config = load_node_config(Some(&cli.config), None);
+    let config = load_node_config(Some(&cli.config), None)?;
 
     // Initialize node
     info!("Initializing DataFold Node...");

--- a/fold_node/src/bin/datafold_http_server.rs
+++ b/fold_node/src/bin/datafold_http_server.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let Cli { port: http_port } = Cli::parse();
 
     // Load node configuration
-    let config = load_node_config(None, None);
+    let config = load_node_config(None, None)?;
     info!("Config loaded successfully");
 
     // Load or initialize node

--- a/fold_node/src/bin/datafold_node.rs
+++ b/fold_node/src/bin/datafold_node.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let Cli { port, tcp_port } = Cli::parse();
 
     // Load node configuration
-    let config = load_node_config(None, Some(port));
+    let config = load_node_config(None, Some(port))?;
     info!("Config loaded successfully");
 
     // Load or initialize node

--- a/fold_node/tests/node_config_tests.rs
+++ b/fold_node/tests/node_config_tests.rs
@@ -5,7 +5,7 @@ use std::env;
 fn default_when_file_missing_with_port() {
     let tmp = tempfile::tempdir().unwrap();
     let missing = tmp.path().join("missing.json");
-    let config = load_node_config(Some(missing.to_str().unwrap()), Some(1234));
+    let config = load_node_config(Some(missing.to_str().unwrap()), Some(1234)).unwrap();
     assert_eq!(config.network_listen_address, "/ip4/0.0.0.0/tcp/1234");
 }
 
@@ -14,7 +14,16 @@ fn default_when_env_missing_file() {
     let tmp = tempfile::tempdir().unwrap();
     let missing = tmp.path().join("missing2.json");
     env::set_var("NODE_CONFIG", missing.to_str().unwrap());
-    let config = load_node_config(None, None);
+    let config = load_node_config(None, None).unwrap();
     env::remove_var("NODE_CONFIG");
     assert_eq!(config.storage_path, std::path::PathBuf::from("data"));
+}
+
+#[test]
+fn error_on_invalid_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("bad.json");
+    std::fs::write(&path, "{invalid json").unwrap();
+    let err = load_node_config(Some(path.to_str().unwrap()), None).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
 }


### PR DESCRIPTION
## Summary
- avoid panic in load_node_config
- return `Result` from load_node_config and log parse errors
- propagate errors in CLI binaries
- adapt tests for new Result type and cover parse failure

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(fails: Unable to find an element with the text: Run Sample Query)*

------
https://chatgpt.com/codex/tasks/task_e_683b3443b3b0832785ac90a90e262e09