### PR TITLE
Add copy logs button

### DIFF
--- a/fold_node/src/datafold_node/static-react/src/components/LogSidebar.jsx
+++ b/fold_node/src/datafold_node/static-react/src/components/LogSidebar.jsx
@@ -4,6 +4,12 @@ function LogSidebar() {
   const [logs, setLogs] = useState([])
   const endRef = useRef(null)
 
+  const handleCopy = () => {
+    Promise.resolve(
+      navigator.clipboard.writeText(logs.join('\n'))
+    ).catch(() => {})
+  }
+
   useEffect(() => {
     fetch('/api/logs')
       .then(res => res.json())
@@ -23,7 +29,15 @@ function LogSidebar() {
 
   return (
     <aside className="w-80 h-screen bg-gray-900 text-white p-4 overflow-y-auto">
-      <h2 className="text-lg font-semibold mb-2">Logs</h2>
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-lg font-semibold">Logs</h2>
+        <button
+          onClick={handleCopy}
+          className="text-xs text-blue-300 hover:underline"
+        >
+          Copy
+        </button>
+      </div>
       <div className="space-y-1 text-xs font-mono">
         {logs.map((line, idx) => (
           <div key={idx}>{line}</div>

--- a/fold_node/src/datafold_node/static-react/src/test/components/LogSidebar.test.jsx
+++ b/fold_node/src/datafold_node/static-react/src/test/components/LogSidebar.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import LogSidebar from '../../components/LogSidebar'
+
+describe('LogSidebar', () => {
+  it('copies logs to clipboard', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, json: async () => ['line1', 'line2'] })
+    const es = { onmessage: null, close: vi.fn() }
+    global.EventSource.mockImplementation(() => es)
+    const writeText = vi.fn()
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    render(<LogSidebar />)
+    await screen.findByText('line1')
+    fireEvent.click(screen.getByText('Copy'))
+    expect(writeText).toHaveBeenCalledWith('line1\nline2')
+  })
+})


### PR DESCRIPTION
## Summary
- add copy button to LogSidebar for copying log output
- test LogSidebar clipboard behavior with Vitest

## Testing
- `cargo test --workspace`
- `cargo clippy --workspace`
- `npm test --silent` *(failed: Vitest suite errors)*
- `npx vitest run src/test/components/LogSidebar.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_6840854acd108327aad181a5e0bfa2aa