### PR TITLE
[0-0] fix remove timestamp update

### DIFF
--- a/src/atom/molecule_range.rs
+++ b/src/atom/molecule_range.rs
@@ -48,12 +48,12 @@ impl MoleculeRange {
 
 
     /// Removes the reference at the specified key.
+    #[allow(clippy::manual_inspect)]
     pub fn remove_atom_uuid(&mut self, key: &str) -> Option<String> {
-        let result = self.atom_uuids.remove(key);
-        if result.is_some() {
+        self.atom_uuids.remove(key).map(|uuid| {
             self.updated_at = Utc::now();
-        }
-        result
+            uuid
+        })
     }
 
 }


### PR DESCRIPTION
## Summary
- update `remove_atom_uuid` to set `updated_at` using map

## Testing
- `cargo clippy`
- `cargo test --workspace`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c6ba1535c8327a4cc32fd9bf00643