### PR TITLE
Refactor Molecule status updates

### DIFF
--- a/src/atom/molecule.rs
+++ b/src/atom/molecule.rs
@@ -1,5 +1,5 @@
 use crate::atom::molecule_behavior::MoleculeBehavior;
-use crate::atom::molecule_types::{MoleculeStatus, MoleculeUpdate};
+use crate::atom::molecule_types::{apply_status_update, MoleculeStatus, MoleculeUpdate};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -58,14 +58,13 @@ impl MoleculeBehavior for Molecule {
     }
 
     fn set_status(&mut self, status: &MoleculeStatus, source_pub_key: String) {
-        let status_clone = status.clone();
-        self.status = status_clone.clone();
-        self.updated_at = Utc::now();
-        self.update_history.push(MoleculeUpdate {
-            timestamp: Utc::now(),
-            status: status_clone,
+        apply_status_update(
+            &mut self.status,
+            &mut self.updated_at,
+            &mut self.update_history,
+            status,
             source_pub_key,
-        });
+        );
     }
 
     fn update_history(&self) -> &Vec<MoleculeUpdate> {

--- a/src/atom/molecule_range.rs
+++ b/src/atom/molecule_range.rs
@@ -1,5 +1,5 @@
 use crate::atom::molecule_behavior::MoleculeBehavior;
-use crate::atom::molecule_types::{MoleculeStatus, MoleculeUpdate};
+use crate::atom::molecule_types::{apply_status_update, MoleculeStatus, MoleculeUpdate};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -72,14 +72,13 @@ impl MoleculeBehavior for MoleculeRange {
     }
 
     fn set_status(&mut self, status: &MoleculeStatus, source_pub_key: String) {
-        let status_clone = status.clone();
-        self.status = status_clone.clone();
-        self.updated_at = Utc::now();
-        self.update_history.push(MoleculeUpdate {
-            timestamp: Utc::now(),
-            status: status_clone,
+        apply_status_update(
+            &mut self.status,
+            &mut self.updated_at,
+            &mut self.update_history,
+            status,
             source_pub_key,
-        });
+        );
     }
 
     fn update_history(&self) -> &Vec<MoleculeUpdate> {

--- a/src/atom/molecule_types.rs
+++ b/src/atom/molecule_types.rs
@@ -13,3 +13,22 @@ pub struct MoleculeUpdate {
     pub(crate) status: MoleculeStatus,
     pub(crate) source_pub_key: String,
 }
+
+/// Helper that updates status related fields.
+pub fn apply_status_update(
+    status_field: &mut MoleculeStatus,
+    updated_at_field: &mut DateTime<Utc>,
+    history: &mut Vec<MoleculeUpdate>,
+    status: &MoleculeStatus,
+    source_pub_key: String,
+) {
+    let now = Utc::now();
+    let status_clone = status.clone();
+    *status_field = status_clone.clone();
+    *updated_at_field = now;
+    history.push(MoleculeUpdate {
+        timestamp: now,
+        status: status_clone,
+        source_pub_key,
+    });
+}


### PR DESCRIPTION
## Summary
- add `apply_status_update` helper to encapsulate status update logic
- use helper in `Molecule::set_status` and `MoleculeRange::set_status`

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6b9630448327b1badd5532a225f8