### PR TITLE
Disable auto loading of available schemas

### DIFF
--- a/available_schemas/README.md
+++ b/available_schemas/README.md
@@ -141,7 +141,7 @@ The SchemaCore has been enhanced with the following methods:
 - `discover_available_schemas()`: Find schemas in available_schemas directory
 - `load_available_schemas_from_directory()`: Load all schemas into SchemaCore
 - `fetch_available_schemas()`: Get schema names from both directories
-- Enhanced `load_schemas_from_disk()`: Loads from both data/schemas and available_schemas
+- Enhanced `load_schemas_from_disk()`: Loads schemas from the data directory only and leaves available_schemas untouched
 
 ## File Format
 

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -9,6 +9,7 @@ This document contains the most up-to-date and condensed information about the p
 | SCHEMA-001 | Once approved, schemas cannot be unloaded. They can only transition between approved and blocked states. | schema_manager, schema_routes | 2025-06-23 19:14:00 | None |
 | SCHEMA-002 | Only approved schemas can be mutated or queried by the user. | query_routes, mutation_tab, query_tab, schema_manager | 2025-06-23 19:17:00 | None |
 | SCHEMA-003 | Transforms can write field values to any schema regardless of state, but cannot modify schema structure. | transform_manager, transform_queue, schema_manager | 2025-06-23 19:23:00 | None |
+| SCHEMA-004 | Available schemas are discovered from JSON files only and are not loaded automatically. | schema/discovery, schema/persistence | 2025-06-24 21:49:43 | None |
 
 ### SCHEMA-001: Schema State Transition Rules
 - **Description**: Enforces valid state transitions for schema lifecycle management

--- a/src/schema/discovery.rs
+++ b/src/schema/discovery.rs
@@ -128,20 +128,31 @@ impl SchemaCore {
                     discovered_schemas.push(schema_name.clone());
 
                     if !loading_sources.contains_key(&schema_name) {
-                        loading_sources.insert(schema_name.clone(), SchemaSource::AvailableDirectory);
+                        loading_sources.insert(
+                            schema_name.clone(),
+                            SchemaSource::AvailableDirectory,
+                        );
                     }
 
-                    if !current_schemas.contains(&schema_name) {
-                        info!(
-                            "Loading new schema '{}' from available_schemas/ (preserving persisted state)",
-                            schema_name
-                        );
-                        if let Err(e) = self.load_schema_internal(schema) {
-                            failed_schemas.push((schema_name, e.to_string()));
-                        }
-                    } else {
-                        info!("Schema '{}' already in memory, skipping reload", schema_name);
+                    // Record schema as available but do not load it automatically
+                    let state = schema_states
+                        .get(&schema_name)
+                        .copied()
+                        .unwrap_or(SchemaState::Available);
+                    {
+                        let mut available = self.available.lock().map_err(|_| {
+                            SchemaError::InvalidData(
+                                "Failed to acquire schema lock".to_string(),
+                            )
+                        })?;
+                        available.insert(schema_name.clone(), (schema, state));
                     }
+
+                    info!(
+                        "Discovered available schema '{}' with state {:?} (not auto-loaded)",
+                        schema_name,
+                        state
+                    );
                 }
             }
             Err(e) => {

--- a/src/schema/persistence.rs
+++ b/src/schema/persistence.rs
@@ -29,19 +29,31 @@ impl SchemaCore {
         self.db_ops.store_schema(&schema.name, schema)
     }
 
-    /// Loads all schema files from both the schemas directory and available_schemas directory and restores their states.
-    /// Schemas marked as Approved will be loaded into active memory.
+    /// Loads schemas from the `schemas` directory and restores their states.
+    ///
+    /// Schemas found in `available_schemas` are only discovered and added to the
+    /// available list but are **not** automatically loaded into memory.
     pub fn load_schemas_from_disk(&self) -> Result<(), SchemaError> {
         let states = self.load_states();
 
-        // Load from default schemas directory
+        // Load from the node's schemas directory
         info!("Loading schemas from {}", self.schemas_dir.display());
         self.load_schemas_from_directory(&self.schemas_dir, &states)?;
 
-        // Load from available_schemas directory
-        let available_schemas_dir = PathBuf::from("available_schemas");
-        info!("Loading schemas from {}", available_schemas_dir.display());
-        self.load_schemas_from_directory(&available_schemas_dir, &states)?;
+        // Discover available schemas without loading them
+        for mut schema in self.discover_available_schemas()? {
+            self.fix_transform_outputs(&mut schema);
+            let name = schema.name.clone();
+            let state = states.get(&name).copied().unwrap_or(SchemaState::Available);
+            let mut available = self.available.lock().map_err(|_| {
+                SchemaError::InvalidData("Failed to acquire schema lock".to_string())
+            })?;
+            available.insert(name.clone(), (schema, state));
+            info!(
+                "Discovered available schema '{}' from available_schemas/ with state: {:?}",
+                name, state
+            );
+        }
 
         // Persist any changes to schema states from newly discovered schemas
         self.persist_states()?;

--- a/tests/integration/available_schemas_test.rs
+++ b/tests/integration/available_schemas_test.rs
@@ -1,0 +1,41 @@
+use datafold::db_operations::DbOperations;
+use datafold::fold_db_core::infrastructure::message_bus::MessageBus;
+use datafold::schema::core::{SchemaCore, SchemaState};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+#[test]
+fn test_discover_available_schemas_json_only() {
+    let temp = TempDir::new().unwrap();
+    let db = sled::open(temp.path().join("db")).unwrap();
+    let db_ops = Arc::new(DbOperations::new(db).unwrap());
+    let message_bus = Arc::new(MessageBus::new());
+    let schema_core = SchemaCore::new(temp.path().to_str().unwrap(), Arc::clone(&db_ops), Arc::clone(&message_bus)).unwrap();
+
+    let schemas = schema_core.discover_available_schemas().unwrap();
+    let names: Vec<String> = schemas.iter().map(|s| s.name.clone()).collect();
+    assert!(!names.is_empty());
+    assert!(!names.iter().any(|n| n.contains("README")));
+}
+
+#[test]
+fn test_available_schemas_not_loaded_by_default() {
+    let temp = TempDir::new().unwrap();
+    let db = sled::open(temp.path().join("db")).unwrap();
+    let db_ops = Arc::new(DbOperations::new(db).unwrap());
+    let message_bus = Arc::new(MessageBus::new());
+    let schema_core = SchemaCore::new(temp.path().to_str().unwrap(), Arc::clone(&db_ops), Arc::clone(&message_bus)).unwrap();
+
+    schema_core.load_schemas_from_disk().unwrap();
+
+    // Available schemas should be discovered but not loaded
+    let available = schema_core.list_available_schemas().unwrap();
+    println!("available count: {}", available.len());
+    assert!(!available.is_empty());
+
+    let loaded = schema_core.list_loaded_schemas().unwrap();
+    assert!(loaded.is_empty());
+
+    // States for available schemas should default to Available
+    assert_eq!(schema_core.get_schema_state(&available[0]).unwrap(), SchemaState::Available);
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -18,3 +18,4 @@ pub mod regression_prevention_test;
 // Security API integration tests
 pub mod security_api_tests;
 pub mod api_security_integration_test;
+pub mod available_schemas_test;

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -201,9 +201,15 @@ impl CommonTestFixture {
 
         // Unified NodeConfig setup - consolidates 7+ duplicate patterns
         let config = NodeConfig::new(temp_dir.path().to_path_buf());
-        let node = DataFoldNode::load(config).await.map_err(|e| {
+        let mut node = DataFoldNode::load(config).await.map_err(|e| {
             SchemaError::InvalidData(format!("Failed to load DataFoldNode: {}", e))
         })?;
+
+        // Explicitly load transform schemas from available_schemas
+        node.load_schema_from_file("available_schemas/TransformBase.json")
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to load TransformBase schema: {}", e)))?;
+        node.load_schema_from_file("available_schemas/TransformSchema.json")
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to load TransformSchema schema: {}", e)))?;
 
         let node_clone = node.clone();
         {


### PR DESCRIPTION
## Summary
- skip auto-loading schemas from `available_schemas`
- update docs and project logic
- explicitly load example schemas in tests
- add tests confirming available schemas discovery

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1c200008832785ff07f558680a8e