### PR TITLE
Add native field definition validation and tests

### DIFF
--- a/docs/delivery/NTS-1/NTS-1-2.md
+++ b/docs/delivery/NTS-1/NTS-1-2.md
@@ -1,0 +1,51 @@
+# NTS-1-2 Implement FieldDefinition struct with validation
+
+[Back to task list](./tasks.md)
+
+## Description
+Introduce native schema field definitions that pair the new `FieldValue`/`FieldType` enums with validation and defaulting logic. This struct will provide the foundation for building transform specifications without relying on loosely typed JSON metadata.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-22 19:16:00 | Status Change | N/A | Proposed | Task file created with implementation outline | AI_Agent |
+| 2025-09-22 19:16:30 | Status Change | Proposed | In Progress | Began implementing native field definition struct and validation | AI_Agent |
+
+## Requirements
+- Define a `FieldDefinition` struct in the native transform module with `name`, `field_type`, `required`, and `default_value` fields.
+- Provide validation helpers that return typed errors for invalid field names and mismatched default values.
+- Support deriving sensible default values based on the declared field type so optional fields can be auto-populated.
+- Re-export the struct (and its error type) through `transform::` for downstream consumers.
+- Add comprehensive unit tests covering validation success/failure and default generation behavior.
+- Update `docs/project_logic.md` to capture the new native field definition rule.
+
+## Implementation Plan
+1. Create `src/transform/native/field_definition.rs` containing the struct, error enum, validation helpers, and default resolution methods.
+2. Extend `src/transform/native/types.rs` with helper methods that compute default values for each `FieldType` variant.
+3. Wire the new module through `src/transform/native/mod.rs` and re-export it (with aliasing) from `src/transform/mod.rs`.
+4. Write targeted unit tests in `tests/unit/native_field_definition_tests.rs` validating name rules, default mismatches, and generated defaults for nested types.
+5. Document the architectural rule in `docs/project_logic.md` and mark the task as in progress within `docs/delivery/NTS-1/tasks.md`.
+6. Run formatting, Rust workspace tests, clippy, and the repository-required frontend test suite.
+
+## Verification
+- Invalid field names (empty, whitespace, illegal characters) produce descriptive validation errors.
+- Default values that do not match the declared type are rejected with typed errors.
+- Optional fields without explicit defaults produce type-derived defaults (e.g., empty array/object, zero numbers).
+- Nested object defaults recursively generate defaults for child field types.
+- Rust and frontend test suites pass after introducing the new native field definition module.
+
+## Files Modified
+- `docs/delivery/NTS-1/tasks.md`
+- `docs/project_logic.md`
+- `src/transform/native/field_definition.rs`
+- `src/transform/native/mod.rs`
+- `src/transform/native/types.rs`
+- `src/transform/mod.rs`
+- `tests/unit/mod.rs`
+- `tests/unit/native_field_definition_tests.rs`
+
+## Test Plan
+- `cargo fmt` to ensure Rust style consistency.
+- `cargo test --workspace` to execute all Rust unit and integration tests.
+- `cargo clippy --workspace --all-targets --all-features` to enforce linting standards.
+- `(cd src/datafold_node/static-react && npm install && npm test)` to satisfy required frontend checks.

--- a/docs/delivery/NTS-1/tasks.md
+++ b/docs/delivery/NTS-1/tasks.md
@@ -9,7 +9,7 @@ This document lists all tasks associated with PBI NTS-1.
 | Task ID | Name | Status | Description |
 | :------ | :--------------------------------------- | :------- | :--------------------------------- |
 | NTS-1-1 | [Implement FieldValue and FieldType enums](./NTS-1-1.md) | In Progress | Create core native data types to replace JsonValue |
-| NTS-1-2 | [Implement FieldDefinition struct with validation](./NTS-1-2.md) | Proposed | Add typed field definitions with validation methods |
+| NTS-1-2 | [Implement FieldDefinition struct with validation](./NTS-1-2.md) | In Progress | Add typed field definitions with validation methods |
 | NTS-1-3 | [Implement TransformSpec with native types](./NTS-1-3.md) | Proposed | Create transform specifications using native types |
 | NTS-1-4 | [Add comprehensive unit tests](./NTS-1-4.md) | Proposed | Test all type operations and edge cases |
 | NTS-1-5 | [Implement JSON boundary conversion utilities](./NTS-1-5.md) | Proposed | Add conversion functions for API boundaries only |

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -19,6 +19,7 @@ This document contains the most up-to-date and condensed information about the p
 | TRANSFORM-001 | Transform system must support both procedural and declarative transform types seamlessly while maintaining backward compatibility. | transform/, schema/types, fold_db_core/transform_manager, fold_db_core/orchestration | 2025-01-27 12:00:00 | None |
 | TRANSFORM-003 | DeclarativeSchemaDefinition requires KeyConfig with hash_field and range_field for HashRange schemas and FieldDefinition metadata for optional atom_uuid and field_type. | schema/types/json_schema.rs | 2025-08-26 19:00:00 | None |
 | TRANSFORM-004 | Native transform data flow must use FieldValue/FieldType enums internally with JSON conversion limited to boundary layers. | transform/native, transform/mod.rs | 2025-09-22 19:14:37 | None |
+| TRANSFORM-005 | Native FieldDefinition must validate names, default types, and generate typed defaults for optional fields. | transform/native | 2025-09-22 19:16:45 | None |
 
 ### SCHEMA-001: Schema State Transition Rules
 - **Description**: Enforces valid state transitions for schema lifecycle management
@@ -272,3 +273,15 @@ This document contains the most up-to-date and condensed information about the p
   - Full migration details in [`docs/delivery/API-STD-1/migration-reference.md`](delivery/API-STD-1/migration-reference.md)
   - Architecture documentation in [`docs/delivery/API-STD-1/api-client-architecture.md`](delivery/API-STD-1/api-client-architecture.md)
   - Developer guide in [`docs/delivery/API-STD-1/developer-guide.md`](delivery/API-STD-1/developer-guide.md)
+### TRANSFORM-005: Native Field Definition Validation Rules
+- **Description**: Establishes validation and defaulting guarantees for native transform field definitions built on top of `FieldValue`/`FieldType`.
+- **Rationale**: Ensures native transforms operate on well-formed field metadata without relying on ad-hoc JSON validation, preventing subtle runtime bugs.
+- **Validation Rules**:
+  - Field names must be trimmed, non-empty, and contain only ASCII letters, digits, or underscores while starting with a letter or underscore.
+  - Default values must satisfy the declared `FieldType`; mismatches raise typed validation errors.
+- **Defaulting Behavior**:
+  - Explicit defaults are preserved exactly as declared.
+  - Optional fields without explicit defaults inherit deterministic defaults generated from their `FieldType` (e.g., empty arrays/objects, zero-valued scalars, `null`).
+- **Implementation Notes**:
+  - Validation surfaces `FieldDefinitionError` variants for name issues or default mismatches.
+  - `FieldType::default_value()` produces recursive defaults for nested object schemas used by optional fields.

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -71,7 +71,10 @@ pub use mutation_examples::{
     BatchMutationExecutor, ConditionalMutationExecutor, MutationBasedDataStorage,
     TransformWithMutationStorage,
 };
-pub use native::{FieldType as NativeFieldType, FieldValue};
+pub use native::{
+    FieldDefinition as NativeFieldDefinition, FieldDefinitionError as NativeFieldDefinitionError,
+    FieldType as NativeFieldType, FieldValue,
+};
 pub use parser::TransformParser;
 pub use restricted_access::{
     MutationBasedPersistence, TransformAccessError, TransformAccessValidator,

--- a/src/transform/native/field_definition.rs
+++ b/src/transform/native/field_definition.rs
@@ -1,0 +1,158 @@
+use super::types::{FieldType, FieldValue};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const MAX_FIELD_NAME_LENGTH: usize = 64;
+
+fn default_required() -> bool {
+    true
+}
+
+/// Native field definition pairing metadata with validation logic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FieldDefinition {
+    /// Field identifier used within transform specifications.
+    pub name: String,
+    /// Declared field type that all values must satisfy.
+    pub field_type: FieldType,
+    /// Whether the field must be present in transform output/input payloads.
+    #[serde(default = "default_required")]
+    pub required: bool,
+    /// Optional default value used when the field is omitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub default_value: Option<FieldValue>,
+}
+
+/// Validation errors emitted when field definitions violate invariants.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum FieldDefinitionError {
+    /// Field name is empty or whitespace.
+    #[error("field name cannot be empty")]
+    EmptyName,
+    /// Field name exceeds the allowed length constraint.
+    #[error("field name '{name}' exceeds maximum length of {max} characters")]
+    NameTooLong { name: String, max: usize },
+    /// Field name starts with an invalid character.
+    #[error("field name '{name}' must start with an ASCII letter or underscore")]
+    InvalidNameStart { name: String },
+    /// Field name contains unsupported characters.
+    #[error("field name '{name}' contains invalid characters; only ASCII letters, digits, and underscores are allowed")]
+    InvalidNameCharacters { name: String },
+    /// Default value does not match the declared type.
+    #[error(
+        "default value for field '{name}' does not match declared type (expected {declared:?}, got {actual:?})"
+    )]
+    DefaultTypeMismatch {
+        name: String,
+        declared: Box<FieldType>,
+        actual: Box<FieldType>,
+    },
+}
+
+impl FieldDefinition {
+    /// Construct a new field definition with the provided name and type.
+    #[must_use]
+    pub fn new(name: impl Into<String>, field_type: FieldType) -> Self {
+        Self {
+            name: name.into(),
+            field_type,
+            required: true,
+            default_value: None,
+        }
+    }
+
+    /// Mark the field as required or optional.
+    #[must_use]
+    pub fn with_required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
+
+    /// Attach an explicit default value to the field definition.
+    #[must_use]
+    pub fn with_default(mut self, default_value: FieldValue) -> Self {
+        self.default_value = Some(default_value);
+        self
+    }
+
+    /// Validate the field definition invariants.
+    pub fn validate(&self) -> Result<(), FieldDefinitionError> {
+        Self::validate_name(&self.name)?;
+
+        if let Some(default_value) = &self.default_value {
+            if !self.field_type.matches(default_value) {
+                return Err(FieldDefinitionError::DefaultTypeMismatch {
+                    name: self.name.clone(),
+                    declared: Box::new(self.field_type.clone()),
+                    actual: Box::new(default_value.field_type()),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Resolve the effective default value for the field.
+    ///
+    /// Explicit defaults win. Optional fields without an explicit default fall back to
+    /// the deterministic default generated from the declared [`FieldType`]. Required
+    /// fields without explicit defaults return `None` to signal that callers must
+    /// provide a value.
+    #[must_use]
+    pub fn effective_default(&self) -> Option<FieldValue> {
+        match (&self.default_value, self.required) {
+            (Some(value), _) => Some(value.clone()),
+            (None, false) => Some(self.field_type.default_value()),
+            (None, true) => None,
+        }
+    }
+
+    fn validate_name(name: &str) -> Result<(), FieldDefinitionError> {
+        let trimmed = name.trim();
+
+        if trimmed.is_empty() {
+            return Err(FieldDefinitionError::EmptyName);
+        }
+
+        if trimmed.len() != name.len() {
+            return Err(FieldDefinitionError::InvalidNameCharacters {
+                name: name.to_string(),
+            });
+        }
+
+        if trimmed.len() > MAX_FIELD_NAME_LENGTH {
+            return Err(FieldDefinitionError::NameTooLong {
+                name: trimmed.to_string(),
+                max: MAX_FIELD_NAME_LENGTH,
+            });
+        }
+
+        let mut chars = trimmed.chars();
+        let Some(first_char) = chars.next() else {
+            return Err(FieldDefinitionError::EmptyName);
+        };
+
+        if !Self::is_valid_start_char(first_char) {
+            return Err(FieldDefinitionError::InvalidNameStart {
+                name: trimmed.to_string(),
+            });
+        }
+
+        if chars.any(|ch| !Self::is_valid_continuation_char(ch)) {
+            return Err(FieldDefinitionError::InvalidNameCharacters {
+                name: trimmed.to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn is_valid_start_char(ch: char) -> bool {
+        ch.is_ascii_alphabetic() || ch == '_'
+    }
+
+    fn is_valid_continuation_char(ch: char) -> bool {
+        ch.is_ascii_alphanumeric() || ch == '_'
+    }
+}

--- a/src/transform/native/mod.rs
+++ b/src/transform/native/mod.rs
@@ -5,6 +5,8 @@
 //! pipeline. Upcoming tasks extend these primitives into field
 //! definitions and transform specifications.
 
+pub mod field_definition;
 pub mod types;
 
+pub use field_definition::{FieldDefinition, FieldDefinitionError};
 pub use types::{FieldType, FieldValue};

--- a/src/transform/native/types.rs
+++ b/src/transform/native/types.rs
@@ -162,4 +162,23 @@ impl FieldType {
             },
         }
     }
+
+    /// Produce a deterministic default value for the declared type.
+    #[must_use]
+    pub fn default_value(&self) -> FieldValue {
+        match self {
+            FieldType::String => FieldValue::String(String::new()),
+            FieldType::Number => FieldValue::Number(0.0),
+            FieldType::Integer => FieldValue::Integer(0),
+            FieldType::Boolean => FieldValue::Boolean(false),
+            FieldType::Null => FieldValue::Null,
+            FieldType::Array { .. } => FieldValue::Array(Vec::new()),
+            FieldType::Object { fields } => FieldValue::Object(
+                fields
+                    .iter()
+                    .map(|(name, field_type)| (name.clone(), field_type.default_value()))
+                    .collect(),
+            ),
+        }
+    }
 }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -10,6 +10,7 @@ pub mod hashrange_mutation_core_test;
 pub mod hashrange_schema_tests;
 pub mod iterator_stack_tests;
 pub mod mutation_completion_tests;
+pub mod native_field_definition_tests;
 pub mod native_types_tests;
 pub mod range_filter_tests;
 pub mod schema;

--- a/tests/unit/native_field_definition_tests.rs
+++ b/tests/unit/native_field_definition_tests.rs
@@ -1,0 +1,99 @@
+use datafold::transform::{
+    FieldValue, NativeFieldDefinition, NativeFieldDefinitionError, NativeFieldType,
+};
+use std::collections::HashMap;
+
+#[test]
+fn validate_rejects_empty_field_name() {
+    let definition = NativeFieldDefinition::new("", NativeFieldType::String);
+
+    let error = definition
+        .validate()
+        .expect_err("empty field name should be rejected");
+    assert_eq!(error, NativeFieldDefinitionError::EmptyName);
+}
+
+#[test]
+fn validate_rejects_invalid_field_name_characters() {
+    let definition = NativeFieldDefinition::new("bad-name", NativeFieldType::Integer);
+
+    let error = definition
+        .validate()
+        .expect_err("hyphenated field name should be rejected");
+    assert_eq!(
+        error,
+        NativeFieldDefinitionError::InvalidNameCharacters {
+            name: "bad-name".to_string(),
+        },
+    );
+}
+
+#[test]
+fn validate_rejects_mismatched_default_value() {
+    let definition = NativeFieldDefinition::new("count", NativeFieldType::Integer)
+        .with_default(FieldValue::String("oops".to_string()));
+
+    let error = definition
+        .validate()
+        .expect_err("default type mismatch should fail validation");
+    assert_eq!(
+        error,
+        NativeFieldDefinitionError::DefaultTypeMismatch {
+            name: "count".to_string(),
+            declared: Box::new(NativeFieldType::Integer),
+            actual: Box::new(NativeFieldType::String),
+        },
+    );
+}
+
+#[test]
+fn validate_accepts_valid_definition() {
+    let definition = NativeFieldDefinition::new("count", NativeFieldType::Integer)
+        .with_required(false)
+        .with_default(FieldValue::Integer(10));
+
+    definition
+        .validate()
+        .expect("valid field definition should pass validation");
+}
+
+#[test]
+fn effective_default_prefers_explicit_defaults() {
+    let definition = NativeFieldDefinition::new("flag", NativeFieldType::Boolean)
+        .with_required(false)
+        .with_default(FieldValue::Boolean(true));
+
+    assert_eq!(
+        definition.effective_default(),
+        Some(FieldValue::Boolean(true))
+    );
+}
+
+#[test]
+fn effective_default_generates_nested_defaults_for_optional_fields() {
+    let nested_type = NativeFieldType::Object {
+        fields: HashMap::from([
+            ("title".to_string(), NativeFieldType::String),
+            (
+                "tags".to_string(),
+                NativeFieldType::Array {
+                    element_type: Box::new(NativeFieldType::String),
+                },
+            ),
+        ]),
+    };
+
+    let definition = NativeFieldDefinition::new("metadata", nested_type).with_required(false);
+
+    let default_value = definition
+        .effective_default()
+        .expect("optional field should provide generated default");
+
+    assert_eq!(
+        default_value,
+        FieldValue::Object(HashMap::from([
+            ("title".to_string(), FieldValue::String(String::new())),
+            ("tags".to_string(), FieldValue::Array(Vec::new())),
+        ])),
+    );
+}

--- a/tests/unit/native_types_tests.rs
+++ b/tests/unit/native_types_tests.rs
@@ -1,5 +1,6 @@
 use datafold::transform::{FieldValue, NativeFieldType};
 use std::collections::HashMap;
+use std::f64::consts::PI;
 
 #[test]
 fn field_type_infers_scalar_and_collection_variants() {
@@ -12,7 +13,7 @@ fn field_type_infers_scalar_and_collection_variants() {
         NativeFieldType::Integer
     );
     assert_eq!(
-        FieldValue::Number(3.14).field_type(),
+        FieldValue::Number(PI).field_type(),
         NativeFieldType::Number
     );
     assert_eq!(


### PR DESCRIPTION
## Summary
- document task NTS-1-2 and record new native field definition architecture rule
- add a native FieldDefinition struct with validation, defaulting helpers, and exports
- cover the new behavior with focused unit tests alongside minor updates to existing tests

## Testing
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features
- npm install
- npm test *(fails: existing React tests reference undefined fetchApiTransforms / auth state wiring)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ae7902548327a0a7e2523e998307