### PR TITLE
refactor: adopt log_feature macro

### DIFF
--- a/src/db_operations/atom_operations.rs
+++ b/src/db_operations/atom_operations.rs
@@ -1,6 +1,7 @@
 use super::core::DbOperations;
 use crate::atom::{Atom, AtomRef, AtomRefRange, AtomStatus};
 use crate::schema::SchemaError;
+use crate::logging::features::{log_feature, LogFeature};
 use serde_json::Value;
 
 impl DbOperations {
@@ -37,42 +38,42 @@ impl DbOperations {
         source_pub_key: String,
     ) -> Result<AtomRef, SchemaError> {
         // DIAGNOSTIC: Log the update attempt
-        log::info!("🔍 DIAGNOSTIC: update_atom_ref called - aref_uuid: {}, atom_uuid: {}", aref_uuid, atom_uuid);
+        log_feature!(LogFeature::Database, info, "🔍 DIAGNOSTIC: update_atom_ref called - aref_uuid: {}, atom_uuid: {}", aref_uuid, atom_uuid);
         
         let mut aref = match self.get_item::<AtomRef>(&format!("ref:{}", aref_uuid))? {
             Some(existing_aref) => {
-                log::info!("🔍 DIAGNOSTIC: Found existing AtomRef - current atom_uuid: {}", existing_aref.get_atom_uuid());
+                log_feature!(LogFeature::Database, info, "🔍 DIAGNOSTIC: Found existing AtomRef - current atom_uuid: {}", existing_aref.get_atom_uuid());
                 existing_aref
             }
             None => {
-                log::info!("🔍 DIAGNOSTIC: Creating new AtomRef");
+                log_feature!(LogFeature::Database, info, "🔍 DIAGNOSTIC: Creating new AtomRef");
                 AtomRef::new(atom_uuid.clone(), source_pub_key)
             }
         };
 
         // DIAGNOSTIC: Log before update
-        log::info!("🔍 DIAGNOSTIC: Before set_atom_uuid - current: {}, new: {}", aref.get_atom_uuid(), atom_uuid);
+        log_feature!(LogFeature::Database, info, "🔍 DIAGNOSTIC: Before set_atom_uuid - current: {}, new: {}", aref.get_atom_uuid(), atom_uuid);
         
         aref.set_atom_uuid(atom_uuid.clone());
         
         // DIAGNOSTIC: Log after update
-        log::info!("🔍 DIAGNOSTIC: After set_atom_uuid - updated to: {}", aref.get_atom_uuid());
+        log_feature!(LogFeature::Database, info, "🔍 DIAGNOSTIC: After set_atom_uuid - updated to: {}", aref.get_atom_uuid());
         
         // DIAGNOSTIC: Log before persistence
-        log::info!("🔍 DIAGNOSTIC: About to persist AtomRef with key: ref:{}", aref_uuid);
+        log_feature!(LogFeature::Database, info, "🔍 DIAGNOSTIC: About to persist AtomRef with key: ref:{}", aref_uuid);
         
         self.store_item(&format!("ref:{}", aref_uuid), &aref)?;
         
         // DIAGNOSTIC: Verify persistence by reading back
         match self.get_item::<AtomRef>(&format!("ref:{}", aref_uuid))? {
             Some(persisted_aref) => {
-                log::info!("🔍 DIAGNOSTIC: Persistence verification - stored atom_uuid: {}", persisted_aref.get_atom_uuid());
+                log_feature!(LogFeature::Database, info, "🔍 DIAGNOSTIC: Persistence verification - stored atom_uuid: {}", persisted_aref.get_atom_uuid());
                 if persisted_aref.get_atom_uuid() != &atom_uuid {
-                    log::error!("❌ DIAGNOSTIC: PERSISTENCE MISMATCH! Expected: {}, Got: {}", atom_uuid, persisted_aref.get_atom_uuid());
+                    log_feature!(LogFeature::Database, error, "❌ DIAGNOSTIC: PERSISTENCE MISMATCH! Expected: {}, Got: {}", atom_uuid, persisted_aref.get_atom_uuid());
                 }
             }
             None => {
-                log::error!("❌ DIAGNOSTIC: PERSISTENCE FAILED! Could not read back stored AtomRef");
+                log_feature!(LogFeature::Database, error, "❌ DIAGNOSTIC: PERSISTENCE FAILED! Could not read back stored AtomRef");
             }
         }
         

--- a/src/db_operations/public_key_operations.rs
+++ b/src/db_operations/public_key_operations.rs
@@ -3,6 +3,7 @@ use crate::security::types::PublicKeyInfo;
 use crate::schema::types::SchemaError;
 use crate::db_operations::error_utils::ErrorUtils;
 use crate::constants::SINGLE_PUBLIC_KEY_ID;
+use crate::logging::features::{log_feature, LogFeature};
 
 impl DbOperations {
     /// Store the system-wide public key. This will overwrite any existing key.
@@ -32,7 +33,7 @@ impl DbOperations {
 
     pub fn close(&self) {
         if let Err(e) = self.db().flush() {
-            log::error!("Failed to flush database: {}", e);
+            log_feature!(LogFeature::Database, error, "Failed to flush database: {}", e);
         }
     }
 }

--- a/src/db_operations/transform_operations.rs
+++ b/src/db_operations/transform_operations.rs
@@ -1,6 +1,7 @@
 use super::core::DbOperations;
 use crate::schema::types::transform::{Transform, TransformRegistration};
 use crate::schema::SchemaError;
+use crate::logging::features::{log_feature, LogFeature};
 
 impl DbOperations {
     /// Stores a transform using generic tree operations
@@ -20,8 +21,8 @@ impl DbOperations {
                 // Enhanced error logging for transform deserialization issues
                 if let Ok(Some(bytes)) = self.transforms_tree.get(transform_id.as_bytes()) {
                     let raw_data = String::from_utf8_lossy(&bytes);
-                    log::error!("Failed to deserialize transform '{}': {}", transform_id, e);
-                    log::error!("Raw transform data: {}", raw_data);
+                    log_feature!(LogFeature::Database, error, "Failed to deserialize transform '{}': {}", transform_id, e);
+                    log_feature!(LogFeature::Database, error, "Raw transform data: {}", raw_data);
                     Err(SchemaError::InvalidData(format!(
                         "Failed to deserialize transform '{}': {}. Raw data: {}",
                         transform_id, e, raw_data

--- a/src/fold_db_core/infrastructure/factory.rs
+++ b/src/fold_db_core/infrastructure/factory.rs
@@ -10,6 +10,7 @@ use crate::fold_db_core::managers::AtomManager;
 use crate::schema::core::SchemaCore;
 use crate::fold_db_core::services::field_retrieval::service::FieldRetrievalService;
 use crate::schema::SchemaError;
+use crate::logging::features::{log_feature, LogFeature};
 
 /// Consolidated factory for creating common infrastructure components
 pub struct InfrastructureFactory;
@@ -89,37 +90,37 @@ pub struct InfrastructureLogger;
 impl InfrastructureLogger {
     /// Log operation start - replaces 🔧 pattern
     pub fn log_operation_start(component: &str, operation: &str, details: &str) {
-        log::info!("🔧 {}: {} - {}", component, operation, details);
+        log_feature!(LogFeature::Database, info, "🔧 {}: {} - {}", component, operation, details);
     }
 
     /// Log operation success - replaces ✅ pattern  
     pub fn log_operation_success(component: &str, operation: &str, details: &str) {
-        log::info!("✅ {}: {} - {}", component, operation, details);
+        log_feature!(LogFeature::Database, info, "✅ {}: {} - {}", component, operation, details);
     }
 
     /// Log operation failure - replaces ❌ pattern
     pub fn log_operation_error(component: &str, operation: &str, error: &str) {
-        log::error!("❌ {}: {} - {}", component, operation, error);
+        log_feature!(LogFeature::Database, error, "❌ {}: {} - {}", component, operation, error);
     }
 
     /// Log debug information - replaces 🎯 pattern
     pub fn log_debug_info(component: &str, info: &str) {
-        log::info!("🎯 DEBUG {}: {}", component, info);
+        log_feature!(LogFeature::Database, info, "🎯 DEBUG {}: {}", component, info);
     }
 
     /// Log investigation/search - replaces 🔍 pattern
     pub fn log_investigation(component: &str, info: &str) {
-        log::info!("🔍 {}: {}", component, info);
+        log_feature!(LogFeature::Database, info, "🔍 {}: {}", component, info);
     }
 
     /// Log processing/execution - replaces 🔄 pattern
     pub fn log_processing(component: &str, info: &str) {
-        log::info!("🔄 {}: {}", component, info);
+        log_feature!(LogFeature::Database, info, "🔄 {}: {}", component, info);
     }
 
     /// Log warning with standard pattern
     pub fn log_warning(component: &str, warning: &str) {
-        log::warn!("⚠️ {}: {}", component, warning);
+        log_feature!(LogFeature::Database, warn, "⚠️ {}: {}", component, warning);
     }
 }
 

--- a/src/fold_db_core/mod.rs
+++ b/src/fold_db_core/mod.rs
@@ -45,6 +45,7 @@ use crate::schema::core::SchemaState;
 use crate::schema::SchemaCore;
 use crate::schema::{Schema, SchemaError};
 use log::{info, warn};
+use crate::logging::features::{log_feature, LogFeature};
 use serde_json::Value;
 use std::time::Instant;
 use crate::schema::types::{Mutation, Query};
@@ -434,12 +435,12 @@ impl FoldDB {
         let operation_type = format!("{:?}", mutation.mutation_type);
         let schema_name = mutation.schema_name.clone();
         
-        log::info!(
+        log_feature!(LogFeature::Mutation, info,
             "Starting mutation execution for schema: {}",
             mutation.schema_name
         );
-        log::info!("Mutation type: {:?}", mutation.mutation_type);
-        log::info!(
+        log_feature!(LogFeature::Mutation, info, "Mutation type: {:?}", mutation.mutation_type);
+        log_feature!(LogFeature::Mutation, info,
             "Fields to mutate: {:?}",
             mutation.fields_and_values.keys().collect::<Vec<_>>()
         );
@@ -523,7 +524,7 @@ impl FoldDB {
     ) -> Result<(), SchemaError> {
         // Check if this is a range schema
         if let Some(range_key) = schema.range_key() {
-            log::info!("🎯 DEBUG: Processing range schema mutation for schema '{}' with range_key '{}'", schema.name, range_key);
+            log_feature!(LogFeature::Mutation, info, "🎯 DEBUG: Processing range schema mutation for schema '{}' with range_key '{}'", schema.name, range_key);
             
             // Extract the range key value from the mutation data
             let range_key_value = mutation.fields_and_values.get(range_key)
@@ -536,7 +537,7 @@ impl FoldDB {
                 _ => range_key_value.to_string().trim_matches('"').to_string(),
             };
             
-            log::info!("🎯 DEBUG: Range key value: '{}'", range_key_str);
+            log_feature!(LogFeature::Mutation, info, "🎯 DEBUG: Range key value: '{}'", range_key_str);
             
             // Use the specialized range schema mutation method
             return mutation_service.update_range_schema_fields(
@@ -546,7 +547,7 @@ impl FoldDB {
                 mutation_hash,
             );
         } else {
-            log::info!("🔍 DEBUG: Processing regular schema mutation for schema '{}'", schema.name);
+            log_feature!(LogFeature::Mutation, info, "🔍 DEBUG: Processing regular schema mutation for schema '{}'", schema.name);
         }
 
         // For non-range schemas, process fields individually
@@ -582,7 +583,7 @@ impl FoldDB {
     /// Execute a transform by ID using direct execution
     /// This executes the transform immediately and returns the result
     pub fn run_transform(&self, transform_id: &str) -> Result<Value, SchemaError> {
-        log::info!("🔄 run_transform called for {} - using direct execution", transform_id);
+        log_feature!(LogFeature::Transform, info, "🔄 run_transform called for {} - using direct execution", transform_id);
         
         // Use direct execution through the transform manager
         match TransformRunner::execute_transform_now(&*self.transform_manager, transform_id) {

--- a/src/fold_db_core/services/mutation.rs
+++ b/src/fold_db_core/services/mutation.rs
@@ -16,6 +16,7 @@ use crate::fold_db_core::infrastructure::message_bus::{
     request_events::FieldValueSetRequest,
 };
 use crate::fold_db_core::infrastructure::factory::InfrastructureLogger;
+use crate::logging::features::{log_feature, LogFeature};
 use crate::schema::types::field::FieldVariant;
 use crate::schema::types::schema::Schema;
 use crate::schema::types::Mutation;
@@ -220,7 +221,7 @@ pub fn validate_range_schema_mutation_format(
     mutation: &Mutation,
 ) -> Result<(), SchemaError> {
     if let Some(range_key) = schema.range_key() {
-        log::info!(
+        log_feature!(LogFeature::Mutation, info,
             "🔍 Validating Range schema mutation format for schema: {} with range_key: {}",
             schema.name,
             range_key

--- a/src/fold_db_core/transform_manager/loading.rs
+++ b/src/fold_db_core/transform_manager/loading.rs
@@ -3,6 +3,7 @@ use crate::schema::types::{SchemaError, Transform, TransformRegistration};
 use crate::transform::TransformExecutor;
 use crate::fold_db_core::transform_manager::utils::*;
 use log::info;
+use crate::logging::features::{log_feature, LogFeature};
 use std::collections::{HashMap, HashSet};
 
 impl TransformManager {
@@ -46,13 +47,13 @@ impl TransformManager {
                     }
                 }
                 Ok(None) => {
-                    log::warn!(
+                    log_feature!(LogFeature::Transform, warn,
                         "Transform '{}' not found in storage during reload",
                         transform_id
                     );
                 }
                 Err(e) => {
-                    log::error!(
+                    log_feature!(LogFeature::Transform, error,
                         "Failed to load transform '{}' during reload: {}",
                         transform_id,
                         e

--- a/src/fold_db_core/transform_manager/manager.rs
+++ b/src/fold_db_core/transform_manager/manager.rs
@@ -3,6 +3,7 @@ use crate::db_operations::DbOperations;
 use crate::fold_db_core::infrastructure::message_bus::MessageBus;
 use crate::schema::types::{SchemaError, Transform};
 use log::{info, error};
+use crate::logging::features::{log_feature, LogFeature};
 use serde_json::Value as JsonValue;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
@@ -76,13 +77,13 @@ impl TransformManager {
                     registered_transforms.insert(transform_id, transform);
                 }
                 Ok(None) => {
-                    log::warn!(
+                    log_feature!(LogFeature::Transform, warn,
                         "Transform '{}' not found in storage during initialization",
                         transform_id
                     );
                 }
                 Err(e) => {
-                    log::error!(
+                    log_feature!(LogFeature::Transform, error,
                         "Failed to load transform '{}' during initialization: {}",
                         transform_id,
                         e

--- a/src/logging/features.rs
+++ b/src/logging/features.rs
@@ -44,6 +44,8 @@ macro_rules! log_feature {
     };
 }
 
+pub use crate::log_feature;
+
 
 // Performance monitoring helper
 pub struct PerformanceTimer {

--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -5,6 +5,7 @@ use crate::schema::types::{
     Field, FieldVariant, JsonSchemaDefinition, JsonSchemaField, Schema, SchemaError, SingleField,
 };
 use log::info;
+use crate::logging::features::{log_feature, LogFeature};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::HashMap;
@@ -220,7 +221,7 @@ impl SchemaCore {
         use crate::fold_db_core::infrastructure::message_bus::schema_events::SchemaLoaded;
         let schema_loaded_event = SchemaLoaded::new(name.to_string(), "loaded");
         if let Err(e) = self.message_bus.publish(schema_loaded_event) {
-            log::warn!("Failed to publish SchemaLoaded event: {}", e);
+            log_feature!(LogFeature::Schema, warn, "Failed to publish SchemaLoaded event: {}", e);
         }
     }
 
@@ -290,16 +291,16 @@ impl SchemaCore {
                 match self.get_schema(schema_name) {
                     Ok(Some(updated_schema)) => {
                         if let Err(e) = self.persist_schema(&updated_schema) {
-                            log::warn!("Failed to persist schema '{}' with field assignments: {}", schema_name, e);
+                            log_feature!(LogFeature::Schema, warn, "Failed to persist schema '{}' with field assignments: {}", schema_name, e);
                         } else {
                             info!("✅ Schema '{}' with field assignments persisted to sled database", schema_name);
                         }
                     }
                     Ok(None) => {
-                        log::warn!("Schema '{}' not found after field mapping", schema_name);
+                        log_feature!(LogFeature::Schema, warn, "Schema '{}' not found after field mapping", schema_name);
                     }
                     Err(e) => {
-                        log::warn!("Failed to retrieve schema '{}' for persistence: {}", schema_name, e);
+                        log_feature!(LogFeature::Schema, warn, "Failed to retrieve schema '{}' for persistence: {}", schema_name, e);
                     }
                 }
             }
@@ -316,21 +317,21 @@ impl SchemaCore {
         // skipped due to target schema state validation should now be registered
         info!("🔄 Re-registering transforms that target newly approved schema '{}'", schema_name);
         if let Err(e) = self.reregister_transforms_for_approved_schema(schema_name) {
-            log::warn!("Failed to re-register transforms for approved schema '{}': {}", schema_name, e);
+            log_feature!(LogFeature::Schema, warn, "Failed to re-register transforms for approved schema '{}': {}", schema_name, e);
         }
 
         // Publish SchemaLoaded event for approval
         use crate::fold_db_core::infrastructure::message_bus::schema_events::SchemaLoaded;
         let schema_loaded_event = SchemaLoaded::new(schema_name, "approved");
         if let Err(e) = self.message_bus.publish(schema_loaded_event) {
-            log::warn!("Failed to publish SchemaLoaded event for approval: {}", e);
+            log_feature!(LogFeature::Schema, warn, "Failed to publish SchemaLoaded event for approval: {}", e);
         }
 
         // Publish SchemaChanged event for approval
         use crate::fold_db_core::infrastructure::message_bus::schema_events::SchemaChanged;
         let schema_changed_event = SchemaChanged::new(schema_name);
         if let Err(e) = self.message_bus.publish(schema_changed_event) {
-            log::warn!("Failed to publish SchemaChanged event for approval: {}", e);
+            log_feature!(LogFeature::Schema, warn, "Failed to publish SchemaChanged event for approval: {}", e);
         }
 
         info!("Schema '{}' approved successfully", schema_name);
@@ -376,14 +377,14 @@ impl SchemaCore {
                                 
                                 // Store the transform in the database
                                 if let Err(e) = self.db_ops.store_transform(&transform_id, transform) {
-                                    log::error!("Failed to store transform {}: {}", transform_id, e);
+                                    log_feature!(LogFeature::Schema, error, "Failed to store transform {}: {}", transform_id, e);
                                     continue;
                                 }
                                 
                                 // Create field-to-transform mappings
                                 for input_field in transform.get_inputs() {
                                     if let Err(e) = self.store_field_to_transform_mapping(input_field, &transform_id) {
-                                        log::error!(
+                                        log_feature!(LogFeature::Schema, error,
                                             "Failed to store field mapping '{}' → '{}': {}",
                                             input_field, transform_id, e
                                         );
@@ -396,7 +397,7 @@ impl SchemaCore {
                                 info!("✅ Registered transform '{}' for newly approved target schema '{}'", transform_id, target_schema_name);
                             }
                             Err(e) => {
-                                log::error!("Error checking if transform '{}' exists: {}", transform_id, e);
+                                log_feature!(LogFeature::Schema, error, "Error checking if transform '{}' exists: {}", transform_id, e);
                                 continue;
                             }
                         }
@@ -507,7 +508,7 @@ impl SchemaCore {
         use crate::fold_db_core::infrastructure::message_bus::schema_events::SchemaChanged;
         let schema_changed_event = SchemaChanged::new(schema_name);
         if let Err(e) = self.message_bus.publish(schema_changed_event) {
-            log::warn!("Failed to publish SchemaChanged event for blocking: {}", e);
+            log_feature!(LogFeature::Schema, warn, "Failed to publish SchemaChanged event for blocking: {}", e);
         }
         
         info!("Schema '{}' blocked successfully", schema_name);

--- a/src/schema/transform.rs
+++ b/src/schema/transform.rs
@@ -1,6 +1,7 @@
 use super::SchemaCore;
 use crate::schema::types::{field::common::Field, Schema, SchemaError};
 use log::info;
+use crate::logging::features::{log_feature, LogFeature};
 
 impl SchemaCore {
     pub(crate) fn fix_transform_outputs(&self, schema: &mut Schema) {
@@ -54,18 +55,18 @@ impl SchemaCore {
                             continue;
                         }
                         Err(e) => {
-                            log::error!("❌ Error checking target schema '{}' state for transform '{}': {}", target_schema_name, transform_id, e);
+                            log_feature!(LogFeature::Schema, error, "❌ Error checking target schema '{}' state for transform '{}': {}", target_schema_name, transform_id, e);
                             continue;
                         }
                     }
                 } else {
-                    log::error!("❌ Invalid transform output format '{}' for transform '{}' - expected 'Schema.field'", transform.get_output(), transform_id);
+                    log_feature!(LogFeature::Schema, error, "❌ Invalid transform output format '{}' for transform '{}' - expected 'Schema.field'", transform.get_output(), transform_id);
                     continue;
                 }
 
                 // Store the transform in the database so it can be loaded by TransformManager
                 if let Err(e) = self.db_ops.store_transform(&transform_id, transform) {
-                    log::error!("Failed to store transform {}: {}", transform_id, e);
+                    log_feature!(LogFeature::Schema, error, "Failed to store transform {}: {}", transform_id, e);
                     continue;
                 }
 
@@ -77,7 +78,7 @@ impl SchemaCore {
 
                     // Store field mapping in database for TransformManager to load
                     if let Err(e) = self.store_field_to_transform_mapping(input_field, &transform_id) {
-                        log::error!(
+                        log_feature!(LogFeature::Schema, error,
                             "Failed to store field mapping '{}' → '{}': {}",
                             input_field, transform_id, e
                         );


### PR DESCRIPTION
## Summary
- switch direct logging calls to `log_feature!` across the codebase
- import `LogFeature` and re-export macro for easier access

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b90c079083279623929e3c05fc8d