### PR TITLE
SKC-6-10: enforce schema-driven universal key resolution

### DIFF
--- a/docs/delivery/SKC-6/SKC-6-10.md
+++ b/docs/delivery/SKC-6/SKC-6-10.md
@@ -9,6 +9,8 @@ Remove the `create_legacy_resolved_keys` fallback function and related fallback 
 | 2025-01-27 18:35:00 | Created | N/A | Proposed | Task file created | ai-agent |
 | 2025-01-27 20:15:00 | Status Update | Proposed | InProgress | Began enforcing strict range-key validation and updating tests | ai-agent |
 | 2025-01-27 22:05:00 | Status Update | InProgress | Review | Completed schema validation updates and verified tests and clippy | ai-agent |
+| 2025-01-28 09:30:00 | Status Update | Review | InProgress | Resumed task to remove remaining universal key fallbacks and tighten error propagation | ai-agent |
+| 2025-01-28 11:45:00 | Status Update | InProgress | Done | Removed legacy fallback logic, refreshed documentation, and verified via tests and clippy | ai-agent |
 
 ## Requirements
 - Remove the `create_legacy_resolved_keys` function from `field_processing.rs`

--- a/docs/delivery/SKC-6/tasks.md
+++ b/docs/delivery/SKC-6/tasks.md
@@ -17,7 +17,7 @@ This document lists all tasks associated with PBI SKC-6.
 | SKC-6-7 | [Align downstream producers with normalized mutation payloads](./SKC-6-7.md) | Done | Refactor transform/message bus producers to use the shared payload shape. |
 | SKC-6-8 | [Expand universal key regression test coverage](./SKC-6-8.md) | Done | Add comprehensive unit and integration tests for universal key workflows. |
 | SKC-6-9 | [Document universal key field processing behavior](./SKC-6-9.md) | Review | Refresh documentation to describe the new helpers and payload structure. |
-| SKC-6-10 | [Remove legacy fallback logic from universal key resolution](./SKC-6-10.md) | Review | Remove create_legacy_resolved_keys fallback introduced in SKC-6-2 to enforce strict schema-driven key extraction. |
+| SKC-6-10 | [Remove legacy fallback logic from universal key resolution](./SKC-6-10.md) | Done | Remove create_legacy_resolved_keys fallback introduced in SKC-6-2 to enforce strict schema-driven key extraction. |
 
 **Documentation References**
 

--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -31,6 +31,7 @@ This document contains the most up-to-date and condensed information about the p
 | SCHEMA-KEY-009 | Transform managers and downstream message bus constructors must publish FieldValueSet requests using normalized helpers so payloads include schema-derived hash/range metadata. | fold_db_core/transform_manager, fold_db_core/infrastructure/message_bus | 2025-09-23 18:30:00 | None |
 | SCHEMA-KEY-010 | Range schema requests must supply the configured key.range_field or a normalized range value; missing configuration or payload values return SchemaError without legacy fallback. | schema/schema_operations.rs, tests/unit/field_processing, tests/unit/mutation | 2025-01-27 22:05:00 | None |
 | SCHEMA-KEY-011 | Transform aggregation pipeline shapes outputs via shape_unified_result to return {hash, range, fields} while preserving legacy top-level keys for compatibility. | transform/aggregation.rs, transform/executor.rs, transform/coordination.rs | 2025-09-20 12:30:00 | None |
+| SCHEMA-KEY-012 | AtomManager universal key resolution surfaces SchemaError failures directly and HashRange molecule storage no longer parses legacy string snapshots; all callers must rely on schema-driven normalized data. | fold_db_core/managers/atom/field_processing.rs | 2025-01-28 11:45:00 | None |
 | AUTH-DEV-001 | All endpoints currently operate in development mode with authentication disabled. All requests use "web-ui" identity automatically. | query_routes, http_server, api/clients | 2025-01-27 16:00:00 | None |
 
 ### AUTH-DEV-001: Development Mode Authentication

--- a/src/fold_db_core/managers/atom/field_processing.rs
+++ b/src/fold_db_core/managers/atom/field_processing.rs
@@ -74,7 +74,7 @@ pub fn resolve_universal_keys(
     manager: &AtomManager,
     schema_name: &str,
     request_payload: &serde_json::Value,
-) -> Result<ResolvedAtomKeys, Box<dyn std::error::Error>> {
+) -> Result<ResolvedAtomKeys, SchemaError> {
     debug!("🔑 Resolving universal keys for schema: {}", schema_name);
 
     // Load schema from database
@@ -84,12 +84,12 @@ pub fn resolve_universal_keys(
         .map_err(|e| {
             let error_msg = format!("Failed to load schema '{}': {}", schema_name, e);
             error!("❌ {}", error_msg);
-            Box::new(SchemaError::InvalidData(error_msg)) as Box<dyn std::error::Error>
+            SchemaError::InvalidData(error_msg)
         })?
         .ok_or_else(|| {
             let error_msg = format!("Schema '{}' not found", schema_name);
             error!("❌ {}", error_msg);
-            Box::new(SchemaError::InvalidData(error_msg)) as Box<dyn std::error::Error>
+            SchemaError::InvalidData(error_msg)
         })?;
 
     debug!(
@@ -102,7 +102,7 @@ pub fn resolve_universal_keys(
         extract_unified_keys(&schema, request_payload).map_err(|e| {
             let error_msg = format!("Failed to extract keys for schema '{}': {}", schema_name, e);
             error!("❌ {}", error_msg);
-            Box::new(SchemaError::InvalidData(error_msg)) as Box<dyn std::error::Error>
+            SchemaError::InvalidData(error_msg)
         })?;
 
     debug!(
@@ -120,7 +120,7 @@ pub fn resolve_universal_keys(
     .map_err(|e| {
         let error_msg = format!("Failed to shape result for schema '{}': {}", schema_name, e);
         error!("❌ {}", error_msg);
-        Box::new(SchemaError::InvalidData(error_msg)) as Box<dyn std::error::Error>
+        SchemaError::InvalidData(error_msg)
     })?;
 
     // Extract fields from the shaped result
@@ -420,23 +420,12 @@ fn create_hashrange_molecule(
         Ok(Some(data)) => data,
         Ok(None) => serde_json::Map::new(),
         Err(e) => {
-            warn!(
-                "⚠️ Failed to load HashRange map for key {}: {}. Attempting legacy string fallback.",
+            let error_msg = format!(
+                "Failed to load HashRange map for key {}: {}",
                 storage_key, e
             );
-            match manager.db_ops.get_item::<String>(&storage_key) {
-                Ok(Some(raw)) => {
-                    serde_json::from_str(&raw).unwrap_or_else(|_| serde_json::Map::new())
-                }
-                Ok(None) => serde_json::Map::new(),
-                Err(inner) => {
-                    warn!(
-                        "⚠️ Legacy fallback for key {} also failed: {}. Using empty map.",
-                        storage_key, inner
-                    );
-                    serde_json::Map::new()
-                }
-            }
+            error!("❌ {}", error_msg);
+            return Err(Box::new(SchemaError::InvalidData(error_msg)) as Box<dyn std::error::Error>);
         }
     };
 
@@ -566,15 +555,18 @@ fn handle_successful_field_value_processing(
     publish_field_value_set_event(manager, request, resolved_keys);
 
     // Fire DataPersisted event to signal that data is now queryable
-    let data_persisted = crate::fold_db_core::infrastructure::message_bus::events::schema_events::DataPersisted::new(
-        request.schema_name.clone(),
-        request.correlation_id.clone(),
-    );
+    let data_persisted =
+        crate::fold_db_core::infrastructure::message_bus::events::schema_events::DataPersisted::new(
+            request.schema_name.clone(),
+            request.correlation_id.clone(),
+        );
     if let Err(e) = manager.message_bus.publish(data_persisted) {
         warn!("⚠️ Failed to publish DataPersisted event: {}", e);
     } else {
-        info!("📊 DataPersisted event fired for schema '{}' with correlation_id '{}'", 
-              request.schema_name, request.correlation_id);
+        info!(
+            "📊 DataPersisted event fired for schema '{}' with correlation_id '{}'",
+            request.schema_name, request.correlation_id
+        );
     }
 
     // Create key snapshot for response


### PR DESCRIPTION
## Summary
- propagate SchemaError from `resolve_universal_keys` and eliminate the HashRange string fallback so field processing fails fast on schema issues
- update SKC-6 documentation and project logic to reflect the stricter universal key handling

## Testing
- cargo test --workspace
- cargo clippy --all-targets --all-features
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d2ef9256dc8327aa82028f7a7e2423