### PR TITLE
Add queue inspection method

### DIFF
--- a/fold_node/src/fold_db_core/transform_orchestrator.rs
+++ b/fold_node/src/fold_db_core/transform_orchestrator.rs
@@ -223,6 +223,18 @@ impl TransformOrchestrator {
         info!("🏁 PROCESS_QUEUE COMPLETE - processed {} transforms", processed_count);
     }
 
+    /// List queued transform IDs without dequeuing or running them.
+    pub fn list_queued_transforms(&self) -> Result<Vec<String>, SchemaError> {
+        let q = self
+            .queue
+            .lock()
+            .map_err(|e| {
+                error!("Failed to acquire queue lock: {}", e);
+                SchemaError::InvalidData("Failed to acquire queue lock".to_string())
+            })?;
+        Ok(q.queue.iter().map(|item| item.id.clone()).collect())
+    }
+
     /// Queue length, useful for tests.
     pub fn len(&self) -> Result<usize, SchemaError> {
         let q = self


### PR DESCRIPTION
## Summary
- add `list_queued_transforms` to `TransformOrchestrator`
- simplify `get_transform_queue_info` to use the new method
- extend transform queue tests to ensure queue inspection is read-only

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test --silent` *(fails: Unable to find an element with the text: Run Sample Query)*

------
https://chatgpt.com/codex/tasks/task_e_683b343569548327bad4081815fdadbc