### PR TITLE
[SEC-7-1] Add parse_log_level helper

### DIFF
--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod config;
 pub mod features;
+pub mod util;
 
 use config::LogConfig;
 use once_cell::sync::OnceCell;

--- a/src/logging/outputs/console.rs
+++ b/src/logging/outputs/console.rs
@@ -1,6 +1,7 @@
 //! Console output handler with color support
 
 use crate::logging::config::ConsoleConfig;
+use crate::logging::util::parse_log_level;
 use crate::logging::LoggingError;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
@@ -25,7 +26,7 @@ impl ConsoleOutput {
     pub fn create_layer(&self) -> Result<impl Layer<Registry> + Send + Sync, LoggingError> {
         let mut layer = fmt::Layer::default()
             .with_writer(io::stdout)
-            .with_filter(self.parse_level_filter()?);
+            .with_filter(parse_log_level(&self.config.level)?);
 
         // Configure formatting based on config
         if self.config.colors {
@@ -51,15 +52,4 @@ impl ConsoleOutput {
         Ok(layer)
     }
 
-    /// Parse the log level filter from configuration
-    fn parse_level_filter(&self) -> Result<tracing::Level, LoggingError> {
-        match self.config.level.as_str() {
-            "TRACE" => Ok(tracing::Level::TRACE),
-            "DEBUG" => Ok(tracing::Level::DEBUG),
-            "INFO" => Ok(tracing::Level::INFO),
-            "WARN" => Ok(tracing::Level::WARN),
-            "ERROR" => Ok(tracing::Level::ERROR),
-            _ => Err(LoggingError::Config(format!("Invalid log level: {}", self.config.level))),
-        }
-    }
 }

--- a/src/logging/outputs/file.rs
+++ b/src/logging/outputs/file.rs
@@ -1,6 +1,7 @@
 //! File output handler with rotation support
 
 use crate::logging::config::FileConfig;
+use crate::logging::util::parse_log_level;
 use crate::logging::LoggingError;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
@@ -59,7 +60,7 @@ impl FileOutput {
     pub fn create_layer(&self) -> Result<impl Layer<Registry> + Send + Sync, LoggingError> {
         let mut layer = fmt::Layer::default()
             .with_ansi(false) // No colors in file output
-            .with_filter(self.parse_level_filter()?);
+            .with_filter(parse_log_level(&self.config.level)?);
 
         if !self.config.include_timestamp {
             layer = layer.without_time();
@@ -76,18 +77,6 @@ impl FileOutput {
         }
 
         Ok(layer)
-    }
-
-    /// Parse the log level filter from configuration
-    fn parse_level_filter(&self) -> Result<tracing::Level, LoggingError> {
-        match self.config.level.as_str() {
-            "TRACE" => Ok(tracing::Level::TRACE),
-            "DEBUG" => Ok(tracing::Level::DEBUG),
-            "INFO" => Ok(tracing::Level::INFO),
-            "WARN" => Ok(tracing::Level::WARN),
-            "ERROR" => Ok(tracing::Level::ERROR),
-            _ => Err(LoggingError::Config(format!("Invalid log level: {}", self.config.level))),
-        }
     }
 
     /// Parse file size string to bytes

--- a/src/logging/outputs/structured.rs
+++ b/src/logging/outputs/structured.rs
@@ -1,6 +1,7 @@
 //! Structured JSON output handler
 
 use crate::logging::config::StructuredConfig;
+use crate::logging::util::parse_log_level;
 use crate::logging::LoggingError;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
@@ -59,20 +60,9 @@ impl StructuredOutput {
             .json() // Enable JSON formatting
             .with_current_span(self.config.include_context)
             .with_span_list(self.config.include_context)
-            .with_filter(self.parse_level_filter()?);
+            .with_filter(parse_log_level(&self.config.level)?);
 
         Ok(layer)
     }
 
-    /// Parse the log level filter from configuration
-    fn parse_level_filter(&self) -> Result<tracing::Level, LoggingError> {
-        match self.config.level.as_str() {
-            "TRACE" => Ok(tracing::Level::TRACE),
-            "DEBUG" => Ok(tracing::Level::DEBUG),
-            "INFO" => Ok(tracing::Level::INFO),
-            "WARN" => Ok(tracing::Level::WARN),
-            "ERROR" => Ok(tracing::Level::ERROR),
-            _ => Err(LoggingError::Config(format!("Invalid log level: {}", self.config.level))),
-        }
-    }
 }

--- a/src/logging/outputs/web.rs
+++ b/src/logging/outputs/web.rs
@@ -1,6 +1,7 @@
 //! Web streaming output handler (maintains backward compatibility)
 
 use crate::logging::config::WebConfig;
+use crate::logging::util::parse_log_level;
 use crate::logging::LoggingError;
 use std::collections::VecDeque;
 use std::sync::Mutex;
@@ -39,7 +40,7 @@ impl WebOutput {
         let layer = fmt::Layer::default()
             .with_writer(writer)
             .with_ansi(false) // No ANSI colors for web
-            .with_filter(self.parse_level_filter()?);
+            .with_filter(parse_log_level(&self.config.level)?);
 
         Ok(layer)
     }
@@ -59,17 +60,6 @@ impl WebOutput {
         self.sender.subscribe()
     }
 
-    /// Parse the log level filter from configuration
-    fn parse_level_filter(&self) -> Result<tracing::Level, LoggingError> {
-        match self.config.level.as_str() {
-            "TRACE" => Ok(tracing::Level::TRACE),
-            "DEBUG" => Ok(tracing::Level::DEBUG),
-            "INFO" => Ok(tracing::Level::INFO),
-            "WARN" => Ok(tracing::Level::WARN),
-            "ERROR" => Ok(tracing::Level::ERROR),
-            _ => Err(LoggingError::Config(format!("Invalid log level: {}", self.config.level))),
-        }
-    }
 }
 
 /// Custom writer that sends logs to both buffer and broadcast channel

--- a/src/logging/util.rs
+++ b/src/logging/util.rs
@@ -1,0 +1,19 @@
+//! Utility helpers for the logging system
+
+use crate::logging::LoggingError;
+
+/// Parse a string log level into a [`tracing::Level`].
+///
+/// Returns an error if the provided level is not one of the
+/// standard log level strings (TRACE, DEBUG, INFO, WARN, ERROR).
+pub fn parse_log_level(level: &str) -> Result<tracing::Level, LoggingError> {
+    match level {
+        "TRACE" => Ok(tracing::Level::TRACE),
+        "DEBUG" => Ok(tracing::Level::DEBUG),
+        "INFO" => Ok(tracing::Level::INFO),
+        "WARN" => Ok(tracing::Level::WARN),
+        "ERROR" => Ok(tracing::Level::ERROR),
+        _ => Err(LoggingError::Config(format!("Invalid log level: {}", level))),
+    }
+}
+


### PR DESCRIPTION
## Summary
- centralize log level parsing with new `parse_log_level` in `src/logging/util.rs`
- use the helper across console, file, web and structured outputs
- expose the new util module

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2b0e27dc8327b56a3fd654c5a327