### PR TITLE
Implement native transform executor

### DIFF
--- a/docs/delivery/NTS-3/NTS-3-1.md
+++ b/docs/delivery/NTS-3/NTS-3-1.md
@@ -1,0 +1,54 @@
+# NTS-3-1 Implement NativeTransformExecutor
+
+[Back to task list](./tasks.md)
+
+## Description
+Implement the first version of the native transform execution engine that consumes strongly typed transform specifications and produces native `FieldValue` outputs. The executor must evaluate map-style transforms using native field definitions, enforce type guarantees, and surface precise errors so future tasks can extend the engine with additional transform kinds, expression handling, and function execution.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-22 21:40:30 | Status Change | N/A | Proposed | Task file created with initial analysis | AI_Agent |
+| 2025-09-22 21:41:00 | Status Change | Proposed | InProgress | Began implementing native executor core and supporting specs | AI_Agent |
+| 2025-09-22 22:30:00 | Status Change | InProgress | Review | Completed native executor implementation, documentation, and tests | AI_Agent |
+
+## Requirements
+- Provide a `NativeTransformExecutor` that accepts native transform specifications and input records of `FieldValue` values.
+- Support map transforms with direct field mapping and constant value emission while validating outputs against `FieldDefinition` metadata.
+- Return well-typed `FieldValue` objects without falling back to JSON conversions except at module boundaries.
+- Emit descriptive errors for missing inputs, unsupported mappings, and type mismatches instead of silently coercing data.
+- Introduce reusable transform specification structures to describe outputs, ensuring future tasks can extend them with new mapping variants.
+- Add targeted unit tests that cover successful execution, default handling, and error scenarios.
+- Document the new execution rule in `docs/project_logic.md` to keep architectural guidance in sync.
+
+## Implementation Plan
+1. Add a `transform_spec` module under `src/transform/native` that defines map transform structures (`MapTransform`, `MapField`, `FieldComputation`) and reusable type aliases for native records.
+2. Create `src/transform/engine` with an `executor` module that exposes `NativeTransformExecutor` and `NativeTransformError` for map execution, validating outputs against `FieldDefinition` metadata and defaults.
+3. Integrate the new engine by wiring the module through `src/transform/mod.rs` and re-exporting the executor for external callers.
+4. Write unit tests covering direct input mapping, constant emission, optional/default handling, and error cases like missing inputs or type mismatches.
+5. Update `docs/project_logic.md` with a `TRANSFORM-006` entry describing the native executor workflow and guarantees.
+6. Run `cargo fmt`, `cargo test --workspace`, `cargo clippy --workspace --all-targets --all-features`, and the repository-mandated frontend test suite to ensure all tooling remains green.
+
+## Verification
+- Map transforms correctly propagate input values and constants while respecting field definitions and defaults.
+- Type mismatches and missing required inputs surface as `NativeTransformError` variants with helpful context.
+- Unit tests assert successful execution and failure paths.
+- Repository formatting, linting, Rust tests, and frontend tests all pass after the implementation.
+
+## Files Modified
+- `docs/delivery/NTS-3/tasks.md`
+- `docs/delivery/NTS-3/NTS-3-1.md`
+- `docs/project_logic.md`
+- `src/transform/mod.rs`
+- `src/transform/native/mod.rs`
+- `src/transform/native/transform_spec.rs`
+- `src/transform/engine/mod.rs`
+- `src/transform/engine/executor.rs`
+- `src/transform/hash_range_executor.rs`
+- `src/fold_db_core/mutation_completion_handler.rs`
+
+## Test Plan
+- `cargo fmt`
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets --all-features`
+- `(cd src/datafold_node/static-react && npm install && npm test)`

--- a/docs/delivery/NTS-3/tasks.md
+++ b/docs/delivery/NTS-3/tasks.md
@@ -8,7 +8,7 @@ This document lists all tasks associated with PBI NTS-3.
 
 | Task ID | Name | Status | Description |
 | :------ | :--------------------------------------- | :------- | :--------------------------------- |
-| NTS-3-1 | [Implement NativeTransformExecutor](./NTS-3-1.md) | Proposed | Create core execution engine with native types |
+| NTS-3-1 | [Implement NativeTransformExecutor](./NTS-3-1.md) | Review | Create core execution engine with native types |
 | NTS-3-2 | [Implement Function Registry](./NTS-3-2.md) | Proposed | Add extensible function system with built-in functions |
 | NTS-3-3 | [Add map/filter/reduce transform support](./NTS-3-3.md) | Proposed | Implement all transform types with native operations |
 | NTS-3-4 | [Implement expression evaluation](./NTS-3-4.md) | Proposed | Add native type expression parsing and evaluation |

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -20,6 +20,7 @@ This document contains the most up-to-date and condensed information about the p
 | TRANSFORM-003 | DeclarativeSchemaDefinition requires KeyConfig with hash_field and range_field for HashRange schemas and FieldDefinition metadata for optional atom_uuid and field_type. | schema/types/json_schema.rs | 2025-08-26 19:00:00 | None |
 | TRANSFORM-004 | Native transform data flow must use FieldValue/FieldType enums internally with JSON conversion limited to boundary layers. | transform/native, transform/mod.rs | 2025-09-22 19:14:37 | None |
 | TRANSFORM-005 | Native FieldDefinition must validate names, default types, and generate typed defaults for optional fields. | transform/native | 2025-09-22 19:16:45 | None |
+| TRANSFORM-006 | NativeTransformExecutor must enforce typed map execution with strict validation and error reporting. | transform/engine, transform/native | 2025-09-22 22:30:00 | None |
 
 ### SCHEMA-001: Schema State Transition Rules
 - **Description**: Enforces valid state transitions for schema lifecycle management
@@ -285,3 +286,20 @@ This document contains the most up-to-date and condensed information about the p
 - **Implementation Notes**:
   - Validation surfaces `FieldDefinitionError` variants for name issues or default mismatches.
   - `FieldType::default_value()` produces recursive defaults for nested object schemas used by optional fields.
+
+### TRANSFORM-006: Native Transform Execution Rules
+- **Description**: Defines how `NativeTransformExecutor` evaluates map-style transforms using strongly typed field metadata and native values.
+- **Rationale**: Guarantees map execution is deterministic, type-safe, and provides actionable errors so additional transform kinds can build upon a consistent execution core.
+- **Execution Guarantees**:
+  - Each output field must declare a `FieldDefinition` that is validated before computation.
+  - Computations may copy input fields or emit constants; unsupported expression/function variants must raise explicit errors until implemented.
+  - Missing required inputs fall back to `FieldDefinition::effective_default()` only when the field is optional or declares an explicit default.
+- **Error Handling Rules**:
+  - Invalid field definitions surface `NativeTransformError::InvalidFieldDefinition` with the underlying validation error.
+  - Missing inputs for required fields raise `NativeTransformError::MissingInput` identifying both input and output fields.
+  - Type mismatches produce `NativeTransformError::TypeMismatch` and include expected/actual `FieldType` metadata.
+  - Unsupported computation variants respond with `NativeTransformError::UnsupportedComputation` until later tasks implement them.
+- **Implementation Notes**:
+  - Execution operates purely on `FieldValue`/`FieldType` without converting to JSON mid-pipeline.
+  - `NativeTransformExecutor::execute` dispatches by transform kind, enabling future expansion beyond map transforms.
+  - Unit tests must cover successful mappings, constant emission, defaults, and each error variant to guard regression.

--- a/src/fold_db_core/mutation_completion_handler.rs
+++ b/src/fold_db_core/mutation_completion_handler.rs
@@ -56,18 +56,18 @@
 //!
 //! ```rust
 //! use datafold::fold_db_core::infrastructure::message_bus::query_events::MutationExecuted;
-//! 
+//!
 //! # async fn event_example() {
 //! // The handler can listen for MutationExecuted events
 //! // and automatically signal completion for tracked mutations
 //! # }
 //! ```
 
+use log::{debug, error, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{oneshot, RwLock};
 use tokio::time::{timeout, Duration};
-use log::{debug, warn, error};
 
 use crate::fold_db_core::infrastructure::message_bus::MessageBus;
 
@@ -83,15 +83,15 @@ pub enum MutationCompletionError {
     /// The mutation ID was not found in the tracking system
     #[error("Mutation ID '{0}' not found in tracking system")]
     MutationNotFound(String),
-    
+
     /// Failed to send completion signal
     #[error("Failed to send completion signal for mutation '{0}': {1}")]
     SignalFailed(String, String),
-    
+
     /// Timeout waiting for mutation completion
     #[error("Timeout waiting for completion of mutation '{0}' after {1:?}")]
     Timeout(String, Duration),
-    
+
     /// Lock acquisition failed
     #[error("Failed to acquire lock for mutation tracking: {0}")]
     LockFailed(String),
@@ -121,7 +121,7 @@ pub struct MutationCompletionHandler {
     /// Each mutation ID can have multiple receivers waiting for completion
     /// The bool indicates whether the mutation has completed
     pending_mutations: Arc<RwLock<HashMap<String, PendingMutationData>>>,
-    
+
     /// Reference to the message bus for event handling integration
     message_bus: Arc<MessageBus>,
 }
@@ -145,7 +145,7 @@ impl MutationCompletionHandler {
     /// ```
     pub fn new(message_bus: Arc<MessageBus>) -> Self {
         debug!("Creating new MutationCompletionHandler");
-        
+
         Self {
             pending_mutations: Arc::new(RwLock::new(HashMap::new())),
             message_bus,
@@ -184,34 +184,51 @@ impl MutationCompletionHandler {
     /// # }
     /// ```
     pub async fn register_mutation(&self, mutation_id: String) -> oneshot::Receiver<()> {
-        debug!("Registering mutation for completion tracking: {}", mutation_id);
-        
+        debug!(
+            "Registering mutation for completion tracking: {}",
+            mutation_id
+        );
+
         let (sender, receiver) = oneshot::channel();
-        
+
         // Acquire write lock and add the sender to the list
         let mut pending = self.pending_mutations.write().await;
-        
+
         // Add the sender to the existing list or create a new list
-        let entry = pending.entry(mutation_id.clone()).or_insert_with(|| (Vec::new(), false));
+        let entry = pending
+            .entry(mutation_id.clone())
+            .or_insert_with(|| (Vec::new(), false));
         entry.0.push(sender);
-        
+
         let count = entry.0.len();
         let is_completed = entry.1;
-        debug!("Mutation '{}' registered. Total receivers: {}, Completed: {}", mutation_id, count, is_completed);
-        
+        debug!(
+            "Mutation '{}' registered. Total receivers: {}, Completed: {}",
+            mutation_id, count, is_completed
+        );
+
         // If the mutation has already completed, send the signal immediately
         if is_completed {
-            debug!("Mutation '{}' already completed, sending immediate signal", mutation_id);
+            debug!(
+                "Mutation '{}' already completed, sending immediate signal",
+                mutation_id
+            );
             // Send signal immediately to the new receiver
             if let Some(sender) = entry.0.pop() {
                 if sender.send(()).is_err() {
-                    debug!("Failed to send immediate signal for completed mutation {}", mutation_id);
+                    debug!(
+                        "Failed to send immediate signal for completed mutation {}",
+                        mutation_id
+                    );
                 } else {
-                    debug!("Successfully sent immediate signal for completed mutation {}", mutation_id);
+                    debug!(
+                        "Successfully sent immediate signal for completed mutation {}",
+                        mutation_id
+                    );
                 }
             }
         }
-        
+
         receiver
     }
 
@@ -234,35 +251,46 @@ impl MutationCompletionHandler {
     /// This method should only be used when an async context is not available.
     /// Prefer the async version when possible.
     pub fn register_mutation_sync(&self, mutation_id: String) -> oneshot::Receiver<()> {
-        debug!("Registering mutation for completion tracking (sync): {}", mutation_id);
-        
+        debug!(
+            "Registering mutation for completion tracking (sync): {}",
+            mutation_id
+        );
+
         let (sender, receiver) = oneshot::channel();
-        
+
         // Use try_write to avoid blocking indefinitely
         let pending_mutations = Arc::clone(&self.pending_mutations);
         let mutation_id_clone = mutation_id.clone();
-        
+
         // Spawn a task to handle the registration
         tokio::spawn(async move {
             let mut pending = pending_mutations.write().await;
-            
+
             // Add the sender to the existing list or create a new list
-            let entry = pending.entry(mutation_id_clone.clone()).or_insert_with(|| (Vec::new(), false));
+            let entry = pending
+                .entry(mutation_id_clone.clone())
+                .or_insert_with(|| (Vec::new(), false));
             entry.0.push(sender);
-            
+
             let count = entry.0.len();
             let is_completed = entry.1;
-            debug!("Mutation '{}' registered (sync). Total receivers: {}, Completed: {}", mutation_id_clone, count, is_completed);
-            
+            debug!(
+                "Mutation '{}' registered (sync). Total receivers: {}, Completed: {}",
+                mutation_id_clone, count, is_completed
+            );
+
             // If the mutation has already completed, send the signal immediately
             if is_completed {
-                debug!("Mutation '{}' already completed, sending immediate signal (sync)", mutation_id_clone);
+                debug!(
+                    "Mutation '{}' already completed, sending immediate signal (sync)",
+                    mutation_id_clone
+                );
                 if let Some(sender) = entry.0.pop() {
                     let _ = sender.send(());
                 }
             }
         });
-        
+
         receiver
     }
 
@@ -292,17 +320,20 @@ impl MutationCompletionHandler {
     /// ```
     pub async fn signal_completion(&self, mutation_id: &str) {
         debug!("Signaling completion for mutation: {}", mutation_id);
-        
+
         // Acquire write lock and get all senders for this mutation
         let mut pending = self.pending_mutations.write().await;
-        
+
         if let Some((senders, completed)) = pending.get_mut(mutation_id) {
             let sender_count = senders.len();
-            debug!("Signaling completion to {} receivers for mutation '{}'", sender_count, mutation_id);
-            
+            debug!(
+                "Signaling completion to {} receivers for mutation '{}'",
+                sender_count, mutation_id
+            );
+
             // Mark as completed
             *completed = true;
-            
+
             // Send completion signal to all registered receivers
             let mut success_count = 0;
             while let Some(sender) = senders.pop() {
@@ -312,14 +343,17 @@ impl MutationCompletionHandler {
                     success_count += 1;
                 }
             }
-            
+
             // Don't remove the entry - keep it marked as completed for future wait_for_mutation calls
             // The entry will be cleaned up later by cleanup_mutation
-            
-            debug!("Successfully signaled completion to {}/{} receivers for mutation '{}'. Remaining pending: {}", 
+
+            debug!("Successfully signaled completion to {}/{} receivers for mutation '{}'. Remaining pending: {}",
                    success_count, sender_count, mutation_id, pending.len());
         } else {
-            warn!("Attempted to signal completion for untracked mutation: {}", mutation_id);
+            warn!(
+                "Attempted to signal completion for untracked mutation: {}",
+                mutation_id
+            );
         }
     }
 
@@ -344,23 +378,23 @@ impl MutationCompletionHandler {
     /// Prefer the async version when possible.
     pub fn signal_completion_sync(&self, mutation_id: &str) -> MutationCompletionResult<()> {
         debug!("Signaling completion for mutation (sync): {}", mutation_id);
-        
+
         // Clone the mutation_id for the async block
         let mutation_id_owned = mutation_id.to_string();
         let pending_mutations = Arc::clone(&self.pending_mutations);
-        
+
         // Use tokio's blocking mechanism to handle the async operation
         let rt = tokio::runtime::Handle::current();
         rt.block_on(async move {
             let mut pending = pending_mutations.write().await;
-            
+
             if let Some((senders, completed)) = pending.get_mut(&mutation_id_owned) {
                 let sender_count = senders.len();
                 debug!("Signaling completion to {} receivers for mutation '{}' (sync)", sender_count, mutation_id_owned);
-                
+
                 // Mark as completed
                 *completed = true;
-                
+
                 // Send completion signal to all registered receivers
                 let mut success_count = 0;
                 while let Some(sender) = senders.pop() {
@@ -370,9 +404,14 @@ impl MutationCompletionHandler {
                         success_count += 1;
                     }
                 }
-                
-                debug!("Successfully signaled completion to {}/{} receivers for mutation '{}'. Remaining pending: {}", 
-                       success_count, sender_count, mutation_id_owned, pending.len());
+
+                debug!(
+                    "Successfully signaled completion to {}/{} receivers for mutation '{}'. Remaining pending: {}",
+                    success_count,
+                    sender_count,
+                    mutation_id_owned,
+                    pending.len()
+                );
                 Ok(())
             } else {
                 warn!("Attempted to signal completion for untracked mutation: {}", mutation_id_owned);
@@ -407,13 +446,20 @@ impl MutationCompletionHandler {
     /// ```
     pub async fn cleanup_mutation(&self, mutation_id: &str) {
         debug!("Cleaning up mutation tracking: {}", mutation_id);
-        
+
         let mut pending = self.pending_mutations.write().await;
-        
+
         if pending.remove(mutation_id).is_some() {
-            debug!("Cleaned up mutation '{}'. Remaining pending: {}", mutation_id, pending.len());
+            debug!(
+                "Cleaned up mutation '{}'. Remaining pending: {}",
+                mutation_id,
+                pending.len()
+            );
         } else {
-            debug!("Mutation '{}' was not in tracking system (may have already been cleaned up)", mutation_id);
+            debug!(
+                "Mutation '{}' was not in tracking system (may have already been cleaned up)",
+                mutation_id
+            );
         }
     }
 
@@ -442,7 +488,10 @@ impl MutationCompletionHandler {
     /// ```
     pub async fn pending_count(&self) -> usize {
         let pending = self.pending_mutations.read().await;
-        pending.values().filter(|(_, is_completed)| !*is_completed).count()
+        pending
+            .values()
+            .filter(|(_, is_completed)| !*is_completed)
+            .count()
     }
 
     /// Waits for a mutation to complete with the default timeout.
@@ -476,7 +525,8 @@ impl MutationCompletionHandler {
     /// # }
     /// ```
     pub async fn wait_for_completion(&self, mutation_id: &str) -> MutationCompletionResult<()> {
-        self.wait_for_completion_with_timeout(mutation_id, DEFAULT_COMPLETION_TIMEOUT).await
+        self.wait_for_completion_with_timeout(mutation_id, DEFAULT_COMPLETION_TIMEOUT)
+            .await
     }
 
     /// Waits for a mutation to complete with a custom timeout.
@@ -515,23 +565,32 @@ impl MutationCompletionHandler {
         mutation_id: &str,
         timeout_duration: Duration,
     ) -> MutationCompletionResult<()> {
-        debug!("Waiting for completion of mutation '{}' with timeout {:?}", mutation_id, timeout_duration);
-        
+        debug!(
+            "Waiting for completion of mutation '{}' with timeout {:?}",
+            mutation_id, timeout_duration
+        );
+
         // Check if mutation is already being tracked
         let receiver = {
             let pending = self.pending_mutations.read().await;
             if pending.contains_key(mutation_id) {
-                debug!("Mutation '{}' is already being tracked, creating new receiver for wait", mutation_id);
+                debug!(
+                    "Mutation '{}' is already being tracked, creating new receiver for wait",
+                    mutation_id
+                );
                 drop(pending);
                 // Create a new receiver for this specific wait operation
                 self.register_mutation(mutation_id.to_string()).await
             } else {
-                debug!("Mutation '{}' not found in tracking, creating new registration", mutation_id);
+                debug!(
+                    "Mutation '{}' not found in tracking, creating new registration",
+                    mutation_id
+                );
                 drop(pending);
                 self.register_mutation(mutation_id.to_string()).await
             }
         };
-        
+
         // Wait for completion with timeout
         let result = match timeout(timeout_duration, receiver).await {
             Ok(Ok(())) => {
@@ -539,31 +598,46 @@ impl MutationCompletionHandler {
                 Ok(())
             }
             Ok(Err(_)) => {
-                error!("Completion channel closed unexpectedly for mutation '{}'", mutation_id);
+                error!(
+                    "Completion channel closed unexpectedly for mutation '{}'",
+                    mutation_id
+                );
                 Err(MutationCompletionError::SignalFailed(
                     mutation_id.to_string(),
                     "Completion channel closed".to_string(),
                 ))
             }
             Err(_) => {
-                warn!("Timeout waiting for completion of mutation '{}' after {:?}", mutation_id, timeout_duration);
-                Err(MutationCompletionError::Timeout(mutation_id.to_string(), timeout_duration))
+                warn!(
+                    "Timeout waiting for completion of mutation '{}' after {:?}",
+                    mutation_id, timeout_duration
+                );
+                Err(MutationCompletionError::Timeout(
+                    mutation_id.to_string(),
+                    timeout_duration,
+                ))
             }
         };
-        
+
         // Only clean up if the mutation was not completed successfully
         // Completed mutations should be kept around for future wait_for_mutation calls
         match &result {
             Ok(()) => {
-                debug!("Mutation '{}' completed successfully, keeping entry for future wait calls", mutation_id);
+                debug!(
+                    "Mutation '{}' completed successfully, keeping entry for future wait calls",
+                    mutation_id
+                );
                 // Don't clean up - keep the completed mutation for future wait calls
             }
             Err(_) => {
-                debug!("Mutation '{}' failed or timed out, cleaning up entry", mutation_id);
+                debug!(
+                    "Mutation '{}' failed or timed out, cleaning up entry",
+                    mutation_id
+                );
                 self.cleanup_mutation(mutation_id).await;
             }
         }
-        
+
         result
     }
 
@@ -605,7 +679,7 @@ impl MutationCompletionHandler {
     /// ```
     pub async fn get_diagnostics(&self) -> MutationCompletionDiagnostics {
         let pending_count = self.pending_count().await;
-        
+
         MutationCompletionDiagnostics {
             pending_mutations_count: pending_count,
             // Additional diagnostic fields can be added here as needed
@@ -622,7 +696,11 @@ pub struct MutationCompletionDiagnostics {
 
 impl std::fmt::Display for MutationCompletionDiagnostics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "MutationCompletionHandler(pending: {})", self.pending_mutations_count)
+        write!(
+            f,
+            "MutationCompletionHandler(pending: {})",
+            self.pending_mutations_count
+        )
     }
 }
 
@@ -647,7 +725,7 @@ mod tests {
     async fn test_register_mutation() {
         let handler = create_test_handler().await;
         let mutation_id = "test-mutation-1".to_string();
-        
+
         let _receiver = handler.register_mutation(mutation_id).await;
         assert_eq!(handler.pending_count().await, 1);
     }
@@ -656,13 +734,13 @@ mod tests {
     async fn test_signal_completion() {
         let handler = create_test_handler().await;
         let mutation_id = "test-mutation-2".to_string();
-        
+
         let receiver = handler.register_mutation(mutation_id.clone()).await;
         assert_eq!(handler.pending_count().await, 1);
-        
+
         // Signal completion
         handler.signal_completion(&mutation_id).await;
-        
+
         // Receiver should get the signal
         assert!(receiver.await.is_ok());
         assert_eq!(handler.pending_count().await, 0);
@@ -672,10 +750,10 @@ mod tests {
     async fn test_cleanup_mutation() {
         let handler = create_test_handler().await;
         let mutation_id = "test-mutation-3".to_string();
-        
+
         let _receiver = handler.register_mutation(mutation_id.clone()).await;
         assert_eq!(handler.pending_count().await, 1);
-        
+
         handler.cleanup_mutation(&mutation_id).await;
         assert_eq!(handler.pending_count().await, 0);
     }
@@ -683,7 +761,7 @@ mod tests {
     #[tokio::test]
     async fn test_signal_completion_for_untracked_mutation() {
         let handler = create_test_handler().await;
-        
+
         // This should not panic or fail
         handler.signal_completion("nonexistent-mutation").await;
         assert_eq!(handler.pending_count().await, 0);
@@ -692,7 +770,7 @@ mod tests {
     #[tokio::test]
     async fn test_cleanup_untracked_mutation() {
         let handler = create_test_handler().await;
-        
+
         // This should not panic or fail
         handler.cleanup_mutation("nonexistent-mutation").await;
         assert_eq!(handler.pending_count().await, 0);
@@ -702,7 +780,7 @@ mod tests {
     async fn test_concurrent_registrations() {
         let handler = Arc::new(create_test_handler().await);
         let mut handles = vec![];
-        
+
         // Register multiple mutations concurrently
         for i in 0..10 {
             let handler_clone = Arc::clone(&handler);
@@ -712,12 +790,12 @@ mod tests {
             });
             handles.push(handle);
         }
-        
+
         // Wait for all registrations to complete
         for handle in handles {
             handle.await.unwrap();
         }
-        
+
         assert_eq!(handler.pending_count().await, 10);
     }
 
@@ -725,22 +803,23 @@ mod tests {
     async fn test_wait_for_completion_success() {
         let handler = Arc::new(create_test_handler().await);
         let mutation_id = "test-wait-success";
-        
+
         // Clone handler for the completion task
         let handler_clone = Arc::clone(&handler);
         let mutation_id_clone = mutation_id.to_string();
-        
+
         // Start waiting for completion
-        let wait_handle = tokio::spawn(async move {
-            handler_clone.wait_for_completion(&mutation_id_clone).await
-        });
-        
+        let wait_handle =
+            tokio::spawn(
+                async move { handler_clone.wait_for_completion(&mutation_id_clone).await },
+            );
+
         // Give a small delay to ensure registration happens first
         sleep(Duration::from_millis(10)).await;
-        
+
         // Signal completion
         handler.signal_completion(mutation_id).await;
-        
+
         // Wait should complete successfully
         let result = wait_handle.await.unwrap();
         assert!(result.is_ok());
@@ -750,15 +829,18 @@ mod tests {
     async fn test_wait_for_completion_timeout() {
         let handler = create_test_handler().await;
         let mutation_id = "test-wait-timeout";
-        
+
         // Wait with a very short timeout
         let result = handler
             .wait_for_completion_with_timeout(mutation_id, Duration::from_millis(10))
             .await;
-        
+
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), MutationCompletionError::Timeout(_, _)));
-        
+        assert!(matches!(
+            result.unwrap_err(),
+            MutationCompletionError::Timeout(_, _)
+        ));
+
         // Mutation should be cleaned up after timeout
         assert_eq!(handler.pending_count().await, 0);
     }
@@ -766,13 +848,13 @@ mod tests {
     #[tokio::test]
     async fn test_diagnostics() {
         let handler = create_test_handler().await;
-        
+
         let diagnostics = handler.get_diagnostics().await;
         assert_eq!(diagnostics.pending_mutations_count, 0);
-        
+
         // Register a mutation
         let _receiver = handler.register_mutation("diag-test".to_string()).await;
-        
+
         let diagnostics = handler.get_diagnostics().await;
         assert_eq!(diagnostics.pending_mutations_count, 1);
     }
@@ -781,15 +863,15 @@ mod tests {
     async fn test_replace_existing_mutation() {
         let handler = create_test_handler().await;
         let mutation_id = "duplicate-mutation".to_string();
-        
+
         // Register first mutation
         let _receiver1 = handler.register_mutation(mutation_id.clone()).await;
         assert_eq!(handler.pending_count().await, 1);
-        
+
         // Register second mutation with same ID (should replace)
         let receiver2 = handler.register_mutation(mutation_id.clone()).await;
         assert_eq!(handler.pending_count().await, 1);
-        
+
         // Signal completion should work with the second receiver
         handler.signal_completion(&mutation_id).await;
         assert!(receiver2.await.is_ok());

--- a/src/transform/engine/executor.rs
+++ b/src/transform/engine/executor.rs
@@ -1,0 +1,336 @@
+use crate::transform::native::{
+    FieldDefinition, FieldDefinitionError, FieldType, FieldValue, NativeFieldComputation,
+    NativeMapField, NativeMapTransform, NativeRecord, NativeTransformSpec, NativeTransformType,
+};
+use std::collections::HashMap;
+use thiserror::Error;
+
+/// Native execution errors emitted by [`NativeTransformExecutor`].
+#[derive(Debug, Error, PartialEq)]
+pub enum NativeTransformError {
+    /// Underlying field definition does not satisfy validation rules.
+    #[error("field definition for '{field}' is invalid: {source}")]
+    InvalidFieldDefinition {
+        field: String,
+        #[source]
+        source: FieldDefinitionError,
+    },
+    /// Required input field is missing from the provided record.
+    #[error("required input field '{input_field}' missing while computing '{output_field}'")]
+    MissingInput {
+        input_field: String,
+        output_field: String,
+    },
+    /// Produced value does not match the declared [`FieldType`].
+    #[error(
+        "output field '{field}' produced value with mismatched type (expected {expected:?}, got {actual:?})"
+    )]
+    TypeMismatch {
+        field: String,
+        expected: Box<FieldType>,
+        actual: Box<FieldType>,
+    },
+    /// Encountered a computation variant that is not yet supported.
+    #[error("computation for field '{field}' is not supported: {reason}")]
+    UnsupportedComputation { field: String, reason: String },
+}
+
+/// Executes native transform specifications against [`FieldValue`] inputs.
+#[derive(Debug, Default)]
+pub struct NativeTransformExecutor;
+
+impl NativeTransformExecutor {
+    /// Construct a new executor instance.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Execute the provided transform specification against the supplied native record.
+    pub fn execute(
+        &self,
+        transform: &NativeTransformSpec,
+        input: &NativeRecord,
+    ) -> Result<NativeRecord, NativeTransformError> {
+        match &transform.transform_type {
+            NativeTransformType::Map(map_transform) => {
+                self.execute_map_transform(map_transform, input)
+            }
+        }
+    }
+
+    fn execute_map_transform(
+        &self,
+        transform: &NativeMapTransform,
+        input: &NativeRecord,
+    ) -> Result<NativeRecord, NativeTransformError> {
+        let mut output: HashMap<String, FieldValue> =
+            HashMap::with_capacity(transform.fields.len());
+
+        for (field_name, map_field) in &transform.fields {
+            let value = self.compute_map_field(field_name, map_field, input)?;
+            output.insert(field_name.clone(), value);
+        }
+
+        Ok(output)
+    }
+
+    fn compute_map_field(
+        &self,
+        field_name: &str,
+        map_field: &NativeMapField,
+        input: &NativeRecord,
+    ) -> Result<FieldValue, NativeTransformError> {
+        map_field.definition.validate().map_err(|source| {
+            NativeTransformError::InvalidFieldDefinition {
+                field: field_name.to_string(),
+                source,
+            }
+        })?;
+
+        let value = match &map_field.computation {
+            NativeFieldComputation::InputField { field } => {
+                self.read_input(field_name, field, &map_field.definition, input)?
+            }
+            NativeFieldComputation::Constant { value } => value.clone(),
+            NativeFieldComputation::Expression { expression } => {
+                return Err(NativeTransformError::UnsupportedComputation {
+                    field: field_name.to_string(),
+                    reason: format!("expression '{expression}' evaluation is not implemented"),
+                })
+            }
+            NativeFieldComputation::Function { name, .. } => {
+                return Err(NativeTransformError::UnsupportedComputation {
+                    field: field_name.to_string(),
+                    reason: format!("function '{name}' execution requires function registry"),
+                })
+            }
+        };
+
+        self.ensure_type_matches(field_name, &map_field.definition, &value)?;
+
+        Ok(value)
+    }
+
+    fn read_input(
+        &self,
+        output_field: &str,
+        input_field: &str,
+        definition: &FieldDefinition,
+        input: &NativeRecord,
+    ) -> Result<FieldValue, NativeTransformError> {
+        if let Some(value) = input.get(input_field) {
+            return Ok(value.clone());
+        }
+
+        if let Some(default_value) = definition.effective_default() {
+            return Ok(default_value);
+        }
+
+        Err(NativeTransformError::MissingInput {
+            input_field: input_field.to_string(),
+            output_field: output_field.to_string(),
+        })
+    }
+
+    fn ensure_type_matches(
+        &self,
+        field_name: &str,
+        definition: &FieldDefinition,
+        value: &FieldValue,
+    ) -> Result<(), NativeTransformError> {
+        if definition.field_type.matches(value) {
+            return Ok(());
+        }
+
+        Err(NativeTransformError::TypeMismatch {
+            field: field_name.to_string(),
+            expected: Box::new(definition.field_type.clone()),
+            actual: Box::new(value.field_type()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transform::native::{FieldType, FieldValue};
+
+    fn string_field(name: &str, required: bool) -> FieldDefinition {
+        FieldDefinition::new(name.to_string(), FieldType::String).with_required(required)
+    }
+
+    #[test]
+    fn map_transform_copies_input_fields() {
+        let mut map = NativeMapTransform::new();
+        map.insert_field(
+            "full_name",
+            NativeMapField::new(
+                string_field("full_name", true),
+                NativeFieldComputation::InputField {
+                    field: "full_name".to_string(),
+                },
+            ),
+        );
+
+        let spec = NativeTransformSpec {
+            name: "copy".to_string(),
+            transform_type: NativeTransformType::Map(map),
+        };
+
+        let mut input = NativeRecord::new();
+        input.insert(
+            "full_name".to_string(),
+            FieldValue::String("Ada Lovelace".to_string()),
+        );
+
+        let executor = NativeTransformExecutor::new();
+        let result = executor.execute(&spec, &input).unwrap();
+
+        assert_eq!(
+            result.get("full_name"),
+            Some(&FieldValue::String("Ada Lovelace".to_string()))
+        );
+    }
+
+    #[test]
+    fn map_transform_uses_defaults_for_optional_fields() {
+        let optional_field =
+            FieldDefinition::new("country", FieldType::String).with_required(false);
+        let mut map = NativeMapTransform::new();
+        map.insert_field(
+            "country",
+            NativeMapField::new(
+                optional_field,
+                NativeFieldComputation::InputField {
+                    field: "country".to_string(),
+                },
+            ),
+        );
+
+        let spec = NativeTransformSpec {
+            name: "optional".to_string(),
+            transform_type: NativeTransformType::Map(map),
+        };
+
+        let executor = NativeTransformExecutor::new();
+        let input = NativeRecord::new();
+        let result = executor.execute(&spec, &input).unwrap();
+
+        assert_eq!(
+            result.get("country"),
+            Some(&FieldValue::String(String::new()))
+        );
+    }
+
+    #[test]
+    fn map_transform_emits_constants() {
+        let mut map = NativeMapTransform::new();
+        map.insert_field(
+            "status",
+            NativeMapField::new(
+                string_field("status", true),
+                NativeFieldComputation::Constant {
+                    value: FieldValue::String("active".to_string()),
+                },
+            ),
+        );
+
+        let spec = NativeTransformSpec {
+            name: "constant".to_string(),
+            transform_type: NativeTransformType::Map(map),
+        };
+
+        let executor = NativeTransformExecutor::new();
+        let input = NativeRecord::new();
+        let result = executor.execute(&spec, &input).unwrap();
+
+        assert_eq!(
+            result.get("status"),
+            Some(&FieldValue::String("active".to_string()))
+        );
+    }
+
+    #[test]
+    fn missing_required_inputs_return_error() {
+        let mut map = NativeMapTransform::new();
+        map.insert_field(
+            "email",
+            NativeMapField::new(
+                string_field("email", true),
+                NativeFieldComputation::InputField {
+                    field: "email".to_string(),
+                },
+            ),
+        );
+
+        let spec = NativeTransformSpec {
+            name: "missing".to_string(),
+            transform_type: NativeTransformType::Map(map),
+        };
+
+        let executor = NativeTransformExecutor::new();
+        let input = NativeRecord::new();
+        let err = executor.execute(&spec, &input).unwrap_err();
+
+        assert!(matches!(
+            err,
+            NativeTransformError::MissingInput {
+                input_field,
+                output_field,
+            } if input_field == "email" && output_field == "email"
+        ));
+    }
+
+    #[test]
+    fn type_mismatch_returns_error() {
+        let mut map = NativeMapTransform::new();
+        map.insert_field(
+            "age",
+            NativeMapField::new(
+                FieldDefinition::new("age", FieldType::Integer),
+                NativeFieldComputation::Constant {
+                    value: FieldValue::String("thirty".to_string()),
+                },
+            ),
+        );
+
+        let spec = NativeTransformSpec {
+            name: "type-check".to_string(),
+            transform_type: NativeTransformType::Map(map),
+        };
+
+        let executor = NativeTransformExecutor::new();
+        let input = NativeRecord::new();
+        let err = executor.execute(&spec, &input).unwrap_err();
+
+        assert!(matches!(err, NativeTransformError::TypeMismatch { field, .. } if field == "age"));
+    }
+
+    #[test]
+    fn unsupported_expression_mapping_returns_error() {
+        let mut map = NativeMapTransform::new();
+        map.insert_field(
+            "full_name",
+            NativeMapField::new(
+                string_field("full_name", true),
+                NativeFieldComputation::Expression {
+                    expression: "${first} ${last}".to_string(),
+                },
+            ),
+        );
+
+        let spec = NativeTransformSpec {
+            name: "expression".to_string(),
+            transform_type: NativeTransformType::Map(map),
+        };
+
+        let executor = NativeTransformExecutor::new();
+        let input = NativeRecord::new();
+        let err = executor.execute(&spec, &input).unwrap_err();
+
+        assert!(
+            matches!(err, NativeTransformError::UnsupportedComputation { field, .. } if field == "full_name")
+        );
+    }
+}

--- a/src/transform/engine/mod.rs
+++ b/src/transform/engine/mod.rs
@@ -1,0 +1,5 @@
+//! Native transform execution engine entry point.
+
+pub mod executor;
+
+pub use executor::{NativeTransformError, NativeTransformExecutor};

--- a/src/transform/hash_range_executor.rs
+++ b/src/transform/hash_range_executor.rs
@@ -4,8 +4,8 @@
 //! validation, key configuration extraction, and coordination.
 
 use crate::schema::types::SchemaError;
-use crate::transform::validation::ValidationTimings;
 use crate::transform::coordination::execute_multi_chain_coordination_with_monitoring;
+use crate::transform::validation::ValidationTimings;
 use log::info;
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
@@ -34,19 +34,19 @@ pub fn execute_hashrange_schema(
 ) -> Result<JsonValue, SchemaError> {
     let start_time = Instant::now();
     info!("🔧 Executing HashRange schema: {}", schema.name);
-    
+
     // Validate schema structure and field alignment
     let validation_timings = crate::transform::validation::validate_hashrange_schema(schema)?;
-    
+
     // Extract key configuration
     let key_config = extract_hashrange_key_config(schema)?;
-    
+
     // Execute multi-chain coordination
     let execution_timing = execute_hashrange_coordination(schema, &input_values, key_config)?;
-    
+
     // Log performance summary
     log_hashrange_performance_summary(start_time, validation_timings, &execution_timing);
-    
+
     Ok(execution_timing.result)
 }
 
@@ -64,14 +64,16 @@ pub fn extract_hashrange_key_config(
 ) -> Result<&crate::schema::types::json_schema::KeyConfig, SchemaError> {
     let key_config = schema.key.as_ref().ok_or_else(|| {
         SchemaError::InvalidTransform(format!(
-            "HashRange schema '{}' must have key configuration with hash_field and range_field", 
+            "HashRange schema '{}' must have key configuration with hash_field and range_field",
             schema.name
         ))
     })?;
-    
-    info!("📊 HashRange key config - hash_field: {}, range_field: {}", 
-          key_config.hash_field, key_config.range_field);
-    
+
+    info!(
+        "📊 HashRange key config - hash_field: {}, range_field: {}",
+        key_config.hash_field, key_config.range_field
+    );
+
     Ok(key_config)
 }
 
@@ -92,9 +94,10 @@ pub fn execute_hashrange_coordination(
     key_config: &crate::schema::types::json_schema::KeyConfig,
 ) -> Result<ExecutionTiming, SchemaError> {
     let execution_start = Instant::now();
-    let result = execute_multi_chain_coordination_with_monitoring(schema, input_values, key_config)?;
+    let result =
+        execute_multi_chain_coordination_with_monitoring(schema, input_values, key_config)?;
     let execution_duration = execution_start.elapsed();
-    
+
     Ok(ExecutionTiming {
         execution_duration,
         result,
@@ -114,9 +117,11 @@ pub fn log_hashrange_performance_summary(
     execution_timing: &ExecutionTiming,
 ) {
     let total_duration = start_time.elapsed();
-    info!("⏱️ HashRange execution completed in {:?} (execution: {:?}, validation: {:?}, alignment: {:?})", 
-          total_duration, 
-          execution_timing.execution_duration, 
-          validation_timings.validation_duration, 
-          validation_timings.alignment_duration);
+    info!(
+        "⏱️ HashRange execution completed in {:?} (execution: {:?}, validation: {:?}, alignment: {:?})",
+        total_duration,
+        execution_timing.execution_duration,
+        validation_timings.validation_duration,
+        validation_timings.alignment_duration,
+    );
 }

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -41,6 +41,7 @@
 //! implementation for all data persistence needs.
 
 pub mod ast;
+pub mod engine;
 pub mod executor;
 pub mod interpreter;
 pub mod mutation_examples;
@@ -65,6 +66,7 @@ pub mod validation;
 // Public re-exports
 pub use crate::schema::types::Transform;
 pub use ast::{Expression, Operator, TransformDeclaration, UnaryOperator, Value};
+pub use engine::{NativeTransformError, NativeTransformExecutor};
 pub use executor::TransformExecutor;
 pub use interpreter::Interpreter;
 pub use mutation_examples::{

--- a/src/transform/native/mod.rs
+++ b/src/transform/native/mod.rs
@@ -6,7 +6,12 @@
 //! definitions and transform specifications.
 
 pub mod field_definition;
+pub mod transform_spec;
 pub mod types;
 
 pub use field_definition::{FieldDefinition, FieldDefinitionError};
+pub use transform_spec::{
+    NativeFieldComputation, NativeMapField, NativeMapTransform, NativeRecord, NativeTransformSpec,
+    NativeTransformType,
+};
 pub use types::{FieldType, FieldValue};

--- a/src/transform/native/transform_spec.rs
+++ b/src/transform/native/transform_spec.rs
@@ -1,0 +1,82 @@
+use super::{FieldDefinition, FieldValue};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Convenience alias for a native record flowing through transforms.
+pub type NativeRecord = HashMap<String, FieldValue>;
+
+/// High-level description of a native transform.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NativeTransformSpec {
+    /// Human-friendly transform identifier.
+    pub name: String,
+    /// Concrete transform behavior.
+    #[serde(rename = "type")]
+    pub transform_type: NativeTransformType,
+}
+
+/// Currently supported native transform kinds.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum NativeTransformType {
+    /// Produce a new record by mapping inputs to outputs.
+    Map(NativeMapTransform),
+}
+
+/// Definition for a map transform where each output field references a computation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct NativeMapTransform {
+    /// Output fields keyed by field name.
+    pub fields: HashMap<String, NativeMapField>,
+}
+
+impl NativeMapTransform {
+    /// Create an empty map transform.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a field definition and computation into the transform.
+    pub fn insert_field(&mut self, name: impl Into<String>, field: NativeMapField) {
+        self.fields.insert(name.into(), field);
+    }
+}
+
+/// Metadata and computation strategy for a single output field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NativeMapField {
+    /// Declared output field definition.
+    pub definition: FieldDefinition,
+    /// How to compute the field value.
+    pub computation: NativeFieldComputation,
+}
+
+impl NativeMapField {
+    /// Convenience constructor for wiring field metadata and computation together.
+    #[must_use]
+    pub fn new(definition: FieldDefinition, computation: NativeFieldComputation) -> Self {
+        Self {
+            definition,
+            computation,
+        }
+    }
+}
+
+/// Supported computation strategies for producing an output field value.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum NativeFieldComputation {
+    /// Directly copy a value from the input payload.
+    InputField { field: String },
+    /// Emit a pre-defined constant value.
+    Constant { value: FieldValue },
+    /// Placeholder for expression-based mappings (implemented in later tasks).
+    Expression { expression: String },
+    /// Placeholder for function invocation (implemented in later tasks).
+    Function {
+        name: String,
+        #[serde(default)]
+        arguments: Vec<NativeFieldComputation>,
+    },
+}


### PR DESCRIPTION
## Summary
- add native transform spec module defining map transform structures and computations
- implement a native transform executor with validation, error reporting, and focused unit tests
- wire the executor into the transform module, document the new logic, and refresh related task status plus logging cleanup

## Testing
- cargo fmt
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features
- (cd src/datafold_node/static-react && npm install && npm test)


------
https://chatgpt.com/codex/tasks/task_e_68d1c113db2c83279ce6ac72808f858a