### PR TITLE
Include stage index in native pipeline transform errors

### DIFF
--- a/docs/delivery/NTS-4/NTS-4-1.md
+++ b/docs/delivery/NTS-4/NTS-4-1.md
@@ -1,0 +1,47 @@
+# NTS-4-1 Implement NativeDataPipeline
+
+[Back to task list](./tasks.md)
+
+## Description
+Define the native data pipeline structure that orchestrates transform execution without falling back to JSON conversions. The pipeline must expose a clean API for running individual transforms or full transform chains and surface typed errors when execution fails.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-22 21:42:00 | Status Change | N/A | Proposed | Captured task scope and created documentation | AI_Agent |
+| 2025-09-22 21:42:10 | Status Change | Proposed | In Progress | Began implementing native pipeline structure and error handling | AI_Agent |
+| 2025-09-22 21:50:00 | Status Change | In Progress | Review | Pipeline struct and error type implemented, ready for review | AI_Agent |
+
+## Requirements
+- Introduce a `NativeDataPipeline` struct that accepts a transform engine and schema registry handles.
+- Define a reusable `NativeTransformExecutor` trait that the pipeline can invoke.
+- Surface pipeline-specific errors when transform stages fail or yield incompatible output shapes.
+- Re-export the pipeline types through existing module entry points for crate consumers.
+- Record architectural guidance for the native pipeline in `docs/project_logic.md`.
+
+## Implementation Plan
+1. Create `src/transform/native/pipeline.rs` housing the pipeline struct, error enum, executor trait, and execution helpers.
+2. Update `src/transform/native/mod.rs` to wire the new module and re-export key types.
+3. Extend `src/transform/mod.rs` to expose the pipeline API to downstream callers.
+4. Refresh `docs/project_logic.md` with a new logic entry covering native pipeline orchestration rules.
+5. Update the NTS-4 task index to reflect the in-progress status and prepare for subsequent tasks.
+
+## Verification
+- Pipeline construction succeeds with shared `Arc` handles for engine and registry.
+- Transform execution errors bubble up as `PipelineError::Transform` values that include the failing stage index.
+- Non-object transform outputs cause `PipelineError::NonObjectOutput` failures.
+- Re-exported pipeline types compile across the crate without missing imports.
+- Project logic entry accurately documents the new behavior.
+
+## Files Modified
+- `docs/delivery/NTS-4/tasks.md`
+- `docs/project_logic.md`
+- `src/transform/mod.rs`
+- `src/transform/native/mod.rs`
+- `src/transform/native/pipeline.rs`
+
+## Test Plan
+- `cargo fmt`
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets --all-features`
+- `(cd src/datafold_node/static-react && npm test)`

--- a/docs/delivery/NTS-4/NTS-4-2.md
+++ b/docs/delivery/NTS-4/NTS-4-2.md
@@ -1,0 +1,44 @@
+# NTS-4-2 Implement ProcessingContext
+
+[Back to task list](./tasks.md)
+
+## Description
+Add a strongly typed processing context to capture schema identity, inbound data, and the ordered transform chain. The context should make it easy for callers to build and inspect pipeline executions without manipulating raw maps directly.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-22 21:50:10 | Status Change | N/A | Proposed | Documented ProcessingContext task scope | AI_Agent |
+| 2025-09-22 21:50:20 | Status Change | Proposed | In Progress | Began adding ProcessingContext API and helpers | AI_Agent |
+| 2025-09-22 21:55:00 | Status Change | In Progress | Review | Context struct implemented with accessor and builder utilities | AI_Agent |
+
+## Requirements
+- Introduce a `ProcessingContext` struct holding schema name, input data, and transform specifications.
+- Provide ergonomic helpers for constructing contexts, appending transforms, and splitting into parts.
+- Ensure references to input data and transforms can be borrowed without cloning when possible.
+- Keep the API generic over transform specification types to avoid premature coupling.
+
+## Implementation Plan
+1. Extend `src/transform/native/pipeline.rs` with the `ProcessingContext` definition and associated methods.
+2. Confirm the context integrates with `NativeDataPipeline::process_data` while maintaining ownership semantics.
+3. Export the new type via `src/transform/native/mod.rs` and `src/transform/mod.rs`.
+4. Update the task index to reflect the work in progress and eventual review state.
+
+## Verification
+- Context creation accepts arbitrary schema names and input maps.
+- `push_transform` appends additional stages without reallocating callers.
+- `transform_specs()` exposes immutable access to the chain for inspection.
+- `into_parts()` returns owned components for downstream processing.
+- Compilation succeeds with the new generic bounds.
+
+## Files Modified
+- `docs/delivery/NTS-4/tasks.md`
+- `src/transform/mod.rs`
+- `src/transform/native/mod.rs`
+- `src/transform/native/pipeline.rs`
+
+## Test Plan
+- `cargo fmt`
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets --all-features`
+- `(cd src/datafold_node/static-react && npm test)`

--- a/docs/delivery/NTS-4/NTS-4-3.md
+++ b/docs/delivery/NTS-4/NTS-4-3.md
@@ -1,0 +1,43 @@
+# NTS-4-3 Add transform chain execution
+
+[Back to task list](./tasks.md)
+
+## Description
+Implement the core execution loop that feeds native data through each transform specification in order. The pipeline must halt on failures, enforce object outputs for chaining, and deliver the final native map for downstream persistence.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-22 21:55:10 | Status Change | N/A | Proposed | Defined transform chain execution task | AI_Agent |
+| 2025-09-22 21:55:20 | Status Change | Proposed | In Progress | Started implementing sequential execution over transform specs | AI_Agent |
+| 2025-09-22 22:00:00 | Status Change | In Progress | Review | Transform chain execution complete with error propagation | AI_Agent |
+
+## Requirements
+- Iterate over each transform specification in the provided context sequentially.
+- Invoke the executor for every stage and propagate failures immediately.
+- Require each stage to return an object map for continued chaining; otherwise emit a descriptive error.
+- Include the index of any failing transform stage in surfaced errors to simplify debugging.
+- Return the final native map when all transforms succeed.
+- Keep the implementation generic over transform specification types.
+
+## Implementation Plan
+1. Update `NativeDataPipeline::process_data` to consume the context and evaluate transform specs in order.
+2. Map executor failures into `PipelineError::Transform` to preserve root causes.
+3. Derive the offending field type when a stage yields a non-object value and wrap it in `PipelineError::NonObjectOutput`.
+4. Ensure the function returns the last successful object map without unnecessary cloning.
+
+## Verification
+- Successful chains return the final transform's object payload.
+- A non-object output triggers a `PipelineError::NonObjectOutput` with the correct index and type.
+- Executor errors surface as `PipelineError::Transform` variants that report the failing stage index.
+- Empty transform lists simply return the original input map.
+
+## Files Modified
+- `docs/delivery/NTS-4/tasks.md`
+- `src/transform/native/pipeline.rs`
+
+## Test Plan
+- `cargo fmt`
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets --all-features`
+- `(cd src/datafold_node/static-react && npm test)`

--- a/docs/delivery/NTS-4/NTS-4-4.md
+++ b/docs/delivery/NTS-4/NTS-4-4.md
@@ -1,0 +1,42 @@
+# NTS-4-4 Add comprehensive pipeline tests
+
+[Back to task list](./tasks.md)
+
+## Description
+Create unit tests that exercise the native pipeline's happy path, error paths, and helper APIs. The tests should validate executor integration, transform chain enforcement, and utility methods exposed by the pipeline module.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-22 22:00:10 | Status Change | N/A | Proposed | Documented coverage expectations for pipeline tests | AI_Agent |
+| 2025-09-22 22:00:20 | Status Change | Proposed | In Progress | Started authoring native pipeline unit tests | AI_Agent |
+| 2025-09-22 22:05:00 | Status Change | In Progress | Review | Pipeline test suite implemented and ready for review | AI_Agent |
+
+## Requirements
+- Add a dedicated unit test module covering pipeline success, empty chains, executor failures, and non-object outputs.
+- Validate `process_single_transform` delegates directly to the executor.
+- Mock the executor without relying on JSON conversions or external dependencies.
+- Ensure the new tests compile against the exported pipeline API.
+
+## Implementation Plan
+1. Create `tests/unit/native_pipeline_tests.rs` with a mock executor and representative scenarios.
+2. Cover success, empty chain, executor error, non-object output, and single transform execution cases.
+3. Register the module within `tests/unit/mod.rs` so the tests run with the existing suite.
+4. Update the NTS-4 task index to reflect review status once coverage is in place.
+
+## Verification
+- All new tests compile and execute successfully via `cargo test --workspace`.
+- Failure scenarios assert the correct `PipelineError` variants and metadata, including failing stage indices.
+- Success scenarios confirm the pipeline returns the expected native data structures.
+- Mock executor usage avoids side effects and maintains deterministic assertions.
+
+## Files Modified
+- `docs/delivery/NTS-4/tasks.md`
+- `tests/unit/mod.rs`
+- `tests/unit/native_pipeline_tests.rs`
+
+## Test Plan
+- `cargo fmt`
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets --all-features`
+- `(cd src/datafold_node/static-react && npm test)`

--- a/docs/delivery/NTS-4/tasks.md
+++ b/docs/delivery/NTS-4/tasks.md
@@ -8,10 +8,10 @@ This document lists all tasks associated with PBI NTS-4.
 
 | Task ID | Name | Status | Description |
 | :------ | :--------------------------------------- | :------- | :--------------------------------- |
-| NTS-4-1 | [Implement NativeDataPipeline](./NTS-4-1.md) | Proposed | Create core processing pipeline with native types |
-| NTS-4-2 | [Implement ProcessingContext](./NTS-4-2.md) | Proposed | Add context management for complex processing |
-| NTS-4-3 | [Add transform chain execution](./NTS-4-3.md) | Proposed | Implement transform chain processing |
-| NTS-4-4 | [Add comprehensive pipeline tests](./NTS-4-4.md) | Proposed | Test end-to-end pipeline processing |
+| NTS-4-1 | [Implement NativeDataPipeline](./NTS-4-1.md) | Review | Create core processing pipeline with native types |
+| NTS-4-2 | [Implement ProcessingContext](./NTS-4-2.md) | Review | Add context management for complex processing |
+| NTS-4-3 | [Add transform chain execution](./NTS-4-3.md) | Review | Implement transform chain processing |
+| NTS-4-4 | [Add comprehensive pipeline tests](./NTS-4-4.md) | Review | Test end-to-end pipeline processing |
 | NTS-4-5 | [Add performance benchmarks](./NTS-4-5.md) | Proposed | Measure performance improvements over JSON system |
 | NTS-4-6 | [Update documentation](./NTS-4-6.md) | Proposed | Document all pipeline operations and usage |
 | NTS-4-7 | [E2E CoS Test](./NTS-4-7.md) | Proposed | End-to-end validation of all acceptance criteria |

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -20,6 +20,7 @@ This document contains the most up-to-date and condensed information about the p
 | TRANSFORM-003 | DeclarativeSchemaDefinition requires KeyConfig with hash_field and range_field for HashRange schemas and FieldDefinition metadata for optional atom_uuid and field_type. | schema/types/json_schema.rs | 2025-08-26 19:00:00 | None |
 | TRANSFORM-004 | Native transform data flow must use FieldValue/FieldType enums internally with JSON conversion limited to boundary layers. | transform/native, transform/mod.rs | 2025-09-22 19:14:37 | None |
 | TRANSFORM-005 | Native FieldDefinition must validate names, default types, and generate typed defaults for optional fields. | transform/native | 2025-09-22 19:16:45 | None |
+| TRANSFORM-006 | Native pipeline executes transform chains sequentially, requiring object outputs and surfacing typed errors with stage indices for failures. | transform/native/pipeline.rs | 2025-09-22 22:30:00 | None |
 
 ### SCHEMA-001: Schema State Transition Rules
 - **Description**: Enforces valid state transitions for schema lifecycle management

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -73,7 +73,8 @@ pub use mutation_examples::{
 };
 pub use native::{
     FieldDefinition as NativeFieldDefinition, FieldDefinitionError as NativeFieldDefinitionError,
-    FieldType as NativeFieldType, FieldValue,
+    FieldType as NativeFieldType, FieldValue, NativeDataPipeline, NativeTransformExecutor,
+    PipelineError, ProcessingContext,
 };
 pub use parser::TransformParser;
 pub use restricted_access::{

--- a/src/transform/native/mod.rs
+++ b/src/transform/native/mod.rs
@@ -6,7 +6,9 @@
 //! definitions and transform specifications.
 
 pub mod field_definition;
+pub mod pipeline;
 pub mod types;
 
 pub use field_definition::{FieldDefinition, FieldDefinitionError};
+pub use pipeline::{NativeDataPipeline, NativeTransformExecutor, PipelineError, ProcessingContext};
 pub use types::{FieldType, FieldValue};

--- a/src/transform/native/pipeline.rs
+++ b/src/transform/native/pipeline.rs
@@ -1,0 +1,181 @@
+use super::types::{FieldType, FieldValue};
+use std::collections::HashMap;
+use std::sync::Arc;
+use thiserror::Error;
+
+/// Executor trait for running native transform specifications.
+pub trait NativeTransformExecutor<S> {
+    /// Error type emitted when execution fails.
+    type Error;
+
+    /// Execute a transform against the provided input data.
+    fn execute_transform(
+        &self,
+        transform_spec: &S,
+        input_data: &HashMap<String, FieldValue>,
+    ) -> Result<FieldValue, Self::Error>;
+}
+
+/// Errors produced by the native data pipeline when orchestrating transform execution.
+#[derive(Debug, Error)]
+pub enum PipelineError<E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    /// Underlying transform execution failed.
+    #[error("transform execution failed at stage {stage_index}: {source}")]
+    Transform {
+        /// Index of the transform that failed.
+        stage_index: usize,
+        /// Root cause error emitted by the executor.
+        #[source]
+        source: E,
+    },
+
+    /// A transform in the chain returned a non-object value.
+    #[error("transform at index {stage_index} returned non-object output ({actual_type:?})")]
+    NonObjectOutput {
+        /// Index of the transform that produced the invalid output.
+        stage_index: usize,
+        /// Type of the value returned by the transform.
+        actual_type: FieldType,
+    },
+}
+
+/// Context required to execute a transform chain.
+#[derive(Debug, Clone)]
+pub struct ProcessingContext<S> {
+    schema_name: String,
+    input_data: HashMap<String, FieldValue>,
+    transform_specs: Vec<S>,
+}
+
+impl<S> ProcessingContext<S> {
+    /// Create a new processing context.
+    #[must_use]
+    pub fn new(
+        schema_name: impl Into<String>,
+        input_data: HashMap<String, FieldValue>,
+        transform_specs: Vec<S>,
+    ) -> Self {
+        Self {
+            schema_name: schema_name.into(),
+            input_data,
+            transform_specs,
+        }
+    }
+
+    /// Name of the schema associated with this processing run.
+    #[must_use]
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+
+    /// Borrow the current input data.
+    #[must_use]
+    pub fn input_data(&self) -> &HashMap<String, FieldValue> {
+        &self.input_data
+    }
+
+    /// Borrow the configured transform specifications.
+    #[must_use]
+    pub fn transform_specs(&self) -> &[S] {
+        &self.transform_specs
+    }
+
+    /// Append an additional transform specification to the execution chain.
+    pub fn push_transform(&mut self, transform_spec: S) {
+        self.transform_specs.push(transform_spec);
+    }
+
+    /// Consume the context and return its constituent parts.
+    #[must_use]
+    pub fn into_parts(self) -> (String, HashMap<String, FieldValue>, Vec<S>) {
+        (self.schema_name, self.input_data, self.transform_specs)
+    }
+}
+
+/// Native data pipeline that orchestrates transform execution with native types.
+#[derive(Debug)]
+pub struct NativeDataPipeline<E, R> {
+    engine: Arc<E>,
+    schema_registry: Arc<R>,
+}
+
+impl<E, R> NativeDataPipeline<E, R> {
+    /// Create a new pipeline with the provided execution engine and schema registry.
+    #[must_use]
+    pub fn new(engine: Arc<E>, schema_registry: Arc<R>) -> Self {
+        Self {
+            engine,
+            schema_registry,
+        }
+    }
+
+    /// Access the underlying execution engine.
+    #[must_use]
+    pub fn engine(&self) -> &Arc<E> {
+        &self.engine
+    }
+
+    /// Access the schema registry reference.
+    #[must_use]
+    pub fn schema_registry(&self) -> &Arc<R> {
+        &self.schema_registry
+    }
+}
+
+impl<E, R> NativeDataPipeline<E, R> {
+    /// Execute the configured transform chain using the provided context.
+    pub fn process_data<S>(
+        &self,
+        context: ProcessingContext<S>,
+    ) -> Result<HashMap<String, FieldValue>, PipelineError<E::Error>>
+    where
+        E: NativeTransformExecutor<S> + Send + Sync,
+        E::Error: std::error::Error + Send + Sync + 'static,
+    {
+        let ProcessingContext {
+            schema_name: _,
+            input_data: mut current_data,
+            transform_specs,
+        } = context;
+
+        for (index, transform_spec) in transform_specs.iter().enumerate() {
+            let result = self
+                .engine
+                .execute_transform(transform_spec, &current_data)
+                .map_err(|source| PipelineError::Transform {
+                    stage_index: index,
+                    source,
+                })?;
+
+            match result {
+                FieldValue::Object(object) => {
+                    current_data = object;
+                }
+                other => {
+                    let actual_type = other.field_type();
+                    return Err(PipelineError::NonObjectOutput {
+                        stage_index: index,
+                        actual_type,
+                    });
+                }
+            }
+        }
+
+        Ok(current_data)
+    }
+
+    /// Execute a single transform outside of a full pipeline run.
+    pub fn process_single_transform<S>(
+        &self,
+        transform_spec: &S,
+        input_data: &HashMap<String, FieldValue>,
+    ) -> Result<FieldValue, E::Error>
+    where
+        E: NativeTransformExecutor<S> + Send + Sync,
+    {
+        self.engine.execute_transform(transform_spec, input_data)
+    }
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -11,6 +11,7 @@ pub mod hashrange_schema_tests;
 pub mod iterator_stack_tests;
 pub mod mutation_completion_tests;
 pub mod native_field_definition_tests;
+pub mod native_pipeline_tests;
 pub mod native_types_tests;
 pub mod range_filter_tests;
 pub mod schema;

--- a/tests/unit/native_pipeline_tests.rs
+++ b/tests/unit/native_pipeline_tests.rs
@@ -1,0 +1,204 @@
+use datafold::transform::{
+    FieldValue, NativeDataPipeline, NativeFieldType, NativeTransformExecutor, PipelineError,
+    ProcessingContext,
+};
+use std::collections::{HashMap, HashSet};
+use std::f64::consts::PI;
+use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+struct TestTransformSpec {
+    id: &'static str,
+}
+
+impl TestTransformSpec {
+    fn new(id: &'static str) -> Self {
+        Self { id }
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("transform {id} failed")]
+struct MockError {
+    id: &'static str,
+}
+
+#[derive(Debug)]
+struct MockExecutor {
+    responses: HashMap<String, FieldValue>,
+    failures: HashSet<String>,
+}
+
+impl MockExecutor {
+    fn new(responses: HashMap<String, FieldValue>, failures: HashSet<String>) -> Self {
+        Self {
+            responses,
+            failures,
+        }
+    }
+}
+
+impl NativeTransformExecutor<TestTransformSpec> for MockExecutor {
+    type Error = MockError;
+
+    fn execute_transform(
+        &self,
+        transform_spec: &TestTransformSpec,
+        input_data: &HashMap<String, FieldValue>,
+    ) -> Result<FieldValue, Self::Error> {
+        if self.failures.contains(transform_spec.id) {
+            return Err(MockError {
+                id: transform_spec.id,
+            });
+        }
+
+        if let Some(value) = self.responses.get(transform_spec.id) {
+            return Ok(value.clone());
+        }
+
+        Ok(FieldValue::Object(input_data.clone()))
+    }
+}
+
+fn empty_executor() -> Arc<MockExecutor> {
+    Arc::new(MockExecutor::new(HashMap::new(), HashSet::new()))
+}
+
+#[test]
+fn pipeline_processes_transform_chain_successfully() {
+    let mut stage_one_map = HashMap::new();
+    stage_one_map.insert("intermediate".to_string(), FieldValue::Integer(1));
+
+    let mut stage_two_map = HashMap::new();
+    stage_two_map.insert("final".to_string(), FieldValue::Integer(2));
+
+    let executor = Arc::new(MockExecutor::new(
+        HashMap::from([
+            (
+                "stage-1".to_string(),
+                FieldValue::Object(stage_one_map.clone()),
+            ),
+            (
+                "stage-2".to_string(),
+                FieldValue::Object(stage_two_map.clone()),
+            ),
+        ]),
+        HashSet::new(),
+    ));
+
+    let pipeline = NativeDataPipeline::new(executor, Arc::new(()));
+
+    let context = ProcessingContext::new(
+        "test-schema",
+        HashMap::from([("initial".to_string(), FieldValue::Integer(0))]),
+        vec![
+            TestTransformSpec::new("stage-1"),
+            TestTransformSpec::new("stage-2"),
+        ],
+    );
+
+    let result = pipeline
+        .process_data(context)
+        .expect("pipeline should succeed");
+
+    assert_eq!(result, stage_two_map);
+}
+
+#[test]
+fn pipeline_allows_empty_transform_chain() {
+    let pipeline = NativeDataPipeline::new(empty_executor(), Arc::new(()));
+
+    let initial_data = HashMap::from([("count".to_string(), FieldValue::Integer(42))]);
+
+    let context = ProcessingContext::new("schema", initial_data.clone(), Vec::new());
+
+    let result = pipeline
+        .process_data(context)
+        .expect("empty chain should return initial data");
+
+    assert_eq!(result, initial_data);
+}
+
+#[test]
+fn pipeline_returns_error_when_transform_output_is_not_object() {
+    let executor = Arc::new(MockExecutor::new(
+        HashMap::from([("stage-1".to_string(), FieldValue::Number(PI))]),
+        HashSet::new(),
+    ));
+
+    let pipeline = NativeDataPipeline::new(executor, Arc::new(()));
+
+    let context = ProcessingContext::new(
+        "schema",
+        HashMap::new(),
+        vec![TestTransformSpec::new("stage-1")],
+    );
+
+    let error = pipeline
+        .process_data(context)
+        .expect_err("non-object output should surface as error");
+
+    match error {
+        PipelineError::NonObjectOutput {
+            stage_index,
+            actual_type,
+        } => {
+            assert_eq!(stage_index, 0);
+            assert_eq!(actual_type, NativeFieldType::Number);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn pipeline_propagates_transform_errors() {
+    let executor = Arc::new(MockExecutor::new(
+        HashMap::new(),
+        HashSet::from(["stage-2".to_string()]),
+    ));
+
+    let pipeline = NativeDataPipeline::new(executor, Arc::new(()));
+
+    let context = ProcessingContext::new(
+        "schema",
+        HashMap::new(),
+        vec![
+            TestTransformSpec::new("stage-1"),
+            TestTransformSpec::new("stage-2"),
+        ],
+    );
+
+    let error = pipeline
+        .process_data(context)
+        .expect_err("executor failure should bubble up");
+
+    match error {
+        PipelineError::Transform {
+            stage_index,
+            source,
+        } => {
+            assert_eq!(stage_index, 1);
+            assert_eq!(source.id, "stage-2");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn process_single_transform_invokes_executor_directly() {
+    let executor = Arc::new(MockExecutor::new(
+        HashMap::from([("stage-1".to_string(), FieldValue::Boolean(true))]),
+        HashSet::new(),
+    ));
+
+    let pipeline = NativeDataPipeline::new(executor, Arc::new(()));
+
+    let input_data = HashMap::from([("flag".to_string(), FieldValue::Boolean(false))]);
+
+    let result = pipeline
+        .process_single_transform(&TestTransformSpec::new("stage-1"), &input_data)
+        .expect("executor should return mocked value");
+
+    assert_eq!(result, FieldValue::Boolean(true));
+}


### PR DESCRIPTION
## Summary
- include the failing stage index in `PipelineError::Transform` for better debugging
- update the native pipeline test to assert the new error metadata and refresh task documentation
- expand the TRANSFORM-006 logic entry to capture the richer error context

## Testing
- `cargo test --workspace` *(fails: integration::hashrange_end_to_end_workflow_test::test_hashrange_query_format_validation due to existing issue)*
- `cargo clippy --workspace --all-targets --all-features`
- `(cd src/datafold_node/static-react && npm install && npm test)`


------
https://chatgpt.com/codex/tasks/task_e_68d1c1231ba483278df89319b323c9be