### PR TITLE
Implement native schema registry infrastructure

### DIFF
--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -20,6 +20,7 @@ This document contains the most up-to-date and condensed information about the p
 | TRANSFORM-003 | DeclarativeSchemaDefinition requires KeyConfig with hash_field and range_field for HashRange schemas and FieldDefinition metadata for optional atom_uuid and field_type. | schema/types/json_schema.rs | 2025-08-26 19:00:00 | None |
 | TRANSFORM-004 | Native transform data flow must use FieldValue/FieldType enums internally with JSON conversion limited to boundary layers. | transform/native, transform/mod.rs | 2025-09-22 19:14:37 | None |
 | TRANSFORM-005 | Native FieldDefinition must validate names, default types, and generate typed defaults for optional fields. | transform/native | 2025-09-22 19:16:45 | None |
+| SCHEMA-NATIVE-001 | Native schema registry validates key configuration and field definitions before registration. | schema/native | 2025-09-22 21:46:07 | None |
 
 ### SCHEMA-001: Schema State Transition Rules
 - **Description**: Enforces valid state transitions for schema lifecycle management

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -39,6 +39,7 @@ pub mod hasher;
 pub mod types;
 pub mod validator;
 pub mod molecule_variants;
+pub mod native;
 pub mod schema_types;
 pub mod schema_field_mapping;
 pub mod schema_interpretation;
@@ -58,6 +59,10 @@ pub use file_operations::SchemaFileOperations;
 pub use hasher::SchemaHasher;
 pub use validator::SchemaValidator;
 pub use molecule_variants::MoleculeVariant;
+pub use native::{
+    KeyConfig as NativeKeyConfig, KeyConfigError, NativeSchema, NativeSchemaError,
+    NativeSchemaRegistry, RegistryError as NativeRegistryError, SchemaValidationError,
+};
 pub use schema_types::{SchemaLoadingReport, SchemaSource, SchemaState};
 pub use schema_field_mapping::map_fields;
 pub use schema_interpretation::{interpret_schema, load_schema_from_json, load_schema_from_file};

--- a/src/schema/native/errors.rs
+++ b/src/schema/native/errors.rs
@@ -1,0 +1,77 @@
+use crate::transform::native::{FieldDefinitionError, FieldType};
+use thiserror::Error;
+
+/// Validation failures emitted while normalizing schema key configuration.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum KeyConfigError {
+    /// A key field was blank or contained only whitespace characters.
+    #[error("{field} cannot be empty")]
+    EmptyField { field: &'static str },
+    /// Hash and range expressions must point at distinct fields.
+    #[error("hash and range fields must be different")]
+    DuplicateHashAndRange,
+}
+
+/// Errors produced while constructing or mutating a native schema definition.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum NativeSchemaError {
+    /// Schema name failed validation.
+    #[error("invalid schema name '{name}': {reason}")]
+    InvalidName { name: String, reason: String },
+    /// An attempt was made to add the same field twice.
+    #[error("duplicate field '{field_name}' in schema '{schema}'")]
+    DuplicateField { schema: String, field_name: String },
+    /// A field definition violated validation invariants.
+    #[error("invalid field definition for schema '{schema}'")]
+    InvalidFieldDefinition {
+        schema: String,
+        #[source]
+        source: FieldDefinitionError,
+    },
+    /// Key configuration referenced a field that does not exist.
+    #[error("schema '{schema}' is missing required key field '{field_name}'")]
+    MissingKeyField { schema: String, field_name: String },
+    /// Key configuration failed structural validation.
+    #[error("invalid key configuration for schema '{schema}'")]
+    InvalidKeyConfig {
+        schema: String,
+        #[source]
+        source: KeyConfigError,
+    },
+}
+
+/// Validation errors returned when verifying a data record against a schema.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SchemaValidationError {
+    /// Required field not present in the record payload.
+    #[error("required field '{field_name}' is missing")]
+    RequiredFieldMissing { field_name: String },
+    /// Field present but with a value that does not match the declared type.
+    #[error("field '{field_name}' has unexpected type (expected {expected:?}, got {actual:?})")]
+    TypeMismatch {
+        field_name: String,
+        expected: Box<FieldType>,
+        actual: Box<FieldType>,
+    },
+    /// Record contained a field that does not belong to the schema.
+    #[error("record contains unknown field '{field_name}'")]
+    UnexpectedField { field_name: String },
+}
+
+/// Errors emitted by the schema registry when schema lifecycle operations fail.
+#[derive(Debug, Error)]
+pub enum RegistryError {
+    /// A schema with the same name already exists.
+    #[error("schema '{name}' already exists in registry")]
+    SchemaExists { name: String },
+    /// Requested schema could not be found.
+    #[error("schema '{name}' not found in registry")]
+    SchemaNotFound { name: String },
+    /// Provided schema failed validation prior to registration.
+    #[error("invalid schema '{name}' provided to registry")]
+    InvalidSchema {
+        name: String,
+        #[source]
+        source: NativeSchemaError,
+    },
+}

--- a/src/schema/native/mod.rs
+++ b/src/schema/native/mod.rs
@@ -1,0 +1,17 @@
+//! Native schema infrastructure built on top of strongly typed transform
+//! primitives.
+//!
+//! The legacy schema system stores definitions as loosely typed JSON
+//! structures that are interpreted at runtime. The native schema module
+//! replaces that indirection with Rust data structures powered by the
+//! native transform types introduced in NTS-1. Schemas constructed through
+//! this module are validated eagerly and stored inside a concurrent
+//! registry that guarantees type safety for downstream consumers.
+
+pub mod errors;
+pub mod registry;
+pub mod schema;
+
+pub use errors::{KeyConfigError, NativeSchemaError, RegistryError, SchemaValidationError};
+pub use registry::NativeSchemaRegistry;
+pub use schema::{KeyConfig, NativeSchema};

--- a/src/schema/native/registry.rs
+++ b/src/schema/native/registry.rs
@@ -1,0 +1,241 @@
+use super::errors::RegistryError;
+use super::schema::NativeSchema;
+use crate::transform::native::FieldDefinition;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Concurrent registry storing native schema definitions.
+#[derive(Debug, Clone, Default)]
+pub struct NativeSchemaRegistry {
+    schemas: Arc<RwLock<HashMap<String, NativeSchema>>>,
+}
+
+impl NativeSchemaRegistry {
+    /// Create an empty registry instance.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a schema. Fails if another schema with the same name exists or
+    /// if the schema fails validation.
+    pub async fn register_schema(&self, schema: NativeSchema) -> Result<(), RegistryError> {
+        schema
+            .validate_integrity()
+            .map_err(|source| RegistryError::InvalidSchema {
+                name: schema.name().to_string(),
+                source,
+            })?;
+
+        let mut guard = self.schemas.write().await;
+        let name = schema.name().to_string();
+        if guard.contains_key(&name) {
+            return Err(RegistryError::SchemaExists { name });
+        }
+
+        guard.insert(name, schema);
+        Ok(())
+    }
+
+    /// Replace an existing schema with a new definition, returning the previous
+    /// version. Validation runs on the new schema before replacement.
+    pub async fn replace_schema(
+        &self,
+        schema: NativeSchema,
+    ) -> Result<Option<NativeSchema>, RegistryError> {
+        schema
+            .validate_integrity()
+            .map_err(|source| RegistryError::InvalidSchema {
+                name: schema.name().to_string(),
+                source,
+            })?;
+
+        let mut guard = self.schemas.write().await;
+        let name = schema.name().to_string();
+        Ok(guard.insert(name, schema))
+    }
+
+    /// Remove a schema by name.
+    pub async fn remove_schema(&self, name: &str) -> Result<NativeSchema, RegistryError> {
+        let mut guard = self.schemas.write().await;
+        guard
+            .remove(name)
+            .ok_or_else(|| RegistryError::SchemaNotFound {
+                name: name.to_string(),
+            })
+    }
+
+    /// Retrieve a schema by name.
+    pub async fn get_schema(&self, name: &str) -> Option<NativeSchema> {
+        let guard = self.schemas.read().await;
+        guard.get(name).cloned()
+    }
+
+    /// Retrieve a single field definition by schema and field name.
+    pub async fn get_field(&self, schema_name: &str, field_name: &str) -> Option<FieldDefinition> {
+        let guard = self.schemas.read().await;
+        guard
+            .get(schema_name)
+            .and_then(|schema| schema.get_field(field_name))
+            .cloned()
+    }
+
+    /// Determine whether a schema exists in the registry.
+    pub async fn contains_schema(&self, name: &str) -> bool {
+        let guard = self.schemas.read().await;
+        guard.contains_key(name)
+    }
+
+    /// Count registered schemas.
+    pub async fn len(&self) -> usize {
+        let guard = self.schemas.read().await;
+        guard.len()
+    }
+
+    /// Returns true if no schemas are registered.
+    pub async fn is_empty(&self) -> bool {
+        let guard = self.schemas.read().await;
+        guard.is_empty()
+    }
+
+    /// Return schema names in deterministic order for predictable testing.
+    pub async fn list_schemas(&self) -> Vec<String> {
+        let guard = self.schemas.read().await;
+        let mut names: Vec<String> = guard.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    /// Remove all schemas from the registry.
+    pub async fn clear(&self) {
+        let mut guard = self.schemas.write().await;
+        guard.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transform::native::{FieldDefinition, FieldType};
+
+    fn build_schema(name: &str) -> NativeSchema {
+        let mut schema = NativeSchema::new(
+            name,
+            KeyConfig::HashRange {
+                hash_field: "hash".into(),
+                range_field: "range".into(),
+            },
+        )
+        .expect("schema");
+        schema
+            .add_fields([
+                FieldDefinition::new("hash", FieldType::String),
+                FieldDefinition::new("range", FieldType::Integer),
+                FieldDefinition::new("value", FieldType::String).with_required(false),
+            ])
+            .expect("fields");
+        schema
+    }
+
+    use super::super::schema::KeyConfig;
+
+    #[tokio::test]
+    async fn register_and_fetch_schema() {
+        let registry = NativeSchemaRegistry::new();
+        let schema = build_schema("Blog");
+
+        registry
+            .register_schema(schema.clone())
+            .await
+            .expect("register");
+        let fetched = registry.get_schema("Blog").await.expect("fetched");
+
+        assert_eq!(fetched, schema);
+    }
+
+    #[tokio::test]
+    async fn duplicate_registration_is_rejected() {
+        let registry = NativeSchemaRegistry::new();
+        let schema = build_schema("Blog");
+
+        registry
+            .register_schema(schema.clone())
+            .await
+            .expect("register");
+        let err = registry
+            .register_schema(schema)
+            .await
+            .expect_err("duplicate");
+        assert!(matches!(err, RegistryError::SchemaExists { name } if name == "Blog"));
+    }
+
+    #[tokio::test]
+    async fn list_schemas_returns_sorted_names() {
+        let registry = NativeSchemaRegistry::new();
+        registry
+            .register_schema(build_schema("beta"))
+            .await
+            .expect("beta");
+        registry
+            .register_schema(build_schema("alpha"))
+            .await
+            .expect("alpha");
+
+        let names = registry.list_schemas().await;
+        assert_eq!(names, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn get_field_returns_cloned_definition() {
+        let registry = NativeSchemaRegistry::new();
+        registry
+            .register_schema(build_schema("Blog"))
+            .await
+            .expect("register");
+
+        let field = registry.get_field("Blog", "value").await.expect("field");
+        assert_eq!(field.name, "value");
+    }
+
+    #[tokio::test]
+    async fn is_empty_reflects_registry_state() {
+        let registry = NativeSchemaRegistry::new();
+        assert!(registry.is_empty().await);
+
+        registry
+            .register_schema(build_schema("Blog"))
+            .await
+            .expect("register");
+
+        assert!(!registry.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn remove_schema_returns_previous_value() {
+        let registry = NativeSchemaRegistry::new();
+        registry
+            .register_schema(build_schema("Blog"))
+            .await
+            .expect("register");
+
+        let removed = registry.remove_schema("Blog").await.expect("removed");
+        assert_eq!(removed.name(), "Blog");
+        assert!(registry.get_schema("Blog").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn invalid_schema_is_rejected() {
+        let registry = NativeSchemaRegistry::new();
+        let schema = NativeSchema::new(
+            "Broken",
+            KeyConfig::Single {
+                key_field: "missing".into(),
+            },
+        )
+        .expect("schema");
+
+        let err = registry.register_schema(schema).await.expect_err("invalid");
+        assert!(matches!(err, RegistryError::InvalidSchema { .. }));
+    }
+}

--- a/src/schema/native/schema.rs
+++ b/src/schema/native/schema.rs
@@ -1,0 +1,389 @@
+use super::errors::{KeyConfigError, NativeSchemaError, SchemaValidationError};
+use crate::transform::native::{FieldDefinition, FieldType, FieldValue};
+use crate::validation_utils::ValidationUtils;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Declarative key configuration describing how records are uniquely addressed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum KeyConfig {
+    /// Single-key schema addressed by a single field.
+    Single { key_field: String },
+    /// Range schema that orders data by a range field.
+    Range { range_field: String },
+    /// Hash-range schema partitioned by hash and range expressions.
+    HashRange {
+        hash_field: String,
+        range_field: String,
+    },
+}
+
+impl KeyConfig {
+    /// Return a copy of the key configuration with trimmed field names.
+    #[must_use]
+    pub fn normalized(self) -> Self {
+        match self {
+            Self::Single { key_field } => Self::Single {
+                key_field: key_field.trim().to_owned(),
+            },
+            Self::Range { range_field } => Self::Range {
+                range_field: range_field.trim().to_owned(),
+            },
+            Self::HashRange {
+                hash_field,
+                range_field,
+            } => Self::HashRange {
+                hash_field: hash_field.trim().to_owned(),
+                range_field: range_field.trim().to_owned(),
+            },
+        }
+    }
+
+    /// Validate structural requirements for the key configuration.
+    pub fn validate(&self) -> Result<(), KeyConfigError> {
+        match self {
+            Self::Single { key_field } => Self::ensure_present(key_field, "key_field"),
+            Self::Range { range_field } => Self::ensure_present(range_field, "range_field"),
+            Self::HashRange {
+                hash_field,
+                range_field,
+            } => {
+                Self::ensure_present(hash_field, "hash_field")?;
+                Self::ensure_present(range_field, "range_field")?;
+                if hash_field == range_field {
+                    return Err(KeyConfigError::DuplicateHashAndRange);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn ensure_present(value: &str, field: &'static str) -> Result<(), KeyConfigError> {
+        if value.trim().is_empty() {
+            Err(KeyConfigError::EmptyField { field })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// List all field names referenced by the key configuration.
+    #[must_use]
+    pub fn key_fields(&self) -> Vec<&str> {
+        match self {
+            Self::Single { key_field } => vec![key_field.as_str()],
+            Self::Range { range_field } => vec![range_field.as_str()],
+            Self::HashRange {
+                hash_field,
+                range_field,
+            } => vec![hash_field.as_str(), range_field.as_str()],
+        }
+    }
+}
+
+/// Strongly typed schema definition backed by native transform primitives.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NativeSchema {
+    name: String,
+    key_config: KeyConfig,
+    fields: HashMap<String, FieldDefinition>,
+}
+
+impl NativeSchema {
+    /// Create a new schema definition.
+    pub fn new(name: impl Into<String>, key_config: KeyConfig) -> Result<Self, NativeSchemaError> {
+        let name = name.into();
+        ValidationUtils::require_valid_schema_name(&name).map_err(|err| {
+            NativeSchemaError::InvalidName {
+                name: name.clone(),
+                reason: err.to_string(),
+            }
+        })?;
+
+        let normalized_config = key_config.normalized();
+        normalized_config
+            .validate()
+            .map_err(|source| NativeSchemaError::InvalidKeyConfig {
+                schema: name.clone(),
+                source,
+            })?;
+
+        Ok(Self {
+            name,
+            key_config: normalized_config,
+            fields: HashMap::new(),
+        })
+    }
+
+    /// Schema identifier.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Access the key configuration.
+    #[must_use]
+    pub fn key_config(&self) -> &KeyConfig {
+        &self.key_config
+    }
+
+    /// Borrow the defined fields.
+    #[must_use]
+    pub fn fields(&self) -> &HashMap<String, FieldDefinition> {
+        &self.fields
+    }
+
+    /// Returns the number of fields defined in the schema.
+    #[must_use]
+    pub fn field_count(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Determine whether the schema defines a particular field.
+    #[must_use]
+    pub fn has_field(&self, field_name: &str) -> bool {
+        self.fields.contains_key(field_name)
+    }
+
+    /// Retrieve a field definition by name.
+    pub fn get_field(&self, field_name: &str) -> Option<&FieldDefinition> {
+        self.fields.get(field_name)
+    }
+
+    /// Add a new field definition to the schema.
+    pub fn add_field(&mut self, field: FieldDefinition) -> Result<(), NativeSchemaError> {
+        field
+            .validate()
+            .map_err(|source| NativeSchemaError::InvalidFieldDefinition {
+                schema: self.name.clone(),
+                source,
+            })?;
+        let field_name = field.name.clone();
+
+        if self.fields.contains_key(&field_name) {
+            return Err(NativeSchemaError::DuplicateField {
+                schema: self.name.clone(),
+                field_name,
+            });
+        }
+
+        self.fields.insert(field_name, field);
+        Ok(())
+    }
+
+    /// Add multiple field definitions atomically.
+    pub fn add_fields<I>(&mut self, fields: I) -> Result<(), NativeSchemaError>
+    where
+        I: IntoIterator<Item = FieldDefinition>,
+    {
+        for field in fields {
+            self.add_field(field)?;
+        }
+        Ok(())
+    }
+
+    /// Ensure key fields exist and field definitions remain valid.
+    pub fn validate_integrity(&self) -> Result<(), NativeSchemaError> {
+        for key_field in self.key_config.key_fields() {
+            if !self.fields.contains_key(key_field) {
+                return Err(NativeSchemaError::MissingKeyField {
+                    schema: self.name.clone(),
+                    field_name: key_field.to_string(),
+                });
+            }
+        }
+
+        for field in self.fields.values() {
+            field
+                .validate()
+                .map_err(|source| NativeSchemaError::InvalidFieldDefinition {
+                    schema: self.name.clone(),
+                    source,
+                })?;
+        }
+
+        Ok(())
+    }
+
+    /// Populate missing optional fields with their effective defaults.
+    pub fn apply_defaults(&self, record: &mut HashMap<String, FieldValue>) {
+        for (field_name, field_def) in &self.fields {
+            if record.contains_key(field_name) {
+                continue;
+            }
+
+            if let Some(default_value) = field_def.effective_default() {
+                record.insert(field_name.clone(), default_value);
+            }
+        }
+    }
+
+    /// Validate a record's fields against the schema definition.
+    pub fn validate_record(
+        &self,
+        record: &HashMap<String, FieldValue>,
+    ) -> Result<(), SchemaValidationError> {
+        for (field_name, field_def) in &self.fields {
+            match record.get(field_name) {
+                Some(value) => {
+                    if !field_def.field_type.matches(value) {
+                        return Err(SchemaValidationError::TypeMismatch {
+                            field_name: field_name.clone(),
+                            expected: Box::new(field_def.field_type.clone()),
+                            actual: Box::new(value.field_type()),
+                        });
+                    }
+                }
+                None if field_def.required => {
+                    return Err(SchemaValidationError::RequiredFieldMissing {
+                        field_name: field_name.clone(),
+                    });
+                }
+                None => {}
+            }
+        }
+
+        for field_name in record.keys() {
+            if !self.fields.contains_key(field_name) {
+                return Err(SchemaValidationError::UnexpectedField {
+                    field_name: field_name.clone(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transform::native::FieldValue;
+    use std::collections::HashMap;
+
+    fn base_schema() -> NativeSchema {
+        let mut schema = NativeSchema::new(
+            "BlogPost",
+            KeyConfig::Single {
+                key_field: "id".into(),
+            },
+        )
+        .expect("schema");
+        schema
+            .add_field(FieldDefinition::new("id", FieldType::String))
+            .expect("id");
+        schema
+            .add_field(FieldDefinition::new("title", FieldType::String))
+            .expect("title");
+        schema
+            .add_field(FieldDefinition::new("views", FieldType::Integer).with_required(false))
+            .expect("views");
+        schema
+    }
+
+    #[test]
+    fn key_config_normalization_trims_whitespace() {
+        let schema = NativeSchema::new(
+            "Example",
+            KeyConfig::Single {
+                key_field: "   identifier   ".into(),
+            },
+        )
+        .expect("schema creation");
+
+        assert_eq!(schema.key_config.key_fields(), vec!["identifier"]);
+    }
+
+    #[test]
+    fn validation_rejects_missing_key_field() {
+        let schema = NativeSchema::new(
+            "Example",
+            KeyConfig::Single {
+                key_field: "id".into(),
+            },
+        )
+        .expect("schema creation");
+
+        let err = schema.validate_integrity().expect_err("missing key field");
+        assert!(
+            matches!(err, NativeSchemaError::MissingKeyField { field_name, .. } if field_name == "id")
+        );
+    }
+
+    #[test]
+    fn apply_defaults_fills_optional_fields() {
+        let mut schema = base_schema();
+        schema
+            .add_field(
+                FieldDefinition::new("status", FieldType::String)
+                    .with_required(false)
+                    .with_default(FieldValue::String("draft".into())),
+            )
+            .expect("status");
+
+        let mut record = HashMap::new();
+        record.insert("id".into(), FieldValue::String("abc".into()));
+        record.insert("title".into(), FieldValue::String("Post".into()));
+        schema.apply_defaults(&mut record);
+
+        assert_eq!(
+            record.get("status"),
+            Some(&FieldValue::String("draft".into()))
+        );
+        assert_eq!(record.get("views"), Some(&FieldValue::Integer(0)));
+    }
+
+    #[test]
+    fn validate_record_detects_missing_required_field() {
+        let schema = base_schema();
+        let mut record = HashMap::new();
+        record.insert("id".into(), FieldValue::String("abc".into()));
+
+        let err = schema
+            .validate_record(&record)
+            .expect_err("missing required field");
+        assert!(matches!(
+            err,
+            SchemaValidationError::RequiredFieldMissing { field_name }
+            if field_name == "title"
+        ));
+    }
+
+    #[test]
+    fn validate_record_detects_type_mismatch() {
+        let mut schema = base_schema();
+        schema
+            .add_field(FieldDefinition::new("published", FieldType::Boolean))
+            .expect("published");
+
+        let mut record = HashMap::new();
+        record.insert("id".into(), FieldValue::String("abc".into()));
+        record.insert("title".into(), FieldValue::String("Post".into()));
+        record.insert("published".into(), FieldValue::Integer(1));
+
+        let err = schema.validate_record(&record).expect_err("type mismatch");
+        assert!(matches!(
+            err,
+            SchemaValidationError::TypeMismatch { field_name, .. }
+            if field_name == "published"
+        ));
+    }
+
+    #[test]
+    fn validate_record_detects_unknown_fields() {
+        let schema = base_schema();
+        let mut record = HashMap::new();
+        record.insert("id".into(), FieldValue::String("abc".into()));
+        record.insert("title".into(), FieldValue::String("Post".into()));
+        record.insert("extra".into(), FieldValue::String("value".into()));
+
+        let err = schema
+            .validate_record(&record)
+            .expect_err("unexpected field");
+        assert!(matches!(
+            err,
+            SchemaValidationError::UnexpectedField { field_name }
+            if field_name == "extra"
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- add a native schema module with typed schema definitions, validation helpers, and an async registry
- expose the native schema API through the existing schema module and document the new logic entry

## Testing
- cargo test --workspace
- cargo clippy
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d1c10465b88327aa719e1b28fe5660