### PR TITLE
Add SchemaType enum

### DIFF
--- a/fold_node/src/error_handling/string_utils.rs
+++ b/fold_node/src/error_handling/string_utils.rs
@@ -99,9 +99,13 @@ mod tests {
     }
     
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_parse_number() {
         assert_eq!(StringUtils::parse_number::<i32>("42", "test").unwrap(), 42);
-        assert_eq!(StringUtils::parse_number::<f64>("3.14", "test").unwrap(), 3.14);
+        assert_eq!(
+            StringUtils::parse_number::<f64>("3.14", "test").unwrap(),
+            3.14
+        );
         assert!(StringUtils::parse_number::<i32>("not_a_number", "test").is_err());
     }
     

--- a/fold_node/src/schema/types/mod.rs
+++ b/fold_node/src/schema/types/mod.rs
@@ -11,5 +11,5 @@ pub use field::{Field, FieldVariant, SingleField, CollectionField, RangeField, F
 pub use json_schema::{JsonSchemaDefinition, JsonSchemaField};
 pub use operation::Operation;
 pub use operations::{Mutation, MutationType, Query};
-pub use schema::Schema;
+pub use schema::{Schema, SchemaType};
 pub use transform::{Transform, TransformRegistration};

--- a/fold_node/src/schema/types/schema.rs
+++ b/fold_node/src/schema/types/schema.rs
@@ -3,6 +3,15 @@ use crate::schema::types::field::FieldVariant;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Represents the schema-level type information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SchemaType {
+    /// Single schema without range semantics
+    Single,
+    /// Schema that stores data in a key range
+    Range { range_key: String },
+}
+
 /// Defines the structure, permissions, and payment requirements for a data collection.
 ///
 /// A Schema is the fundamental building block for data organization in the database.


### PR DESCRIPTION
## Summary
- add `SchemaType` enum with `Single` and `Range` variants
- export new enum from schema types module
- silence clippy approx_constant lint in `test_parse_number`
- rename enum variant from `Standard` to `Single`

## Testing
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`
- `npm test -- --run` *(fails: TestingLibraryElementError: Unable to find an element with the text: Run Sample Query)*

------
https://chatgpt.com/codex/tasks/task_e_683c7146ee0c8327a35a6f005be3d6a4