### PR TITLE
Implement native persistence layer

### DIFF
--- a/docs/delivery/NTS-6/NTS-6-1.md
+++ b/docs/delivery/NTS-6/NTS-6-1.md
@@ -1,0 +1,50 @@
+# NTS-6-1 Implement NativePersistence
+
+[Back to task list](./tasks.md)
+
+## Description
+Introduce a native persistence layer that accepts strongly typed `FieldValue` payloads, validates them against typed schema metadata, and stores them using the existing sled-backed `DbOperations`. This removes the need for callers to manipulate raw `serde_json::Value` instances and establishes the foundation for native data flows across the node.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-25 09:30:00 | Status Change | N/A | In Progress | Began implementing native persistence module and schema provider abstraction. | AI_Agent |
+| 2025-09-25 11:45:00 | Status Change | In Progress | Done | Completed native persistence implementation and validation utilities. | AI_Agent |
+
+## Requirements
+- Provide a `NativePersistence` helper that stores and loads native records without exposing JSON to callers.
+- Support single-key and composite (hash/range) schemas with deterministic key serialization.
+- Validate input payloads against typed schema metadata before persistence and reject mismatches.
+- Integrate with existing `DbOperations` for storage while minimising JSON usage to conversion boundaries.
+- Ensure interfaces remain thread-safe for use inside async managers.
+
+## Implementation Plan
+1. Create `src/persistence` module to host native persistence helpers and re-export them through `lib.rs`.
+2. Implement `NativeSchemaProvider`, `SchemaDescription`, and `KeyConfig` to describe typed schema metadata required for persistence.
+3. Build `NativePersistence` with validation, key extraction, and storage helpers that utilise `DbOperations`.
+4. Provide `NativeRecordKey` utilities to serialise composite keys safely using base64 encoding.
+5. Add module-level unit tests to ensure key round-tripping and error paths operate as expected.
+6. Write integration tests that persist and load records through the new helper using in-memory schema definitions.
+7. Update documentation (`project_logic.md`, task files) to capture the new persistence guarantees.
+
+## Verification
+- Native persistence stores records and loads them back with defaults applied for optional fields.
+- Attempts to persist data with missing required fields or type mismatches surface explicit `PersistenceError` variants.
+- Composite key schemas round-trip correctly with deterministic hash/range components.
+- Workspace builds succeed with `cargo test --workspace` and `cargo clippy --workspace`.
+- Frontend vitest suite runs successfully to maintain repository policy compliance.
+
+## Files Modified
+- `docs/delivery/NTS-6/tasks.md`
+- `docs/delivery/NTS-6/NTS-6-1.md`
+- `docs/project_logic.md`
+- `src/lib.rs`
+- `src/persistence/mod.rs`
+- `src/persistence/native_persistence.rs`
+- `tests/native_persistence_tests.rs`
+
+## Test Plan
+- `rustfmt src/persistence/mod.rs src/persistence/native_persistence.rs tests/native_persistence_tests.rs`
+- `cargo test --workspace`
+- `cargo clippy --workspace`
+- `(cd src/datafold_node/static-react && npm ci && npm test)`

--- a/docs/delivery/NTS-6/NTS-6-2.md
+++ b/docs/delivery/NTS-6/NTS-6-2.md
@@ -1,0 +1,45 @@
+# NTS-6-2 Implement database format conversion
+
+[Back to task list](./tasks.md)
+
+## Description
+Deliver conversion utilities that bridge native `FieldValue` payloads with the sled storage format. The utilities must enforce typed schemas, apply defaults, serialise composite keys safely, and recover native values when loading records.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-25 09:45:00 | Status Change | N/A | In Progress | Started implementing conversion helpers for native persistence. | AI_Agent |
+| 2025-09-25 11:45:00 | Status Change | In Progress | Done | Finalised conversion logic and integrated validation plus key serialisation. | AI_Agent |
+
+## Requirements
+- Provide helpers to convert native maps into JSON values for storage without exposing JSON to callers.
+- Support round-trip conversion from persisted JSON to native `FieldValue` instances.
+- Apply schema-driven defaults for optional fields and validate required fields during load.
+- Encode composite keys deterministically and losslessly for sled storage.
+- Surface descriptive errors when conversion or validation fails.
+
+## Implementation Plan
+1. Add `convert_to_db_format` and `convert_from_db_format` helpers inside `NativePersistence` to manage JSON boundaries.
+2. Implement `normalize_and_validate` to apply defaults and reject payloads that violate schema definitions.
+3. Add key serialisation helpers (base64-encoded segments) to guarantee reversible storage keys.
+4. Integrate conversion helpers with `store_data` and `load_data` paths to enforce validation before and after persistence.
+5. Extend integration tests to verify round-trip behaviour, error cases, and default application.
+
+## Verification
+- Native records persist and reload with optional defaults applied automatically.
+- Type mismatches and missing required fields return `PersistenceError` variants instead of silent failures.
+- Composite key records round-trip with identical hash/range values.
+- Unit tests confirm key serialisation is reversible.
+- Workspace and frontend test suites pass after the conversion utilities are integrated.
+
+## Files Modified
+- `docs/delivery/NTS-6/tasks.md`
+- `docs/delivery/NTS-6/NTS-6-2.md`
+- `src/persistence/native_persistence.rs`
+- `tests/native_persistence_tests.rs`
+
+## Test Plan
+- `rustfmt src/persistence/mod.rs src/persistence/native_persistence.rs tests/native_persistence_tests.rs`
+- `cargo test --workspace`
+- `cargo clippy --workspace`
+- `(cd src/datafold_node/static-react && npm ci && npm test)`

--- a/docs/delivery/NTS-6/tasks.md
+++ b/docs/delivery/NTS-6/tasks.md
@@ -8,8 +8,8 @@ This document lists all tasks associated with PBI NTS-6.
 
 | Task ID | Name | Status | Description |
 | :------ | :--------------------------------------- | :------- | :--------------------------------- |
-| NTS-6-1 | [Implement NativePersistence](./NTS-6-1.md) | Proposed | Create core persistence layer with minimal JSON usage |
-| NTS-6-2 | [Implement database format conversion](./NTS-6-2.md) | Proposed | Add efficient conversion utilities |
+| NTS-6-1 | [Implement NativePersistence](./NTS-6-1.md) | Done | Create core persistence layer with minimal JSON usage |
+| NTS-6-2 | [Implement database format conversion](./NTS-6-2.md) | Done | Add efficient conversion utilities |
 | NTS-6-3 | [Add storage optimization](./NTS-6-3.md) | Proposed | Implement performance improvements |
 | NTS-6-4 | [Add comprehensive persistence tests](./NTS-6-4.md) | Proposed | Test data integrity and performance |
 | NTS-6-5 | [Add performance benchmarks](./NTS-6-5.md) | Proposed | Measure performance improvements over JSON system |

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -20,6 +20,7 @@ This document contains the most up-to-date and condensed information about the p
 | TRANSFORM-003 | DeclarativeSchemaDefinition requires KeyConfig with hash_field and range_field for HashRange schemas and FieldDefinition metadata for optional atom_uuid and field_type. | schema/types/json_schema.rs | 2025-08-26 19:00:00 | None |
 | TRANSFORM-004 | Native transform data flow must use FieldValue/FieldType enums internally with JSON conversion limited to boundary layers. | transform/native, transform/mod.rs | 2025-09-22 19:14:37 | None |
 | TRANSFORM-005 | Native FieldDefinition must validate names, default types, and generate typed defaults for optional fields. | transform/native | 2025-09-22 19:16:45 | None |
+| PERSIST-001 | Native persistence stores typed FieldValue records and only converts to JSON at storage boundaries after schema validation. | persistence/native_persistence.rs | 2025-09-25 11:45:00 | None |
 
 ### SCHEMA-001: Schema State Transition Rules
 - **Description**: Enforces valid state transitions for schema lifecycle management

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 
 pub mod atom;
 pub mod config_utils;
+pub mod constants;
 pub mod datafold_node;
 pub mod db_operations;
 pub mod error;
@@ -37,13 +38,13 @@ pub mod ingestion;
 pub mod logging;
 pub mod network;
 pub mod permissions;
+pub mod persistence;
 pub mod schema;
 pub mod security;
 pub mod testing_utils;
 pub mod transform;
 pub mod validation_utils;
 pub mod web_logger;
-pub mod constants;
 
 // Re-export main types for convenience
 pub use datafold_node::config::load_node_config;
@@ -54,24 +55,22 @@ pub use fold_db_core::FoldDB;
 pub use network::{NetworkConfig, NetworkCore, NetworkError, NetworkResult, PeerId, SchemaService};
 
 // Re-export schema types needed for CLI
-pub use schema::SchemaState;
 pub use schema::types::operation::Operation;
 pub use schema::types::operations::MutationType;
 pub use schema::Schema;
+pub use schema::SchemaState;
 
 // Re-export security types
 pub use security::{
-    SecurityConfig, SecurityManager, SecurityError, SecurityResult,
-    SignedMessage, PublicKeyInfo, VerificationResult, EncryptedData,
-    KeyRegistrationRequest, KeyRegistrationResponse,
-    Ed25519KeyPair, Ed25519PublicKey, MessageSigner, MessageVerifier,
-    EncryptionManager, ConditionalEncryption,
-    ClientSecurity, SecurityMiddleware, SecurityConfigBuilder,
-    KeyUtils, SigningUtils, EncryptionUtils,
+    ClientSecurity, ConditionalEncryption, Ed25519KeyPair, Ed25519PublicKey, EncryptedData,
+    EncryptionManager, EncryptionUtils, KeyRegistrationRequest, KeyRegistrationResponse, KeyUtils,
+    MessageSigner, MessageVerifier, PublicKeyInfo, SecurityConfig, SecurityConfigBuilder,
+    SecurityError, SecurityManager, SecurityMiddleware, SecurityResult, SignedMessage,
+    SigningUtils, VerificationResult,
 };
 
 // Re-export ingestion types
 pub use ingestion::{IngestionConfig, IngestionCore, IngestionError, IngestionResponse};
 
 // Re-export commonly used constants
-pub use constants::{DEFAULT_P2P_PORT, DEFAULT_HTTP_PORT};
+pub use constants::{DEFAULT_HTTP_PORT, DEFAULT_P2P_PORT};

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,0 +1,15 @@
+//! Persistence utilities for working with native (non-JSON) data paths.
+//!
+//! The persistence module centralizes storage logic for native
+//! `FieldValue` structures so the rest of the application can avoid
+//! touching raw `serde_json::Value` instances. The initial
+//! implementation introduces [`NativePersistence`], a helper that
+//! validates records against typed schema metadata before converting
+//! them into the database representation.
+
+pub mod native_persistence;
+
+pub use native_persistence::{
+    KeyConfig, NativePersistence, NativeRecordKey, NativeSchemaProvider, PersistenceError,
+    SchemaDescription,
+};

--- a/src/persistence/native_persistence.rs
+++ b/src/persistence/native_persistence.rs
@@ -1,0 +1,416 @@
+use std::{collections::HashMap, sync::Arc};
+
+use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+
+use crate::{
+    db_operations::DbOperations,
+    schema::SchemaError,
+    transform::native::{FieldDefinition, FieldType, FieldValue},
+};
+
+const STORAGE_PREFIX: &str = "native";
+
+/// Provides schema metadata required for native persistence validation.
+pub trait NativeSchemaProvider: Send + Sync {
+    /// Lookup schema description by name.
+    fn schema_for(&self, schema_name: &str) -> Result<SchemaDescription, PersistenceError>;
+}
+
+/// Describes the typed structure of a native schema.
+#[derive(Clone, Debug)]
+pub struct SchemaDescription {
+    /// Name of the schema.
+    pub name: String,
+    /// Key configuration used to derive unique record keys.
+    pub key: KeyConfig,
+    /// Field definitions keyed by field name.
+    pub fields: HashMap<String, FieldDefinition>,
+}
+
+/// Supported key configurations for native persistence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum KeyConfig {
+    /// Single-field key.
+    Single { key_field: String },
+    /// Composite hash/range key pair used for ordered storage.
+    Range {
+        hash_field: String,
+        range_field: String,
+    },
+    /// Hash-range configuration used by declarative schemas.
+    HashRange {
+        hash_field: String,
+        range_field: String,
+    },
+}
+
+/// Identifier for a persisted native record.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NativeRecordKey {
+    /// Single-field key value.
+    Single(String),
+    /// Composite hash/range key values.
+    Composite { hash: String, range: String },
+}
+
+impl NativeRecordKey {
+    /// Create a new single-field key.
+    #[must_use]
+    pub fn single(value: impl Into<String>) -> Self {
+        Self::Single(value.into())
+    }
+
+    /// Create a new composite hash/range key.
+    #[must_use]
+    pub fn composite(hash: impl Into<String>, range: impl Into<String>) -> Self {
+        Self::Composite {
+            hash: hash.into(),
+            range: range.into(),
+        }
+    }
+
+    /// Serialize the key into a stable string representation.
+    #[must_use]
+    pub fn serialize(&self) -> String {
+        match self {
+            Self::Single(value) => format!("single:{}", encode_segment(value)),
+            Self::Composite { hash, range } => format!(
+                "composite:{}:{}",
+                encode_segment(hash),
+                encode_segment(range)
+            ),
+        }
+    }
+
+    /// Reconstruct a [`NativeRecordKey`] from its serialized representation.
+    pub fn from_serialized(serialized: &str) -> Result<Self, PersistenceError> {
+        let mut parts = serialized.split(':');
+        match parts.next() {
+            Some("single") => {
+                let encoded = parts.next().ok_or_else(|| {
+                    PersistenceError::KeySerialization("missing single key payload".into())
+                })?;
+                let value = decode_segment(encoded)?;
+                Ok(Self::Single(value))
+            }
+            Some("composite") => {
+                let hash_encoded = parts.next().ok_or_else(|| {
+                    PersistenceError::KeySerialization("missing hash component".into())
+                })?;
+                let range_encoded = parts.next().ok_or_else(|| {
+                    PersistenceError::KeySerialization("missing range component".into())
+                })?;
+                let hash = decode_segment(hash_encoded)?;
+                let range = decode_segment(range_encoded)?;
+                Ok(Self::Composite { hash, range })
+            }
+            _ => Err(PersistenceError::KeySerialization(format!(
+                "unrecognised key format: {serialized}"
+            ))),
+        }
+    }
+
+    /// Build the sled storage key for the given schema.
+    #[must_use]
+    pub fn to_storage_key(&self, schema_name: &str) -> String {
+        format!("{}:{}:{}", STORAGE_PREFIX, schema_name, self.serialize())
+    }
+
+    /// Returns a user-friendly description of the key for diagnostics.
+    #[must_use]
+    pub fn debug_summary(&self) -> String {
+        match self {
+            Self::Single(value) => format!("single({value})"),
+            Self::Composite { hash, range } => format!("composite(hash={hash}, range={range})"),
+        }
+    }
+}
+
+/// Persistence-specific error type that captures validation and storage failures.
+#[derive(Debug, Error)]
+pub enum PersistenceError {
+    /// Requested schema is not registered with the provider.
+    #[error("schema '{schema}' not found")]
+    SchemaNotFound { schema: String },
+
+    /// Input payload references a field that is not part of the schema.
+    #[error("unknown field '{field}' for schema '{schema}'")]
+    UnknownField { schema: String, field: String },
+
+    /// Required field is missing from the payload and cannot be defaulted.
+    #[error("missing required field '{field}' for schema '{schema}'")]
+    MissingRequiredField { schema: String, field: String },
+
+    /// Key-defining field is missing from the payload.
+    #[error("key field '{field}' missing for schema '{schema}'")]
+    MissingKeyField { schema: String, field: String },
+
+    /// Key-defining field contains a value that cannot be serialised into a stable key.
+    #[error("key field '{field}' for schema '{schema}' contains unsupported value")]
+    InvalidKeyValue { schema: String, field: String },
+
+    /// Field value does not match the declared field type.
+    #[error(
+        "field '{field}' in schema '{schema}' type mismatch: expected {expected:?}, got {actual:?}"
+    )]
+    FieldTypeMismatch {
+        schema: String,
+        field: String,
+        expected: Box<FieldType>,
+        actual: Box<FieldType>,
+    },
+
+    /// Record was not found for the specified key.
+    #[error("record not found for schema '{schema}' and key '{key}'")]
+    RecordNotFound { schema: String, key: String },
+
+    /// Conversion to/from storage key failed.
+    #[error("key serialization failed: {0}")]
+    KeySerialization(String),
+
+    /// Underlying database layer produced an error.
+    #[error("database error: {0}")]
+    Database(#[from] SchemaError),
+}
+
+/// Internal representation of a persisted record.
+#[derive(Debug, Serialize, Deserialize)]
+struct NativeStoredRecord {
+    schema: String,
+    key: String,
+    data: HashMap<String, JsonValue>,
+}
+
+/// Provides typed persistence over [`DbOperations`] without leaking JSON usage into callers.
+#[derive(Clone)]
+pub struct NativePersistence {
+    db_ops: Arc<DbOperations>,
+    schema_provider: Arc<dyn NativeSchemaProvider>,
+}
+
+impl NativePersistence {
+    /// Create a new persistence helper.
+    #[must_use]
+    pub fn new(db_ops: Arc<DbOperations>, schema_provider: Arc<dyn NativeSchemaProvider>) -> Self {
+        Self {
+            db_ops,
+            schema_provider,
+        }
+    }
+
+    /// Persist native data for the provided schema, returning the computed record key.
+    pub fn store_data(
+        &self,
+        schema_name: &str,
+        data: &HashMap<String, FieldValue>,
+    ) -> Result<NativeRecordKey, PersistenceError> {
+        let schema = self.schema_provider.schema_for(schema_name)?;
+        let normalized = Self::normalize_and_validate(schema_name, &schema, data)?;
+        let record_key = Self::extract_record_key(schema_name, &schema.key, &normalized)?;
+
+        let storage_key = record_key.to_storage_key(schema_name);
+        let stored_record = NativeStoredRecord {
+            schema: schema.name,
+            key: record_key.serialize(),
+            data: Self::convert_to_db_format(&normalized),
+        };
+
+        self.db_ops
+            .store_item(&storage_key, &stored_record)
+            .map_err(PersistenceError::from)?;
+
+        Ok(record_key)
+    }
+
+    /// Load a record for the provided key, returning native values after schema validation.
+    pub fn load_data(
+        &self,
+        schema_name: &str,
+        key: &NativeRecordKey,
+    ) -> Result<HashMap<String, FieldValue>, PersistenceError> {
+        let schema = self.schema_provider.schema_for(schema_name)?;
+        let storage_key = key.to_storage_key(schema_name);
+
+        let stored = self
+            .db_ops
+            .get_item::<NativeStoredRecord>(&storage_key)
+            .map_err(PersistenceError::from)?
+            .ok_or_else(|| PersistenceError::RecordNotFound {
+                schema: schema_name.to_string(),
+                key: key.serialize(),
+            })?;
+
+        let field_values = Self::convert_from_db_format(&stored.data);
+        Self::normalize_and_validate(schema_name, &schema, &field_values)
+    }
+
+    /// Convenience helper to load data using the serialized key string.
+    pub fn load_data_by_serialized_key(
+        &self,
+        schema_name: &str,
+        serialized_key: &str,
+    ) -> Result<HashMap<String, FieldValue>, PersistenceError> {
+        let key = NativeRecordKey::from_serialized(serialized_key)?;
+        self.load_data(schema_name, &key)
+    }
+
+    fn normalize_and_validate(
+        schema_name: &str,
+        schema: &SchemaDescription,
+        data: &HashMap<String, FieldValue>,
+    ) -> Result<HashMap<String, FieldValue>, PersistenceError> {
+        let mut normalized = HashMap::new();
+
+        for (field_name, definition) in &schema.fields {
+            if let Some(value) = data.get(field_name) {
+                if !definition.field_type.matches(value) {
+                    return Err(PersistenceError::FieldTypeMismatch {
+                        schema: schema_name.to_string(),
+                        field: field_name.clone(),
+                        expected: Box::new(definition.field_type.clone()),
+                        actual: Box::new(value.field_type()),
+                    });
+                }
+                normalized.insert(field_name.clone(), value.clone());
+            } else if let Some(default_value) = definition.effective_default() {
+                normalized.insert(field_name.clone(), default_value);
+            } else {
+                return Err(PersistenceError::MissingRequiredField {
+                    schema: schema_name.to_string(),
+                    field: field_name.clone(),
+                });
+            }
+        }
+
+        for field_name in data.keys() {
+            if !schema.fields.contains_key(field_name) {
+                return Err(PersistenceError::UnknownField {
+                    schema: schema_name.to_string(),
+                    field: field_name.clone(),
+                });
+            }
+        }
+
+        Ok(normalized)
+    }
+
+    fn extract_record_key(
+        schema_name: &str,
+        key_config: &KeyConfig,
+        data: &HashMap<String, FieldValue>,
+    ) -> Result<NativeRecordKey, PersistenceError> {
+        match key_config {
+            KeyConfig::Single { key_field } => {
+                let value =
+                    data.get(key_field)
+                        .ok_or_else(|| PersistenceError::MissingKeyField {
+                            schema: schema_name.to_string(),
+                            field: key_field.clone(),
+                        })?;
+                let segment = Self::key_segment(schema_name, key_field, value)?;
+                Ok(NativeRecordKey::single(segment))
+            }
+            KeyConfig::Range {
+                hash_field,
+                range_field,
+            }
+            | KeyConfig::HashRange {
+                hash_field,
+                range_field,
+            } => {
+                let hash_value =
+                    data.get(hash_field)
+                        .ok_or_else(|| PersistenceError::MissingKeyField {
+                            schema: schema_name.to_string(),
+                            field: hash_field.clone(),
+                        })?;
+                let range_value =
+                    data.get(range_field)
+                        .ok_or_else(|| PersistenceError::MissingKeyField {
+                            schema: schema_name.to_string(),
+                            field: range_field.clone(),
+                        })?;
+
+                let hash_segment = Self::key_segment(schema_name, hash_field, hash_value)?;
+                let range_segment = Self::key_segment(schema_name, range_field, range_value)?;
+                Ok(NativeRecordKey::composite(hash_segment, range_segment))
+            }
+        }
+    }
+
+    fn key_segment(
+        schema_name: &str,
+        field_name: &str,
+        value: &FieldValue,
+    ) -> Result<String, PersistenceError> {
+        match value {
+            FieldValue::String(v) => Ok(v.clone()),
+            FieldValue::Integer(v) => Ok(v.to_string()),
+            FieldValue::Number(v) => Ok(v.to_string()),
+            FieldValue::Boolean(v) => Ok(v.to_string()),
+            FieldValue::Null | FieldValue::Array(_) | FieldValue::Object(_) => {
+                Err(PersistenceError::InvalidKeyValue {
+                    schema: schema_name.to_string(),
+                    field: field_name.to_string(),
+                })
+            }
+        }
+    }
+
+    fn convert_to_db_format(data: &HashMap<String, FieldValue>) -> HashMap<String, JsonValue> {
+        data.iter()
+            .map(|(field, value)| (field.clone(), value.to_json_value()))
+            .collect()
+    }
+
+    fn convert_from_db_format(data: &HashMap<String, JsonValue>) -> HashMap<String, FieldValue> {
+        data.iter()
+            .map(|(field, value)| (field.clone(), FieldValue::from_json_value(value.clone())))
+            .collect()
+    }
+}
+
+fn encode_segment(segment: &str) -> String {
+    STANDARD_NO_PAD.encode(segment.as_bytes())
+}
+
+fn decode_segment(encoded: &str) -> Result<String, PersistenceError> {
+    let bytes = STANDARD_NO_PAD
+        .decode(encoded)
+        .map_err(|err| PersistenceError::KeySerialization(err.to_string()))?;
+    String::from_utf8(bytes).map_err(|err| PersistenceError::KeySerialization(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_key_round_trip_single() {
+        let original = NativeRecordKey::single("identifier-123");
+        let serialized = original.serialize();
+        let decoded = NativeRecordKey::from_serialized(&serialized).unwrap();
+        assert_eq!(original, decoded);
+        assert_eq!(
+            original.to_storage_key("schema"),
+            decoded.to_storage_key("schema")
+        );
+    }
+
+    #[test]
+    fn record_key_round_trip_composite() {
+        let original = NativeRecordKey::composite("customer_42", "2025-09-24");
+        let serialized = original.serialize();
+        let decoded = NativeRecordKey::from_serialized(&serialized).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn record_key_invalid_format() {
+        let error = NativeRecordKey::from_serialized("invalid").unwrap_err();
+        assert!(matches!(error, PersistenceError::KeySerialization(_)));
+    }
+}

--- a/tests/native_persistence_tests.rs
+++ b/tests/native_persistence_tests.rs
@@ -1,0 +1,215 @@
+use std::{collections::HashMap, sync::Arc};
+
+use datafold::{
+    db_operations::DbOperations,
+    persistence::{
+        KeyConfig, NativePersistence, NativeRecordKey, NativeSchemaProvider, PersistenceError,
+        SchemaDescription,
+    },
+    transform::native::{FieldDefinition, FieldType, FieldValue},
+};
+use tempfile::tempdir;
+
+struct InMemorySchemaProvider {
+    schemas: HashMap<String, SchemaDescription>,
+}
+
+impl InMemorySchemaProvider {
+    fn new() -> Self {
+        Self {
+            schemas: HashMap::new(),
+        }
+    }
+
+    fn with_schema(mut self, schema: SchemaDescription) -> Self {
+        self.schemas.insert(schema.name.clone(), schema);
+        self
+    }
+}
+
+impl NativeSchemaProvider for InMemorySchemaProvider {
+    fn schema_for(&self, schema_name: &str) -> Result<SchemaDescription, PersistenceError> {
+        self.schemas
+            .get(schema_name)
+            .cloned()
+            .ok_or_else(|| PersistenceError::SchemaNotFound {
+                schema: schema_name.to_string(),
+            })
+    }
+}
+
+fn create_persistence(provider: InMemorySchemaProvider) -> (NativePersistence, tempfile::TempDir) {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let db = sled::Config::new()
+        .path(temp_dir.path())
+        .temporary(true)
+        .open()
+        .expect("failed to open sled database");
+    let db_ops = Arc::new(DbOperations::new(db).expect("failed to create db operations"));
+    let provider: Arc<dyn NativeSchemaProvider> = Arc::new(provider);
+    let persistence = NativePersistence::new(db_ops, provider);
+    (persistence, temp_dir)
+}
+
+fn user_schema() -> SchemaDescription {
+    let mut fields = HashMap::new();
+    fields.insert(
+        "id".to_string(),
+        FieldDefinition::new("id", FieldType::String),
+    );
+    fields.insert(
+        "name".to_string(),
+        FieldDefinition::new("name", FieldType::String),
+    );
+    fields.insert(
+        "visits".to_string(),
+        FieldDefinition::new("visits", FieldType::Integer).with_required(false),
+    );
+
+    SchemaDescription {
+        name: "users".to_string(),
+        key: KeyConfig::Single {
+            key_field: "id".to_string(),
+        },
+        fields,
+    }
+}
+
+fn session_schema() -> SchemaDescription {
+    let mut fields = HashMap::new();
+    fields.insert(
+        "user_id".to_string(),
+        FieldDefinition::new("user_id", FieldType::String),
+    );
+    fields.insert(
+        "timestamp".to_string(),
+        FieldDefinition::new("timestamp", FieldType::String),
+    );
+    fields.insert(
+        "duration".to_string(),
+        FieldDefinition::new("duration", FieldType::Integer).with_required(false),
+    );
+
+    SchemaDescription {
+        name: "sessions".to_string(),
+        key: KeyConfig::HashRange {
+            hash_field: "user_id".to_string(),
+            range_field: "timestamp".to_string(),
+        },
+        fields,
+    }
+}
+
+#[test]
+fn store_and_load_single_key() {
+    let provider = InMemorySchemaProvider::new().with_schema(user_schema());
+    let (persistence, _temp_dir) = create_persistence(provider);
+
+    let mut record = HashMap::new();
+    record.insert("id".to_string(), FieldValue::String("user-1".to_string()));
+    record.insert("name".to_string(), FieldValue::String("Ada".to_string()));
+
+    let key = persistence
+        .store_data("users", &record)
+        .expect("store should succeed");
+    assert!(matches!(key, NativeRecordKey::Single(_)));
+
+    let loaded = persistence
+        .load_data("users", &key)
+        .expect("load should succeed");
+
+    assert_eq!(
+        loaded.get("id"),
+        Some(&FieldValue::String("user-1".to_string()))
+    );
+    assert_eq!(
+        loaded.get("name"),
+        Some(&FieldValue::String("Ada".to_string()))
+    );
+}
+
+#[test]
+fn missing_required_field_errors() {
+    let provider = InMemorySchemaProvider::new().with_schema(user_schema());
+    let (persistence, _temp_dir) = create_persistence(provider);
+
+    let mut record = HashMap::new();
+    record.insert("id".to_string(), FieldValue::String("user-1".to_string()));
+
+    let err = persistence.store_data("users", &record).unwrap_err();
+    assert!(matches!(
+        err,
+        PersistenceError::MissingRequiredField { field, .. } if field == "name"
+    ));
+}
+
+#[test]
+fn type_mismatch_errors() {
+    let provider = InMemorySchemaProvider::new().with_schema(user_schema());
+    let (persistence, _temp_dir) = create_persistence(provider);
+
+    let mut record = HashMap::new();
+    record.insert("id".to_string(), FieldValue::Integer(7));
+    record.insert("name".to_string(), FieldValue::String("Grace".to_string()));
+
+    let err = persistence.store_data("users", &record).unwrap_err();
+    assert!(matches!(
+        err,
+        PersistenceError::FieldTypeMismatch { field, .. } if field == "id"
+    ));
+}
+
+#[test]
+fn optional_field_defaults_are_applied() {
+    let provider = InMemorySchemaProvider::new().with_schema(user_schema());
+    let (persistence, _temp_dir) = create_persistence(provider);
+
+    let mut record = HashMap::new();
+    record.insert("id".to_string(), FieldValue::String("user-2".to_string()));
+    record.insert("name".to_string(), FieldValue::String("Lin".to_string()));
+
+    let key = persistence
+        .store_data("users", &record)
+        .expect("store should succeed");
+
+    let loaded = persistence
+        .load_data("users", &key)
+        .expect("load should succeed");
+
+    assert_eq!(loaded.get("visits"), Some(&FieldValue::Integer(0)));
+}
+
+#[test]
+fn composite_key_round_trip() {
+    let provider = InMemorySchemaProvider::new().with_schema(session_schema());
+    let (persistence, _temp_dir) = create_persistence(provider);
+
+    let mut record = HashMap::new();
+    record.insert(
+        "user_id".to_string(),
+        FieldValue::String("user-9".to_string()),
+    );
+    record.insert(
+        "timestamp".to_string(),
+        FieldValue::String("2025-09-24T10:00:00Z".to_string()),
+    );
+    record.insert("duration".to_string(), FieldValue::Integer(42));
+
+    let key = persistence
+        .store_data("sessions", &record)
+        .expect("store should succeed");
+
+    match &key {
+        NativeRecordKey::Composite { hash, range } => {
+            assert_eq!(hash, "user-9");
+            assert_eq!(range, "2025-09-24T10:00:00Z");
+        }
+        _ => panic!("expected composite key"),
+    }
+
+    let loaded = persistence
+        .load_data("sessions", &key)
+        .expect("load should succeed");
+
+    assert_eq!(loaded.get("duration"), Some(&FieldValue::Integer(42)));
+}


### PR DESCRIPTION
## Summary
- add a native persistence module that validates FieldValue records against typed schema metadata before storing them via DbOperations
- provide schema provider abstractions, record key serialization utilities, and round-trip conversion helpers for native data
- document the completed NTS-6 tasks, update project logic, and add targeted tests for the new persistence layer

## Testing
- rustfmt src/persistence/mod.rs src/persistence/native_persistence.rs tests/native_persistence_tests.rs
- cargo test --workspace
- cargo clippy --workspace
- (cd src/datafold_node/static-react && npm ci && npm test -- --run)

------
https://chatgpt.com/codex/tasks/task_e_68d1c142dbc8832794e04ad73ad0362e