### PR TITLE
Add native schema representation

### DIFF
--- a/docs/delivery/NTS-2/NTS-2-1.md
+++ b/docs/delivery/NTS-2/NTS-2-1.md
@@ -1,0 +1,73 @@
+# NTS-2-1 Implement NativeSchema struct
+
+[Back to task list](./tasks.md)
+
+## Description
+Create the foundational native schema representation that replaces JSON-centric
+structs with strongly typed field definitions. The struct must capture schema
+metadata, enforce key configuration invariants, and provide validation utilities
+for downstream registry and boundary components planned in later tasks.
+
+## Status History
+| Timestamp | Event Type | From Status | To Status | Details | User |
+|-----------|------------|-------------|-----------|---------|------|
+| 2025-09-24 10:05:00 | Status Change | N/A | Proposed | Task file created with initial scope review | AI_Agent |
+| 2025-09-24 10:10:00 | Status Change | Proposed | In Progress | Began implementing native schema module and error types | AI_Agent |
+| 2025-09-24 12:45:00 | Status Change | In Progress | Review | Implementation complete with tests and documentation updates | AI_Agent |
+
+## Requirements
+- Introduce a native schema module under `src/schema` that exposes `NativeSchema`
+  and `KeyConfig` types with typed field maps.
+- Enforce key configuration invariants (field existence, required flags, and
+  prohibiting null-only key types) via structured errors.
+- Provide payload validation helpers that flag unknown fields, missing required
+  data, and type mismatches while supporting default population for optional
+  fields.
+- Supply a builder API for assembling schemas that performs eager validation and
+  prevents duplicate registrations.
+- Cover the new behaviour with comprehensive unit tests exercising success and
+  failure scenarios.
+- Update architectural logic documentation to record the new native schema rule
+  and ensure task tracking reflects progress.
+
+## Implementation Plan
+1. Create `src/schema/native` module with `mod.rs` re-exporting the schema
+   primitives.
+2. Implement `NativeSchema`, `KeyConfig`, builder, and error types inside
+   `schema.rs`, including payload validation and normalisation helpers.
+3. Wire the new module through `src/schema/mod.rs` so callers can import native
+   schema types from the crate root.
+4. Add focused unit tests in `tests/unit/native_schema_tests.rs` covering builder
+   failures, payload validation, and default normalisation behaviour.
+5. Register the new test module in `tests/unit/mod.rs` and keep documentation in
+   `docs/project_logic.md` and `docs/delivery/NTS-2/tasks.md` synchronized.
+6. Run formatting, Rust workspace tests, clippy, and the repository-required
+   frontend vitest suite.
+
+## Verification
+- Builder rejects duplicate, invalid, or missing key field definitions with the
+  expected error variants.
+- `validate_payload` accepts valid data and surfaces descriptive errors for
+  unknown fields, missing required fields, and type mismatches.
+- `normalise_payload` and `project_payload` populate optional fields with typed
+  defaults without mutating the original payload map.
+- Unit tests in `tests/unit/native_schema_tests.rs` cover success and failure
+  paths for schema construction and payload handling.
+- All mandated formatting and test commands pass after the changes.
+
+## Files Modified
+- `docs/delivery/NTS-2/tasks.md`
+- `docs/delivery/NTS-2/NTS-2-1.md`
+- `docs/project_logic.md`
+- `src/schema/mod.rs`
+- `src/schema/native/mod.rs`
+- `src/schema/native/schema.rs`
+- `tests/unit/mod.rs`
+- `tests/unit/native_schema_tests.rs`
+
+## Test Plan
+- `cargo fmt`
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets --all-features`
+- `(cd src/datafold_node/static-react && npm ci)`
+- `(cd src/datafold_node/static-react && npm test)`

--- a/docs/delivery/NTS-2/tasks.md
+++ b/docs/delivery/NTS-2/tasks.md
@@ -8,7 +8,7 @@ This document lists all tasks associated with PBI NTS-2.
 
 | Task ID | Name | Status | Description |
 | :------ | :--------------------------------------- | :------- | :--------------------------------- |
-| NTS-2-1 | [Implement NativeSchema struct](./NTS-2-1.md) | Proposed | Create native schema representation with typed fields |
+| NTS-2-1 | [Implement NativeSchema struct](./NTS-2-1.md) | Review | Create native schema representation with typed fields |
 | NTS-2-2 | [Implement NativeSchemaRegistry](./NTS-2-2.md) | Proposed | Add async schema registry with concurrent access |
 | NTS-2-3 | [Add schema validation with native types](./NTS-2-3.md) | Proposed | Implement native type validation for schemas |
 | NTS-2-4 | [Add comprehensive integration tests](./NTS-2-4.md) | Proposed | Test all schema operations and edge cases |

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -22,6 +22,7 @@ This document contains the most up-to-date and condensed information about the p
 | TRANSFORM-005 | Native FieldDefinition must validate names, default types, and generate typed defaults for optional fields. | transform/native | 2025-09-22 19:16:45 | None |
 | TRANSFORM-006 | Native TransformSpec definitions must validate field references and use typed inputs/outputs with FieldDefinition metadata. | transform/native/transform_spec.rs | 2025-09-23 11:45:00 | None |
 | BOUNDARY-001 | JsonBoundaryLayer converts between JSON payloads and native FieldValue maps using registered schema definitions, rejecting unknown fields unless explicitly allowed. | api/json_boundary.rs | 2025-09-23 15:30:00 | None |
+| NATIVE-SCHEMA-001 | Native schemas must register key fields present in the definition map, mark them as required, and forbid null-only key types. | schema/native/schema.rs | 2025-09-24 12:40:00 | None |
 
 ### SCHEMA-001: Schema State Transition Rules
 - **Description**: Enforces valid state transitions for schema lifecycle management

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -27,45 +27,47 @@
 //! queries and mutations against the database.
 
 // Internal modules
-pub mod core;
 pub mod constants;
+pub mod core;
 pub mod discovery;
-pub mod persistence;
-pub mod transform;
 pub mod duplicate_detection;
 pub mod field_factory;
 pub mod file_operations;
 pub mod hasher;
-pub mod types;
-pub mod validator;
 pub mod molecule_variants;
-pub mod schema_types;
+pub mod native;
+pub mod persistence;
 pub mod schema_field_mapping;
 pub mod schema_interpretation;
+pub mod schema_types;
+pub mod transform;
+pub mod types;
+pub mod validator;
 
 // New split modules from core.rs
 pub mod schema_operations;
-pub mod schema_state_management;
 pub mod schema_persistence;
+pub mod schema_state_management;
 pub mod schema_validation;
 
 // Public re-exports
 pub use core::*;
-pub use field_factory::*;
-pub use types::*;
 pub use duplicate_detection::SchemaDuplicateDetector;
+pub use field_factory::*;
 pub use file_operations::SchemaFileOperations;
 pub use hasher::SchemaHasher;
-pub use validator::SchemaValidator;
 pub use molecule_variants::MoleculeVariant;
-pub use schema_types::{SchemaLoadingReport, SchemaSource, SchemaState};
+pub use native::*;
 pub use schema_field_mapping::map_fields;
-pub use schema_interpretation::{interpret_schema, load_schema_from_json, load_schema_from_file};
+pub use schema_interpretation::{interpret_schema, load_schema_from_file, load_schema_from_json};
+pub use schema_types::{SchemaLoadingReport, SchemaSource, SchemaState};
+pub use types::*;
+pub use validator::SchemaValidator;
 
 // Re-export functionality from split modules
 pub use schema_operations::*;
-pub use schema_state_management::*;
 pub use schema_persistence::*;
+pub use schema_state_management::*;
 pub use schema_validation::*;
 
 /// Public prelude module containing types needed by tests and external code

--- a/src/schema/native/mod.rs
+++ b/src/schema/native/mod.rs
@@ -1,0 +1,13 @@
+//! Native schema representation with strongly typed field definitions.
+//!
+//! This module provides the building blocks for the native schema registry
+//! introduced in the NTS-2 workstream. Schemas are composed from
+//! [`crate::transform::native::FieldDefinition`] instances and keep track of the
+//! key configuration that governs how records are addressed inside the
+//! datastore. The registry itself will be implemented by follow-up tasks.
+
+mod schema;
+
+pub use schema::{
+    KeyConfig, NativeSchema, NativeSchemaBuilder, NativeSchemaError, SchemaValidationError,
+};

--- a/src/schema/native/schema.rs
+++ b/src/schema/native/schema.rs
@@ -1,0 +1,450 @@
+use crate::transform::native::{FieldDefinition, FieldDefinitionError, FieldType, FieldValue};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use thiserror::Error;
+
+/// Native representation of a schema with strongly typed field definitions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NativeSchema {
+    name: String,
+    fields: HashMap<String, FieldDefinition>,
+    key_config: KeyConfig,
+}
+
+/// Key configuration describing how records are addressed in storage.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum KeyConfig {
+    /// Schemas indexed by a single field.
+    Single { key_field: String },
+    /// Schemas indexed by a hash/range pair (legacy range behaviour).
+    Range {
+        hash_field: String,
+        range_field: String,
+    },
+    /// Schemas indexed by a hash/range pair (HashRange semantics).
+    HashRange {
+        hash_field: String,
+        range_field: String,
+    },
+}
+
+/// Builder that validates schema definitions before instantiating [`NativeSchema`].
+#[derive(Debug, Clone)]
+pub struct NativeSchemaBuilder {
+    name: String,
+    key_config: KeyConfig,
+    fields: HashMap<String, FieldDefinition>,
+}
+
+/// Errors encountered while constructing native schema definitions.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum NativeSchemaError {
+    /// The schema must contain at least one field definition.
+    #[error("schema '{schema}' must contain at least one field")]
+    EmptySchema { schema: String },
+
+    /// Duplicate field definitions are not permitted.
+    #[error("schema '{schema}' already defines field '{field}'")]
+    DuplicateField { schema: String, field: String },
+
+    /// The stored definition name must match the key used in the map.
+    #[error(
+        "field definition name '{definition_name}' does not match registration key '{field}' in schema '{schema}'"
+    )]
+    FieldNameMismatch {
+        schema: String,
+        field: String,
+        definition_name: String,
+    },
+
+    /// Field definitions must pass validation before registration.
+    #[error("field '{field}' in schema '{schema}' is invalid: {source}")]
+    InvalidFieldDefinition {
+        schema: String,
+        field: String,
+        #[source]
+        source: FieldDefinitionError,
+    },
+
+    /// The key configuration references a field that does not exist.
+    #[error("schema '{schema}' is missing required key field '{field}'")]
+    MissingKeyField { schema: String, field: String },
+
+    /// Key fields must be marked as required.
+    #[error("key field '{field}' in schema '{schema}' must be marked as required")]
+    KeyFieldNotRequired { schema: String, field: String },
+
+    /// Key configuration cannot reference the same field multiple times.
+    #[error("key configuration for schema '{schema}' references '{field}' multiple times")]
+    DuplicateKeyField { schema: String, field: String },
+
+    /// Key fields cannot rely on null-only types.
+    #[error("key field '{field}' in schema '{schema}' cannot use type {actual:?}")]
+    InvalidKeyFieldType {
+        schema: String,
+        field: String,
+        actual: FieldType,
+    },
+}
+
+/// Errors emitted while validating data against a [`NativeSchema`].
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SchemaValidationError {
+    /// Payload supplied a field that is not declared by the schema.
+    #[error("schema '{schema}' does not define field '{field}'")]
+    UnknownField { schema: String, field: String },
+
+    /// A required field is missing from the payload.
+    #[error("schema '{schema}' is missing required field '{field}'")]
+    MissingRequiredField { schema: String, field: String },
+
+    /// A field value does not match the declared type.
+    #[error(
+        "field '{field}' in schema '{schema}' has type mismatch: expected {expected:?}, got {actual:?}"
+    )]
+    TypeMismatch {
+        schema: String,
+        field: String,
+        expected: Box<FieldType>,
+        actual: Box<FieldType>,
+    },
+
+    /// Optional field could not resolve a default value while normalising data.
+    #[error("schema '{schema}' could not resolve default for optional field '{field}'")]
+    DefaultResolutionFailed { schema: String, field: String },
+}
+
+impl NativeSchema {
+    /// Create a builder for assembling a schema incrementally.
+    #[must_use]
+    pub fn builder(name: impl Into<String>, key_config: KeyConfig) -> NativeSchemaBuilder {
+        NativeSchemaBuilder::new(name, key_config)
+    }
+
+    /// Construct a schema directly from an iterator of field definitions.
+    pub fn try_from_definitions(
+        name: impl Into<String>,
+        key_config: KeyConfig,
+        definitions: impl IntoIterator<Item = FieldDefinition>,
+    ) -> Result<Self, NativeSchemaError> {
+        let mut builder = Self::builder(name, key_config);
+        builder.add_fields(definitions)?;
+        builder.build()
+    }
+
+    /// Name of the schema.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Key configuration associated with the schema.
+    #[must_use]
+    pub fn key_config(&self) -> &KeyConfig {
+        &self.key_config
+    }
+
+    /// Access the registered field definitions.
+    #[must_use]
+    pub fn fields(&self) -> &HashMap<String, FieldDefinition> {
+        &self.fields
+    }
+
+    /// Retrieve a field definition by name.
+    #[must_use]
+    pub fn get_field(&self, field: &str) -> Option<&FieldDefinition> {
+        self.fields.get(field)
+    }
+
+    /// Return the number of registered fields.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Check whether the schema contains at least one field.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Register an additional field after the schema has been created.
+    pub fn add_field(&mut self, definition: FieldDefinition) -> Result<(), NativeSchemaError> {
+        let field_name = definition.name.clone();
+        self.ensure_definition_valid(&field_name, &definition)?;
+
+        if self.fields.contains_key(&field_name) {
+            return Err(NativeSchemaError::DuplicateField {
+                schema: self.name.clone(),
+                field: field_name,
+            });
+        }
+
+        self.fields.insert(field_name.clone(), definition);
+        self.validate_key_config()?;
+        Ok(())
+    }
+
+    /// Validate a payload against the schema without mutating it.
+    pub fn validate_payload(
+        &self,
+        payload: &HashMap<String, FieldValue>,
+    ) -> Result<(), SchemaValidationError> {
+        self.ensure_known_fields(payload.keys())?;
+
+        for (field_name, definition) in &self.fields {
+            match payload.get(field_name) {
+                Some(value) => {
+                    if !definition.field_type.matches(value) {
+                        return Err(SchemaValidationError::TypeMismatch {
+                            schema: self.name.clone(),
+                            field: field_name.clone(),
+                            expected: Box::new(definition.field_type.clone()),
+                            actual: Box::new(value.field_type()),
+                        });
+                    }
+                }
+                None if definition.required => {
+                    return Err(SchemaValidationError::MissingRequiredField {
+                        schema: self.name.clone(),
+                        field: field_name.clone(),
+                    });
+                }
+                None => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate payload types and populate omitted optional fields with defaults.
+    pub fn normalise_payload(
+        &self,
+        payload: &mut HashMap<String, FieldValue>,
+    ) -> Result<(), SchemaValidationError> {
+        self.ensure_known_fields(payload.keys())?;
+
+        for (field_name, definition) in &self.fields {
+            match payload.get(field_name) {
+                Some(value) => {
+                    if !definition.field_type.matches(value) {
+                        return Err(SchemaValidationError::TypeMismatch {
+                            schema: self.name.clone(),
+                            field: field_name.clone(),
+                            expected: Box::new(definition.field_type.clone()),
+                            actual: Box::new(value.field_type()),
+                        });
+                    }
+                }
+                None if definition.required => {
+                    return Err(SchemaValidationError::MissingRequiredField {
+                        schema: self.name.clone(),
+                        field: field_name.clone(),
+                    });
+                }
+                None => {
+                    let Some(default_value) = definition.effective_default() else {
+                        return Err(SchemaValidationError::DefaultResolutionFailed {
+                            schema: self.name.clone(),
+                            field: field_name.clone(),
+                        });
+                    };
+                    payload.insert(field_name.clone(), default_value);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Produce a payload that includes defaults for optional fields.
+    pub fn project_payload(
+        &self,
+        payload: &HashMap<String, FieldValue>,
+    ) -> Result<HashMap<String, FieldValue>, SchemaValidationError> {
+        let mut normalised = payload.clone();
+        self.normalise_payload(&mut normalised)?;
+        Ok(normalised)
+    }
+
+    fn validate_structure(&self) -> Result<(), NativeSchemaError> {
+        if self.fields.is_empty() {
+            return Err(NativeSchemaError::EmptySchema {
+                schema: self.name.clone(),
+            });
+        }
+
+        for (field_name, definition) in &self.fields {
+            if definition.name != *field_name {
+                return Err(NativeSchemaError::FieldNameMismatch {
+                    schema: self.name.clone(),
+                    field: field_name.clone(),
+                    definition_name: definition.name.clone(),
+                });
+            }
+
+            definition
+                .validate()
+                .map_err(|source| NativeSchemaError::InvalidFieldDefinition {
+                    schema: self.name.clone(),
+                    field: field_name.clone(),
+                    source,
+                })?;
+        }
+
+        self.validate_key_config()
+    }
+
+    fn validate_key_config(&self) -> Result<(), NativeSchemaError> {
+        let mut seen = HashSet::new();
+        for field_name in self.key_config.field_names() {
+            if !seen.insert(field_name) {
+                return Err(NativeSchemaError::DuplicateKeyField {
+                    schema: self.name.clone(),
+                    field: field_name.to_string(),
+                });
+            }
+
+            let Some(definition) = self.fields.get(field_name) else {
+                return Err(NativeSchemaError::MissingKeyField {
+                    schema: self.name.clone(),
+                    field: field_name.to_string(),
+                });
+            };
+
+            if !definition.required {
+                return Err(NativeSchemaError::KeyFieldNotRequired {
+                    schema: self.name.clone(),
+                    field: field_name.to_string(),
+                });
+            }
+
+            let field_type = definition.field_type.clone();
+            if field_type == FieldType::Null {
+                return Err(NativeSchemaError::InvalidKeyFieldType {
+                    schema: self.name.clone(),
+                    field: field_name.to_string(),
+                    actual: field_type,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn ensure_definition_valid(
+        &self,
+        field_name: &str,
+        definition: &FieldDefinition,
+    ) -> Result<(), NativeSchemaError> {
+        if definition.name != field_name {
+            return Err(NativeSchemaError::FieldNameMismatch {
+                schema: self.name.clone(),
+                field: field_name.to_string(),
+                definition_name: definition.name.clone(),
+            });
+        }
+
+        definition
+            .validate()
+            .map_err(|source| NativeSchemaError::InvalidFieldDefinition {
+                schema: self.name.clone(),
+                field: field_name.to_string(),
+                source,
+            })
+    }
+
+    fn ensure_known_fields<'a>(
+        &self,
+        payload_fields: impl IntoIterator<Item = &'a String>,
+    ) -> Result<(), SchemaValidationError> {
+        for field in payload_fields {
+            if !self.fields.contains_key(field.as_str()) {
+                return Err(SchemaValidationError::UnknownField {
+                    schema: self.name.clone(),
+                    field: field.clone(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl NativeSchemaBuilder {
+    /// Create a new builder for the provided schema name and key configuration.
+    #[must_use]
+    pub fn new(name: impl Into<String>, key_config: KeyConfig) -> Self {
+        Self {
+            name: name.into(),
+            key_config,
+            fields: HashMap::new(),
+        }
+    }
+
+    /// Add a field definition to the schema under construction.
+    pub fn add_field(
+        &mut self,
+        definition: FieldDefinition,
+    ) -> Result<&mut Self, NativeSchemaError> {
+        let field_name = definition.name.clone();
+
+        if self.fields.contains_key(&field_name) {
+            return Err(NativeSchemaError::DuplicateField {
+                schema: self.name.clone(),
+                field: field_name,
+            });
+        }
+
+        definition
+            .validate()
+            .map_err(|source| NativeSchemaError::InvalidFieldDefinition {
+                schema: self.name.clone(),
+                field: field_name.clone(),
+                source,
+            })?;
+
+        self.fields.insert(field_name, definition);
+        Ok(self)
+    }
+
+    /// Extend the builder with multiple field definitions.
+    pub fn add_fields(
+        &mut self,
+        definitions: impl IntoIterator<Item = FieldDefinition>,
+    ) -> Result<&mut Self, NativeSchemaError> {
+        for definition in definitions {
+            self.add_field(definition)?;
+        }
+        Ok(self)
+    }
+
+    /// Finalise the builder into a [`NativeSchema`], running validation checks.
+    pub fn build(self) -> Result<NativeSchema, NativeSchemaError> {
+        let schema = NativeSchema {
+            name: self.name,
+            fields: self.fields,
+            key_config: self.key_config,
+        };
+
+        schema.validate_structure()?;
+        Ok(schema)
+    }
+}
+
+impl KeyConfig {
+    fn field_names(&self) -> Vec<&str> {
+        match self {
+            KeyConfig::Single { key_field } => vec![key_field.as_str()],
+            KeyConfig::Range {
+                hash_field,
+                range_field,
+            }
+            | KeyConfig::HashRange {
+                hash_field,
+                range_field,
+            } => vec![hash_field.as_str(), range_field.as_str()],
+        }
+    }
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -12,6 +12,7 @@ pub mod iterator_stack_tests;
 pub mod json_boundary_layer_tests;
 pub mod mutation_completion_tests;
 pub mod native_field_definition_tests;
+pub mod native_schema_tests;
 pub mod native_transform_spec_tests;
 pub mod native_types_tests;
 pub mod range_filter_tests;

--- a/tests/unit/native_schema_tests.rs
+++ b/tests/unit/native_schema_tests.rs
@@ -1,0 +1,301 @@
+use datafold::schema::native::{
+    KeyConfig, NativeSchema, NativeSchemaBuilder, NativeSchemaError, SchemaValidationError,
+};
+use datafold::transform::{
+    FieldValue, NativeFieldDefinition, NativeFieldDefinitionError, NativeFieldType,
+};
+use std::collections::HashMap;
+
+fn make_schema_builder(name: &str) -> NativeSchemaBuilder {
+    NativeSchema::builder(
+        name.to_string(),
+        KeyConfig::Single {
+            key_field: "id".to_string(),
+        },
+    )
+}
+
+fn make_string_field(name: &str) -> NativeFieldDefinition {
+    NativeFieldDefinition::new(name, NativeFieldType::String)
+}
+
+#[test]
+fn builder_rejects_duplicate_field_names() {
+    let mut builder = make_schema_builder("BlogPost");
+    builder
+        .add_field(make_string_field("id"))
+        .expect("first field should be accepted");
+
+    let error = builder
+        .add_field(make_string_field("id"))
+        .expect_err("duplicate field must fail");
+
+    assert_eq!(
+        error,
+        NativeSchemaError::DuplicateField {
+            schema: "BlogPost".to_string(),
+            field: "id".to_string(),
+        }
+    );
+}
+
+#[test]
+fn builder_rejects_invalid_field_definition() {
+    let mut builder = make_schema_builder("Articles");
+    let invalid_definition = NativeFieldDefinition::new("", NativeFieldType::String);
+
+    let error = builder
+        .add_field(invalid_definition)
+        .expect_err("invalid field should be rejected");
+
+    assert!(matches!(
+        error,
+        NativeSchemaError::InvalidFieldDefinition {
+            schema,
+            field,
+            source: NativeFieldDefinitionError::EmptyName,
+        } if schema == "Articles" && field.is_empty()
+    ));
+}
+
+#[test]
+fn builder_rejects_missing_key_field() {
+    let mut builder = make_schema_builder("Comment");
+    builder
+        .add_field(make_string_field("title"))
+        .expect("non-key field should be accepted");
+
+    let error = builder
+        .build()
+        .expect_err("schema should fail when key field is missing");
+
+    assert_eq!(
+        error,
+        NativeSchemaError::MissingKeyField {
+            schema: "Comment".to_string(),
+            field: "id".to_string(),
+        }
+    );
+}
+
+#[test]
+fn builder_rejects_optional_key_field() {
+    let mut builder = make_schema_builder("User");
+    let optional_id = make_string_field("id").with_required(false);
+    builder
+        .add_field(optional_id)
+        .expect("field registration should succeed before build");
+
+    let error = builder
+        .build()
+        .expect_err("key field must be marked required");
+
+    assert_eq!(
+        error,
+        NativeSchemaError::KeyFieldNotRequired {
+            schema: "User".to_string(),
+            field: "id".to_string(),
+        }
+    );
+}
+
+#[test]
+fn builder_rejects_null_key_field_type() {
+    let mut builder = make_schema_builder("NullKey");
+    let null_field = NativeFieldDefinition::new("id", NativeFieldType::Null);
+    builder
+        .add_field(null_field)
+        .expect("field registration should succeed before build");
+
+    let error = builder
+        .build()
+        .expect_err("null key field should be rejected");
+
+    assert_eq!(
+        error,
+        NativeSchemaError::InvalidKeyFieldType {
+            schema: "NullKey".to_string(),
+            field: "id".to_string(),
+            actual: NativeFieldType::Null,
+        }
+    );
+}
+
+#[test]
+fn builder_produces_valid_schema() {
+    let mut builder = make_schema_builder("Article");
+    builder
+        .add_field(make_string_field("id"))
+        .expect("key field should be accepted");
+    builder
+        .add_field(make_string_field("title"))
+        .expect("secondary field should be accepted");
+
+    let schema = builder.build().expect("schema build should succeed");
+
+    assert_eq!(schema.name(), "Article");
+    assert_eq!(schema.len(), 2);
+    assert!(schema.get_field("title").is_some());
+}
+
+#[test]
+fn validate_payload_accepts_matching_data() {
+    let schema = NativeSchema::try_from_definitions(
+        "Post",
+        KeyConfig::Single {
+            key_field: "id".to_string(),
+        },
+        vec![
+            make_string_field("id"),
+            make_string_field("title").with_required(false),
+        ],
+    )
+    .expect("schema creation should succeed");
+
+    let mut payload = HashMap::new();
+    payload.insert("id".to_string(), FieldValue::String("123".to_string()));
+
+    schema
+        .validate_payload(&payload)
+        .expect("payload should be considered valid");
+}
+
+#[test]
+fn validate_payload_rejects_missing_required_field() {
+    let schema = NativeSchema::try_from_definitions(
+        "Inventory",
+        KeyConfig::Single {
+            key_field: "id".to_string(),
+        },
+        vec![make_string_field("id"), make_string_field("sku")],
+    )
+    .expect("schema creation should succeed");
+
+    let mut payload = HashMap::new();
+    payload.insert("id".to_string(), FieldValue::String("1".to_string()));
+
+    let error = schema
+        .validate_payload(&payload)
+        .expect_err("missing required field should be rejected");
+
+    assert_eq!(
+        error,
+        SchemaValidationError::MissingRequiredField {
+            schema: "Inventory".to_string(),
+            field: "sku".to_string(),
+        }
+    );
+}
+
+#[test]
+fn validate_payload_rejects_unknown_field() {
+    let schema = NativeSchema::try_from_definitions(
+        "Product",
+        KeyConfig::Single {
+            key_field: "id".to_string(),
+        },
+        vec![make_string_field("id")],
+    )
+    .expect("schema creation should succeed");
+
+    let mut payload = HashMap::new();
+    payload.insert("id".to_string(), FieldValue::String("1".to_string()));
+    payload.insert(
+        "extra".to_string(),
+        FieldValue::String("surplus".to_string()),
+    );
+
+    let error = schema
+        .validate_payload(&payload)
+        .expect_err("unknown field should be rejected");
+
+    assert_eq!(
+        error,
+        SchemaValidationError::UnknownField {
+            schema: "Product".to_string(),
+            field: "extra".to_string(),
+        }
+    );
+}
+
+#[test]
+fn validate_payload_rejects_type_mismatch() {
+    let schema = NativeSchema::try_from_definitions(
+        "Metrics",
+        KeyConfig::Single {
+            key_field: "id".to_string(),
+        },
+        vec![make_string_field("id")],
+    )
+    .expect("schema creation should succeed");
+
+    let mut payload = HashMap::new();
+    payload.insert("id".to_string(), FieldValue::Integer(42));
+
+    let error = schema
+        .validate_payload(&payload)
+        .expect_err("incorrect type should be rejected");
+
+    assert_eq!(
+        error,
+        SchemaValidationError::TypeMismatch {
+            schema: "Metrics".to_string(),
+            field: "id".to_string(),
+            expected: Box::new(NativeFieldType::String),
+            actual: Box::new(FieldValue::Integer(42).field_type()),
+        }
+    );
+}
+
+#[test]
+fn normalise_payload_inserts_defaults_for_optional_fields() {
+    let schema = NativeSchema::try_from_definitions(
+        "Profiles",
+        KeyConfig::Single {
+            key_field: "id".to_string(),
+        },
+        vec![
+            make_string_field("id"),
+            make_string_field("display_name").with_required(false),
+        ],
+    )
+    .expect("schema creation should succeed");
+
+    let mut payload = HashMap::from([("id".to_string(), FieldValue::String("user-1".to_string()))]);
+
+    schema
+        .normalise_payload(&mut payload)
+        .expect("normalisation should succeed");
+
+    assert_eq!(
+        payload.get("display_name"),
+        Some(&FieldValue::String(String::new()))
+    );
+}
+
+#[test]
+fn project_payload_returns_clone_with_defaults() {
+    let schema = NativeSchema::try_from_definitions(
+        "Accounts",
+        KeyConfig::Single {
+            key_field: "id".to_string(),
+        },
+        vec![
+            make_string_field("id"),
+            make_string_field("nickname").with_required(false),
+        ],
+    )
+    .expect("schema creation should succeed");
+
+    let payload = HashMap::from([("id".to_string(), FieldValue::String("acct-42".to_string()))]);
+
+    let projected = schema
+        .project_payload(&payload)
+        .expect("projection should succeed");
+
+    assert_eq!(payload.len(), 1, "original payload must stay untouched");
+    assert_eq!(
+        projected.get("nickname"),
+        Some(&FieldValue::String(String::new()))
+    );
+}


### PR DESCRIPTION
## Summary
- add a native schema module with builder, validation, and payload normalization helpers
- expose the native schema types through the schema module and cover them with comprehensive unit tests
- document the new native schema logic and mark task NTS-2-1 as in review

## Testing
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features
- npm ci
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d7b1e5cc83278d4cede1913b9dd6