### PR TITLE
Add shared test wait constant

### DIFF
--- a/tests/integration/complete_mutation_query_flow_test.rs
+++ b/tests/integration/complete_mutation_query_flow_test.rs
@@ -28,6 +28,7 @@ use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 use std::thread;
+use crate::test_utils::TEST_WAIT_MS;
 use std::collections::HashMap;
 use tempfile::tempdir;
 
@@ -383,7 +384,7 @@ fn test_concurrent_mutations_and_queries() {
             
             // Publish and wait for response
             message_bus.publish(request).expect("Failed to publish request");
-            thread::sleep(Duration::from_millis(100));
+            thread::sleep(Duration::from_millis(TEST_WAIT_MS));
             
             let response = response_consumer.recv_timeout(Duration::from_millis(1000))
                 .expect("Failed to receive response");

--- a/tests/integration/range_architecture_test.rs
+++ b/tests/integration/range_architecture_test.rs
@@ -25,6 +25,7 @@ use serde_json::json;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::thread;
+use crate::test_utils::TEST_WAIT_MS;
 use tempfile::tempdir;
 use uuid::Uuid;
 
@@ -146,7 +147,7 @@ impl RangeArchitectureTestFixture {
         self.message_bus.publish(request)?;
         
         // Wait for processing
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(TEST_WAIT_MS));
         
         let response = response_consumer.recv_timeout(Duration::from_millis(2000))
             .map_err(|_| "Timeout waiting for FieldValueSetResponse")?;

--- a/tests/integration/stress_performance_test.rs
+++ b/tests/integration/stress_performance_test.rs
@@ -25,6 +25,7 @@ use serde_json::json;
 use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
 use std::time::{Duration, Instant};
 use std::thread;
+use crate::test_utils::TEST_WAIT_MS;
 use tempfile::tempdir;
 use uuid::Uuid;
 
@@ -173,7 +174,7 @@ impl StressPerformanceTestFixture {
                     
                     if message_bus.publish(request).is_ok() {
                         // Try to get response (with short timeout for high throughput)
-                        match response_consumer.recv_timeout(Duration::from_millis(100)) {
+                        match response_consumer.recv_timeout(Duration::from_millis(TEST_WAIT_MS)) {
                             Ok(response) if response.success => {
                                 successful.fetch_add(1, Ordering::Relaxed);
                             }
@@ -320,7 +321,7 @@ fn test_high_volume_mutations() {
         println!("   Burst {}: {:.2} mutations/sec", burst_num + 1, burst_rate);
         
         // Small delay between bursts
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(TEST_WAIT_MS));
     }
     
     let avg_burst_rate = burst_rates.iter().sum::<f64>() / burst_rates.len() as f64;
@@ -405,7 +406,7 @@ fn test_concurrent_transform_execution() {
     let monitor_timeout = Duration::from_secs(10);
     
     while monitor_start.elapsed() < monitor_timeout {
-        match executed_consumer.recv_timeout(Duration::from_millis(100)) {
+        match executed_consumer.recv_timeout(Duration::from_millis(TEST_WAIT_MS)) {
             Ok(_executed_event) => {
                 executed_count.fetch_add(1, Ordering::Relaxed);
             }
@@ -899,7 +900,7 @@ fn test_event_system_performance_under_load() {
             consumer_done = true;
             println!("Slow consumer completed");
         }
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(TEST_WAIT_MS));
     }
     
     // Force completion

--- a/tests/range_key_query_bug_test.rs
+++ b/tests/range_key_query_bug_test.rs
@@ -15,6 +15,8 @@ use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 use std::thread;
+mod test_utils;
+use test_utils::TEST_WAIT_MS;
 use tempfile::TempDir;
 
 struct RangeKeyTestFixture {
@@ -69,7 +71,7 @@ impl RangeKeyTestFixture {
     
     fn store_range_data(&self, range_key: &str, test_id_value: &str, test_data_value: &str) -> Result<(), Box<dyn std::error::Error>> {
         // Give the atom manager time to initialize its event processing
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(TEST_WAIT_MS));
         
         // Subscribe to responses
         let mut response_consumer = self.message_bus.subscribe::<FieldValueSetResponse>();
@@ -87,7 +89,7 @@ impl RangeKeyTestFixture {
         );
         
         self.message_bus.publish(test_id_request)?;
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(TEST_WAIT_MS));
         let _response1 = response_consumer.recv_timeout(Duration::from_millis(2000))?;
         
         // Store test_data field
@@ -103,7 +105,7 @@ impl RangeKeyTestFixture {
         );
         
         self.message_bus.publish(test_data_request)?;
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(TEST_WAIT_MS));
         let _response2 = response_consumer.recv_timeout(Duration::from_millis(2000))?;
         
         Ok(())

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -17,6 +17,9 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use uuid::Uuid;
 
+/// Default wait duration for asynchronous test operations
+pub const TEST_WAIT_MS: u64 = 100;
+
 /// Single unified test fixture eliminating all duplication
 pub struct TestFixture {
     pub transform_manager: Arc<TransformManager>,
@@ -164,7 +167,7 @@ impl TestFixture {
 
     /// Unified wait function - consolidates sleep patterns
     pub async fn wait_for_async_operation() {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(TEST_WAIT_MS)).await;
     }
 
     /// Unified correlation ID generation

--- a/tests/transform_trigger_diagnostic_test.rs
+++ b/tests/transform_trigger_diagnostic_test.rs
@@ -19,6 +19,8 @@ use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 use std::thread;
+mod test_utils;
+use test_utils::TEST_WAIT_MS;
 use std::collections::HashSet;
 use tempfile::tempdir;
 
@@ -105,7 +107,7 @@ fn test_transform_trigger_diagnostic_fix() {
     
     // Verify FieldValueSetResponse
     println!("🔍 Checking for FieldValueSetResponse");
-    let response = response_consumer.recv_timeout(Duration::from_millis(100))
+    let response = response_consumer.recv_timeout(Duration::from_millis(TEST_WAIT_MS))
         .expect("Should receive FieldValueSetResponse");
     
     println!("✅ DIAGNOSTIC: Received FieldValueSetResponse - success: {}", response.success);
@@ -114,7 +116,7 @@ fn test_transform_trigger_diagnostic_fix() {
     
     // CRITICAL CHECK: Verify FieldValueSet event was published (THE FIX)
     println!("🔍 DIAGNOSTIC: Checking for FieldValueSet event (the critical fix)");
-    match field_value_consumer.recv_timeout(Duration::from_millis(100)) {
+    match field_value_consumer.recv_timeout(Duration::from_millis(TEST_WAIT_MS)) {
         Ok(field_event) => {
             println!("✅ DIAGNOSTIC FIX SUCCESS: FieldValueSet event received!");
             println!("   Field: {}", field_event.field);
@@ -129,7 +131,7 @@ fn test_transform_trigger_diagnostic_fix() {
             
             // Check for TransformTriggered event
             println!("🔍 DIAGNOSTIC: Checking for TransformTriggered event");
-            match triggered_consumer.recv_timeout(Duration::from_millis(100)) {
+            match triggered_consumer.recv_timeout(Duration::from_millis(TEST_WAIT_MS)) {
                 Ok(triggered_event) => {
                     println!("✅ DIAGNOSTIC: TransformTriggered event received!");
                     println!("   Transform ID: {}", triggered_event.transform_id);
@@ -199,13 +201,13 @@ fn test_transform_trigger_with_no_transforms() {
     thread::sleep(Duration::from_millis(300));
     
     // Should still receive FieldValueSet event
-    let field_event = field_value_consumer.recv_timeout(Duration::from_millis(100))
+    let field_event = field_value_consumer.recv_timeout(Duration::from_millis(TEST_WAIT_MS))
         .expect("Should receive FieldValueSet event even with no transforms");
     
     println!("✅ FieldValueSet event received for field with no transforms: {}", field_event.field);
     
     // Should NOT receive TransformTriggered event
-    match triggered_consumer.recv_timeout(Duration::from_millis(100)) {
+    match triggered_consumer.recv_timeout(Duration::from_millis(TEST_WAIT_MS)) {
         Ok(_) => panic!("Should not receive TransformTriggered for field with no transforms"),
         Err(_) => println!("✅ Correctly no TransformTriggered event for field with no transforms"),
     }

--- a/tests/ui_range_filter_test.rs
+++ b/tests/ui_range_filter_test.rs
@@ -8,6 +8,8 @@ use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 use std::thread;
+mod test_utils;
+use test_utils::TEST_WAIT_MS;
 use datafold::{
     db_operations::DbOperations,
     fold_db_core::{
@@ -79,7 +81,7 @@ impl UIRangeFilterTestFixture {
     
     fn store_ui_test_data(&self, range_key: &str, test_id_value: &str, test_data_value: &str) -> Result<(), Box<dyn std::error::Error>> {
         // Give the atom manager time to initialize its event processing
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(TEST_WAIT_MS));
         
         // Subscribe to responses
         let mut response_consumer = self.message_bus.subscribe::<FieldValueSetResponse>();
@@ -97,7 +99,7 @@ impl UIRangeFilterTestFixture {
         );
         
         self.message_bus.publish(test_id_request)?;
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(TEST_WAIT_MS));
         let _response1 = response_consumer.recv_timeout(Duration::from_millis(2000))?;
         
         // Store test_data field
@@ -113,7 +115,7 @@ impl UIRangeFilterTestFixture {
         );
         
         self.message_bus.publish(test_data_request)?;
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(TEST_WAIT_MS));
         let _response2 = response_consumer.recv_timeout(Duration::from_millis(2000))?;
         
         Ok(())


### PR DESCRIPTION
## Summary
- centralize a common async wait duration for tests
- replace hardcoded waits with `TEST_WAIT_MS`

## Testing
- `cargo test --workspace`
- `cargo clippy --workspace`
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685600756cf88327ae983df6ae8fd25c