### PR TITLE
NTS-1: add native transform spec support

### DIFF
--- a/docs/delivery/NTS-1/NTS-1-3.md
+++ b/docs/delivery/NTS-1/NTS-1-3.md
@@ -1,0 +1,52 @@
+# NTS-1-3 Implement TransformSpec with native types
+
+[Back to task list](./tasks.md)
+
+## Description
+Build native transform specifications that pair the new field types with declarative mapping metadata. The specification layer replaces JSON blobs with strongly typed structures that describe inputs, outputs, and transform operations (map, filter, reduce, chain). This enables later execution tasks to consume rich native metadata without repeated JSON parsing.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-23 09:30:00 | Status Change | N/A | Proposed | Task file created with initial analysis for native transform specifications | AI_Agent |
+| 2025-09-23 09:32:00 | Status Change | Proposed | In Progress | Began implementing native transform specification module and supporting validation | AI_Agent |
+| 2025-09-23 11:45:00 | Status Change | In Progress | Review | Submitted native transform specification module with unit tests for review | AI_Agent |
+
+## Requirements
+- Define native `TransformSpec` data structures that capture transform name, inputs, output, and transform kind (map, filter, reduce, chain).
+- Provide serde serialization for the new structures so they can be persisted or exchanged when needed.
+- Implement validation logic that enforces unique inputs, validates field definitions, and checks field references within mappings, conditions, reducers, and chains.
+- Propagate typed errors describing validation failures (unknown field references, empty mappings, empty condition groups, etc.).
+- Re-export the new types through the `transform` module for downstream consumers.
+- Add comprehensive unit tests covering success and failure scenarios for map, filter, reduce, and chain specifications.
+- Document the architectural rule in `docs/project_logic.md` to reflect the new native transform specification contract.
+
+## Implementation Plan
+1. Create `src/transform/native/transform_spec.rs` implementing the data structures, serde support, and validation helpers.
+2. Update `src/transform/native/mod.rs` and `src/transform/mod.rs` to expose the new types to the rest of the codebase.
+3. Write unit tests in `tests/unit/native_transform_spec_tests.rs` verifying validation across all transform kinds.
+4. Update task tracking metadata and add a new logic entry to `docs/project_logic.md` describing the native transform specification requirement.
+5. Run formatting, linting, Rust tests, and the required frontend vitest suite.
+
+## Verification
+- `TransformSpec::validate` accepts well-formed map, filter, reduce, and chain specifications.
+- Validation rejects unknown field references, empty mapping collections, empty condition groups, and reducer variants missing source fields.
+- Chain validation surfaces nested errors with contextual indices.
+- New unit tests cover the success and failure cases noted above.
+- Repository linting and automated test suites all pass.
+
+## Files Modified
+- `docs/delivery/NTS-1/tasks.md`
+- `docs/project_logic.md`
+- `src/transform/native/mod.rs`
+- `src/transform/native/transform_spec.rs`
+- `src/transform/mod.rs`
+- `tests/unit/mod.rs`
+- `tests/unit/native_transform_spec_tests.rs`
+
+## Test Plan
+- `cargo fmt`
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets --all-features`
+- `(cd src/datafold_node/static-react && npm install)`
+- `(cd src/datafold_node/static-react && npm test)`

--- a/docs/delivery/NTS-1/tasks.md
+++ b/docs/delivery/NTS-1/tasks.md
@@ -10,7 +10,7 @@ This document lists all tasks associated with PBI NTS-1.
 | :------ | :--------------------------------------- | :------- | :--------------------------------- |
 | NTS-1-1 | [Implement FieldValue and FieldType enums](./NTS-1-1.md) | In Progress | Create core native data types to replace JsonValue |
 | NTS-1-2 | [Implement FieldDefinition struct with validation](./NTS-1-2.md) | In Progress | Add typed field definitions with validation methods |
-| NTS-1-3 | [Implement TransformSpec with native types](./NTS-1-3.md) | Proposed | Create transform specifications using native types |
+| NTS-1-3 | [Implement TransformSpec with native types](./NTS-1-3.md) | Review | Create transform specifications using native types |
 | NTS-1-4 | [Add comprehensive unit tests](./NTS-1-4.md) | Proposed | Test all type operations and edge cases |
 | NTS-1-5 | [Implement JSON boundary conversion utilities](./NTS-1-5.md) | Proposed | Add conversion functions for API boundaries only |
 | NTS-1-6 | [Add performance benchmarks](./NTS-1-6.md) | Proposed | Measure performance improvements over JSON system |

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -20,6 +20,7 @@ This document contains the most up-to-date and condensed information about the p
 | TRANSFORM-003 | DeclarativeSchemaDefinition requires KeyConfig with hash_field and range_field for HashRange schemas and FieldDefinition metadata for optional atom_uuid and field_type. | schema/types/json_schema.rs | 2025-08-26 19:00:00 | None |
 | TRANSFORM-004 | Native transform data flow must use FieldValue/FieldType enums internally with JSON conversion limited to boundary layers. | transform/native, transform/mod.rs | 2025-09-22 19:14:37 | None |
 | TRANSFORM-005 | Native FieldDefinition must validate names, default types, and generate typed defaults for optional fields. | transform/native | 2025-09-22 19:16:45 | None |
+| TRANSFORM-006 | Native TransformSpec definitions must validate field references and use typed inputs/outputs with FieldDefinition metadata. | transform/native/transform_spec.rs | 2025-09-23 11:45:00 | None |
 | BOUNDARY-001 | JsonBoundaryLayer converts between JSON payloads and native FieldValue maps using registered schema definitions, rejecting unknown fields unless explicitly allowed. | api/json_boundary.rs | 2025-09-23 15:30:00 | None |
 
 ### SCHEMA-001: Schema State Transition Rules

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -73,7 +73,11 @@ pub use mutation_examples::{
 };
 pub use native::{
     FieldDefinition as NativeFieldDefinition, FieldDefinitionError as NativeFieldDefinitionError,
-    FieldType as NativeFieldType, FieldValue,
+    FieldMapping as NativeFieldMapping, FieldType as NativeFieldType, FieldValue,
+    FilterCondition as NativeFilterCondition, FilterTransform as NativeFilterTransform,
+    MapTransform as NativeMapTransform, ReduceTransform as NativeReduceTransform,
+    ReducerType as NativeReducerType, TransformSpec as NativeTransformSpec,
+    TransformSpecError as NativeTransformSpecError, TransformType as NativeTransformType,
 };
 pub use parser::TransformParser;
 pub use restricted_access::{

--- a/src/transform/native/mod.rs
+++ b/src/transform/native/mod.rs
@@ -6,7 +6,12 @@
 //! definitions and transform specifications.
 
 pub mod field_definition;
+pub mod transform_spec;
 pub mod types;
 
 pub use field_definition::{FieldDefinition, FieldDefinitionError};
+pub use transform_spec::{
+    FieldMapping, FilterCondition, FilterTransform, MapTransform, ReduceTransform, ReducerType,
+    TransformSpec, TransformSpecError, TransformType,
+};
 pub use types::{FieldType, FieldValue};

--- a/src/transform/native/transform_spec.rs
+++ b/src/transform/native/transform_spec.rs
@@ -1,0 +1,404 @@
+use super::field_definition::{FieldDefinition, FieldDefinitionError};
+use super::types::FieldValue;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use thiserror::Error;
+
+/// Native transform specification describing inputs, output, and execution kind.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TransformSpec {
+    /// Logical identifier for the transform specification.
+    pub name: String,
+    /// Input field definitions required by the transform.
+    #[serde(default)]
+    pub inputs: Vec<FieldDefinition>,
+    /// Output field definition produced by the transform.
+    pub output: FieldDefinition,
+    /// Transform behaviour description.
+    #[serde(rename = "type")]
+    pub transform_type: TransformType,
+}
+
+impl TransformSpec {
+    /// Construct a new transform specification.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        inputs: Vec<FieldDefinition>,
+        output: FieldDefinition,
+        transform_type: TransformType,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            inputs,
+            output,
+            transform_type,
+        }
+    }
+
+    /// Validate structural invariants and field references for the specification.
+    pub fn validate(&self) -> Result<(), TransformSpecError> {
+        if self.name.trim().is_empty() {
+            return Err(TransformSpecError::EmptyName);
+        }
+
+        let mut input_names = HashSet::new();
+        for input in &self.inputs {
+            input
+                .validate()
+                .map_err(|source| TransformSpecError::InputValidation {
+                    field: input.name.clone(),
+                    source,
+                })?;
+
+            if !input_names.insert(input.name.clone()) {
+                return Err(TransformSpecError::DuplicateInputField {
+                    field: input.name.clone(),
+                });
+            }
+        }
+
+        self.output
+            .validate()
+            .map_err(|source| TransformSpecError::OutputValidation {
+                field: self.output.name.clone(),
+                source,
+            })?;
+
+        match &self.transform_type {
+            TransformType::Map(map_transform) => {
+                self.validate_map_transform(map_transform, &input_names)
+            }
+            TransformType::Filter(filter_transform) => {
+                self.validate_filter_transform(filter_transform, &input_names)
+            }
+            TransformType::Reduce(reduce_transform) => {
+                self.validate_reduce_transform(reduce_transform, &input_names)
+            }
+            TransformType::Chain(chain) => self.validate_chain(chain),
+        }
+    }
+
+    fn validate_map_transform(
+        &self,
+        map_transform: &MapTransform,
+        input_names: &HashSet<String>,
+    ) -> Result<(), TransformSpecError> {
+        if map_transform.field_mappings.is_empty() {
+            return Err(TransformSpecError::EmptyFieldMappings);
+        }
+
+        for (output_field, mapping) in &map_transform.field_mappings {
+            if output_field.trim().is_empty() {
+                return Err(TransformSpecError::InvalidOutputFieldName {
+                    field: output_field.clone(),
+                });
+            }
+
+            match mapping {
+                FieldMapping::Direct { field } => {
+                    ensure_known_field(field, input_names)?;
+                }
+                FieldMapping::Expression { expression } => {
+                    if expression.trim().is_empty() {
+                        return Err(TransformSpecError::EmptyExpressionMapping {
+                            field: output_field.clone(),
+                        });
+                    }
+                }
+                FieldMapping::Constant { .. } => {}
+                FieldMapping::Function { name, arguments } => {
+                    if name.trim().is_empty() {
+                        return Err(TransformSpecError::EmptyFunctionName {
+                            field: output_field.clone(),
+                        });
+                    }
+
+                    for argument in arguments {
+                        if !input_names.contains(argument) {
+                            return Err(TransformSpecError::UnknownFunctionArgument {
+                                function: name.clone(),
+                                argument: argument.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_filter_transform(
+        &self,
+        filter_transform: &FilterTransform,
+        input_names: &HashSet<String>,
+    ) -> Result<(), TransformSpecError> {
+        Self::validate_filter_condition(&filter_transform.condition, input_names)
+    }
+
+    fn validate_filter_condition(
+        condition: &FilterCondition,
+        input_names: &HashSet<String>,
+    ) -> Result<(), TransformSpecError> {
+        match condition {
+            FilterCondition::Equals { field, .. }
+            | FilterCondition::NotEquals { field, .. }
+            | FilterCondition::GreaterThan { field, .. }
+            | FilterCondition::LessThan { field, .. }
+            | FilterCondition::Contains { field, .. } => ensure_known_field(field, input_names),
+            FilterCondition::And { conditions } | FilterCondition::Or { conditions } => {
+                if conditions.is_empty() {
+                    return Err(TransformSpecError::EmptyConditionGroup);
+                }
+
+                for nested in conditions {
+                    Self::validate_filter_condition(nested, input_names)?;
+                }
+
+                Ok(())
+            }
+        }
+    }
+
+    fn validate_reduce_transform(
+        &self,
+        reduce_transform: &ReduceTransform,
+        input_names: &HashSet<String>,
+    ) -> Result<(), TransformSpecError> {
+        for field in &reduce_transform.group_by {
+            if field.trim().is_empty() {
+                return Err(TransformSpecError::UnknownGroupByField {
+                    field: field.clone(),
+                });
+            }
+
+            ensure_known_field(field, input_names).map_err(|_| {
+                TransformSpecError::UnknownGroupByField {
+                    field: field.clone(),
+                }
+            })?;
+        }
+
+        if let Some((label, field_name)) = reduce_transform.reducer.field_requirement() {
+            if field_name.trim().is_empty() {
+                return Err(TransformSpecError::ReducerMissingField);
+            }
+
+            if !input_names.contains(field_name) {
+                return Err(TransformSpecError::UnknownReducerField {
+                    reducer: label,
+                    field: field_name.clone(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_chain(&self, chain: &[TransformSpec]) -> Result<(), TransformSpecError> {
+        if chain.is_empty() {
+            return Err(TransformSpecError::EmptyTransformChain);
+        }
+
+        for (index, spec) in chain.iter().enumerate() {
+            if let Err(source) = spec.validate() {
+                return Err(TransformSpecError::InvalidNestedSpec {
+                    index,
+                    source: Box::new(source),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn ensure_known_field(
+    field: &str,
+    known_fields: &HashSet<String>,
+) -> Result<(), TransformSpecError> {
+    if field.trim().is_empty() || !known_fields.contains(field) {
+        return Err(TransformSpecError::UnknownFieldReference {
+            field: field.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Supported transform behaviours.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransformType {
+    Map(MapTransform),
+    Filter(FilterTransform),
+    Reduce(ReduceTransform),
+    Chain(Vec<TransformSpec>),
+}
+
+/// Mapping transform metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MapTransform {
+    /// Map of output field names to mapping behaviour.
+    #[serde(default)]
+    pub field_mappings: HashMap<String, FieldMapping>,
+}
+
+impl MapTransform {
+    /// Construct a new mapping transform.
+    #[must_use]
+    pub fn new(field_mappings: HashMap<String, FieldMapping>) -> Self {
+        Self { field_mappings }
+    }
+}
+
+/// Field mapping definition for map transforms.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FieldMapping {
+    Direct {
+        field: String,
+    },
+    Expression {
+        expression: String,
+    },
+    Constant {
+        value: FieldValue,
+    },
+    Function {
+        name: String,
+        #[serde(default)]
+        arguments: Vec<String>,
+    },
+}
+
+/// Filter transform metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FilterTransform {
+    pub condition: FilterCondition,
+}
+
+/// Supported filter conditions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FilterCondition {
+    Equals { field: String, value: FieldValue },
+    NotEquals { field: String, value: FieldValue },
+    GreaterThan { field: String, value: FieldValue },
+    LessThan { field: String, value: FieldValue },
+    Contains { field: String, value: FieldValue },
+    And { conditions: Vec<FilterCondition> },
+    Or { conditions: Vec<FilterCondition> },
+}
+
+/// Reduce transform metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReduceTransform {
+    pub reducer: ReducerType,
+    #[serde(default)]
+    pub group_by: Vec<String>,
+}
+
+impl ReduceTransform {
+    /// Construct a new reducer transform.
+    #[must_use]
+    pub fn new(reducer: ReducerType, group_by: Vec<String>) -> Self {
+        Self { reducer, group_by }
+    }
+}
+
+/// Supported reducer types for aggregate transforms.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ReducerType {
+    Sum { field: String },
+    Count,
+    Average { field: String },
+    Min { field: String },
+    Max { field: String },
+    First { field: String },
+    Last { field: String },
+}
+
+impl ReducerType {
+    fn field_requirement(&self) -> Option<(&'static str, &String)> {
+        match self {
+            ReducerType::Sum { field } => Some(("sum", field)),
+            ReducerType::Average { field } => Some(("average", field)),
+            ReducerType::Min { field } => Some(("min", field)),
+            ReducerType::Max { field } => Some(("max", field)),
+            ReducerType::First { field } => Some(("first", field)),
+            ReducerType::Last { field } => Some(("last", field)),
+            ReducerType::Count => None,
+        }
+    }
+}
+
+/// Validation errors emitted by [`TransformSpec::validate`].
+#[derive(Debug, Error)]
+pub enum TransformSpecError {
+    /// Transform name is empty or whitespace.
+    #[error("transform spec name cannot be empty")]
+    EmptyName,
+    /// Duplicate input field definitions were provided.
+    #[error("duplicate input field '{field}' in transform spec")]
+    DuplicateInputField { field: String },
+    /// Input field definition failed validation.
+    #[error("input field '{field}' failed validation: {source}")]
+    InputValidation {
+        field: String,
+        #[source]
+        source: FieldDefinitionError,
+    },
+    /// Output field definition failed validation.
+    #[error("output field '{field}' failed validation: {source}")]
+    OutputValidation {
+        field: String,
+        #[source]
+        source: FieldDefinitionError,
+    },
+    /// Map transform contained no mappings.
+    #[error("map transform must declare at least one field mapping")]
+    EmptyFieldMappings,
+    /// Map transform output field name is invalid.
+    #[error("map transform output field name '{field}' cannot be empty")]
+    InvalidOutputFieldName { field: String },
+    /// Mapping references an unknown input field.
+    #[error("mapping references unknown input field '{field}'")]
+    UnknownFieldReference { field: String },
+    /// Expression mapping provided an empty expression string.
+    #[error("expression mapping for field '{field}' cannot be empty")]
+    EmptyExpressionMapping { field: String },
+    /// Function mapping omitted the function name.
+    #[error("function mapping for '{field}' must provide a function name")]
+    EmptyFunctionName { field: String },
+    /// Function mapping references an unknown argument.
+    #[error("function '{function}' references unknown input field '{argument}'")]
+    UnknownFunctionArgument { function: String, argument: String },
+    /// Logical condition group contains no conditions.
+    #[error("logical condition groups must contain at least one condition")]
+    EmptyConditionGroup,
+    /// Reducer variant requires a field name but none was provided.
+    #[error("reduce transform reducer variant requires a source field name")]
+    ReducerMissingField,
+    /// Reducer references an unknown input field.
+    #[error("reduce transform reducer '{reducer}' references unknown input field '{field}'")]
+    UnknownReducerField {
+        reducer: &'static str,
+        field: String,
+    },
+    /// Group-by clause references an unknown field.
+    #[error("reduce transform group-by field '{field}' is unknown")]
+    UnknownGroupByField { field: String },
+    /// Transform chain was empty.
+    #[error("chain transform must contain at least one transform specification")]
+    EmptyTransformChain,
+    /// Nested transform specification failed validation.
+    #[error("nested transform spec at index {index} failed validation: {source}")]
+    InvalidNestedSpec {
+        index: usize,
+        #[source]
+        source: Box<TransformSpecError>,
+    },
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -12,6 +12,7 @@ pub mod iterator_stack_tests;
 pub mod json_boundary_layer_tests;
 pub mod mutation_completion_tests;
 pub mod native_field_definition_tests;
+pub mod native_transform_spec_tests;
 pub mod native_types_tests;
 pub mod range_filter_tests;
 pub mod schema;

--- a/tests/unit/native_transform_spec_tests.rs
+++ b/tests/unit/native_transform_spec_tests.rs
@@ -1,0 +1,276 @@
+use datafold::transform::{
+    FieldValue, NativeFieldDefinition, NativeFieldMapping, NativeFieldType, NativeFilterCondition,
+    NativeFilterTransform, NativeMapTransform, NativeReduceTransform, NativeReducerType,
+    NativeTransformSpec, NativeTransformSpecError, NativeTransformType,
+};
+use std::collections::HashMap;
+
+#[test]
+fn map_transform_spec_validates_successfully() {
+    let inputs = vec![
+        NativeFieldDefinition::new("name", NativeFieldType::String),
+        NativeFieldDefinition::new("age", NativeFieldType::Integer),
+    ];
+
+    let output = NativeFieldDefinition::new(
+        "profile",
+        NativeFieldType::Object {
+            fields: HashMap::new(),
+        },
+    )
+    .with_required(false);
+
+    let mut mappings = HashMap::new();
+    mappings.insert(
+        "full_name".to_string(),
+        NativeFieldMapping::Direct {
+            field: "name".to_string(),
+        },
+    );
+    mappings.insert(
+        "age_next_year".to_string(),
+        NativeFieldMapping::Function {
+            name: "increment".to_string(),
+            arguments: vec!["age".to_string()],
+        },
+    );
+
+    let spec = NativeTransformSpec::new(
+        "profile_builder",
+        inputs,
+        output,
+        NativeTransformType::Map(NativeMapTransform::new(mappings)),
+    );
+
+    spec.validate().expect("map transform should validate");
+}
+
+#[test]
+fn map_transform_spec_rejects_unknown_field_reference() {
+    let inputs = vec![NativeFieldDefinition::new("name", NativeFieldType::String)];
+    let output = NativeFieldDefinition::new(
+        "profile",
+        NativeFieldType::Object {
+            fields: HashMap::new(),
+        },
+    )
+    .with_required(false);
+
+    let mut mappings = HashMap::new();
+    mappings.insert(
+        "full_name".to_string(),
+        NativeFieldMapping::Direct {
+            field: "missing".to_string(),
+        },
+    );
+
+    let spec = NativeTransformSpec::new(
+        "profile_builder",
+        inputs,
+        output,
+        NativeTransformType::Map(NativeMapTransform::new(mappings)),
+    );
+
+    let error = spec
+        .validate()
+        .expect_err("unknown field reference should fail validation");
+
+    match error {
+        NativeTransformSpecError::UnknownFieldReference { field } => {
+            assert_eq!(field, "missing");
+        }
+        other => panic!("expected UnknownFieldReference error, got {other:?}"),
+    }
+}
+
+#[test]
+fn filter_transform_rejects_empty_condition_group() {
+    let inputs = vec![NativeFieldDefinition::new("age", NativeFieldType::Integer)];
+    let output = NativeFieldDefinition::new(
+        "filtered",
+        NativeFieldType::Object {
+            fields: HashMap::new(),
+        },
+    )
+    .with_required(false);
+
+    let filter_transform = NativeFilterTransform {
+        condition: NativeFilterCondition::And {
+            conditions: Vec::new(),
+        },
+    };
+
+    let spec = NativeTransformSpec::new(
+        "age_filter",
+        inputs,
+        output,
+        NativeTransformType::Filter(filter_transform),
+    );
+
+    let error = spec
+        .validate()
+        .expect_err("empty condition group should fail validation");
+
+    match error {
+        NativeTransformSpecError::EmptyConditionGroup => {}
+        other => panic!("expected EmptyConditionGroup error, got {other:?}"),
+    }
+}
+
+#[test]
+fn reduce_transform_requires_known_source_field() {
+    let inputs = vec![NativeFieldDefinition::new(
+        "amount",
+        NativeFieldType::Number,
+    )];
+    let output = NativeFieldDefinition::new(
+        "totals",
+        NativeFieldType::Object {
+            fields: HashMap::new(),
+        },
+    )
+    .with_required(false);
+
+    let reducer = NativeReducerType::Sum {
+        field: "unknown".to_string(),
+    };
+
+    let spec = NativeTransformSpec::new(
+        "sum_values",
+        inputs,
+        output,
+        NativeTransformType::Reduce(NativeReduceTransform::new(reducer, Vec::new())),
+    );
+
+    let error = spec
+        .validate()
+        .expect_err("unknown reducer field should fail validation");
+
+    match error {
+        NativeTransformSpecError::UnknownReducerField { reducer, field } => {
+            assert_eq!(reducer, "sum");
+            assert_eq!(field, "unknown");
+        }
+        other => panic!("expected UnknownReducerField error, got {other:?}"),
+    }
+}
+
+#[test]
+fn chain_transform_surfaces_nested_errors() {
+    let nested_inputs = vec![NativeFieldDefinition::new(
+        "value",
+        NativeFieldType::Integer,
+    )];
+    let nested_output = NativeFieldDefinition::new(
+        "result",
+        NativeFieldType::Object {
+            fields: HashMap::new(),
+        },
+    )
+    .with_required(false);
+
+    let mut nested_mappings = HashMap::new();
+    nested_mappings.insert(
+        "copied".to_string(),
+        NativeFieldMapping::Direct {
+            field: "missing".to_string(),
+        },
+    );
+
+    let nested_spec = NativeTransformSpec::new(
+        "inner",
+        nested_inputs,
+        nested_output.clone(),
+        NativeTransformType::Map(NativeMapTransform::new(nested_mappings)),
+    );
+
+    let chain_spec = NativeTransformSpec::new(
+        "chain",
+        Vec::new(),
+        nested_output,
+        NativeTransformType::Chain(vec![nested_spec]),
+    );
+
+    let error = chain_spec
+        .validate()
+        .expect_err("invalid nested spec should surface through chain validation");
+
+    match error {
+        NativeTransformSpecError::InvalidNestedSpec { index, source } => {
+            assert_eq!(index, 0);
+            match source.as_ref() {
+                NativeTransformSpecError::UnknownFieldReference { field } => {
+                    assert_eq!(field, "missing");
+                }
+                other => panic!("unexpected nested error {other:?}"),
+            }
+        }
+        other => panic!("expected InvalidNestedSpec error, got {other:?}"),
+    }
+}
+
+#[test]
+fn expression_mapping_rejects_empty_string() {
+    let inputs = vec![NativeFieldDefinition::new("field", NativeFieldType::String)];
+    let output = NativeFieldDefinition::new(
+        "result",
+        NativeFieldType::Object {
+            fields: HashMap::new(),
+        },
+    )
+    .with_required(false);
+
+    let mut mappings = HashMap::new();
+    mappings.insert(
+        "output".to_string(),
+        NativeFieldMapping::Expression {
+            expression: "  ".to_string(),
+        },
+    );
+
+    let spec = NativeTransformSpec::new(
+        "expression",
+        inputs,
+        output,
+        NativeTransformType::Map(NativeMapTransform::new(mappings)),
+    );
+
+    let error = spec
+        .validate()
+        .expect_err("empty expression should fail validation");
+
+    match error {
+        NativeTransformSpecError::EmptyExpressionMapping { field } => {
+            assert_eq!(field, "output");
+        }
+        other => panic!("expected EmptyExpressionMapping error, got {other:?}"),
+    }
+}
+
+#[test]
+fn filter_condition_allows_known_field_references() {
+    let inputs = vec![NativeFieldDefinition::new("age", NativeFieldType::Integer)];
+    let output = NativeFieldDefinition::new(
+        "result",
+        NativeFieldType::Object {
+            fields: HashMap::new(),
+        },
+    )
+    .with_required(false);
+
+    let filter_transform = NativeFilterTransform {
+        condition: NativeFilterCondition::GreaterThan {
+            field: "age".to_string(),
+            value: FieldValue::Integer(18),
+        },
+    };
+
+    let spec = NativeTransformSpec::new(
+        "age_filter",
+        inputs,
+        output,
+        NativeTransformType::Filter(filter_transform),
+    );
+
+    spec.validate().expect("filter condition should be valid");
+}


### PR DESCRIPTION
## Summary
- add native transform specification module with validation and typed errors
- re-export native transform spec types and hook unit tests into the suite
- document task NTS-1-3 progress and register architectural rule TRANSFORM-006

## Testing
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features
- (cd src/datafold_node/static-react && npm install)
- (cd src/datafold_node/static-react && npm test) *(fails: TextField debounce test currently red in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ccdafb488327a18bd419adb77b5f