### PR TITLE
Add key ID handling in KeyGenerationComponent

### DIFF
--- a/src/datafold_node/static-react/src/components/KeyGenerationComponent.jsx
+++ b/src/datafold_node/static-react/src/components/KeyGenerationComponent.jsx
@@ -47,6 +47,7 @@ const KeyGenerationComponent = ({
 }) => {
   const [isRegistering, setIsRegistering] = useState(false);
   const [copiedField, setCopiedField] = useState(null);
+  const [publicKeyId, setPublicKeyId] = useState(null);
 
   const {
     result: verificationResult,
@@ -101,6 +102,9 @@ const KeyGenerationComponent = ({
       const data = await response.json();
       if (data.success) {
         setIsRegistered(true);
+        if (data.public_key_id) {
+          setPublicKeyId(data.public_key_id);
+        }
       } else {
         throw new Error(data.error || 'Registration failed');
       }
@@ -201,6 +205,7 @@ const KeyGenerationComponent = ({
               <div className="text-sm text-green-700">
                 <p className="font-medium">Success!</p>
                 <p>Public key has been registered with the server.</p>
+                {publicKeyId && <p>Key ID: {publicKeyId}</p>}
               </div>
             </div>
           </div>

--- a/src/datafold_node/static-react/src/test/components/KeyGenerationComponent.test.jsx
+++ b/src/datafold_node/static-react/src/test/components/KeyGenerationComponent.test.jsx
@@ -21,7 +21,7 @@ describe('KeyGenerationComponent', () => {
     // Setup default fetch response
     global.fetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ success: true }),
+      json: () => Promise.resolve({ success: true, public_key_id: 'key123' }),
     });
   });
 
@@ -79,7 +79,7 @@ describe('KeyGenerationComponent', () => {
     fireEvent.click(registerButton);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith('/api/security/register-key', {
+      expect(global.fetch).toHaveBeenCalledWith('/api/security/keys/register', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -106,6 +106,24 @@ describe('KeyGenerationComponent', () => {
     await waitFor(() => {
       expect(screen.getByText('Success!')).toBeInTheDocument();
       expect(screen.getByText('Public key has been registered with the server.')).toBeInTheDocument();
+    });
+  });
+
+  it('displays key ID after registration', async () => {
+    render(<KeyGenerationComponent />);
+
+    const generateButton = screen.getByText('Generate New Keypair');
+    fireEvent.click(generateButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Register Public Key')).toBeInTheDocument();
+    });
+
+    const registerButton = screen.getByText('Register Public Key');
+    fireEvent.click(registerButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Key ID: key123')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- store returned `public_key_id` in state when registering a key
- display key ID in success message
- expect ID in unit tests and add coverage for it

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test --silent` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_6856d104f7d483279569f1f8584a34b9