### PR TITLE
Add range schema tests

### DIFF
--- a/fold_node/src/testing.rs
+++ b/fold_node/src/testing.rs
@@ -23,13 +23,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 pub fn create_test_schema(name: &str) -> Schema {
-    Schema {
-        name: name.to_string(),
-        schema_type: default_schema_type(),
-        fields: HashMap::new(),
-        payment_config: Default::default(),
-        hash: None,
-    }
+    Schema::new_range(name.to_string(), "key".to_string())
 }
 
 pub fn create_test_value(value: &str) -> Value {

--- a/fold_node/tests/schema_new_range_tests.rs
+++ b/fold_node/tests/schema_new_range_tests.rs
@@ -1,0 +1,24 @@
+use fold_node::testing::Schema;
+use fold_node::schema::types::SchemaType;
+
+#[test]
+fn test_new_range_sets_range_key() {
+    let schema = Schema::new_range("range_schema".to_string(), "user_id".to_string());
+    assert_eq!(schema.name, "range_schema");
+    match schema.schema_type {
+        SchemaType::Range { ref range_key } => assert_eq!(range_key, "user_id"),
+        _ => panic!("Expected Range variant"),
+    }
+    assert!(schema.fields.is_empty());
+}
+
+#[test]
+fn test_new_range_serialization_preserves_key() {
+    let schema = Schema::new_range("serialize_schema".to_string(), "custom_key".to_string());
+    let json = serde_json::to_string(&schema).expect("serialize failed");
+    let deserialized: Schema = serde_json::from_str(&json).expect("deserialize failed");
+    match deserialized.schema_type {
+        SchemaType::Range { ref range_key } => assert_eq!(range_key, "custom_key"),
+        _ => panic!("Expected Range variant"),
+    }
+}

--- a/fold_node/tests/test_data/schema_test_data.rs
+++ b/fold_node/tests/test_data/schema_test_data.rs
@@ -11,7 +11,7 @@ pub fn create_default_payment_config() -> FieldPaymentConfig {
 
 #[allow(dead_code)]
 pub fn create_test_schema(name: &str) -> Schema {
-    let mut schema = Schema::new(name.to_string());
+    let mut schema = Schema::new_range(name.to_string(), "key".to_string());
     let field_name = "test_field".to_string();
     let mut field = SingleField::new(
         PermissionsPolicy::default(),
@@ -26,7 +26,7 @@ pub fn create_test_schema(name: &str) -> Schema {
 
 #[allow(dead_code)]
 pub fn create_user_profile_schema() -> Schema {
-    let mut schema = Schema::new("user_profile".to_string());
+    let mut schema = Schema::new_range("user_profile".to_string(), "key".to_string());
 
     // Public fields - basic profile info
     let mut username_field = SingleField::new(
@@ -66,7 +66,7 @@ pub fn create_user_profile_schema() -> Schema {
 
 #[allow(dead_code)]
 pub fn create_multi_field_schema() -> Schema {
-    let mut schema = Schema::new("test_schema".to_string());
+    let mut schema = Schema::new_range("test_schema".to_string(), "key".to_string());
 
     let fields = vec![
         ("public_field", PermissionsPolicy::default()),

--- a/fold_node/tests/test_data/test_helpers/schema_builder.rs
+++ b/fold_node/tests/test_data/test_helpers/schema_builder.rs
@@ -32,7 +32,7 @@ pub fn create_field_with_permissions(
 
 #[allow(dead_code)]
 pub fn create_schema_with_fields(name: String, fields: HashMap<String, FieldVariant>) -> Schema {
-    Schema::new(name)
+    Schema::new_range(name, "key".to_string())
         .with_fields(fields)
         .with_payment_config(SchemaPaymentConfig::default())
 }

--- a/tests/test_data/schema_test_data.rs
+++ b/tests/test_data/schema_test_data.rs
@@ -10,7 +10,7 @@ pub fn create_default_payment_config() -> FieldPaymentConfig {
 
 #[allow(dead_code)]
 pub fn create_test_schema(name: &str) -> Schema {
-    let mut schema = Schema::new(name.to_string());
+    let mut schema = Schema::new_range(name.to_string(), "key".to_string());
     let field_name = "test_field".to_string();
     let field = FieldVariant::Single(SingleField::new(
         PermissionsPolicy::default(),
@@ -24,7 +24,7 @@ pub fn create_test_schema(name: &str) -> Schema {
 
 #[allow(dead_code)]
 pub fn create_basic_user_profile_schema() -> Schema {
-    let mut schema = Schema::new("user_profile".to_string());
+    let mut schema = Schema::new_range("user_profile".to_string(), "key".to_string());
 
     let name_field = FieldVariant::Single(SingleField::new(
         PermissionsPolicy::new(TrustDistance::Distance(1), TrustDistance::Distance(1)),
@@ -45,7 +45,7 @@ pub fn create_basic_user_profile_schema() -> Schema {
 
 #[allow(dead_code)]
 pub fn create_user_profile_schema() -> Schema {
-    let mut schema = Schema::new("user_profile".to_string());
+    let mut schema = Schema::new_range("user_profile".to_string(), "key".to_string());
 
     // Public fields - basic profile info
     schema.add_field(
@@ -90,7 +90,7 @@ pub fn create_user_profile_schema() -> Schema {
 
 #[allow(dead_code)]
 pub fn create_multi_field_schema() -> Schema {
-    let mut schema = Schema::new("test_schema".to_string());
+    let mut schema = Schema::new_range("test_schema".to_string(), "key".to_string());
 
     let fields = vec![
         ("public_field", PermissionsPolicy::default()),

--- a/tests/test_data/test_helpers/schema_builder.rs
+++ b/tests/test_data/test_helpers/schema_builder.rs
@@ -37,7 +37,7 @@ pub fn create_field_with_permissions(
 }
 
 pub fn create_schema_with_fields(name: String, fields: HashMap<String, FieldVariant>) -> Schema {
-    Schema::new(name)
+    Schema::new_range(name, "key".to_string())
         .with_fields(fields)
         .with_payment_config(SchemaPaymentConfig::default())
 }


### PR DESCRIPTION
## Summary
- test `Schema::new_range` constructor in `fold_node/tests`
- support `Schema::new_range` in schema helpers

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(fails: Unable to run integration test suite)*

------
https://chatgpt.com/codex/tasks/task_e_683c857a620c8327bd3d7fff22008326