### PR TITLE
Refactor mapping utilities

### DIFF
--- a/src/fold_db_core/transform_manager/utils/mod.rs
+++ b/src/fold_db_core/transform_manager/utils/mod.rs
@@ -332,6 +332,39 @@ impl TransformUtils {
     ) {
         info!("🔍 DEBUG {}: {} collection state: {:?}", operation, collection_name, collection);
     }
+
+    /// Read a persisted mapping or return a default value
+    pub fn read_mapping<T>(
+        db_ops: &Arc<crate::db_operations::DbOperations>,
+        key: &str,
+        name: &str,
+    ) -> Result<T, SchemaError>
+    where
+        T: serde::de::DeserializeOwned + Default,
+    {
+        if let Some(data) = db_ops.get_transform_mapping(key)? {
+            Self::deserialize_mapping(&data, name)
+        } else {
+            Ok(T::default())
+        }
+    }
+
+    /// Insert a value into a set mapping
+    pub fn insert_mapping_set(
+        map: &mut HashMap<String, HashSet<String>>,
+        key: &str,
+        value: &str,
+    ) {
+        map.entry(key.to_string())
+            .or_default()
+            .insert(value.to_string());
+    }
+
+    /// Wrap an error with context and log it
+    pub fn handle_error<E: std::fmt::Display>(context: &str, err: E) -> SchemaError {
+        error!("❌ {}: {}", context, err);
+        SchemaError::InvalidData(format!("{}: {}", context, err))
+    }
 }
 
 // Type aliases for backward compatibility and reduced import burden

--- a/src/schema/transform.rs
+++ b/src/schema/transform.rs
@@ -1,5 +1,6 @@
 use super::SchemaCore;
 use crate::schema::types::{field::common::Field, Schema, SchemaError};
+use crate::fold_db_core::transform_manager::utils::TransformUtils;
 use log::info;
 use crate::logging::features::{log_feature, LogFeature};
 
@@ -95,22 +96,13 @@ impl SchemaCore {
     /// Store field-to-transform mapping in database for TransformManager to load
     pub(crate) fn store_field_to_transform_mapping(&self, field_key: &str, transform_id: &str) -> Result<(), SchemaError> {
         const FIELD_TO_TRANSFORMS_KEY: &str = "map_field_to_transforms";
-
         let mut field_mappings: std::collections::HashMap<String, std::collections::HashSet<String>> =
-            if let Some(data) = self.db_ops.get_transform_mapping(FIELD_TO_TRANSFORMS_KEY)? {
-                serde_json::from_slice(&data).unwrap_or_default()
-            } else {
-                std::collections::HashMap::new()
-            };
+            TransformUtils::read_mapping(&self.db_ops, FIELD_TO_TRANSFORMS_KEY, "field_to_transforms")?;
 
-        field_mappings
-            .entry(field_key.to_string())
-            .or_default()
-            .insert(transform_id.to_string());
+        TransformUtils::insert_mapping_set(&mut field_mappings, field_key, transform_id);
 
-        let json = serde_json::to_vec(&field_mappings).map_err(|e| {
-            SchemaError::InvalidData(format!("Failed to serialize field mappings: {}", e))
-        })?;
+        let json = serde_json::to_vec(&field_mappings)
+            .map_err(|e| TransformUtils::handle_error("Failed to serialize field mappings", e))?;
         self.db_ops.store_transform_mapping(FIELD_TO_TRANSFORMS_KEY, &json)?;
 
         info!("💾 Updated field mappings in database: {} fields mapped", field_mappings.len());

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -4,3 +4,4 @@
 //! in isolation and maintains its specific responsibilities.
 
 pub mod transform_manager_module_tests;
+pub mod transform_utils_helper_tests;

--- a/tests/unit/transform_utils_helper_tests.rs
+++ b/tests/unit/transform_utils_helper_tests.rs
@@ -1,0 +1,45 @@
+use std::collections::{HashMap, HashSet};
+
+use datafold::fold_db_core::transform_manager::utils::TransformUtils;
+use crate::test_utils::TestFixture;
+
+#[tokio::test]
+async fn test_read_mapping_returns_default() {
+    let fixture = TestFixture::new().expect("fixture");
+    let map: HashMap<String, HashSet<String>> =
+        TransformUtils::read_mapping(&fixture.db_ops, "missing", "test").unwrap();
+    assert!(map.is_empty());
+}
+
+#[tokio::test]
+async fn test_read_mapping_invalid_json() {
+    let fixture = TestFixture::new().expect("fixture");
+    fixture
+        .db_ops
+        .store_transform_mapping("bad", b"not json")
+        .unwrap();
+    let map: HashMap<String, HashSet<String>> =
+        TransformUtils::read_mapping(&fixture.db_ops, "bad", "bad").unwrap();
+    assert!(map.is_empty());
+}
+
+#[test]
+fn test_insert_mapping_set() {
+    let mut map: HashMap<String, HashSet<String>> = HashMap::new();
+    TransformUtils::insert_mapping_set(&mut map, "field", "t1");
+    TransformUtils::insert_mapping_set(&mut map, "field", "t2");
+    let set = map.get("field").expect("set");
+    assert!(set.contains("t1") && set.contains("t2"));
+}
+
+#[test]
+fn test_handle_error() {
+    let err = TransformUtils::handle_error("context", "oops");
+    match err {
+        datafold::schema::types::SchemaError::InvalidData(msg) => {
+            assert!(msg.contains("context") && msg.contains("oops"));
+        }
+        _ => panic!("wrong error"),
+    }
+}
+


### PR DESCRIPTION
## Summary
- add helpers for reading transform mappings and error handling
- use helper functions in `store_field_to_transform_mapping`
- test helper edge cases

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b4d0e8e48832789e1f1d5a58721a1