### PR TITLE
Refactor logging file size parser

### DIFF
--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -10,6 +10,7 @@ This document contains the most up-to-date and condensed information about the p
 | SCHEMA-002 | Only approved schemas can be mutated or queried by the user. | query_routes, mutation_tab, query_tab, schema_manager | 2025-06-23 19:17:00 | None |
 | SCHEMA-003 | Transforms can write field values to any schema regardless of state, but cannot modify schema structure. | transform_manager, transform_queue, schema_manager | 2025-06-23 19:23:00 | None |
 | SCHEMA-004 | Available schemas are discovered from JSON files only and are not loaded automatically. | schema/discovery, schema/persistence | 2025-06-24 21:49:43 | None |
+| LOG-001 | File size strings for log rotation must be numeric with optional KB, MB, or GB suffixes and are parsed by `parse_file_size`. | logging/config, logging/outputs | 2025-06-25 00:28:57 | None |
 
 ### SCHEMA-001: Schema State Transition Rules
 - **Description**: Enforces valid state transitions for schema lifecycle management
@@ -48,3 +49,13 @@ This document contains the most up-to-date and condensed information about the p
   - Backend should distinguish between schema structure modifications and field value updates
   - Transform execution should use field value update operations, not schema modification operations
   - Error handling should clearly differentiate between these operation types
+
+### LOG-001: File Size Parsing for Logging
+- **Description**: Defines how file size strings are interpreted for log rotation
+- **Rationale**: Ensures consistent configuration and prevents invalid log rotation sizes
+- **Accepted Formats**:
+  - Numeric value only (bytes)
+  - Numbers ending with `KB`, `MB`, or `GB`
+- **Implementation Notes**:
+  - Parsing logic resides in `logging::utils::parse_file_size`
+  - Both configuration validation and file output initialization use this shared parser

--- a/src/logging/config.rs
+++ b/src/logging/config.rs
@@ -327,42 +327,12 @@ impl LogConfig {
 
         // Validate file size format
         if self.outputs.file.enabled {
-            self.parse_file_size(&self.outputs.file.max_size)?;
+            super::utils::parse_file_size(&self.outputs.file.max_size)?;
         }
 
         Ok(())
     }
 
-    /// Parse file size string (e.g., "10MB", "1GB") to bytes
-    fn parse_file_size(&self, size_str: &str) -> Result<u64, ConfigError> {
-        let size_str = size_str.to_uppercase();
-
-        if let Some(num_str) = size_str.strip_suffix("GB") {
-            let num: u64 = num_str
-                .parse()
-                .map_err(|_| ConfigError::InvalidFileSize(size_str.clone()))?;
-            Ok(num * 1024 * 1024 * 1024)
-        } else if let Some(num_str) = size_str.strip_suffix("MB") {
-            let num: u64 = num_str
-                .parse()
-                .map_err(|_| ConfigError::InvalidFileSize(size_str.clone()))?;
-            Ok(num * 1024 * 1024)
-        } else if let Some(num_str) = size_str.strip_suffix("KB") {
-            let num: u64 = num_str
-                .parse()
-                .map_err(|_| ConfigError::InvalidFileSize(size_str.clone()))?;
-            Ok(num * 1024)
-        } else if let Some(num_str) = size_str.strip_suffix("B") {
-            num_str
-                .parse()
-                .map_err(|_| ConfigError::InvalidFileSize(size_str.clone()))
-        } else {
-            // Default to bytes if no suffix
-            size_str
-                .parse()
-                .map_err(|_| ConfigError::InvalidFileSize(size_str.clone()))
-        }
-    }
 }
 
 /// Configuration errors

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod config;
 pub mod features;
+pub mod utils;
 
 use config::LogConfig;
 use once_cell::sync::OnceCell;

--- a/src/logging/outputs/file.rs
+++ b/src/logging/outputs/file.rs
@@ -1,6 +1,7 @@
 //! File output handler with rotation support
 
 use crate::logging::config::FileConfig;
+use crate::logging::utils::parse_file_size;
 use crate::logging::LoggingError;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
@@ -24,6 +25,9 @@ impl FileOutput {
             tokio::fs::create_dir_all(parent).await
                 .map_err(|e| LoggingError::Io(e))?;
         }
+
+        // Validate configured max file size
+        parse_file_size(&config.max_size)?;
 
         // Set up file appender with rotation
         let file_appender = if config.max_files > 1 {
@@ -90,29 +94,4 @@ impl FileOutput {
         }
     }
 
-    /// Parse file size string to bytes
-    fn parse_file_size(size_str: &str) -> Result<u64, LoggingError> {
-        let size_str = size_str.to_uppercase();
-        
-        if let Some(num_str) = size_str.strip_suffix("GB") {
-            let num: u64 = num_str.parse()
-                .map_err(|_| LoggingError::Config(format!("Invalid file size: {}", size_str)))?;
-            Ok(num * 1024 * 1024 * 1024)
-        } else if let Some(num_str) = size_str.strip_suffix("MB") {
-            let num: u64 = num_str.parse()
-                .map_err(|_| LoggingError::Config(format!("Invalid file size: {}", size_str)))?;
-            Ok(num * 1024 * 1024)
-        } else if let Some(num_str) = size_str.strip_suffix("KB") {
-            let num: u64 = num_str.parse()
-                .map_err(|_| LoggingError::Config(format!("Invalid file size: {}", size_str)))?;
-            Ok(num * 1024)
-        } else if let Some(num_str) = size_str.strip_suffix("B") {
-            num_str.parse()
-                .map_err(|_| LoggingError::Config(format!("Invalid file size: {}", size_str)))
-        } else {
-            // Default to bytes if no suffix
-            size_str.parse()
-                .map_err(|_| LoggingError::Config(format!("Invalid file size: {}", size_str)))
-        }
-    }
 }

--- a/src/logging/utils.rs
+++ b/src/logging/utils.rs
@@ -1,0 +1,32 @@
+use crate::logging::config::ConfigError;
+
+/// Parse file size string (e.g., "10MB", "1GB") to bytes
+pub fn parse_file_size(size_str: &str) -> Result<u64, ConfigError> {
+    let size_str = size_str.to_uppercase();
+
+    if let Some(num_str) = size_str.strip_suffix("GB") {
+        let num: u64 = num_str
+            .parse()
+            .map_err(|_| ConfigError::InvalidFileSize(size_str.clone()))?;
+        Ok(num * 1024 * 1024 * 1024)
+    } else if let Some(num_str) = size_str.strip_suffix("MB") {
+        let num: u64 = num_str
+            .parse()
+            .map_err(|_| ConfigError::InvalidFileSize(size_str.clone()))?;
+        Ok(num * 1024 * 1024)
+    } else if let Some(num_str) = size_str.strip_suffix("KB") {
+        let num: u64 = num_str
+            .parse()
+            .map_err(|_| ConfigError::InvalidFileSize(size_str.clone()))?;
+        Ok(num * 1024)
+    } else if let Some(num_str) = size_str.strip_suffix("B") {
+        num_str
+            .parse()
+            .map_err(|_| ConfigError::InvalidFileSize(size_str.clone()))
+    } else {
+        // Default to bytes if no suffix
+        size_str
+            .parse()
+            .map_err(|_| ConfigError::InvalidFileSize(size_str.clone()))
+    }
+}

--- a/tests/unit/logging_utils_test.rs
+++ b/tests/unit/logging_utils_test.rs
@@ -1,0 +1,26 @@
+use datafold::logging::utils::parse_file_size;
+
+#[test]
+fn parse_file_size_kilobytes() {
+    assert_eq!(parse_file_size("10KB").unwrap(), 10 * 1024);
+}
+
+#[test]
+fn parse_file_size_megabytes() {
+    assert_eq!(parse_file_size("2MB").unwrap(), 2 * 1024 * 1024);
+}
+
+#[test]
+fn parse_file_size_gigabytes() {
+    assert_eq!(parse_file_size("1GB").unwrap(), 1024 * 1024 * 1024);
+}
+
+#[test]
+fn parse_file_size_no_suffix() {
+    assert_eq!(parse_file_size("500").unwrap(), 500);
+}
+
+#[test]
+fn parse_file_size_invalid() {
+    assert!(parse_file_size("abc").is_err());
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -4,3 +4,4 @@
 //! in isolation and maintains its specific responsibilities.
 
 pub mod transform_manager_module_tests;
+pub mod logging_utils_test;


### PR DESCRIPTION
## Summary
- move `parse_file_size` logic into a shared module
- remove the old method from `FileOutput`
- validate file size using the shared function

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2b292518832796a4fa121cb6237b