### PR TITLE
SKC-6-7: finish normalized FieldValueSet integration

### DIFF
--- a/docs/delivery/SKC-6/SKC-6-7.md
+++ b/docs/delivery/SKC-6/SKC-6-7.md
@@ -7,6 +7,7 @@ Update downstream components that fabricate `FieldValueSetRequest` messages—su
 | Timestamp | Event Type | From Status | To Status | Details | User |
 |-----------|------------|-------------|-----------|---------|------|
 | 2025-09-23 09:35:00 | Created | N/A | Proposed | Task created for downstream alignment | ai-agent |
+| 2025-09-23 18:30:00 | Status Update | Proposed | In Review | Transform manager processors and constructors emit normalized requests via shared helpers. | ai-agent |
 
 ## Requirements
 - Identify all non-MutationService producers of `FieldValueSetRequest`, including `transform_manager::hashrange_processor`, `transform_manager::result_storage`, and message bus constructors.
@@ -16,7 +17,7 @@ Update downstream components that fabricate `FieldValueSetRequest` messages—su
 - Keep the code DRY by extracting shared helpers when multiple downstream modules require similar normalization logic.
 
 ## Implementation Plan
-1. Catalog all call sites generating `FieldValueSetRequest` outside MutationService using `rg` and document them in the task notes.
+1. Catalog all call sites generating `FieldValueSetRequest` outside MutationService using `rg` and document them in the task notes. Identified producers include `transform_manager::result_storage`, `transform_manager::hashrange_processor`, and the message bus constructors.
 2. For each call site, replace bespoke payload construction with a call to the shared builder or helper, adjusting signatures to accept the normalized context where needed.
 3. Update supporting test fixtures and helper constructors to use the normalized structure, preventing brittle test expectations.
 4. Remove redundant helper functions in downstream modules after the alignment is complete.

--- a/docs/delivery/SKC-6/tasks.md
+++ b/docs/delivery/SKC-6/tasks.md
@@ -14,7 +14,7 @@ This document lists all tasks associated with PBI SKC-6.
 | SKC-6-4 | [Retire legacy key heuristics and tighten error reporting](./SKC-6-4.md) | Done | Remove obsolete key extraction helpers and unify error handling. |
 | SKC-6-5 | [Implement normalized FieldValueSet payload builder in MutationService](./SKC-6-5.md) | Done | Create a builder that assembles schema-derived mutation payloads. |
 | SKC-6-6 | [Adopt normalized payload builder in mutation workflows](./SKC-6-6.md) | Done | Update MutationService flows to publish normalized payloads. |
-| SKC-6-7 | [Align downstream producers with normalized mutation payloads](./SKC-6-7.md) | Proposed | Refactor transform/message bus producers to use the shared payload shape. |
+| SKC-6-7 | [Align downstream producers with normalized mutation payloads](./SKC-6-7.md) | In Review | Refactor transform/message bus producers to use the shared payload shape. |
 | SKC-6-8 | [Expand universal key regression test coverage](./SKC-6-8.md) | Proposed | Add comprehensive unit and integration tests for universal key workflows. |
 | SKC-6-9 | [Document universal key field processing behavior](./SKC-6-9.md) | Proposed | Refresh documentation to describe the new helpers and payload structure. |
 | SKC-6-10 | [Remove legacy fallback logic from universal key resolution](./SKC-6-10.md) | Proposed | Remove create_legacy_resolved_keys fallback introduced in SKC-6-2 to enforce strict schema-driven key extraction. |

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -26,6 +26,7 @@ This document contains the most up-to-date and condensed information about the p
 | SCHEMA-KEY-006 | Atom field processing relies exclusively on `resolve_universal_keys`; missing schemas or key extraction failures return SchemaError-driven responses with no legacy fallback heuristics. | fold_db_core/managers/atom/field_processing.rs, tests/unit/field_processing | 2025-01-27 21:10:00 | None |
 | SCHEMA-KEY-007 | MutationService exposes normalized FieldValueSet builder returning schema-driven hash/range metadata for Single, Range, and HashRange payloads. | fold_db_core/services/mutation.rs, tests/unit/mutation | 2025-09-23 15:15:00 | None |
 | SCHEMA-KEY-008 | MutationService mutation workflows publish FieldValueSet requests exclusively through the normalized builder, and integration tests verify normalized key snapshots for Single and Range flows. | fold_db_core/services/mutation.rs, tests/integration | 2025-09-23 16:45:00 | None |
+| SCHEMA-KEY-009 | Transform managers and downstream message bus constructors must publish FieldValueSet requests using normalized helpers so payloads include schema-derived hash/range metadata. | fold_db_core/transform_manager, fold_db_core/infrastructure/message_bus | 2025-09-23 18:30:00 | None |
 | AUTH-DEV-001 | All endpoints currently operate in development mode with authentication disabled. All requests use "web-ui" identity automatically. | query_routes, http_server, api/clients | 2025-01-27 16:00:00 | None |
 
 ### AUTH-DEV-001: Development Mode Authentication

--- a/src/fold_db_core/infrastructure/message_bus/constructors.rs
+++ b/src/fold_db_core/infrastructure/message_bus/constructors.rs
@@ -5,7 +5,8 @@
 
 use super::events::*;
 use super::request_events::KeySnapshot;
-use serde_json::Value;
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
 
 // ========== Core Event Constructors ==========
 
@@ -336,7 +337,70 @@ impl MoleculeUpdateResponse {
     }
 }
 
+/// Normalized payload data used to construct FieldValueSetRequest instances.
+pub struct NormalizedRequestParts {
+    pub correlation_id: String,
+    pub schema_name: String,
+    pub field_name: String,
+    pub fields: Map<String, Value>,
+    pub hash: Option<String>,
+    pub range: Option<String>,
+    pub source_pub_key: String,
+    pub mutation_hash: Option<String>,
+}
+
 impl FieldValueSetRequest {
+    /// Create a new FieldValueSetRequest from normalized key/value parts
+    pub fn from_normalized_parts(parts: NormalizedRequestParts) -> Self {
+        let NormalizedRequestParts {
+            correlation_id,
+            schema_name,
+            field_name,
+            fields,
+            hash,
+            range,
+            source_pub_key,
+            mutation_hash,
+        } = parts;
+
+        let normalized_hash = normalize_optional_string(hash);
+        let normalized_range = normalize_optional_string(range);
+
+        let sorted_fields = Map::from_iter(BTreeMap::from_iter(fields));
+
+        let mut normalized_payload = Map::new();
+        normalized_payload.insert(
+            "hash".to_string(),
+            Value::String(normalized_hash.clone().unwrap_or_default()),
+        );
+        normalized_payload.insert(
+            "range".to_string(),
+            Value::String(normalized_range.clone().unwrap_or_default()),
+        );
+        normalized_payload.insert("fields".to_string(), Value::Object(sorted_fields));
+
+        let incremental = normalized_hash.is_some() || normalized_range.is_some();
+        let mutation_context = if incremental || mutation_hash.is_some() {
+            Some(atom_events::MutationContext {
+                range_key: normalized_range,
+                hash_key: normalized_hash,
+                mutation_hash,
+                incremental,
+            })
+        } else {
+            None
+        };
+
+        Self {
+            correlation_id,
+            schema_name,
+            field_name,
+            value: Value::Object(normalized_payload),
+            source_pub_key,
+            mutation_context,
+        }
+    }
+
     /// Create a new FieldValueSetRequest
     pub fn new(
         correlation_id: String,
@@ -373,6 +437,17 @@ impl FieldValueSetRequest {
             mutation_context: Some(mutation_context),
         }
     }
+}
+
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value.and_then(|candidate| {
+        let trimmed = candidate.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
 }
 
 impl FieldValueSetResponse {

--- a/src/fold_db_core/infrastructure/message_bus/mod.rs
+++ b/src/fold_db_core/infrastructure/message_bus/mod.rs
@@ -110,6 +110,7 @@
 
 // Re-export all public types and event modules
 pub use async_bus::{AsyncConsumer, AsyncEventHandler, AsyncMessageBus};
+pub use constructors::NormalizedRequestParts;
 pub use error_handling::{
     AsyncRecvError, AsyncTryRecvError, DeadLetterEvent, EventHistoryEntry, MessageBusError,
     MessageBusResult, RetryableEvent,

--- a/src/fold_db_core/services/mutation.rs
+++ b/src/fold_db_core/services/mutation.rs
@@ -29,7 +29,7 @@
 
 use crate::fold_db_core::infrastructure::factory::InfrastructureLogger;
 use crate::fold_db_core::infrastructure::message_bus::{
-    request_events::FieldValueSetRequest, MessageBus,
+    request_events::FieldValueSetRequest, MessageBus, NormalizedRequestParts,
 };
 use crate::logging::features::{log_feature, LogFeature};
 use crate::schema::schema_operations::{extract_unified_keys, shape_unified_result};
@@ -287,51 +287,17 @@ impl MutationService {
             .unwrap_or_default();
         let sorted_fields = sort_fields(&fields_object);
 
-        let mut normalized_payload = Map::new();
-        normalized_payload.insert(
-            "hash".to_string(),
-            Value::String(normalized_hash.clone().unwrap_or_default()),
-        );
-        normalized_payload.insert(
-            "range".to_string(),
-            Value::String(normalized_range.clone().unwrap_or_default()),
-        );
-        normalized_payload.insert("fields".to_string(), Value::Object(sorted_fields.clone()));
-
-        let incremental = normalized_hash.is_some() || normalized_range.is_some();
-        let mutation_context = if incremental || mutation_hash.is_some() {
-            Some(
-                crate::fold_db_core::infrastructure::message_bus::atom_events::MutationContext {
-                    range_key: normalized_range.clone(),
-                    hash_key: normalized_hash.clone(),
-                    mutation_hash: mutation_hash.map(|value| value.to_string()),
-                    incremental,
-                },
-            )
-        } else {
-            None
-        };
-
-        let request_value = Value::Object(normalized_payload);
         let correlation_id = Uuid::new_v4().to_string();
-        let request = if let Some(context) = mutation_context {
-            FieldValueSetRequest::with_context(
-                correlation_id,
-                schema.name.clone(),
-                field_name.to_string(),
-                request_value,
-                MUTATION_SERVICE_SOURCE.to_string(),
-                context,
-            )
-        } else {
-            FieldValueSetRequest::new(
-                correlation_id,
-                schema.name.clone(),
-                field_name.to_string(),
-                request_value,
-                MUTATION_SERVICE_SOURCE.to_string(),
-            )
-        };
+        let request = FieldValueSetRequest::from_normalized_parts(NormalizedRequestParts {
+            correlation_id,
+            schema_name: schema.name.clone(),
+            field_name: field_name.to_string(),
+            fields: sorted_fields.clone(),
+            hash: normalized_hash.clone(),
+            range: normalized_range.clone(),
+            source_pub_key: MUTATION_SERVICE_SOURCE.to_string(),
+            mutation_hash: mutation_hash.map(|value| value.to_string()),
+        });
 
         InfrastructureLogger::log_debug_info(
             "MutationService",

--- a/src/fold_db_core/transform_manager/hashrange_processor.rs
+++ b/src/fold_db_core/transform_manager/hashrange_processor.rs
@@ -1,10 +1,10 @@
+use crate::fold_db_core::services::mutation::MutationService;
 use crate::schema::constants::TRANSFORM_SYSTEM_ID;
 use crate::schema::types::{Mutation, MutationType, SchemaError};
 use log::{debug, info};
 use serde_json::{json, Value as JsonValue};
 use std::collections::HashMap;
 use std::sync::Arc;
-use uuid;
 
 /// Data structure for HashRange transform results
 #[derive(Debug, Clone)]
@@ -41,7 +41,13 @@ impl HashRangeProcessor {
             field_names.len()
         );
 
-        Self::process_hashrange_data(schema_name, &transform_data, &field_names, message_bus)
+        Self::process_hashrange_data(
+            &schema,
+            schema_name,
+            &transform_data,
+            &field_names,
+            message_bus,
+        )
     }
 
     /// Get HashRange schema and validate it exists
@@ -156,6 +162,7 @@ impl HashRangeProcessor {
 
     /// Process HashRange data and submit through message bus
     fn process_hashrange_data(
+        schema: &crate::schema::types::Schema,
         schema_name: &str,
         transform_data: &HashRangeTransformData,
         field_names: &[String],
@@ -205,6 +212,7 @@ impl HashRangeProcessor {
                 );
 
                 Self::submit_word_mutations(
+                    schema,
                     schema_name,
                     &words_from_transform,
                     &field_values,
@@ -232,6 +240,7 @@ impl HashRangeProcessor {
 
                 if !word_from_transform.is_empty() {
                     Self::submit_word_mutations(
+                        schema,
                         schema_name,
                         &[word_from_transform],
                         &field_values,
@@ -286,6 +295,7 @@ impl HashRangeProcessor {
 
     /// Submit mutations for all words in a data entry
     fn submit_word_mutations(
+        schema: &crate::schema::types::Schema,
         schema_name: &str,
         words: &[String],
         field_values: &HashMap<String, JsonValue>,
@@ -294,7 +304,7 @@ impl HashRangeProcessor {
     ) -> Result<(), SchemaError> {
         for word in words {
             let mutation = Self::create_hashrange_mutation(schema_name, word, field_values, range)?;
-            Self::submit_mutation_through_message_bus(schema_name, &mutation, message_bus)?;
+            Self::submit_mutation_through_message_bus(schema, schema_name, &mutation, message_bus)?;
         }
         Ok(())
     }
@@ -328,6 +338,7 @@ impl HashRangeProcessor {
 
     /// Submit a mutation through the message bus
     fn submit_mutation_through_message_bus(
+        schema: &crate::schema::types::Schema,
         schema_name: &str,
         mutation: &Mutation,
         message_bus: &Arc<crate::fold_db_core::infrastructure::MessageBus>,
@@ -340,13 +351,17 @@ impl HashRangeProcessor {
                 SchemaError::InvalidData("HashRange mutation missing hash_key".to_string())
             })?;
 
-        let range_key = mutation
+        let _range_key = mutation
             .fields_and_values
             .get("range_key")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
                 SchemaError::InvalidData("HashRange mutation missing range_key".to_string())
             })?;
+
+        let hash_value = mutation.fields_and_values.get("hash_key").cloned();
+        let range_value = mutation.fields_and_values.get("range_key").cloned();
+        let mutation_service = MutationService::new(Arc::clone(message_bus));
 
         // Submit each field value through the message bus
         for (field_name, value) in &mutation.fields_and_values {
@@ -356,22 +371,24 @@ impl HashRangeProcessor {
                     field_name, hash_key
                 );
 
-                let hashrange_aware_value = serde_json::json!({
-                    "hash_key": hash_key,
-                    "range_key": range_key,
-                    "value": value
-                });
+                let normalized_request = mutation_service.normalized_field_value_request(
+                    schema,
+                    field_name,
+                    value,
+                    hash_value.as_ref(),
+                    range_value.as_ref(),
+                    None,
+                )?;
 
-                let correlation_id = uuid::Uuid::new_v4().to_string();
-                let field_value_request = crate::fold_db_core::infrastructure::message_bus::request_events::FieldValueSetRequest::new(
-                    correlation_id,
-                    schema_name.to_string(),
-                    field_name.clone(),
-                    hashrange_aware_value,
-                    TRANSFORM_SYSTEM_ID.to_string(),
-                );
+                let mut request = normalized_request.request;
+                let context = normalized_request.context;
+                let hash_state = context.hash.as_deref().unwrap_or("∅");
+                let range_state = context.range.as_deref().unwrap_or("∅");
 
-                message_bus.publish(field_value_request).map_err(|e| {
+                request.source_pub_key = TRANSFORM_SYSTEM_ID.to_string();
+                let correlation_id = request.correlation_id.clone();
+
+                message_bus.publish(request).map_err(|e| {
                     SchemaError::InvalidData(format!(
                         "Failed to submit field value for {}.{}: {}",
                         schema_name, field_name, e
@@ -379,8 +396,13 @@ impl HashRangeProcessor {
                 })?;
 
                 debug!(
-                    "✅ HashRange field value submitted successfully for {}.{} with word '{}'",
-                    schema_name, field_name, hash_key
+                    "✅ HashRange field value submitted successfully for {}.{} with word '{}' [correlation_id: {}, hash: {}, range: {}]",
+                    schema_name,
+                    field_name,
+                    hash_key,
+                    correlation_id,
+                    hash_state,
+                    range_state
                 );
             }
         }

--- a/src/fold_db_core/transform_manager/result_storage.rs
+++ b/src/fold_db_core/transform_manager/result_storage.rs
@@ -1,9 +1,9 @@
+use crate::fold_db_core::services::mutation::{MutationService, NormalizedFieldValueRequest};
 use crate::schema::constants::TRANSFORM_SYSTEM_ID;
 use crate::schema::types::{SchemaError, Transform};
 use log::{info, warn};
 use serde_json::Value as JsonValue;
 use std::sync::Arc;
-use uuid;
 
 /// Handles storing transform results
 pub struct ResultStorage;
@@ -26,7 +26,7 @@ impl ResultStorage {
             }
 
             // For non-HashRange schemas, submit through message bus if available
-            Self::handle_regular_storage(schema_name, field_name, result, message_bus)
+            Self::handle_regular_storage(db_ops, schema_name, field_name, result, message_bus)
         } else {
             Err(SchemaError::InvalidField(format!(
                 "Invalid output field format '{}', expected 'Schema.field'",
@@ -74,6 +74,7 @@ impl ResultStorage {
 
     /// Handle regular (non-HashRange) schema storage
     fn handle_regular_storage(
+        db_ops: &Arc<crate::db_operations::DbOperations>,
         schema_name: &str,
         field_name: &str,
         result: &JsonValue,
@@ -85,17 +86,30 @@ impl ResultStorage {
                 schema_name, field_name
             );
 
-            // Create FieldValueSetRequest and publish through message bus
-            let correlation_id = uuid::Uuid::new_v4().to_string();
-            let field_value_request = crate::fold_db_core::infrastructure::message_bus::request_events::FieldValueSetRequest::new(
-                correlation_id.clone(),
-                schema_name.to_string(),
-                field_name.to_string(),
-                result.clone(),
-                TRANSFORM_SYSTEM_ID.to_string(),
-            );
+            let schema = db_ops.get_schema(schema_name)?.ok_or_else(|| {
+                SchemaError::InvalidData(format!("Schema '{}' not found", schema_name))
+            })?;
 
-            if let Err(e) = message_bus.publish(field_value_request) {
+            let mutation_service = MutationService::new(Arc::clone(message_bus));
+            let (field_value, hash_value, range_value) =
+                Self::extract_field_value_and_keys(schema_name, field_name, result);
+
+            let NormalizedFieldValueRequest {
+                mut request,
+                context,
+            } = mutation_service.normalized_field_value_request(
+                &schema,
+                field_name,
+                &field_value,
+                hash_value.as_ref(),
+                range_value.as_ref(),
+                None,
+            )?;
+
+            request.source_pub_key = TRANSFORM_SYSTEM_ID.to_string();
+            let correlation_id = request.correlation_id.clone();
+
+            if let Err(e) = message_bus.publish(request) {
                 warn!(
                     "⚠️ Failed to publish FieldValueSetRequest for {}.{}: {}",
                     schema_name, field_name, e
@@ -106,9 +120,16 @@ impl ResultStorage {
                 )));
             }
 
+            let hash_state = context.hash.as_deref().unwrap_or("∅");
+            let range_state = context.range.as_deref().unwrap_or("∅");
+
             info!(
-                "✅ FieldValueSetRequest submitted successfully for {}.{} with correlation_id: {}",
-                schema_name, field_name, correlation_id
+                "✅ FieldValueSetRequest submitted successfully for {}.{} with correlation_id: {} (hash: {}, range: {})",
+                schema_name,
+                field_name,
+                correlation_id,
+                hash_state,
+                range_state
             );
             Ok(())
         } else {
@@ -119,6 +140,45 @@ impl ResultStorage {
             Err(SchemaError::InvalidData(
                 "Message bus not available for field value submission".to_string(),
             ))
+        }
+    }
+
+    fn extract_field_value_and_keys(
+        schema_name: &str,
+        field_name: &str,
+        result: &JsonValue,
+    ) -> (JsonValue, Option<JsonValue>, Option<JsonValue>) {
+        if let Some(obj) = result.as_object() {
+            let hash_value = obj
+                .get("hash")
+                .cloned()
+                .or_else(|| obj.get("hash_key").cloned());
+            let range_value = obj
+                .get("range")
+                .cloned()
+                .or_else(|| obj.get("range_key").cloned());
+
+            if let Some(fields_obj) = obj.get("fields").and_then(|value| value.as_object()) {
+                let field_value = fields_obj.get(field_name).cloned().unwrap_or_else(|| {
+                    warn!(
+                        "⚠️ Normalized payload for {}.{} missing field value in 'fields' map",
+                        schema_name, field_name
+                    );
+                    JsonValue::Null
+                });
+                (field_value, hash_value, range_value)
+            } else {
+                let field_value = obj.get(field_name).cloned().unwrap_or_else(|| {
+                    warn!(
+                        "⚠️ Transform result for {}.{} missing direct field value",
+                        schema_name, field_name
+                    );
+                    JsonValue::Null
+                });
+                (field_value, hash_value, range_value)
+            }
+        } else {
+            (result.clone(), None, None)
         }
     }
 }

--- a/src/transform/restricted_access.rs
+++ b/src/transform/restricted_access.rs
@@ -189,7 +189,6 @@ pub enum TransformAccessError {
 ///
 /// This macro can be used to wrap transform execution and ensure
 /// all data persistence goes through mutations.
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/transform/safe_access.rs
+++ b/src/transform/safe_access.rs
@@ -206,7 +206,6 @@ impl TransformSafeDataAccess for DatabaseTransformDataAccess {
 ///
 /// This macro wraps transform execution to ensure only read-only access
 /// to atoms and molecules.
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/molecule_update_diagnosis_test.rs
+++ b/tests/molecule_update_diagnosis_test.rs
@@ -6,8 +6,7 @@
 use datafold::db_operations::DbOperations;
 use datafold::fees::types::config::FieldPaymentConfig;
 use datafold::fold_db_core::infrastructure::message_bus::{
-    request_events::{FieldValueSetRequest, FieldValueSetResponse},
-    MessageBus,
+    request_events::FieldValueSetResponse, MessageBus,
 };
 use datafold::fold_db_core::managers::atom::AtomManager;
 use datafold::permissions::types::policy::PermissionsPolicy;
@@ -19,6 +18,11 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use tempfile::tempdir;
+
+#[path = "test_utils.rs"]
+mod shared_test_utils;
+
+use shared_test_utils::normalized_field_value_request;
 
 fn register_user_schema(db_ops: &DbOperations) {
     let mut schema = Schema::new("user_schema".to_string());
@@ -69,12 +73,12 @@ fn test_molecule_update_complete_flow() {
     println!("📝 STEP 1: Creating first field value (initial state)");
 
     // Create first FieldValueSetRequest for user.username field
-    let request1 = FieldValueSetRequest::new(
-        "test_correlation_001".to_string(),
-        "user_schema".to_string(),
-        "username".to_string(),
-        json!({ "username": "alice_v1" }),
-        "test_pubkey_001".to_string(),
+    let request1 = normalized_field_value_request(
+        "test_correlation_001",
+        "user_schema",
+        "username",
+        json!("alice_v1"),
+        "test_pubkey_001",
     );
 
     message_bus
@@ -103,12 +107,12 @@ fn test_molecule_update_complete_flow() {
     println!("📝 STEP 2: Creating second field value (should update Molecule)");
 
     // Create second FieldValueSetRequest for same field (should update Molecule)
-    let request2 = FieldValueSetRequest::new(
-        "test_correlation_002".to_string(),
-        "user_schema".to_string(),
-        "username".to_string(),            // Same schema.field combination
-        json!({ "username": "alice_v2" }), // Different value
-        "test_pubkey_002".to_string(),
+    let request2 = normalized_field_value_request(
+        "test_correlation_002",
+        "user_schema",
+        "username",
+        json!("alice_v2"),
+        "test_pubkey_002",
     );
 
     message_bus
@@ -144,12 +148,12 @@ fn test_molecule_update_complete_flow() {
     println!("📝 STEP 3: Creating third field value (final update test)");
 
     // Create third FieldValueSetRequest to test multiple updates
-    let request3 = FieldValueSetRequest::new(
-        "test_correlation_003".to_string(),
-        "user_schema".to_string(),
-        "username".to_string(),            // Same schema.field combination
-        json!({ "username": "alice_v3" }), // Different value
-        "test_pubkey_003".to_string(),
+    let request3 = normalized_field_value_request(
+        "test_correlation_003",
+        "user_schema",
+        "username",
+        json!("alice_v3"),
+        "test_pubkey_003",
     );
 
     message_bus
@@ -211,20 +215,20 @@ fn test_molecule_update_different_fields() {
     let mut response_consumer = message_bus.subscribe::<FieldValueSetResponse>();
 
     // Create requests for different fields
-    let request_username = FieldValueSetRequest::new(
-        "test_username".to_string(),
-        "user_schema".to_string(),
-        "username".to_string(),
-        json!({ "username": "alice" }),
-        "test_pubkey".to_string(),
+    let request_username = normalized_field_value_request(
+        "test_username",
+        "user_schema",
+        "username",
+        json!("alice"),
+        "test_pubkey",
     );
 
-    let request_email = FieldValueSetRequest::new(
-        "test_email".to_string(),
-        "user_schema".to_string(),
-        "email".to_string(), // Different field
-        json!({ "email": "alice@example.com" }),
-        "test_pubkey".to_string(),
+    let request_email = normalized_field_value_request(
+        "test_email",
+        "user_schema",
+        "email", // Different field
+        json!("alice@example.com"),
+        "test_pubkey",
     );
 
     message_bus

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -12,10 +12,13 @@
 use datafold::datafold_node::config::NodeConfig;
 use datafold::datafold_node::DataFoldNode;
 use datafold::db_operations::DbOperations;
-use datafold::fold_db_core::infrastructure::message_bus::MessageBus;
+use datafold::fold_db_core::infrastructure::message_bus::{
+    request_events::FieldValueSetRequest, MessageBus, NormalizedRequestParts,
+};
 use datafold::fold_db_core::managers::atom::AtomManager;
 use datafold::fold_db_core::transform_manager::TransformManager;
 use datafold::schema::types::{SchemaError, Transform, TransformRegistration};
+use serde_json::Value as JsonValue;
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -29,13 +32,64 @@ pub const TEST_DB_PATH: &str = "test_db";
 
 /// Extract the nested normalized fields map from universal key snapshots.
 #[allow(dead_code)]
-pub fn normalized_fields<'a>(
-    fields: &'a serde_json::Map<String, serde_json::Value>,
-) -> &'a serde_json::Map<String, serde_json::Value> {
+pub fn normalized_fields(
+    fields: &serde_json::Map<String, serde_json::Value>,
+) -> &serde_json::Map<String, serde_json::Value> {
     fields
         .get("fields")
         .and_then(|value| value.as_object())
         .unwrap_or(fields)
+}
+
+/// Build a normalized FieldValueSetRequest for tests without hash/range keys.
+#[allow(dead_code)]
+pub fn normalized_field_value_request(
+    correlation_id: impl Into<String>,
+    schema_name: impl Into<String>,
+    field_name: impl Into<String>,
+    field_value: JsonValue,
+    source_pub_key: impl Into<String>,
+) -> FieldValueSetRequest {
+    normalized_field_value_request_with_keys(
+        correlation_id,
+        schema_name,
+        field_name,
+        field_value,
+        None,
+        None,
+        source_pub_key,
+    )
+}
+
+/// Build a normalized FieldValueSetRequest for tests with optional hash/range keys.
+#[allow(dead_code)]
+pub fn normalized_field_value_request_with_keys(
+    correlation_id: impl Into<String>,
+    schema_name: impl Into<String>,
+    field_name: impl Into<String>,
+    field_value: JsonValue,
+    hash: Option<&str>,
+    range: Option<&str>,
+    source_pub_key: impl Into<String>,
+) -> FieldValueSetRequest {
+    let correlation_id = correlation_id.into();
+    let schema_name = schema_name.into();
+    let field_name = field_name.into();
+    let source_pub_key = source_pub_key.into();
+
+    let mut fields = serde_json::Map::new();
+    fields.insert(field_name.clone(), field_value);
+
+    FieldValueSetRequest::from_normalized_parts(NormalizedRequestParts {
+        correlation_id,
+        schema_name,
+        field_name,
+        fields,
+        hash: hash.map(|value| value.to_string()),
+        range: range.map(|value| value.to_string()),
+        source_pub_key,
+        mutation_hash: None,
+    })
 }
 
 /// Single unified test fixture eliminating all duplication


### PR DESCRIPTION
## Summary
- wrap `FieldValueSetRequest::from_normalized_parts` around a reusable `NormalizedRequestParts` struct and re-export it from the message bus module
- update the mutation service, transform processors, and test helpers to build requests via the normalized struct (including the molecule diagnosis test)
- clean up lingering lint issues such as option deref usage and doc comment spacing

## Testing
- cargo clippy --all-targets --all-features
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68d081edbcf08327b2c1a671474bbb1a