### PR TITLE
refactor: unify node logs

### DIFF
--- a/src/datafold_node/config.rs
+++ b/src/datafold_node/config.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use crate::security::SecurityConfig;
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 
 /// Configuration for a DataFoldNode instance.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,7 +79,7 @@ pub fn load_node_config(
                 Ok(cfg)
             }
             Err(e) => {
-                log::error!("Failed to parse node configuration: {}", e);
+                log_feature!(LogFeature::HttpServer, error, "Failed to parse node configuration: {}", e);
                 Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
             }
         }

--- a/src/datafold_node/db.rs
+++ b/src/datafold_node/db.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use crate::error::{FoldDbError, FoldDbResult};
 use crate::schema::types::{Mutation, Operation, Query, Transform};
 use crate::schema::SchemaError;
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 
 use super::DataFoldNode;
 
@@ -213,7 +215,9 @@ impl DataFoldNode {
             db.get_schema_permissions(node_id)
         };
 
-        log::error!(
+        log_feature!(
+            LogFeature::Permissions,
+            error,
             "Permission denied for {} on schema '{}': Node '{}' permissions: {:?}",
             operation_type,
             schema_name,

--- a/src/datafold_node/http_server.rs
+++ b/src/datafold_node/http_server.rs
@@ -8,7 +8,8 @@ use crate::ingestion::routes as ingestion_routes;
 use actix_cors::Cors;
 use actix_files::Files;
 use actix_web::{web, App, HttpServer as ActixHttpServer};
-use log::info;
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -60,7 +61,9 @@ impl DataFoldHttpServer {
     pub async fn new(node: DataFoldNode, bind_address: &str) -> FoldDbResult<Self> {
         // Initialize the enhanced logging system
         if let Err(e) = crate::logging::LoggingSystem::init_default().await {
-            log::warn!(
+            log_feature!(
+                LogFeature::HttpServer,
+                warn,
                 "Failed to initialize enhanced logging system, falling back to web logger: {}",
                 e
             );
@@ -90,7 +93,12 @@ impl DataFoldHttpServer {
     /// * There is an error binding to the specified address
     /// * There is an error starting the server
     pub async fn run(&self) -> FoldDbResult<()> {
-        info!("HTTP server running on {}", self.bind_address);
+        log_feature!(
+            LogFeature::HttpServer,
+            info,
+            "HTTP server running on {}",
+            self.bind_address
+        );
 
         // Create shared application state
         let app_state = web::Data::new(AppState {

--- a/src/datafold_node/network.rs
+++ b/src/datafold_node/network.rs
@@ -1,4 +1,5 @@
-use log::info;
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -39,9 +40,12 @@ impl DataFoldNode {
 
         let local_peer_id = network_core.local_peer_id();
         network_core.register_node_id(&self.node_id, local_peer_id);
-        info!(
+        log_feature!(
+            LogFeature::Network,
+            info,
             "Registered node ID {} with peer ID {}",
-            self.node_id, local_peer_id
+            self.node_id,
+            local_peer_id
         );
 
         self.network = Some(Arc::new(tokio::sync::Mutex::new(network_core)));
@@ -88,7 +92,7 @@ impl DataFoldNode {
     pub async fn stop_network(&self) -> FoldDbResult<()> {
         if let Some(network) = &self.network {
             let mut network_guard = network.lock().await;
-            info!("Stopping network service");
+            log_feature!(LogFeature::Network, info, "Stopping network service");
             network_guard.stop();
             Ok(())
         } else {
@@ -114,7 +118,7 @@ impl DataFoldNode {
         if let Some(network) = &self.network {
             let network_guard = network.lock().await;
 
-            info!("Triggering mDNS discovery...");
+            log_feature!(LogFeature::Network, info, "Triggering mDNS discovery...");
 
             let known_peers: Vec<PeerId> = network_guard.known_peers().iter().cloned().collect();
 
@@ -193,14 +197,26 @@ impl DataFoldNode {
                 .get_node_id_for_peer(&peer_id)
                 .unwrap_or_else(|| peer_id.to_string());
 
-            info!("Forwarding request to node {} (peer {})", node_id, peer_id);
+            log_feature!(
+                LogFeature::Network,
+                info,
+                "Forwarding request to node {} (peer {})",
+                node_id,
+                peer_id
+            );
 
             let response = network
                 .forward_request(peer_id, request)
                 .await
                 .map_err(|e| FoldDbError::Network(e.into()))?;
 
-            info!("Received response from node {} (peer {})", node_id, peer_id);
+            log_feature!(
+                LogFeature::Network,
+                info,
+                "Received response from node {} (peer {})",
+                node_id,
+                peer_id
+            );
 
             Ok(response)
         } else {
@@ -233,12 +249,12 @@ impl DataFoldNode {
 
     /// Restart the node by reinitializing all components
     pub async fn restart(&mut self) -> FoldDbResult<()> {
-        info!("Restarting DataFoldNode...");
+        log_feature!(LogFeature::Network, info, "Restarting DataFoldNode...");
 
         if self.network.is_some() {
-            info!("Stopping network service for restart");
+            log_feature!(LogFeature::Network, info, "Stopping network service for restart");
             if let Err(e) = self.stop_network().await {
-                log::warn!("Failed to stop network during restart: {}", e);
+                log_feature!(LogFeature::Network, warn, "Failed to stop network during restart: {}", e);
             }
         }
 
@@ -249,7 +265,7 @@ impl DataFoldNode {
             .ok_or_else(|| FoldDbError::Config("Invalid storage path".to_string()))?
             .to_string();
 
-        info!("Closing existing database");
+        log_feature!(LogFeature::Network, info, "Closing existing database");
         let old_db = std::mem::replace(
             &mut self.db,
             Arc::new(Mutex::new(FoldDB::new(&format!("{}_temp", storage_path))?)),
@@ -259,7 +275,7 @@ impl DataFoldNode {
 
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-        info!("Reinitializing database");
+        log_feature!(LogFeature::Network, info, "Reinitializing database");
         let new_db = Arc::new(Mutex::new(FoldDB::new(&storage_path)?));
         self.db = new_db;
 
@@ -275,13 +291,13 @@ impl DataFoldNode {
                 .map_err(|e| FoldDbError::SecurityError(e.to_string()))?,
         );
 
-        info!("DataFoldNode restart completed successfully");
+        log_feature!(LogFeature::Network, info, "DataFoldNode restart completed successfully");
         Ok(())
     }
 
     /// Perform a soft restart that preserves network connections
     pub async fn soft_restart(&mut self) -> FoldDbResult<()> {
-        info!("Performing soft restart of DataFoldNode...");
+        log_feature!(LogFeature::Network, info, "Performing soft restart of DataFoldNode...");
 
         let storage_path = self
             .config
@@ -290,7 +306,7 @@ impl DataFoldNode {
             .ok_or_else(|| FoldDbError::Config("Invalid storage path".to_string()))?
             .to_string();
 
-        info!("Closing existing database");
+        log_feature!(LogFeature::Network, info, "Closing existing database");
         let old_db = std::mem::replace(
             &mut self.db,
             Arc::new(Mutex::new(FoldDB::new(&format!("{}_temp", storage_path))?)),
@@ -300,11 +316,11 @@ impl DataFoldNode {
 
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-        info!("Reinitializing database");
+        log_feature!(LogFeature::Network, info, "Reinitializing database");
         let new_db = Arc::new(Mutex::new(FoldDB::new(&storage_path)?));
         self.db = new_db;
 
-        info!("DataFoldNode soft restart completed successfully");
+        log_feature!(LogFeature::Network, info, "DataFoldNode soft restart completed successfully");
         Ok(())
     }
 }

--- a/src/datafold_node/node.rs
+++ b/src/datafold_node/node.rs
@@ -1,4 +1,5 @@
-use log::info;
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -131,7 +132,7 @@ impl DataFoldNode {
 
     /// Loads an existing database node from the specified configuration.
 pub async fn load(config: NodeConfig) -> FoldDbResult<Self> {
-        info!("Loading DataFoldNode from config");
+        log_feature!(LogFeature::Database, info, "Loading DataFoldNode from config");
         let node = Self::new(config)?;
 
         // Delegate to SchemaCore for unified schema discovery and loading
@@ -146,7 +147,11 @@ pub async fn load(config: NodeConfig) -> FoldDbResult<Self> {
             })?;
         }
 
-        info!("DataFoldNode loaded successfully with schema system initialized");
+        log_feature!(
+            LogFeature::Database,
+            info,
+            "DataFoldNode loaded successfully with schema system initialized"
+        );
         Ok(node)
     }
 

--- a/src/datafold_node/permissions.rs
+++ b/src/datafold_node/permissions.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
 use crate::error::{FoldDbError, FoldDbResult};
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 
 use super::config::NodeInfo;
 use super::DataFoldNode;
@@ -95,7 +97,9 @@ impl DataFoldNode {
     /// Only approved schemas are accessible - available and blocked schemas are denied.
     pub fn check_schema_permission(&self, schema_name: &str) -> FoldDbResult<bool> {
         let db = self.db.lock().map_err(|e| {
-            log::error!(
+            log_feature!(
+                LogFeature::Permissions,
+                error,
                 "Failed to lock database mutex for permission check: {:?}",
                 e
             );
@@ -106,18 +110,20 @@ impl DataFoldNode {
         match db.schema_manager.get_schema_state(schema_name) {
             Some(crate::schema::core::SchemaState::Approved) => Ok(true),
             Some(crate::schema::core::SchemaState::Available) => {
-                log::warn!(
+                log_feature!(
+                    LogFeature::Permissions,
+                    warn,
                     "Schema '{}' is available but not approved - access denied",
                     schema_name
                 );
                 Ok(false)
             }
             Some(crate::schema::core::SchemaState::Blocked) => {
-                log::warn!("Schema '{}' is blocked - access denied", schema_name);
+                log_feature!(LogFeature::Permissions, warn, "Schema '{}' is blocked - access denied", schema_name);
                 Ok(false)
             }
             None => {
-                log::warn!("Schema '{}' not found - access denied", schema_name);
+                log_feature!(LogFeature::Permissions, warn, "Schema '{}' not found - access denied", schema_name);
                 Ok(false)
             }
         }

--- a/src/datafold_node/query_routes.rs
+++ b/src/datafold_node/query_routes.rs
@@ -8,6 +8,8 @@ use actix_web::{web, HttpResponse, Responder};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use base64::{engine::general_purpose, Engine as _};
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 
 /// Execute an operation (query or mutation).
 #[derive(Deserialize)]
@@ -41,7 +43,9 @@ pub async fn execute_operation(
 /// Execute a query.
 pub async fn execute_query(query: web::Json<Value>, state: web::Data<AppState>) -> impl Responder {
     let query_value = query.into_inner();
-    log::info!(
+    log_feature!(
+        LogFeature::Query,
+        info,
         "Received query request: {}",
         serde_json::to_string(&query_value).unwrap_or_else(|_| "Invalid JSON".to_string())
     );
@@ -83,7 +87,7 @@ pub async fn execute_query(query: web::Json<Value>, state: web::Data<AppState>) 
 
     match node_guard.query(internal_query) {
         Ok(results) => {
-            log::info!("Query executed successfully");
+            log_feature!(LogFeature::Query, info, "Query executed successfully");
             // Convert Vec<Result<Value, SchemaError>> to Vec<Value> with errors as JSON
             let unwrapped: Vec<Value> = results
                 .into_iter()
@@ -92,7 +96,7 @@ pub async fn execute_query(query: web::Json<Value>, state: web::Data<AppState>) 
             HttpResponse::Ok().json(json!({"data": unwrapped}))
         }
         Err(e) => {
-            log::error!("Query execution failed: {}", e);
+            log_feature!(LogFeature::Query, error, "Query execution failed: {}", e);
             HttpResponse::InternalServerError()
                 .json(json!({"error": format!("Failed to execute query: {}", e)}))
         }
@@ -110,14 +114,16 @@ pub async fn execute_mutation(
     let verification_result = node_guard.security_manager.verify_message(&signed_message);
 
     if let Err(e) = verification_result {
-        log::warn!("Signature verification failed: {}", e);
+        log_feature!(LogFeature::Mutation, warn, "Signature verification failed: {}", e);
         return HttpResponse::Unauthorized()
             .json(json!({"error": format!("Signature verification failed: {}", e)}));
     }
 
     let verification_data = verification_result.unwrap();
     if !verification_data.is_valid {
-        log::warn!(
+        log_feature!(
+            LogFeature::Mutation,
+            warn,
             "Invalid signature for public key: {}",
             signed_message.public_key_id
         );
@@ -128,7 +134,7 @@ pub async fn execute_mutation(
     let decoded_payload = match general_purpose::STANDARD.decode(&signed_message.payload) {
         Ok(bytes) => bytes,
         Err(e) => {
-            log::warn!("Base64 decoding failed: {}", e);
+            log_feature!(LogFeature::Mutation, warn, "Base64 decoding failed: {}", e);
             return HttpResponse::BadRequest().json(json!({"error": "Invalid base64 payload"}));
         }
     };
@@ -136,13 +142,15 @@ pub async fn execute_mutation(
     let mutation_value: Value = match serde_json::from_slice(&decoded_payload) {
         Ok(val) => val,
         Err(e) => {
-            log::warn!("Payload JSON parsing failed: {}", e);
+            log_feature!(LogFeature::Mutation, warn, "Payload JSON parsing failed: {}", e);
             return HttpResponse::BadRequest()
                 .json(json!({"error": "Invalid JSON payload format"}));
         }
     };
 
-    log::info!(
+    log_feature!(
+        LogFeature::Mutation,
+        info,
         "Received mutation request: {}",
         serde_json::to_string(&mutation_value).unwrap_or_else(|_| "Invalid JSON".to_string())
     );
@@ -197,11 +205,11 @@ pub async fn execute_mutation(
 
     match node_guard.mutate(internal_mutation) {
         Ok(_) => {
-            log::info!("Mutation executed successfully");
+            log_feature!(LogFeature::Mutation, info, "Mutation executed successfully");
             HttpResponse::Ok().json(json!({"success": true}))
         }
         Err(e) => {
-            log::error!("Mutation execution failed: {}", e);
+            log_feature!(LogFeature::Mutation, error, "Mutation execution failed: {}", e);
             HttpResponse::InternalServerError()
                 .json(json!({"error": format!("Failed to execute mutation: {}", e)}))
         }

--- a/src/datafold_node/schema_routes.rs
+++ b/src/datafold_node/schema_routes.rs
@@ -1,17 +1,20 @@
 use super::http_server::AppState;
 use crate::schema::Schema;
 use actix_web::{web, HttpResponse, Responder};
-use log::{error, info};
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 use serde_json::json;
 
 /// List all schemas.
 pub async fn list_schemas(state: web::Data<AppState>) -> impl Responder {
-    info!("Received request to list schemas");
+    log_feature!(LogFeature::Schema, info, "Received request to list schemas");
     let node_guard = state.node.lock().await;
 
     match node_guard.list_schemas_with_state() {
         Ok(schemas) => {
-            info!(
+            log_feature!(
+                LogFeature::Schema,
+                info,
                 "Successfully loaded {} schemas with states: {:?}",
                 schemas.len(),
                 schemas
@@ -19,7 +22,7 @@ pub async fn list_schemas(state: web::Data<AppState>) -> impl Responder {
             HttpResponse::Ok().json(json!({"data": schemas}))
         }
         Err(e) => {
-            error!("Failed to list schemas: {}", e);
+            log_feature!(LogFeature::Schema, error, "Failed to list schemas: {}", e);
             HttpResponse::InternalServerError()
                 .json(json!({"error": format!("Failed to list schemas: {}", e)}))
         }
@@ -98,16 +101,16 @@ pub async fn load_schema_route(
 
 /// List all available schemas (any state)
 pub async fn list_available_schemas(state: web::Data<AppState>) -> impl Responder {
-    info!("Received request to list available schemas");
+    log_feature!(LogFeature::Schema, info, "Received request to list available schemas");
     let node_guard = state.node.lock().await;
 
     match node_guard.list_available_schemas() {
         Ok(schemas) => {
-            info!("Successfully retrieved {} available schemas", schemas.len());
+            log_feature!(LogFeature::Schema, info, "Successfully retrieved {} available schemas", schemas.len());
             HttpResponse::Ok().json(json!({"data": schemas}))
         },
         Err(e) => {
-            error!("Failed to list available schemas: {}", e);
+            log_feature!(LogFeature::Schema, error, "Failed to list available schemas: {}", e);
             HttpResponse::InternalServerError()
                 .json(json!({"error": format!("Failed to list available schemas: {}", e)}))
         }
@@ -120,7 +123,7 @@ pub async fn list_schemas_by_state(
     state: web::Data<AppState>,
 ) -> impl Responder {
     let state_str = path.into_inner();
-    info!("Received request to list schemas by state: {}", state_str);
+    log_feature!(LogFeature::Schema, info, "Received request to list schemas by state: {}", state_str);
 
     let schema_state = match state_str.as_str() {
         "available" => crate::schema::core::SchemaState::Available,
@@ -140,7 +143,7 @@ pub async fn list_schemas_by_state(
             "state": state_str
         })),
         Err(e) => {
-            error!("Failed to list schemas by state '{}': {}", state_str, e);
+            log_feature!(LogFeature::Schema, error, "Failed to list schemas by state '{}': {}", state_str, e);
             HttpResponse::InternalServerError().json(json!({
                 "error": format!("Failed to list schemas by state: {}", e)
             }))
@@ -151,12 +154,12 @@ pub async fn list_schemas_by_state(
 /// Approve a schema for queries and mutations
 pub async fn approve_schema(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
     let schema_name = path.into_inner();
-    info!("Received request to approve schema: {}", schema_name);
+    log_feature!(LogFeature::Schema, info, "Received request to approve schema: {}", schema_name);
 
     let mut node_guard = state.node.lock().await;
     match node_guard.approve_schema(&schema_name) {
         Ok(()) => {
-            info!("Schema '{}' approved successfully", schema_name);
+            log_feature!(LogFeature::Schema, info, "Schema '{}' approved successfully", schema_name);
             HttpResponse::Ok().json(json!({
                 "message": format!("Schema '{}' approved successfully", schema_name),
                 "schema": schema_name,
@@ -164,7 +167,7 @@ pub async fn approve_schema(path: web::Path<String>, state: web::Data<AppState>)
             }))
         }
         Err(e) => {
-            error!("Failed to approve schema '{}': {}", schema_name, e);
+            log_feature!(LogFeature::Schema, error, "Failed to approve schema '{}': {}", schema_name, e);
             HttpResponse::BadRequest().json(json!({
                 "error": format!("Failed to approve schema: {}", e)
             }))
@@ -175,12 +178,12 @@ pub async fn approve_schema(path: web::Path<String>, state: web::Data<AppState>)
 /// Block a schema from queries and mutations
 pub async fn block_schema(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
     let schema_name = path.into_inner();
-    info!("Received request to block schema: {}", schema_name);
+    log_feature!(LogFeature::Schema, info, "Received request to block schema: {}", schema_name);
 
     let mut node_guard = state.node.lock().await;
     match node_guard.block_schema(&schema_name) {
         Ok(()) => {
-            info!("Schema '{}' blocked successfully", schema_name);
+            log_feature!(LogFeature::Schema, info, "Schema '{}' blocked successfully", schema_name);
             HttpResponse::Ok().json(json!({
                 "message": format!("Schema '{}' blocked successfully", schema_name),
                 "schema": schema_name,
@@ -188,7 +191,7 @@ pub async fn block_schema(path: web::Path<String>, state: web::Data<AppState>) -
             }))
         }
         Err(e) => {
-            error!("Failed to block schema '{}': {}", schema_name, e);
+            log_feature!(LogFeature::Schema, error, "Failed to block schema '{}': {}", schema_name, e);
             HttpResponse::BadRequest().json(json!({
                 "error": format!("Failed to block schema: {}", e)
             }))
@@ -202,7 +205,7 @@ pub async fn get_schema_state(
     state: web::Data<AppState>,
 ) -> impl Responder {
     let schema_name = path.into_inner();
-    info!("Received request to get state for schema: {}", schema_name);
+    log_feature!(LogFeature::Schema, info, "Received request to get state for schema: {}", schema_name);
 
     let node_guard = state.node.lock().await;
     match node_guard.get_schema_state(&schema_name) {
@@ -218,7 +221,7 @@ pub async fn get_schema_state(
             }))
         }
         Err(e) => {
-            error!("Failed to get state for schema '{}': {}", schema_name, e);
+            log_feature!(LogFeature::Schema, error, "Failed to get state for schema '{}': {}", schema_name, e);
             HttpResponse::NotFound().json(json!({
                 "error": format!("Failed to get schema state: {}", e)
             }))
@@ -228,13 +231,13 @@ pub async fn get_schema_state(
 
 /// Get comprehensive schema status (NEW UNIFIED ENDPOINT)
 pub async fn get_schema_status(state: web::Data<AppState>) -> impl Responder {
-    info!("Received request to get comprehensive schema status");
+    log_feature!(LogFeature::Schema, info, "Received request to get comprehensive schema status");
     let node_guard = state.node.lock().await;
 
     match node_guard.get_schema_status() {
         Ok(report) => HttpResponse::Ok().json(json!({"data": report})),
         Err(e) => {
-            error!("Failed to get schema status: {}", e);
+            log_feature!(LogFeature::Schema, error, "Failed to get schema status: {}", e);
             HttpResponse::InternalServerError()
                 .json(json!({"error": format!("Failed to get schema status: {}", e)}))
         }
@@ -243,12 +246,12 @@ pub async fn get_schema_status(state: web::Data<AppState>) -> impl Responder {
 
 /// Refresh schemas from all sources (NEW UNIFIED ENDPOINT)
 pub async fn refresh_schemas(state: web::Data<AppState>) -> impl Responder {
-    info!("Received request to refresh schemas from all sources");
+    log_feature!(LogFeature::Schema, info, "Received request to refresh schemas from all sources");
     let node_guard = state.node.lock().await;
 
     match node_guard.refresh_schemas() {
         Ok(report) => {
-            info!(
+            log_feature!(LogFeature::Schema, info, 
                 "Schema refresh completed: {} discovered, {} loaded, {} failed",
                 report.discovered_schemas.len(),
                 report.loaded_schemas.len(),
@@ -257,7 +260,7 @@ pub async fn refresh_schemas(state: web::Data<AppState>) -> impl Responder {
             HttpResponse::Ok().json(json!({"data": report}))
         }
         Err(e) => {
-            error!("Failed to refresh schemas: {}", e);
+            log_feature!(LogFeature::Schema, error, "Failed to refresh schemas: {}", e);
             HttpResponse::InternalServerError()
                 .json(json!({"error": format!("Failed to refresh schemas: {}", e)}))
         }
@@ -269,7 +272,7 @@ pub async fn add_schema_to_available(
     schema_data: web::Json<serde_json::Value>,
     state: web::Data<AppState>,
 ) -> impl Responder {
-    info!("Received request to add schema to available_schemas directory");
+    log_feature!(LogFeature::Schema, info, "Received request to add schema to available_schemas directory");
     let node_guard = state.node.lock().await;
 
     // Extract optional custom name from query parameters or JSON
@@ -282,7 +285,7 @@ pub async fn add_schema_to_available(
     let json_content = match serde_json::to_string(&*schema_data) {
         Ok(content) => content,
         Err(e) => {
-            error!("Failed to serialize JSON: {}", e);
+            log_feature!(LogFeature::Schema, error, "Failed to serialize JSON: {}", e);
             return HttpResponse::BadRequest().json(json!({
                 "error": format!("Invalid JSON format: {}", e)
             }));
@@ -291,7 +294,7 @@ pub async fn add_schema_to_available(
 
     match node_guard.add_schema_to_available_directory(&json_content, custom_name) {
         Ok(schema_name) => {
-            info!(
+            log_feature!(LogFeature::Schema, info, 
                 "Successfully added schema '{}' to available_schemas directory",
                 schema_name
             );
@@ -302,7 +305,7 @@ pub async fn add_schema_to_available(
             }))
         }
         Err(e) => {
-            error!("Failed to add schema to available_schemas: {}", e);
+            log_feature!(LogFeature::Schema, error, "Failed to add schema to available_schemas: {}", e);
             HttpResponse::BadRequest().json(json!({
                 "error": format!("Failed to add schema: {}", e)
             }))

--- a/src/datafold_node/security_routes.rs
+++ b/src/datafold_node/security_routes.rs
@@ -9,6 +9,8 @@ use crate::security::{
 use actix_web::{web, HttpResponse, Result as ActixResult};
 use serde_json::json;
 use std::sync::Arc;
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 
 /// Get the security manager from the node
 async fn get_security_manager(data: &web::Data<AppState>) -> Arc<SecurityManager> {
@@ -26,7 +28,7 @@ pub async fn register_system_public_key(
     match security_manager.register_system_public_key(request.into_inner()) {
         Ok(response) => Ok(HttpResponse::Ok().json(response)),
         Err(e) => {
-            log::error!("Failed to register public key: {}", e);
+            log_feature!(LogFeature::HttpServer, error, "Failed to register public key: {}", e);
             // Let the framework handle the error response
             Err(actix_web::error::ErrorBadRequest(e.to_string()))
         }

--- a/src/datafold_node/system_routes.rs
+++ b/src/datafold_node/system_routes.rs
@@ -1,4 +1,6 @@
 use actix_web::{web, HttpResponse, Responder};
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -63,14 +65,18 @@ pub async fn reset_database(
 
     match restart_result {
         Ok(_) => {
-            log::info!("Database reset completed successfully");
+            log_feature!(
+                LogFeature::HttpServer,
+                info,
+                "Database reset completed successfully"
+            );
             HttpResponse::Ok().json(ResetDatabaseResponse {
                 success: true,
                 message: "Database reset successfully. All data has been cleared.".to_string(),
             })
         }
         Err(e) => {
-            log::error!("Database reset failed: {}", e);
+            log_feature!(LogFeature::HttpServer, error, "Database reset failed: {}", e);
             HttpResponse::InternalServerError().json(ResetDatabaseResponse {
                 success: false,
                 message: format!("Database reset failed: {}", e),

--- a/src/datafold_node/tcp_command_router.rs
+++ b/src/datafold_node/tcp_command_router.rs
@@ -3,7 +3,8 @@ use crate::error::{FoldDbError, FoldDbResult};
 use crate::schema::types::operations::MutationType;
 use crate::schema::Schema;
 use libp2p::PeerId;
-use log::info;
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -14,7 +15,9 @@ impl TcpServer {
         request: &Value,
         node: Arc<Mutex<DataFoldNode>>,
     ) -> FoldDbResult<Value> {
-        info!(
+        log_feature!(
+            LogFeature::TcpServer,
+            info,
             "Processing request: {}",
             serde_json::to_string_pretty(request).unwrap_or_else(|_| request.to_string())
         );
@@ -31,7 +34,9 @@ impl TcpServer {
             };
 
             if target_node_id != local_node_id {
-                info!(
+                log_feature!(
+                    LogFeature::TcpServer,
+                    info,
                     "Request targeted for node {}, forwarding...",
                     target_node_id
                 );
@@ -309,20 +314,35 @@ impl TcpServer {
 
         let peer_id = match network.get_peer_id_for_node(target_node_id) {
             Some(id) => {
-                info!("Found PeerId {} for node ID {}", id, target_node_id);
+                log_feature!(
+                    LogFeature::TcpServer,
+                    info,
+                    "Found PeerId {} for node ID {}",
+                    id,
+                    target_node_id
+                );
                 id
             }
             None => match target_node_id.parse::<PeerId>() {
                 Ok(id) => {
-                    info!("Parsed node ID {} as PeerId {}", target_node_id, id);
+                    log_feature!(
+                        LogFeature::TcpServer,
+                        info,
+                        "Parsed node ID {} as PeerId {}",
+                        target_node_id,
+                        id
+                    );
                     network.register_node_id(target_node_id, id);
                     id
                 }
                 Err(_) => {
                     let id = PeerId::random();
-                    info!(
+                    log_feature!(
+                        LogFeature::TcpServer,
+                        info,
                         "Using placeholder PeerId {} for node ID {}",
-                        id, target_node_id
+                        id,
+                        target_node_id
                     );
                     network.register_node_id(target_node_id, id);
                     id
@@ -353,22 +373,30 @@ impl TcpServer {
             "unknown".to_string()
         };
 
-        info!(
+        log_feature!(
+            LogFeature::TcpServer,
+            info,
             "Assuming schema {} is available on target node",
             schema_name
         );
-        info!(
+        log_feature!(
+            LogFeature::TcpServer,
+            info,
             "Forwarding request to node {} (peer {})",
-            target_node_id, peer_id
+            target_node_id,
+            peer_id
         );
 
         let response = node_guard
             .forward_request(peer_id, forwarded_request)
             .await?;
 
-        info!(
+        log_feature!(
+            LogFeature::TcpServer,
+            info,
             "Received response from node {} (peer {})",
-            target_node_id, peer_id
+            target_node_id,
+            peer_id
         );
         Ok(response)
     }

--- a/src/datafold_node/tcp_connections.rs
+++ b/src/datafold_node/tcp_connections.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use log::{error, info};
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 
@@ -23,7 +24,12 @@ impl TcpServer {
             let response = match Self::process_request(&request, node.clone()).await {
                 Ok(resp) => resp,
                 Err(e) => {
-                    error!("Error processing request: {}", e);
+                    log_feature!(
+                        LogFeature::TcpServer,
+                        error,
+                        "Error processing request: {}",
+                        e
+                    );
                     json!({ "error": format!("Error processing request: {}", e) })
                 }
             };
@@ -31,7 +37,7 @@ impl TcpServer {
             if let Err(e) = send_response(&mut socket, &response).await {
                 match &e {
                     FoldDbError::Io(io_err) if io_err.kind() == std::io::ErrorKind::BrokenPipe => {
-                        info!("Client disconnected while sending response");
+                        log_feature!(LogFeature::TcpServer, info, "Client disconnected while sending response");
                         return Ok(());
                     }
                     _ => return Err(e),

--- a/src/datafold_node/tcp_protocol.rs
+++ b/src/datafold_node/tcp_protocol.rs
@@ -1,4 +1,5 @@
-use log::{error, info, warn};
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 use serde_json::{json, Value};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -18,16 +19,16 @@ pub async fn read_request(socket: &mut TcpStream) -> FoldDbResult<Option<Value>>
         Ok(len) => len as usize,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::UnexpectedEof {
-                info!("Client disconnected");
+                log_feature!(LogFeature::TcpServer, info, "Client disconnected");
                 return Ok(None);
             }
-            error!("Error reading request length: {}", e);
+            log_feature!(LogFeature::TcpServer, error, "Error reading request length: {}", e);
             return Err(e.into());
         }
     };
 
     if request_len > MAX_REQUEST_SIZE {
-        warn!("Request too large: {} bytes", request_len);
+        log_feature!(LogFeature::TcpServer, warn, "Request too large: {} bytes", request_len);
         let error_response = json!({
             "error": "Request too large",
             "max_size": MAX_REQUEST_SIZE,
@@ -40,9 +41,9 @@ pub async fn read_request(socket: &mut TcpStream) -> FoldDbResult<Option<Value>>
     match socket.read_exact(&mut request_bytes).await {
         Ok(_) => {}
         Err(e) => {
-            error!("Error reading request: {}", e);
+            log_feature!(LogFeature::TcpServer, error, "Error reading request: {}", e);
             if e.kind() == std::io::ErrorKind::UnexpectedEof {
-                info!("Client disconnected while reading request");
+                log_feature!(LogFeature::TcpServer, info, "Client disconnected while reading request");
                 return Ok(None);
             }
             let error_response = json!({
@@ -56,7 +57,7 @@ pub async fn read_request(socket: &mut TcpStream) -> FoldDbResult<Option<Value>>
     match serde_json::from_slice(&request_bytes) {
         Ok(req) => Ok(Some(req)),
         Err(e) => {
-            error!("Error deserializing request: {}", e);
+            log_feature!(LogFeature::TcpServer, error, "Error deserializing request: {}", e);
             let error_response = json!({
                 "error": format!("Error deserializing request: {}", e),
             });

--- a/src/datafold_node/tcp_server.rs
+++ b/src/datafold_node/tcp_server.rs
@@ -1,6 +1,7 @@
 use crate::datafold_node::DataFoldNode;
 use crate::error::FoldDbResult;
-use log::{error, info};
+use crate::log_feature;
+use crate::logging::features::LogFeature;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
@@ -98,7 +99,7 @@ impl TcpServer {
     pub async fn new(node: DataFoldNode, port: u16) -> FoldDbResult<Self> {
         let addr = format!("127.0.0.1:{}", port);
         let listener = TcpListener::bind(&addr).await?;
-        info!("TCP server listening on {}", addr);
+        log_feature!(LogFeature::TcpServer, info, "TCP server listening on {}", addr);
 
         // Register this node's address with the network if available
         if let Ok(mut net) = node.get_network_mut().await {
@@ -150,11 +151,11 @@ impl TcpServer {
     /// }
     /// ```
     pub async fn run(&self) -> FoldDbResult<()> {
-        info!("TCP server running...");
+        log_feature!(LogFeature::TcpServer, info, "TCP server running...");
 
         loop {
             let (socket, _) = self.listener.accept().await?;
-            info!("New client connected");
+            log_feature!(LogFeature::TcpServer, info, "New client connected");
 
             // Clone the node reference for the new connection
             let node_clone = self.node.clone();
@@ -162,7 +163,7 @@ impl TcpServer {
             // Spawn a new task to handle the connection
             tokio::spawn(async move {
                 if let Err(e) = Self::handle_connection(socket, node_clone).await {
-                    error!("Error handling connection: {}", e);
+                    log_feature!(LogFeature::TcpServer, error, "Error handling connection: {}", e);
                 }
             });
         }


### PR DESCRIPTION
## Summary
- use log_feature! macro consistently across datafold_node
- map log messages to proper LogFeature targets

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598eaa8fec83279c84b106e8c10200