### PR TITLE
Add native transform field value types

### DIFF
--- a/docs/delivery/NTS-1/NTS-1-1.md
+++ b/docs/delivery/NTS-1/NTS-1-1.md
@@ -1,0 +1,49 @@
+# NTS-1-1 Implement FieldValue and FieldType enums
+
+[Back to task list](./tasks.md)
+
+## Description
+Implement the foundational native data representations that will replace the current JSON-centric values inside the transform system. This task introduces strongly typed enums for values and their declared types so later tasks can build native field definitions, transform specifications, and execution paths without relying on `serde_json::Value` everywhere.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-22 19:14:07 | Status Change | N/A | Proposed | Task file created and initial analysis started | AI_Agent |
+| 2025-09-22 19:14:30 | Status Change | Proposed | In Progress | Began implementing native value and type enums | AI_Agent |
+
+## Requirements
+- Provide `FieldValue` enum that captures supported native value kinds (string, numeric, boolean, array, object, null).
+- Provide `FieldType` enum that captures expected type declarations for schema fields, including nested array/object metadata.
+- Support round-trip conversion between the native enums and `serde_json::Value` for boundary interactions.
+- Offer helper methods for basic introspection (`field_type`) and validation (`matches`).
+- Ensure enums derive `Serialize`/`Deserialize` for persistence and future API compatibility.
+- Include thorough unit tests that cover conversions, matching semantics, and edge cases (empty arrays, nested objects, null handling).
+
+## Implementation Plan
+1. Create `src/transform/native` module with `types.rs` defining `FieldValue` and `FieldType` enums plus helper functions.
+2. Add module wiring to `src/transform/mod.rs` to expose the new native module and re-export the enums for callers.
+3. Implement conversion helpers (`to_json_value`, `from_json_value`) and type inspection utilities on `FieldValue` alongside `FieldType::matches`.
+4. Introduce focused unit tests under `tests/unit` validating conversions, inferred element typing, and matching behavior for common and nested structures.
+5. Update `docs/project_logic.md` with the new native type rule to keep architectural documentation aligned.
+6. Run formatting, Rust workspace tests, clippy, and UI vitest suite to confirm the change integrates cleanly.
+
+## Verification
+- `FieldValue` correctly infers nested array/object element types and preserves data through JSON round-trips.
+- `FieldType::matches` accepts valid combinations (including null values for optional fields) and rejects mismatches.
+- New unit tests cover representative cases and guard against regressions.
+- Cargo workspace builds cleanly with `cargo fmt`, `cargo test --workspace`, and `cargo clippy`.
+- Frontend vitest suite (`npm test`) continues to pass, confirming the broader workspace remains healthy.
+
+## Files Modified
+- `docs/delivery/NTS-1/tasks.md`
+- `docs/project_logic.md`
+- `src/transform/mod.rs`
+- `src/transform/native/mod.rs`
+- `src/transform/native/types.rs`
+- `tests/unit/native_types_tests.rs`
+
+## Test Plan
+- `cargo fmt` to maintain style before running tests.
+- `cargo test --workspace` to execute Rust unit and integration suites with the new native types.
+- `cargo clippy --workspace --all-targets --all-features` to enforce lint hygiene for the new module.
+- `(cd src/datafold_node/static-react && npm install && npm test)` to satisfy repository policy on frontend tests.

--- a/docs/delivery/NTS-1/tasks.md
+++ b/docs/delivery/NTS-1/tasks.md
@@ -8,7 +8,7 @@ This document lists all tasks associated with PBI NTS-1.
 
 | Task ID | Name | Status | Description |
 | :------ | :--------------------------------------- | :------- | :--------------------------------- |
-| NTS-1-1 | [Implement FieldValue and FieldType enums](./NTS-1-1.md) | Proposed | Create core native data types to replace JsonValue |
+| NTS-1-1 | [Implement FieldValue and FieldType enums](./NTS-1-1.md) | In Progress | Create core native data types to replace JsonValue |
 | NTS-1-2 | [Implement FieldDefinition struct with validation](./NTS-1-2.md) | Proposed | Add typed field definitions with validation methods |
 | NTS-1-3 | [Implement TransformSpec with native types](./NTS-1-3.md) | Proposed | Create transform specifications using native types |
 | NTS-1-4 | [Add comprehensive unit tests](./NTS-1-4.md) | Proposed | Test all type operations and edge cases |

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -18,6 +18,7 @@ This document contains the most up-to-date and condensed information about the p
 | INGESTION-001 | Large file ingestion must use streaming architecture with configurable batch processing to handle files of any size without memory constraints. | ingestion/core, ingestion/large_file | 2025-01-27 15:30:00 | None |
 | TRANSFORM-001 | Transform system must support both procedural and declarative transform types seamlessly while maintaining backward compatibility. | transform/, schema/types, fold_db_core/transform_manager, fold_db_core/orchestration | 2025-01-27 12:00:00 | None |
 | TRANSFORM-003 | DeclarativeSchemaDefinition requires KeyConfig with hash_field and range_field for HashRange schemas and FieldDefinition metadata for optional atom_uuid and field_type. | schema/types/json_schema.rs | 2025-08-26 19:00:00 | None |
+| TRANSFORM-004 | Native transform data flow must use FieldValue/FieldType enums internally with JSON conversion limited to boundary layers. | transform/native, transform/mod.rs | 2025-09-22 19:14:37 | None |
 
 ### SCHEMA-001: Schema State Transition Rules
 - **Description**: Enforces valid state transitions for schema lifecycle management

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -37,50 +37,52 @@
 //! - Data integrity
 //! - Security compliance
 //!
-//! Use the `TransformDataPersistence` trait and `MutationBasedPersistence` 
+//! Use the `TransformDataPersistence` trait and `MutationBasedPersistence`
 //! implementation for all data persistence needs.
 
 pub mod ast;
 pub mod executor;
 pub mod interpreter;
-pub mod parser;
-pub mod standardized_executor;
 pub mod mutation_examples;
+pub mod parser;
 pub mod restricted_access;
-pub mod safe_access;
 pub mod restricted_access_example;
 pub mod restricted_access_integration_test;
+pub mod safe_access;
+pub mod standardized_executor;
 
 // New modular components
-pub mod validation;
-pub mod coordination;
-pub mod shared_utilities;
 pub mod aggregation;
+pub mod coordination;
 pub mod hash_range_executor;
-pub mod range_executor;
-pub mod single_executor;
 pub mod iterator_stack;
+pub mod native;
+pub mod range_executor;
+pub mod shared_utilities;
+pub mod single_executor;
+pub mod validation;
 
 // Public re-exports
 pub use crate::schema::types::Transform;
 pub use ast::{Expression, Operator, TransformDeclaration, UnaryOperator, Value};
 pub use executor::TransformExecutor;
 pub use interpreter::Interpreter;
-pub use parser::TransformParser;
-pub use standardized_executor::{
-    StandardizedTransformExecutor, StandardizedExecutionResult, ExecutionMetadata,
-    InputProvider, MutationExecutor, DatabaseInputProvider, MutationServiceExecutor,
-    EventDrivenInputProvider, OrchestratedTransformExecutor,
-};
 pub use mutation_examples::{
-    MutationBasedDataStorage, TransformWithMutationStorage, BatchMutationExecutor,
-    ConditionalMutationExecutor,
+    BatchMutationExecutor, ConditionalMutationExecutor, MutationBasedDataStorage,
+    TransformWithMutationStorage,
 };
+pub use native::{FieldType as NativeFieldType, FieldValue};
+pub use parser::TransformParser;
 pub use restricted_access::{
-    TransformDataPersistence, MutationBasedPersistence, TransformAccessValidator,
-    TransformAccessError,
+    MutationBasedPersistence, TransformAccessError, TransformAccessValidator,
+    TransformDataPersistence,
 };
 pub use safe_access::{
-    ReadOnlyAtom, ReadOnlyMolecule, ReadOnlyMoleculeRange, TransformSafeDataAccess,
-    DatabaseTransformDataAccess,
+    DatabaseTransformDataAccess, ReadOnlyAtom, ReadOnlyMolecule, ReadOnlyMoleculeRange,
+    TransformSafeDataAccess,
+};
+pub use standardized_executor::{
+    DatabaseInputProvider, EventDrivenInputProvider, ExecutionMetadata, InputProvider,
+    MutationExecutor, MutationServiceExecutor, OrchestratedTransformExecutor,
+    StandardizedExecutionResult, StandardizedTransformExecutor,
 };

--- a/src/transform/native/mod.rs
+++ b/src/transform/native/mod.rs
@@ -1,0 +1,10 @@
+//! Native transform data structures.
+//!
+//! This module hosts strongly typed building blocks that replace the
+//! historical reliance on `serde_json::Value` within the transform
+//! pipeline. Upcoming tasks extend these primitives into field
+//! definitions and transform specifications.
+
+pub mod types;
+
+pub use types::{FieldType, FieldValue};

--- a/src/transform/native/types.rs
+++ b/src/transform/native/types.rs
@@ -1,0 +1,165 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Number, Value as JsonValue};
+use std::collections::HashMap;
+
+const DEFAULT_FLOAT_FALLBACK: f64 = 0.0;
+const DEFAULT_INTEGER_FALLBACK: i64 = 0;
+
+/// Native representation of a field value flowing through the transform system.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FieldValue {
+    String(String),
+    Integer(i64),
+    Number(f64),
+    Boolean(bool),
+    Array(Vec<FieldValue>),
+    Object(HashMap<String, FieldValue>),
+    Null,
+}
+
+impl FieldValue {
+    /// Return the [`FieldType`] that best describes this value.
+    #[must_use]
+    pub fn field_type(&self) -> FieldType {
+        match self {
+            FieldValue::String(_) => FieldType::String,
+            FieldValue::Integer(_) => FieldType::Integer,
+            FieldValue::Number(_) => FieldType::Number,
+            FieldValue::Boolean(_) => FieldType::Boolean,
+            FieldValue::Array(values) => FieldType::Array {
+                element_type: Box::new(Self::infer_array_element_type(values)),
+            },
+            FieldValue::Object(entries) => FieldType::Object {
+                fields: entries
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.field_type()))
+                    .collect(),
+            },
+            FieldValue::Null => FieldType::Null,
+        }
+    }
+
+    /// Convert the native value into a [`serde_json::Value`] for boundary operations.
+    #[must_use]
+    pub fn to_json_value(&self) -> JsonValue {
+        match self {
+            FieldValue::String(value) => JsonValue::String(value.clone()),
+            FieldValue::Integer(value) => JsonValue::Number(Number::from(*value)),
+            FieldValue::Number(value) => JsonValue::Number(Self::safe_number_from_f64(*value)),
+            FieldValue::Boolean(value) => JsonValue::Bool(*value),
+            FieldValue::Array(values) => {
+                JsonValue::Array(values.iter().map(FieldValue::to_json_value).collect())
+            }
+            FieldValue::Object(entries) => JsonValue::Object(
+                entries
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.to_json_value()))
+                    .collect(),
+            ),
+            FieldValue::Null => JsonValue::Null,
+        }
+    }
+
+    /// Construct a native value from a [`serde_json::Value`].
+    #[must_use]
+    pub fn from_json_value(value: JsonValue) -> Self {
+        match value {
+            JsonValue::String(s) => FieldValue::String(s),
+            JsonValue::Number(number) => {
+                if let Some(int_value) = number.as_i64() {
+                    FieldValue::Integer(int_value)
+                } else if let Some(float_value) = number.as_f64() {
+                    FieldValue::Number(float_value)
+                } else {
+                    FieldValue::Number(DEFAULT_FLOAT_FALLBACK)
+                }
+            }
+            JsonValue::Bool(flag) => FieldValue::Boolean(flag),
+            JsonValue::Array(values) => FieldValue::Array(
+                values
+                    .into_iter()
+                    .map(FieldValue::from_json_value)
+                    .collect(),
+            ),
+            JsonValue::Object(map) => FieldValue::Object(
+                map.into_iter()
+                    .map(|(key, value)| (key, FieldValue::from_json_value(value)))
+                    .collect(),
+            ),
+            JsonValue::Null => FieldValue::Null,
+        }
+    }
+
+    fn safe_number_from_f64(value: f64) -> Number {
+        Number::from_f64(value).unwrap_or_else(|| Number::from(DEFAULT_INTEGER_FALLBACK))
+    }
+
+    fn infer_array_element_type(values: &[FieldValue]) -> FieldType {
+        let mut inferred: Option<FieldType> = None;
+
+        for value in values {
+            if matches!(value, FieldValue::Null) {
+                continue;
+            }
+
+            let current_type = value.field_type();
+            match &inferred {
+                Some(existing) if existing == &current_type => {}
+                Some(_) => return FieldType::Null,
+                None => inferred = Some(current_type),
+            }
+        }
+
+        inferred.unwrap_or(FieldType::Null)
+    }
+}
+
+/// Declarative type information for schema fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FieldType {
+    String,
+    Number,
+    Integer,
+    Boolean,
+    Null,
+    Array {
+        #[serde(rename = "element_type")]
+        element_type: Box<FieldType>,
+    },
+    Object {
+        fields: HashMap<String, FieldType>,
+    },
+}
+
+impl FieldType {
+    /// Determine whether the provided [`FieldValue`] satisfies this type definition.
+    #[must_use]
+    pub fn matches(&self, value: &FieldValue) -> bool {
+        if matches!(value, FieldValue::Null) {
+            return true;
+        }
+
+        match self {
+            FieldType::String => matches!(value, FieldValue::String(_)),
+            FieldType::Number => matches!(value, FieldValue::Number(_)),
+            FieldType::Integer => matches!(value, FieldValue::Integer(_)),
+            FieldType::Boolean => matches!(value, FieldValue::Boolean(_)),
+            FieldType::Null => false,
+            FieldType::Array { element_type } => match value {
+                FieldValue::Array(values) => values.iter().all(|item| element_type.matches(item)),
+                _ => false,
+            },
+            FieldType::Object { fields } => match value {
+                FieldValue::Object(entries) => fields.iter().all(|(field_name, field_type)| {
+                    entries
+                        .get(field_name)
+                        .map(|field_value| field_type.matches(field_value))
+                        .unwrap_or(false)
+                }),
+                _ => false,
+            },
+        }
+    }
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -3,17 +3,18 @@
 //! These tests validate that each decomposed module functions correctly
 //! in isolation and maintains its specific responsibilities.
 
+pub mod chain_parser_tests;
+pub mod declarative_transform_tests;
+pub mod field_alignment_tests;
+pub mod hashrange_mutation_core_test;
+pub mod hashrange_schema_tests;
+pub mod iterator_stack_tests;
 pub mod mutation_completion_tests;
+pub mod native_types_tests;
 pub mod range_filter_tests;
 pub mod schema;
+pub mod schema_declarative_transform_interpretation_tests;
 pub mod schema_parsing_test;
 pub mod transform;
 pub mod transform_manager_module_tests;
 pub mod transform_utils_helper_tests;
-pub mod declarative_transform_tests;
-pub mod hashrange_schema_tests;
-pub mod schema_declarative_transform_interpretation_tests;
-pub mod iterator_stack_tests;
-pub mod field_alignment_tests;
-pub mod chain_parser_tests;
-pub mod hashrange_mutation_core_test;

--- a/tests/unit/native_types_tests.rs
+++ b/tests/unit/native_types_tests.rs
@@ -1,0 +1,131 @@
+use datafold::transform::{FieldValue, NativeFieldType};
+use std::collections::HashMap;
+
+#[test]
+fn field_type_infers_scalar_and_collection_variants() {
+    assert_eq!(
+        FieldValue::String("hello".to_string()).field_type(),
+        NativeFieldType::String
+    );
+    assert_eq!(
+        FieldValue::Integer(42).field_type(),
+        NativeFieldType::Integer
+    );
+    assert_eq!(
+        FieldValue::Number(3.14).field_type(),
+        NativeFieldType::Number
+    );
+    assert_eq!(
+        FieldValue::Boolean(true).field_type(),
+        NativeFieldType::Boolean
+    );
+
+    let array_value = FieldValue::Array(vec![
+        FieldValue::String("a".to_string()),
+        FieldValue::Null,
+        FieldValue::String("b".to_string()),
+    ]);
+    assert_eq!(
+        array_value.field_type(),
+        NativeFieldType::Array {
+            element_type: Box::new(NativeFieldType::String),
+        }
+    );
+
+    let mut object_entries = HashMap::new();
+    object_entries.insert("name".to_string(), FieldValue::String("Ada".to_string()));
+    object_entries.insert("age".to_string(), FieldValue::Integer(37));
+    let object_value = FieldValue::Object(object_entries);
+
+    let expected_object_type = NativeFieldType::Object {
+        fields: HashMap::from([
+            ("name".to_string(), NativeFieldType::String),
+            ("age".to_string(), NativeFieldType::Integer),
+        ]),
+    };
+    assert_eq!(object_value.field_type(), expected_object_type);
+
+    assert_eq!(FieldValue::Null.field_type(), NativeFieldType::Null);
+
+    let mixed_array = FieldValue::Array(vec![
+        FieldValue::String("x".to_string()),
+        FieldValue::Number(1.0),
+    ]);
+    assert_eq!(
+        mixed_array.field_type(),
+        NativeFieldType::Array {
+            element_type: Box::new(NativeFieldType::Null),
+        }
+    );
+}
+
+#[test]
+fn field_value_json_round_trip_preserves_structure() {
+    let value = FieldValue::Object(HashMap::from([
+        (
+            "title".to_string(),
+            FieldValue::String("Rust Native Types".to_string()),
+        ),
+        ("views".to_string(), FieldValue::Integer(128)),
+        (
+            "tags".to_string(),
+            FieldValue::Array(vec![
+                FieldValue::String("rust".to_string()),
+                FieldValue::Null,
+                FieldValue::String("transforms".to_string()),
+            ]),
+        ),
+    ]));
+
+    let json_value = value.to_json_value();
+    let round_tripped = FieldValue::from_json_value(json_value);
+
+    assert_eq!(round_tripped, value);
+}
+
+#[test]
+fn field_type_matching_validates_values() {
+    let string_type = NativeFieldType::String;
+    assert!(string_type.matches(&FieldValue::String("value".to_string())));
+    assert!(string_type.matches(&FieldValue::Null));
+    assert!(!string_type.matches(&FieldValue::Integer(5)));
+
+    let array_type = NativeFieldType::Array {
+        element_type: Box::new(NativeFieldType::Number),
+    };
+    let numeric_array = FieldValue::Array(vec![
+        FieldValue::Number(1.23),
+        FieldValue::Null,
+        FieldValue::Number(9.87),
+    ]);
+    assert!(array_type.matches(&numeric_array));
+
+    let invalid_array = FieldValue::Array(vec![
+        FieldValue::Number(1.23),
+        FieldValue::String("nope".to_string()),
+    ]);
+    assert!(!array_type.matches(&invalid_array));
+
+    let object_type = NativeFieldType::Object {
+        fields: HashMap::from([
+            ("name".to_string(), NativeFieldType::String),
+            ("active".to_string(), NativeFieldType::Boolean),
+        ]),
+    };
+    let valid_object = FieldValue::Object(HashMap::from([
+        ("name".to_string(), FieldValue::String("Riley".to_string())),
+        ("active".to_string(), FieldValue::Boolean(true)),
+        ("extra".to_string(), FieldValue::Integer(1)),
+    ]));
+    assert!(object_type.matches(&valid_object));
+
+    let missing_field_object = FieldValue::Object(HashMap::from([(
+        "name".to_string(),
+        FieldValue::String("Riley".to_string()),
+    )]));
+    assert!(!object_type.matches(&missing_field_object));
+
+    let null_type = NativeFieldType::Null;
+    assert!(null_type.matches(&FieldValue::Null));
+    assert!(!null_type.matches(&FieldValue::Boolean(true)));
+}


### PR DESCRIPTION
## Summary
- add a `transform::native` module that introduces strongly typed `FieldValue`/`FieldType` enums with JSON conversion helpers and validation logic
- export the new native types through the transform facade and cover them with focused unit tests
- document task NTS-1-1 progress and update project logic to note the new native type policy

## Testing
- `cargo fmt` *(fails: rustfmt reports existing trailing whitespace in unrelated files)*
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features` *(fails: repository already has numerous clippy warnings such as `clippy::useless_vec`)*
- `(cd src/datafold_node/static-react && npm test)` *(fails: vitest suite currently errors because `fetchApiTransforms` is undefined and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d19e1bf0f083278c7846aa3e11fc56