### PR TITLE
Add test coverage tasks for SEC-7

### DIFF
--- a/docs/delivery/SEC-7/SEC-7-2.md
+++ b/docs/delivery/SEC-7/SEC-7-2.md
@@ -1,0 +1,17 @@
+# SEC-7-2: Add Unit Tests for Logging
+
+[Back to task list](./tasks.md)
+
+## Description
+Create unit tests covering audit and performance logging modules to ensure individual functions record events correctly and handle errors without panicking.
+
+## Status History
+
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-06-24 12:00:00 | Created | N/A | Proposed | Initial task for logging unit tests | AI Agent |
+
+## Test Plan
+- [ ] Write unit tests for audit log formatting helpers.
+- [ ] Test performance metric capture functions with mocked timers.
+- [ ] Verify error paths log appropriate messages.

--- a/docs/delivery/SEC-7/SEC-7-3.md
+++ b/docs/delivery/SEC-7/SEC-7-3.md
@@ -1,0 +1,17 @@
+# SEC-7-3: Add Integration Tests for Logging
+
+[Back to task list](./tasks.md)
+
+## Description
+Implement integration tests that exercise audit and performance logging through the public API endpoints. These tests should run against the HTTP server and verify log output for typical and erroneous requests.
+
+## Status History
+
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-06-24 12:00:00 | Created | N/A | Proposed | Initial task for logging integration tests | AI Agent |
+
+## Test Plan
+- [ ] Start the HTTP server in test mode and perform authenticated requests.
+- [ ] Assert that audit logs contain request metadata and outcomes.
+- [ ] Measure logged performance metrics for key operations.

--- a/docs/delivery/SEC-7/SEC-7-4.md
+++ b/docs/delivery/SEC-7/SEC-7-4.md
@@ -1,0 +1,17 @@
+# SEC-7-4: E2E Logging Verification
+
+[Back to task list](./tasks.md)
+
+## Description
+Conduct end-to-end tests covering typical user workflows to confirm that audit and performance logs capture the entire request cycle.
+
+## Status History
+
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-06-24 12:00:00 | Created | N/A | Proposed | Initial task for E2E logging verification | AI Agent |
+
+## Test Plan
+- [ ] Execute full application flows using the UI test framework.
+- [ ] Verify that log files contain entries for each step in the workflows.
+- [ ] Ensure logs show performance metrics for page load and API calls.

--- a/docs/delivery/SEC-7/tasks.md
+++ b/docs/delivery/SEC-7/tasks.md
@@ -9,6 +9,9 @@ This document lists all tasks associated with PBI SEC-7.
 | Task ID | Name | Status | Description |
 | :------ | :--------------------------------------- | :------- | :--------------------------------- |
 | SEC-7-1 | [Add Performance and Audit Logging](./SEC-7-1.md) | InProgress | Add logging and monitoring to the security layers for auditing and performance analysis |
+| SEC-7-2 | [Add Unit Tests for Logging](./SEC-7-2.md) | Proposed | Create unit tests for audit and performance logging modules |
+| SEC-7-3 | [Add Integration Tests for Logging](./SEC-7-3.md) | Proposed | Verify logging behavior across security modules |
+| SEC-7-4 | [E2E Logging Verification](./SEC-7-4.md) | Proposed | Validate logging in full system workflows |
 
 ## Implementation Notes
 


### PR DESCRIPTION
## Summary
- add proposed tasks for unit, integration, and e2e logging tests
- document each new task under SEC-7

## Testing
- `cargo test --workspace` *(failed: lock step aborted)*
- `cargo clippy` *(failed: component not installed)*
- `npm test` *(failed: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afb1eb15483278ef7006fd6c82871