### PR TITLE
Document universal key workflow

### DIFF
--- a/docs/delivery/SKC-6/SKC-6-9.md
+++ b/docs/delivery/SKC-6/SKC-6-9.md
@@ -7,10 +7,11 @@ Update developer-facing documentation so the universal key field processing flow
 | Timestamp | Event Type | From Status | To Status | Details | User |
 |-----------|------------|-------------|-----------|---------|------|
 | 2025-09-23 09:45:00 | Created | N/A | Proposed | Documentation task created alongside the SKC-6 task split | ai-agent |
+| 2025-09-24 14:30:00 | Status Update | Proposed | Done | Published normalized workflow docs and cross-links. | ai-agent |
 
 ## Requirements
-- Document the universal key snapshot helper workflow in `docs/guides/operations/universal-key-migration-guide.md`, including how `{hash, range, fields}` travel through AtomManager and MutationService.
-- Update API/reference docs describing `FieldValueSetRequest`, `MutationService`, and field processing so they reference the normalized payload structure and helper utilities.
+- Document the universal key snapshot helper workflow in `docs/universal-key-migration-guide.md`, including how `{hash, range, fields}` travel through AtomManager and MutationService.
+- Update API/reference docs describing `FieldValueSetRequest`, `MutationService`, and field processing so they reference the normalized payload structure and helper utilities in `docs/reference/fold_db_core/`.
 - Add troubleshooting notes for common error scenarios (missing key configuration, dotted-path resolution failures, inconsistent payloads).
 - Ensure documentation cross-links from the SKC-6 PRD and task list to the updated sections for discoverability.
 - Maintain consistency with existing terminology and style guides; remove obsolete references to legacy heuristic helpers.
@@ -33,11 +34,12 @@ Update developer-facing documentation so the universal key field processing flow
 - Links from PRD and task documents resolve to the new sections.
 
 ## Files Modified
-- `docs/guides/operations/universal-key-migration-guide.md`
+- `docs/universal-key-migration-guide.md`
 - `docs/reference/fold_db_core/mutation_service.md`
 - `docs/reference/fold_db_core/field_processing.md`
 - `src/fold_db_core/managers/atom/field_processing.rs`
 - `src/fold_db_core/services/mutation.rs`
 - `docs/delivery/SKC-6/prd.md`
+- `docs/delivery/SKC-6/tasks.md`
 
 [Back to task list](../tasks.md)

--- a/docs/delivery/SKC-6/prd.md
+++ b/docs/delivery/SKC-6/prd.md
@@ -47,6 +47,9 @@ The current field processing utilities (`src/fold_db_core/managers/atom/field_pr
 - All existing tests pass
 - New tests validate universal key functionality
 - Field processing handles dotted path expressions correctly
+- Documentation links to the [migration workflow](../../universal-key-migration-guide.md#field-processing-and-mutation-workflow)
+  and the reference pages for the [MutationService](../../reference/fold_db_core/mutation_service.md) and
+  [AtomManager field processing](../../reference/fold_db_core/field_processing.md)
 
 ## Dependencies
 

--- a/docs/delivery/SKC-6/tasks.md
+++ b/docs/delivery/SKC-6/tasks.md
@@ -16,5 +16,5 @@ This document lists all tasks associated with PBI SKC-6.
 | SKC-6-6 | [Adopt normalized payload builder in mutation workflows](./SKC-6-6.md) | Done | Update MutationService flows to publish normalized payloads. |
 | SKC-6-7 | [Align downstream producers with normalized mutation payloads](./SKC-6-7.md) | Done | Refactor transform/message bus producers to use the shared payload shape. |
 | SKC-6-8 | [Expand universal key regression test coverage](./SKC-6-8.md) | Done | Add comprehensive unit and integration tests for universal key workflows. |
-| SKC-6-9 | [Document universal key field processing behavior](./SKC-6-9.md) | Done | Refresh documentation to describe the new helpers and payload structure. |
-| SKC-6-10 | [Remove legacy fallback logic from universal key resolution](./SKC-6-10.md) | Done | Remove create_legacy_resolved_keys fallback introduced in SKC-6-2 to enforce strict schema-driven key extraction. |
+| SKC-6-9 | [Document universal key field processing behavior](./SKC-6-9.md) | Done | Refresh documentation to describe the new helpers and payload structure. See [migration workflow](../../universal-key-migration-guide.md#field-processing-and-mutation-workflow). |
+| SKC-6-10 | [Remove legacy fallback logic from universal key resolution](./SKC-6-10.md) | Review | Remove create_legacy_resolved_keys fallback introduced in SKC-6-2 to enforce strict schema-driven key extraction. |

--- a/docs/delivery/SKC-6/tasks.md
+++ b/docs/delivery/SKC-6/tasks.md
@@ -16,5 +16,5 @@ This document lists all tasks associated with PBI SKC-6.
 | SKC-6-6 | [Adopt normalized payload builder in mutation workflows](./SKC-6-6.md) | Done | Update MutationService flows to publish normalized payloads. |
 | SKC-6-7 | [Align downstream producers with normalized mutation payloads](./SKC-6-7.md) | Done | Refactor transform/message bus producers to use the shared payload shape. |
 | SKC-6-8 | [Expand universal key regression test coverage](./SKC-6-8.md) | Proposed | Add comprehensive unit and integration tests for universal key workflows. |
-| SKC-6-9 | [Document universal key field processing behavior](./SKC-6-9.md) | Proposed | Refresh documentation to describe the new helpers and payload structure. |
+| SKC-6-9 | [Document universal key field processing behavior](./SKC-6-9.md) | Done | Refresh documentation to describe the new helpers and payload structure. See [migration workflow](../../universal-key-migration-guide.md#field-processing-and-mutation-workflow). |
 | SKC-6-10 | [Remove legacy fallback logic from universal key resolution](./SKC-6-10.md) | Proposed | Remove create_legacy_resolved_keys fallback introduced in SKC-6-2 to enforce strict schema-driven key extraction. |

--- a/docs/reference/fold_db_core/field_processing.md
+++ b/docs/reference/fold_db_core/field_processing.md
@@ -1,0 +1,61 @@
+# Field Processing Reference
+
+`AtomManager`'s field processing pipeline consumes `FieldValueSetRequest` events published by `MutationService` and persists the
+resulting atoms, molecules, and normalized key metadata.
+
+## Universal Key Resolution
+
+The [`resolve_universal_keys`](../../../src/fold_db_core/managers/atom/field_processing.rs) helper is the first step for every
+request. It performs three responsibilities:
+
+1. Loads the schema definition from storage, returning a `SchemaError::InvalidData` if the schema cannot be found.
+2. Uses `extract_unified_keys` to resolve hash and range values from the request payload for any schema type (Single, Range,
+   HashRange), including dotted-path lookups.
+3. Calls `shape_unified_result` to produce the normalized `{ hash, range, fields }` map stored in a `ResolvedAtomKeys` snapshot.
+
+The snapshot is later serialized into the `KeySnapshot` that rides on the `FieldValueSetResponse` message.
+
+## FieldValueSetRequest Handling Flow
+
+1. `handle_fieldvalueset_request` receives the normalized request from the message bus and records statistics.
+2. `create_atom_for_field_value` writes the new atom and returns its UUID.
+3. `create_molecule_for_field` stores the derived molecule, reusing the `ResolvedAtomKeys` snapshot to ensure molecules and
+   downstream events share the same key metadata.
+4. `handle_successful_field_value_processing` publishes a `FieldValueSetResponse` containing the molecule UUID and the
+   `KeySnapshot` built from the resolved keys.
+5. Any failure along the way short-circuits and emits a detailed error response; no fallback heuristics attempt to guess key
+   values.
+
+### KeySnapshot Example
+
+A successful response includes the normalized snapshot:
+
+```json
+{
+  "correlation_id": "uuid",
+  "success": true,
+  "molecule_uuid": "atom-uuid",
+  "key_snapshot": {
+    "hash": "technology",
+    "range": "2025-01-15",
+    "fields": {
+      "word": "technology",
+      "publish_date": "2025-01-15",
+      "content": "AI updates"
+    }
+  }
+}
+```
+
+Consumers can rely on the snapshot to understand exactly what key metadata was persisted without rehydrating the atom payload.
+
+## Troubleshooting Signals
+
+* Missing schema or key configuration errors bubble up from `resolve_universal_keys` and are logged with the schema name and
+  field that failed validation.
+* Dotted-path extraction failures annotate the missing path segment, indicating whether the hash or range lookup failed.
+* Inconsistent payloads (e.g., mismatched hash/range between molecule creation and response publishing) cannot occur because the
+  same `ResolvedAtomKeys` snapshot is reused across all steps.
+
+See the [Universal Key Migration Guide](../../universal-key-migration-guide.md#field-processing-and-mutation-workflow) for an
+operational overview and escalation steps.

--- a/docs/reference/fold_db_core/mutation_service.md
+++ b/docs/reference/fold_db_core/mutation_service.md
@@ -1,0 +1,93 @@
+# MutationService Reference
+
+The `MutationService` assembles normalized mutation payloads that travel across the message bus to `AtomManager`. It is the
+single entry point for constructing `FieldValueSetRequest` events and guarantees a consistent `{ hash, range, fields }` shape
+for every schema type.
+
+## Normalized Request Builder
+
+The `MutationService::normalized_field_value_request` helper loads schema metadata, resolves universal key values, and returns
+a `NormalizedFieldValueRequest` wrapper:
+
+```rust
+let builder = MutationService::new(message_bus.clone());
+let schema = schema_store.load("BlogPostWordIndex");
+let request = builder
+    .normalized_field_value_request(
+        &schema,
+        "content",
+        &Value::String("AI updates".into()),
+        Some(&Value::String("technology".into())),
+        Some(&Value::String("2025-01-15".into())),
+        Some("mutation-uuid"),
+    )?;
+```
+
+`NormalizedFieldValueRequest` exposes two fields:
+
+- `request`: the serialized `FieldValueSetRequest` event that is ready to publish.
+- `context`: a lightweight `NormalizedFieldContext` containing the resolved hash, range, and payload field map for downstream
+  consumers that do not need to deserialize the request body again.
+
+### Context Normalization Rules
+
+* Empty strings are converted to `None` in the context object so callers can distinguish "missing" from "provided but empty".
+* Field names are sorted consistently before serialization to avoid nondeterministic payload signatures.
+* Mutation hashes are threaded through the `MutationContext` when provided so incremental processors can link follow-up events.
+
+## FieldValueSetRequest Payload Structure
+
+`FieldValueSetRequest::from_normalized_parts` takes a `NormalizedRequestParts` struct and emits the transport payload consumed by
+`AtomManager`:
+
+```json
+{
+  "correlation_id": "uuid",
+  "schema_name": "BlogPostWordIndex",
+  "field_name": "content",
+  "value": {
+    "hash": "technology",
+    "range": "2025-01-15",
+    "fields": {
+      "content": "AI updates",
+      "publish_date": "2025-01-15",
+      "word": "technology"
+    }
+  },
+  "source_pub_key": "web-ui",
+  "mutation_context": {
+    "hash_key": "technology",
+    "range_key": "2025-01-15",
+    "mutation_hash": "mutation-uuid",
+    "incremental": true
+  }
+}
+```
+
+Important guarantees:
+
+1. `value.hash` and `value.range` are always present but may be empty strings when a schema type does not supply the key.
+2. `value.fields` contains the normalized field map produced by `shape_unified_result`, ensuring dotted-path extractions are
+   flattened into the event payload.
+3. `mutation_context` is populated whenever either key is present or a `mutation_hash` was provided, supplying AtomManager and
+   downstream processors with consistent incremental metadata.
+
+## Failure Modes
+
+The builder surfaces schema-driven validation errors rather than constructing partial payloads:
+
+- Missing schema definitions raise `SchemaError::InvalidData` before any request is published.
+- If a HashRange schema omits either hash or range values, request construction fails with descriptive error messages and a
+  structured infrastructure log entry.
+- Dotted-path key extraction uses `extract_unified_keys` and bubbles up the precise field that failed to resolve, helping callers
+  correct payloads quickly.
+
+## Workflow Integration
+
+1. `MutationService` publishes the normalized `FieldValueSetRequest`.
+2. `AtomManager` receives the event, invokes `resolve_universal_keys`, and stores a `KeySnapshot` alongside the processed atom.
+3. `FieldValueSetResponse` echoes the normalized snapshot so callers can correlate stored atoms with universal key metadata.
+
+Refer to the [Field Processing reference](./field_processing.md) for AtomManager behavior and to the
+[Universal Key Migration Guide](../../universal-key-migration-guide.md#field-processing-and-mutation-workflow) for an operational
+overview.

--- a/docs/universal-key-migration-guide.md
+++ b/docs/universal-key-migration-guide.md
@@ -186,6 +186,55 @@ let (hash_key, range_key) = extract_unified_keys(&schema);
 3. **Monitor Performance**: Watch for improvements in key-based operations
 4. **Complete Migration**: Migrate remaining schemas
 
+## Field Processing and Mutation Workflow
+
+Universal key adoption is only complete when the normalized payload travels cleanly from mutation entrypoints through
+AtomManager. The pipeline now relies on two reusable helpers:
+
+- **MutationService builder** – constructs a `FieldValueSetRequest` whose `value` body always contains `{ hash, range, fields }`
+  populated via schema metadata. See the [MutationService reference](reference/fold_db_core/mutation_service.md).
+- **AtomManager resolver** – ingests the request, resolves universal keys with `resolve_universal_keys`, and publishes a
+  `FieldValueSetResponse` that echoes the normalized snapshot. See the
+  [Field Processing reference](reference/fold_db_core/field_processing.md).
+
+### Sequence Overview
+
+```text
+Mutation caller
+   │
+   │ normalized_field_value_request (hash, range, fields)
+   ▼
+MutationService ── FieldValueSetRequest ──▶ Message Bus ──▶ AtomManager
+                                                        │
+                                                        ├─ resolve_universal_keys → KeySnapshot
+                                                        └─ FieldValueSetResponse (hash, range, fields)
+```
+
+1. `MutationService::normalized_field_value_request` resolves schema keys, sorts payload fields, and attaches a
+   `MutationContext` when incremental metadata is present.
+2. The message bus transports the serialized `FieldValueSetRequest` with a correlation identifier and signer metadata.
+3. `AtomManager::handle_fieldvalueset_request` reuses the normalized snapshot when creating molecules and when emitting the
+   `FieldValueSetResponse` so downstream consumers never see divergent key data.
+
+### Normalized Payload Anatomy
+
+Every `FieldValueSetRequest` now carries the same JSON structure inside `value`:
+
+```json
+{
+  "hash": "technology",
+  "range": "2025-01-15",
+  "fields": {
+    "word": "technology",
+    "publish_date": "2025-01-15",
+    "content": "AI updates"
+  }
+}
+```
+
+The `fields` object mirrors the output of `shape_unified_result`, so dotted-path extractions are already flattened and safe for
+AtomManager, transform pipelines, and analytics subscribers.
+
 ## Backward Compatibility
 
 ### Legacy Support
@@ -485,37 +534,28 @@ Legacy mutations continue to work without changes:
 
 ### Common Issues
 
-**Issue**: Schema validation errors after adding `key`
-```json
-{
-  "error": "Range schema requires range_field in key configuration"
-}
-```
+#### Missing Key Configuration
 
-**Solution**: Ensure Range schemas include `range_field`:
-```json
-{
-  "schema_type": "Range",
-  "key": {
-    "range_field": "timestamp"  // Required for Range schemas
-  }
-}
-```
+- **Symptom**: Errors such as `HashRange schema 'BlogPostWordIndex' requires hash key value` appear when constructing the
+  normalized payload.
+- **Resolution**: Ensure the schema's universal key configuration lists both `hash_field` and `range_field` for HashRange
+  schemas, and that the mutation payload provides the required values. See the
+  [MutationService reference](reference/fold_db_core/mutation_service.md#failure-modes) for validation details.
 
-**Issue**: Legacy `range_key` not working
-```json
-{
-  "error": "Unknown field: range_key"
-}
-```
+#### Dotted-Path Resolution Failures
 
-**Solution**: Legacy `range_key` is still supported. Check schema parsing:
-```json
-{
-  "schema_type": "Range",
-  "range_key": "timestamp"  // Still works
-}
-```
+- **Symptom**: AtomManager logs report `Failed to extract keys for schema 'UserActivity': activities.0.timestamp missing` or
+  similar dotted-path errors.
+- **Resolution**: Verify that the mutation payload includes the nested structure referenced by the dotted path. The
+  [Field Processing reference](reference/fold_db_core/field_processing.md#troubleshooting-signals) explains how
+  `resolve_universal_keys` identifies the failing segment and how to inspect the published request.
+
+#### Inconsistent Payload Snapshots
+
+- **Symptom**: Downstream processors observe mismatched hash/range metadata compared to stored atoms.
+- **Resolution**: Confirm every mutation entry point uses `MutationService::normalized_field_value_request` (or
+  `FieldValueSetRequest::from_normalized_parts`) instead of manual JSON assembly. Cross-check the event body with the
+  [normalized payload anatomy](#normalized-payload-anatomy) section above.
 
 ### Getting Help
 

--- a/src/fold_db_core/managers/atom/field_processing.rs
+++ b/src/fold_db_core/managers/atom/field_processing.rs
@@ -2,7 +2,9 @@
 //!
 //! The module exclusively relies on the schema-driven universal key helper to
 //! derive hash/range metadata and normalized field payloads. All ad-hoc
-//! heuristics have been removed in favor of descriptive error propagation.
+//! heuristics have been removed in favor of descriptive error propagation. See
+//! `docs/reference/fold_db_core/field_processing.md` for a step-by-step
+//! description of how normalized snapshots move through AtomManager.
 
 use super::AtomManager;
 use crate::atom::{Atom, AtomStatus};

--- a/src/fold_db_core/services/mutation.rs
+++ b/src/fold_db_core/services/mutation.rs
@@ -2,7 +2,7 @@
 //!
 //! This module handles ONLY mutation-specific domain logic:
 //! - Field value updates
-//! - Atom modifications  
+//! - Atom modifications
 //! - Collection updates
 //! - Universal key configuration support for HashRange schemas
 //!
@@ -14,6 +14,9 @@
 //! - Dynamic field name extraction from schema key configuration
 //! - Automatic skipping of key fields during mutation processing
 //! - Support for both new universal key format and legacy range_key patterns
+//!
+//! See `docs/reference/fold_db_core/mutation_service.md` for normalized payload
+//! anatomy, error modes, and the message bus workflow shared with AtomManager.
 //!
 //! ## Schema Type Support
 //!


### PR DESCRIPTION
## Summary
- add dedicated mutation and field processing reference pages under docs/reference/fold_db_core that describe the normalized `{hash, range, fields}` payload and shared helpers
- expand the universal key migration guide with the new workflow diagram, payload anatomy, and troubleshooting guidance, and cross-link SKC-6 docs to the updated sections
- update inline Rust module docs to point at the new references so developers can jump from code to documentation

## Testing
- `cargo test --workspace`
- `cargo clippy --all-targets --all-features`
- `cd fold_node/src/datafold_node/static-react && npm test` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d095c81d5c832790258673ff4bf4fb