### PR TITLE
feat: add declarative schema definitions

### DIFF
--- a/docs/delivery/DTS-1/DTS-1-2.md
+++ b/docs/delivery/DTS-1/DTS-1-2.md
@@ -11,6 +11,7 @@ Implement the core data structures for declarative transforms including `Declara
 | Timestamp | Event Type | From Status | To Status | Details | User |
 |-----------|------------|-------------|-----------|---------|------|
 | 2025-01-27 12:00:00 | Status Change | N/A | Proposed | Task file created | User |
+| 2025-08-26 18:26:00 | Status Change | Proposed | In Review | Initial implementation | AI |
 
 ## Requirements
 

--- a/docs/delivery/DTS-1/tasks.md
+++ b/docs/delivery/DTS-1/tasks.md
@@ -9,7 +9,7 @@ This document lists all tasks associated with PBI DTS-1.
 | Task ID | Name | Status | Description |
 | :------ | :--- | :----- | :---------- |
 | DTS-1-1 | [Implement TransformKind enum with Procedural and Declarative variants](./DTS-1-1.md) | Proposed | Create the TransformKind enum to support both procedural and declarative transform types |
-| DTS-1-2 | [Implement DeclarativeSchemaDefinition and supporting structs](./DTS-1-2.md) | Proposed | Create the core data structures for declarative transforms including KeyConfig and FieldDefinition |
+| DTS-1-2 | [Implement DeclarativeSchemaDefinition and supporting structs](./DTS-1-2.md) | In Review | Create the core data structures for declarative transforms including KeyConfig and FieldDefinition |
 | DTS-1-3 | [Update JsonTransform to support both transform types](./DTS-1-3.md) | Proposed | Modify JsonTransform to use TransformKind and maintain backward compatibility |
 | DTS-1-4 | [Add comprehensive serialization/deserialization tests](./DTS-1-4.md) | Proposed | Create unit tests to verify both transform types serialize and deserialize correctly |
 | DTS-1-5 | [Implement validation for declarative transform structures](./DTS-1-5.md) | Proposed | Add validation logic to ensure declarative transforms have required fields and valid configurations |

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -10,6 +10,7 @@ This document contains the most up-to-date and condensed information about the p
 | SCHEMA-002 | Only approved schemas can be mutated or queried by the user. | query_routes, mutation_tab, query_tab, schema_manager | 2025-06-23 19:17:00 | None |
 | SCHEMA-003 | Transforms can write field values to any schema regardless of state, but cannot modify schema structure. | transform_manager, transform_queue, schema_manager | 2025-06-23 19:23:00 | None |
 | SCHEMA-004 | Available schemas are discovered from JSON files only and are not loaded automatically. | schema/discovery, schema/persistence | 2025-06-24 21:49:43 | None |
+| SCHEMA-005 | HashRange schemas require key config with hash and range expressions; fields need atom UUID or type | schema/types | 2025-08-26 18:26:05 | None |
 | API-CLIENT-001 | All frontend API operations must use specialized unified API clients instead of direct fetch() calls. | api/clients/*, api/core/*, components/tabs/* | 2025-06-28 19:02:00 | None |
 | API-ERROR-001 | API error handling must be standardized across all clients with consistent error types and user messages. | api/core/errors, api/clients/* | 2025-06-28 19:02:00 | None |
 | API-CONFIG-001 | API endpoint URLs and configuration must be centralized to eliminate duplication and ensure consistency. | constants/api, api/endpoints | 2025-06-28 19:02:00 | None |

--- a/src/schema/types/json_schema.rs
+++ b/src/schema/types/json_schema.rs
@@ -186,3 +186,68 @@ impl JsonSchemaDefinition {
         Ok(())
     }
 }
+
+/// Key configuration for HashRange schemas
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyConfig {
+    /// Expression defining the hash key field
+    pub hash_field: String,
+    /// Expression defining the range key field
+    pub range_field: String,
+}
+
+/// Definition of an individual field in a declarative schema
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FieldDefinition {
+    /// Optional atom UUID mapping for the field
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub atom_uuid: Option<String>,
+    /// Optional field type specification
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field_type: Option<String>,
+}
+
+/// Declarative schema definition for transform generation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeclarativeSchemaDefinition {
+    /// Name identifying this declarative schema
+    pub name: String,
+    /// Type of schema this definition represents
+    #[serde(default = "crate::schema::types::schema::default_schema_type")]
+    pub schema_type: crate::schema::types::schema::SchemaType,
+    /// Key configuration required for HashRange schemas
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<KeyConfig>,
+    /// Collection of field definitions
+    pub fields: HashMap<String, FieldDefinition>,
+}
+
+impl DeclarativeSchemaDefinition {
+    /// Validate the declarative schema definition
+    pub fn validate(&self) -> Result<(), SchemaError> {
+        use crate::schema::types::schema::SchemaType;
+
+        if let SchemaType::HashRange { .. } = self.schema_type {
+            let key = self.key.as_ref().ok_or_else(|| {
+                SchemaError::InvalidField("HashRange schemas require key configuration".to_string())
+            })?;
+
+            if key.hash_field.is_empty() || key.range_field.is_empty() {
+                return Err(SchemaError::InvalidField(
+                    "KeyConfig fields cannot be empty".to_string(),
+                ));
+            }
+        }
+
+        for (name, field) in &self.fields {
+            if field.atom_uuid.is_none() && field.field_type.is_none() {
+                return Err(SchemaError::InvalidField(format!(
+                    "Field '{}' must have atom_uuid or field_type",
+                    name
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/schema/types/mod.rs
+++ b/src/schema/types/mod.rs
@@ -8,7 +8,9 @@ pub mod transform;
 
 pub use errors::SchemaError;
 pub use field::{Field, FieldType, FieldVariant, RangeField, SingleField};
-pub use json_schema::{JsonSchemaDefinition, JsonSchemaField};
+pub use json_schema::{
+    DeclarativeSchemaDefinition, FieldDefinition, JsonSchemaDefinition, JsonSchemaField, KeyConfig,
+};
 pub use operation::Operation;
 pub use operations::{Mutation, MutationType, Query};
 pub use schema::{Schema, SchemaType};

--- a/src/schema/types/schema.rs
+++ b/src/schema/types/schema.rs
@@ -10,6 +10,8 @@ pub enum SchemaType {
     Single,
     /// Schema that stores data in a key range
     Range { range_key: String },
+    /// Schema partitioned by both hash and range keys
+    HashRange { hash_key: String, range_key: String },
 }
 
 pub fn default_schema_type() -> SchemaType {
@@ -86,7 +88,9 @@ impl Schema {
     /// Returns the range_key if this schema is a Range schema, otherwise None.
     pub fn range_key(&self) -> Option<&str> {
         match &self.schema_type {
-            SchemaType::Range { range_key } => Some(range_key.as_str()),
+            SchemaType::Range { range_key } | SchemaType::HashRange { range_key, .. } => {
+                Some(range_key.as_str())
+            }
             _ => None,
         }
     }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -3,6 +3,7 @@
 //! These tests validate that each decomposed module functions correctly
 //! in isolation and maintains its specific responsibilities.
 
-pub mod transform_manager_module_tests;
 pub mod mutation_completion_tests;
+pub mod schema;
+pub mod transform_manager_module_tests;
 pub mod transform_utils_helper_tests;

--- a/tests/unit/schema/declarative_schema_tests.rs
+++ b/tests/unit/schema/declarative_schema_tests.rs
@@ -1,0 +1,82 @@
+use datafold::schema::types::{
+    DeclarativeSchemaDefinition, FieldDefinition, KeyConfig, SchemaType,
+};
+use std::collections::HashMap;
+
+#[test]
+fn schema_type_hashrange_serializes() {
+    let ty = SchemaType::HashRange {
+        hash_key: "h".into(),
+        range_key: "r".into(),
+    };
+    let json = serde_json::to_string(&ty).unwrap();
+    assert!(json.contains("HashRange"));
+}
+
+#[test]
+fn key_config_serializes() {
+    let key = KeyConfig {
+        hash_field: "user_id".into(),
+        range_field: "ts".into(),
+    };
+    let json = serde_json::to_string(&key).unwrap();
+    assert_eq!(json, "{\"hash_field\":\"user_id\",\"range_field\":\"ts\"}");
+}
+
+#[test]
+fn declarative_schema_validate() {
+    let mut fields = HashMap::new();
+    fields.insert(
+        "id".into(),
+        FieldDefinition {
+            atom_uuid: Some("atom".into()),
+            field_type: None,
+        },
+    );
+    let schema = DeclarativeSchemaDefinition {
+        name: "test".into(),
+        schema_type: SchemaType::HashRange {
+            hash_key: "id".into(),
+            range_key: "ts".into(),
+        },
+        key: Some(KeyConfig {
+            hash_field: "id".into(),
+            range_field: "ts".into(),
+        }),
+        fields,
+    };
+    assert!(schema.validate().is_ok());
+}
+
+#[test]
+fn declarative_schema_validate_errors_without_key() {
+    let schema = DeclarativeSchemaDefinition {
+        name: "test".into(),
+        schema_type: SchemaType::HashRange {
+            hash_key: "id".into(),
+            range_key: "ts".into(),
+        },
+        key: None,
+        fields: HashMap::new(),
+    };
+    assert!(schema.validate().is_err());
+}
+
+#[test]
+fn field_definition_requires_atom_or_type() {
+    let mut fields = HashMap::new();
+    fields.insert(
+        "id".into(),
+        FieldDefinition {
+            atom_uuid: None,
+            field_type: None,
+        },
+    );
+    let schema = DeclarativeSchemaDefinition {
+        name: "test".into(),
+        schema_type: SchemaType::Single,
+        key: None,
+        fields,
+    };
+    assert!(schema.validate().is_err());
+}

--- a/tests/unit/schema/mod.rs
+++ b/tests/unit/schema/mod.rs
@@ -1,0 +1,1 @@
+pub mod declarative_schema_tests;


### PR DESCRIPTION
## Summary
- extend SchemaType with HashRange variant
- add declarative schema structures and validation
- add unit tests for declarative schema features

## Testing
- `cargo test --test mod unit::schema::declarative_schema_tests::schema_type_hashrange_serializes -- --nocapture`
- `cargo clippy`
- `cd fold_node/src/datafold_node/static-react && npm test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adfb9ad5ec8327948fe1e9fbfb3085