### PR TITLE
Refactor default port values into constants

### DIFF
--- a/src/bin/datafold_http_server.rs
+++ b/src/bin/datafold_http_server.rs
@@ -1,5 +1,8 @@
 use clap::Parser;
-use datafold::datafold_node::{load_node_config, DataFoldHttpServer, DataFoldNode};
+use datafold::{
+    constants::DEFAULT_HTTP_PORT,
+    datafold_node::{load_node_config, DataFoldHttpServer, DataFoldNode},
+};
 use log::info;
 
 /// Command line options for the HTTP server binary.
@@ -7,7 +10,7 @@ use log::info;
 #[command(author, version, about)]
 struct Cli {
     /// Port for the HTTP server
-    #[arg(long, default_value_t = 9001)]
+    #[arg(long, default_value_t = DEFAULT_HTTP_PORT)]
     port: u16,
 }
 
@@ -70,11 +73,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 mod tests {
     use super::Cli;
     use clap::Parser;
+    use datafold::constants::DEFAULT_HTTP_PORT;
 
     #[test]
     fn defaults() {
         let cli = Cli::parse_from(["test"]);
-        assert_eq!(cli.port, 9001);
+        assert_eq!(cli.port, DEFAULT_HTTP_PORT);
     }
 
     #[test]

--- a/src/bin/datafold_node.rs
+++ b/src/bin/datafold_node.rs
@@ -1,4 +1,5 @@
 use datafold::{
+    constants::DEFAULT_P2P_PORT,
     datafold_node::{load_node_config, DataFoldNode, TcpServer},
     network::NetworkConfig,
 };
@@ -11,11 +12,11 @@ use log::{error, info};
 #[command(author, version, about)]
 struct Cli {
     /// Port for the P2P network
-    #[arg(long, default_value_t = 9000)]
+    #[arg(long, default_value_t = DEFAULT_P2P_PORT)]
     port: u16,
 
     /// Port for the TCP server
-    #[arg(long, default_value_t = 9000)]
+    #[arg(long, default_value_t = DEFAULT_P2P_PORT)]
     tcp_port: u16,
 }
 
@@ -107,12 +108,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 mod tests {
     use super::Cli;
     use clap::Parser;
+    use datafold::constants::DEFAULT_P2P_PORT;
 
     #[test]
     fn defaults() {
         let cli = Cli::parse_from(["test"]);
-        assert_eq!(cli.port, 9000);
-        assert_eq!(cli.tcp_port, 9000);
+        assert_eq!(cli.port, DEFAULT_P2P_PORT);
+        assert_eq!(cli.tcp_port, DEFAULT_P2P_PORT);
     }
 
     #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,6 @@
+/// Common constants used across the DataFold project.
+///
+/// These defaults are used for command line arguments and
+/// configuration when explicit values are not provided.
+pub const DEFAULT_P2P_PORT: u16 = 9000;
+pub const DEFAULT_HTTP_PORT: u16 = 9001;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod testing_utils;
 pub mod transform;
 pub mod validation_utils;
 pub mod web_logger;
+pub mod constants;
 
 // Re-export main types for convenience
 pub use datafold_node::config::load_node_config;
@@ -71,3 +72,6 @@ pub use security::{
 
 // Re-export ingestion types
 pub use ingestion::{IngestionConfig, IngestionCore, IngestionError, IngestionResponse};
+
+// Re-export commonly used constants
+pub use constants::{DEFAULT_P2P_PORT, DEFAULT_HTTP_PORT};


### PR DESCRIPTION
## Summary
- add constants for the default P2P and HTTP ports
- use these constants in the node and HTTP server binaries
- expose constants from the library API

## Testing
- `cargo test --workspace`
- `cargo clippy -- -D warnings`
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6855ceef735c83278ea7ec0fcd05553b