### PR TITLE
Add schema_type to Schema

### DIFF
--- a/fold_node/src/db_operations/tests.rs
+++ b/fold_node/src/db_operations/tests.rs
@@ -349,6 +349,7 @@ mod tests {
     fn test_schema_core_integration_with_unified_db_ops() {
         use crate::schema::{SchemaCore, Schema};
         use crate::schema::core::SchemaState;
+        use crate::schema::types::schema::default_schema_type;
         use crate::fees::payment_config::SchemaPaymentConfig;
         use std::sync::Arc;
         use std::collections::HashMap;
@@ -362,6 +363,7 @@ mod tests {
         // Create a test schema and add it to SchemaCore
         let test_schema = Schema {
             name: "TestSchema".to_string(),
+            schema_type: default_schema_type(),
             fields: HashMap::new(),
             payment_config: SchemaPaymentConfig::default(),
             hash: None,

--- a/fold_node/src/schema/core.rs
+++ b/fold_node/src/schema/core.rs
@@ -1,7 +1,9 @@
 use crate::atom::AtomRef;
 use crate::schema::types::{
-    JsonSchemaDefinition, JsonSchemaField, Schema, SchemaError, Field, FieldVariant, SingleField,
+    JsonSchemaDefinition, JsonSchemaField, Schema, SchemaError, Field, FieldVariant,
+    SingleField,
 };
+use crate::schema::types::schema::default_schema_type;
 use serde_json;
 use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
@@ -1099,6 +1101,7 @@ impl SchemaCore {
         // Create the schema
         Ok(Schema {
             name: json_schema.name,
+            schema_type: default_schema_type(),
             fields,
             payment_config: json_schema.payment_config,
             hash: json_schema.hash,

--- a/fold_node/src/schema/types/schema.rs
+++ b/fold_node/src/schema/types/schema.rs
@@ -12,6 +12,12 @@ pub enum SchemaType {
     Range { range_key: String },
 }
 
+pub fn default_schema_type() -> SchemaType {
+    SchemaType::Range {
+        range_key: "key".to_string(),
+    }
+}
+
 /// Defines the structure, permissions, and payment requirements for a data collection.
 ///
 /// A Schema is the fundamental building block for data organization in the database.
@@ -31,6 +37,9 @@ pub enum SchemaType {
 pub struct Schema {
     /// Unique name identifying this schema
     pub name: String,
+    /// The type of schema. Defaults to a key range schema.
+    #[serde(default = "default_schema_type")]
+    pub schema_type: SchemaType,
     /// Collection of fields with their definitions and configurations
     pub fields: HashMap<String, FieldVariant>,
     /// Payment configuration for schema-level access control
@@ -54,6 +63,7 @@ impl Schema {
     pub fn new(name: String) -> Self {
         Self {
             name,
+            schema_type: default_schema_type(),
             fields: HashMap::new(),
             payment_config: SchemaPaymentConfig::default(),
             hash: None,

--- a/fold_node/src/testing.rs
+++ b/fold_node/src/testing.rs
@@ -5,6 +5,7 @@ pub use crate::schema::types::{Mutation, MutationType, Operation, Query, Transfo
 pub use crate::schema::Schema;
 pub use crate::schema::SchemaCore;
 pub use crate::schema::SchemaError;
+pub use crate::schema::types::schema::default_schema_type;
 pub use crate::schema::SchemaValidator;
 
 pub use crate::transform::parser::TransformParser;
@@ -24,6 +25,7 @@ use std::collections::HashMap;
 pub fn create_test_schema(name: &str) -> Schema {
     Schema {
         name: name.to_string(),
+        schema_type: default_schema_type(),
         fields: HashMap::new(),
         payment_config: Default::default(),
         hash: None,

--- a/fold_node/tests/folddb_tests.rs
+++ b/fold_node/tests/folddb_tests.rs
@@ -2,6 +2,7 @@ use fold_node::testing::{
     ExplicitCounts, Field, FieldPaymentConfig, Mutation, MutationType, PermissionsPolicy,
     Query, Schema, SingleField, FieldVariant, SchemaPaymentConfig, TrustDistance, TrustDistanceScaling,
 };
+use fold_node::schema::types::schema::default_schema_type;
 use serde_json::json;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -49,6 +50,7 @@ fn test_schema_operations() {
 
     let schema = Schema {
         name: "test_schema".to_string(),
+        schema_type: default_schema_type(),
         fields,
         payment_config: SchemaPaymentConfig::default(),
         hash: None,
@@ -90,6 +92,7 @@ fn test_write_and_query() {
 
     let schema = Schema {
         name: "test_schema".to_string(),
+        schema_type: default_schema_type(),
         fields,
         payment_config: SchemaPaymentConfig::default(),
         hash: None,
@@ -161,6 +164,7 @@ fn test_atom_history() {
 
     let schema = Schema {
         name: "test_schema".to_string(),
+        schema_type: default_schema_type(),
         fields,
         payment_config: SchemaPaymentConfig::default(),
         hash: None,

--- a/fold_node/tests/permissions_tests.rs
+++ b/fold_node/tests/permissions_tests.rs
@@ -3,6 +3,7 @@ use fold_node::testing::{
     PermissionsPolicy, Query, Schema, SchemaCore, SingleField, FieldVariant, SchemaPaymentConfig, TrustDistance,
     TrustDistanceScaling,
 };
+use fold_node::schema::types::schema::default_schema_type;
 use fold_node::schema::types::Transform;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -36,6 +37,7 @@ fn test_non_reversible_transform_not_writable() {
 
     let schema = Schema {
         name: "test_schema".to_string(),
+        schema_type: default_schema_type(),
         fields,
         payment_config: SchemaPaymentConfig::default(),
         hash: None,
@@ -84,6 +86,7 @@ fn test_permission_wrapper_query() {
 
     let schema = Schema {
         name: "test_schema".to_string(),
+        schema_type: default_schema_type(),
         fields,
         payment_config: SchemaPaymentConfig::default(),
         hash: None,
@@ -148,6 +151,7 @@ fn test_permission_wrapper_no_requirement() {
 
     let schema = Schema {
         name: "test_schema".to_string(),
+        schema_type: default_schema_type(),
         fields,
         payment_config: SchemaPaymentConfig::default(),
         hash: None,
@@ -208,6 +212,7 @@ fn test_permission_wrapper_mutation() {
 
     let schema = Schema {
         name: "test_schema".to_string(),
+        schema_type: default_schema_type(),
         fields,
         payment_config: SchemaPaymentConfig::default(),
         hash: None,


### PR DESCRIPTION
## Summary
- add `schema_type` to `Schema` struct with default `Range`
- initialize `schema_type` in `Schema::new`
- update schema creation sites and tests

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(fails: Unable to find an element with the text: Run Sample Query)*

------
https://chatgpt.com/codex/tasks/task_e_683c78b397bc83278a9ceb03e5af2642