### PR TITLE
Add typed field value wrappers and integrate with requests

### DIFF
--- a/docs/project_logic.md
+++ b/docs/project_logic.md
@@ -32,6 +32,7 @@ This document contains the most up-to-date and condensed information about the p
 | SCHEMA-KEY-010 | Range schema requests must supply the configured key.range_field or a normalized range value; missing configuration or payload values return SchemaError without legacy fallback. | schema/schema_operations.rs, tests/unit/field_processing, tests/unit/mutation | 2025-01-27 22:05:00 | None |
 | SCHEMA-KEY-011 | Transform aggregation pipeline shapes outputs via shape_unified_result to return {hash, range, fields} while preserving legacy top-level keys for compatibility. | transform/aggregation.rs, transform/executor.rs, transform/coordination.rs | 2025-09-20 12:30:00 | None |
 | SCHEMA-KEY-012 | AtomManager universal key resolution surfaces SchemaError failures directly and HashRange molecule storage no longer parses legacy string snapshots; all callers must rely on schema-driven normalized data. | fold_db_core/managers/atom/field_processing.rs | 2025-01-28 11:45:00 | None |
+| TSW-001 | TypedFieldValue wrappers must be used at API boundaries to validate schema field payloads before processing. | field_value, fold_db_core::infrastructure::message_bus::request_events | 2025-01-27 23:30:00 | None |
 | AUTH-DEV-001 | All endpoints currently operate in development mode with authentication disabled. All requests use "web-ui" identity automatically. | query_routes, http_server, api/clients | 2025-01-27 16:00:00 | None |
 
 ### AUTH-DEV-001: Development Mode Authentication

--- a/docs/reference/fold_db_core/typed_field_value.md
+++ b/docs/reference/fold_db_core/typed_field_value.md
@@ -1,0 +1,75 @@
+# Typed Field Value Wrappers
+
+The type-safe field value wrappers introduced in **TSW-1** provide a reliable
+bridge between the flexible JSON payloads exchanged across FoldDB and the
+strongly typed expectations of the Rust services that consume them.
+
+## Core Types
+
+- `TypedFieldValue` wraps a `serde_json::Value` and exposes typed accessors.
+- `FieldType` classifies JSON data as `string`, `integer`, `float`, `boolean`,
+  `array`, `object`, etc., enabling precise validation and error reporting.
+
+The wrapper retains the original JSON payload so existing serialization remains
+unchanged while enabling consumers to opt-in to strict type checks whenever they
+need them.
+
+## Accessor Methods
+
+`TypedFieldValue` surfaces ergonomic accessors that validate the payload before
+returning data:
+
+- `as_string()`, `as_bool()`, `as_number()`, `as_i64()`, `as_u64()`, `as_f64()`
+- `as_array()` / `into_typed_array()`
+- `as_object()` / `into_typed_object()` (returns a `BTreeMap<String, TypedFieldValue>`)
+
+Each method returns a `SchemaError::InvalidData` with detailed context if the
+payload does not match the requested type.
+
+## Validation Helpers
+
+Two helper methods make it easy to ensure an incoming payload matches a desired
+shape:
+
+- `ensure_type(expected)` – Validates against a `FieldType` and returns `Ok(())`
+  on success.
+- `ensure_type_with_context(expected, context)` – Same validation but includes a
+  fully qualified field name (e.g. `"User.email"`) in the error message.
+
+## Message Bus Integration
+
+`FieldValueSetRequest` and `FieldUpdateRequest` now expose helper constructors
+and accessors that leverage the typed wrappers:
+
+- `typed_value()` – Returns a `TypedFieldValue` clone of the payload.
+- `typed_value_with_validation(expected)` – Extracts the typed value and
+  validates it against an expected `FieldType`, automatically including the
+  request's `field_name` in any error message.
+- `from_typed_value(...)` – Creates a new request while automatically converting
+  the typed payload back into JSON for transport.
+
+These helpers ensure API boundary code can validate incoming mutations without
+re-implementing conversion logic or duplicating error handling.
+
+## Usage Example
+
+```rust
+use fold_db::field_value::{TypedFieldValue, ValueFieldType};
+use fold_db::fold_db_core::infrastructure::message_bus::request_events::FieldValueSetRequest;
+
+let request = FieldValueSetRequest::from_typed_value(
+    "corr-123".into(),
+    "User".into(),
+    "User.email".into(),
+    TypedFieldValue::from("user@example.com"),
+    "pubkey".into(),
+    None,
+);
+
+let typed_value = request
+    .typed_value_with_validation(ValueFieldType::String)?;
+println!("Email: {}", typed_value.as_string()?);
+```
+
+The resulting workflow keeps JSON payloads compatible with existing consumers
+while ensuring type mismatches are caught immediately with actionable errors.

--- a/src/field_value/mod.rs
+++ b/src/field_value/mod.rs
@@ -1,0 +1,418 @@
+//! Type-safe wrappers for field values exchanged at API boundaries.
+//!
+//! The [`TypedFieldValue`] type provides ergonomic accessors that validate
+//! the underlying [`serde_json::Value`] before exposing it as a strongly-typed
+//! value. This enables callers to surface clear error messages whenever a
+//! payload contains an unexpected type while preserving the flexibility of the
+//! existing JSON-based transport between services.
+
+use crate::schema::types::SchemaError;
+use serde_json::{Map, Number, Value};
+use std::collections::BTreeMap;
+
+/// Supported field value classifications.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FieldType {
+    Null,
+    Boolean,
+    String,
+    Integer,
+    UnsignedInteger,
+    Float,
+    Object,
+    Array,
+}
+
+impl FieldType {
+    /// Determine the [`FieldType`] that matches the provided JSON value.
+    pub fn from_value(value: &Value) -> Self {
+        match value {
+            Value::Null => FieldType::Null,
+            Value::Bool(_) => FieldType::Boolean,
+            Value::String(_) => FieldType::String,
+            Value::Number(number) => {
+                if number.is_i64() {
+                    FieldType::Integer
+                } else if number.is_u64() {
+                    FieldType::UnsignedInteger
+                } else {
+                    FieldType::Float
+                }
+            }
+            Value::Object(_) => FieldType::Object,
+            Value::Array(_) => FieldType::Array,
+        }
+    }
+
+    /// Human readable name used in error messages.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FieldType::Null => "null",
+            FieldType::Boolean => "boolean",
+            FieldType::String => "string",
+            FieldType::Integer => "integer",
+            FieldType::UnsignedInteger => "unsigned integer",
+            FieldType::Float => "float",
+            FieldType::Object => "object",
+            FieldType::Array => "array",
+        }
+    }
+}
+
+impl std::fmt::Display for FieldType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Wrapper that exposes type-safe accessors over [`serde_json::Value`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypedFieldValue {
+    value: Value,
+}
+
+impl TypedFieldValue {
+    /// Creates a new wrapper around the provided JSON value.
+    pub fn new(value: Value) -> Self {
+        Self { value }
+    }
+
+    /// Returns the detected [`FieldType`] for the wrapped value.
+    pub fn field_type(&self) -> FieldType {
+        FieldType::from_value(&self.value)
+    }
+
+    /// Returns a reference to the raw JSON value.
+    pub fn as_json(&self) -> &Value {
+        &self.value
+    }
+
+    /// Consumes the wrapper and returns the raw JSON value.
+    pub fn into_inner(self) -> Value {
+        self.value
+    }
+
+    /// Validates that the wrapped value matches the expected [`FieldType`].
+    pub fn ensure_type(&self, expected: FieldType) -> Result<(), SchemaError> {
+        self.ensure_type_with_context(expected, None)
+    }
+
+    /// Validates the wrapped value and includes the provided context in errors.
+    pub fn ensure_type_with_context(
+        &self,
+        expected: FieldType,
+        context: Option<&str>,
+    ) -> Result<(), SchemaError> {
+        let actual = self.field_type();
+        if actual == expected {
+            Ok(())
+        } else {
+            Err(Self::type_mismatch_error(
+                expected.as_str(),
+                actual,
+                context,
+            ))
+        }
+    }
+
+    /// Returns the wrapped string if present.
+    pub fn as_string(&self) -> Result<&str, SchemaError> {
+        match &self.value {
+            Value::String(value) => Ok(value.as_str()),
+            other => Err(Self::type_mismatch_error(
+                FieldType::String.as_str(),
+                FieldType::from_value(other),
+                None,
+            )),
+        }
+    }
+
+    /// Returns the wrapped boolean if present.
+    pub fn as_bool(&self) -> Result<bool, SchemaError> {
+        match &self.value {
+            Value::Bool(value) => Ok(*value),
+            other => Err(Self::type_mismatch_error(
+                FieldType::Boolean.as_str(),
+                FieldType::from_value(other),
+                None,
+            )),
+        }
+    }
+
+    /// Returns the wrapped [`serde_json::Number`] if present.
+    pub fn as_number(&self) -> Result<&Number, SchemaError> {
+        match &self.value {
+            Value::Number(number) => Ok(number),
+            other => Err(Self::type_mismatch_error(
+                "number",
+                FieldType::from_value(other),
+                None,
+            )),
+        }
+    }
+
+    /// Returns the wrapped number as `i64` when available.
+    pub fn as_i64(&self) -> Result<i64, SchemaError> {
+        let number = self.as_number()?;
+        let actual_type = self.field_type();
+        number.as_i64().ok_or_else(|| {
+            Self::type_mismatch_error(FieldType::Integer.as_str(), actual_type, None)
+        })
+    }
+
+    /// Returns the wrapped number as `u64` when available.
+    pub fn as_u64(&self) -> Result<u64, SchemaError> {
+        let number = self.as_number()?;
+        let actual_type = self.field_type();
+        number.as_u64().ok_or_else(|| {
+            Self::type_mismatch_error(FieldType::UnsignedInteger.as_str(), actual_type, None)
+        })
+    }
+
+    /// Returns the wrapped number as `f64` when available.
+    pub fn as_f64(&self) -> Result<f64, SchemaError> {
+        let number = self.as_number()?;
+        let actual_type = self.field_type();
+        number
+            .as_f64()
+            .ok_or_else(|| Self::type_mismatch_error(FieldType::Float.as_str(), actual_type, None))
+    }
+
+    /// Returns the wrapped JSON object if present.
+    pub fn as_object(&self) -> Result<&Map<String, Value>, SchemaError> {
+        match &self.value {
+            Value::Object(map) => Ok(map),
+            other => Err(Self::type_mismatch_error(
+                FieldType::Object.as_str(),
+                FieldType::from_value(other),
+                None,
+            )),
+        }
+    }
+
+    /// Returns the wrapped JSON array if present.
+    pub fn as_array(&self) -> Result<&Vec<Value>, SchemaError> {
+        match &self.value {
+            Value::Array(values) => Ok(values),
+            other => Err(Self::type_mismatch_error(
+                FieldType::Array.as_str(),
+                FieldType::from_value(other),
+                None,
+            )),
+        }
+    }
+
+    /// Converts the wrapped JSON array into a vector of [`TypedFieldValue`].
+    pub fn into_typed_array(self) -> Result<Vec<TypedFieldValue>, SchemaError> {
+        match self.value {
+            Value::Array(values) => Ok(values.into_iter().map(TypedFieldValue::from).collect()),
+            other => Err(Self::type_mismatch_error(
+                FieldType::Array.as_str(),
+                FieldType::from_value(&other),
+                None,
+            )),
+        }
+    }
+
+    /// Converts the wrapped JSON object into a typed map.
+    pub fn into_typed_object(self) -> Result<BTreeMap<String, TypedFieldValue>, SchemaError> {
+        match self.value {
+            Value::Object(values) => Ok(values
+                .into_iter()
+                .map(|(key, value)| (key, TypedFieldValue::from(value)))
+                .collect::<BTreeMap<_, _>>()),
+            other => Err(Self::type_mismatch_error(
+                FieldType::Object.as_str(),
+                FieldType::from_value(&other),
+                None,
+            )),
+        }
+    }
+
+    fn type_mismatch_error(
+        expected_label: &str,
+        actual: FieldType,
+        context: Option<&str>,
+    ) -> SchemaError {
+        let message = match context {
+            Some(field_name) => format!(
+                "Field '{}' expected {} but received {}",
+                field_name, expected_label, actual
+            ),
+            None => format!("Expected {} but received {}", expected_label, actual),
+        };
+        SchemaError::InvalidData(message)
+    }
+}
+
+impl From<Value> for TypedFieldValue {
+    fn from(value: Value) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&Value> for TypedFieldValue {
+    fn from(value: &Value) -> Self {
+        Self::new(value.clone())
+    }
+}
+
+impl From<String> for TypedFieldValue {
+    fn from(value: String) -> Self {
+        Self::new(Value::String(value))
+    }
+}
+
+impl From<&str> for TypedFieldValue {
+    fn from(value: &str) -> Self {
+        Self::new(Value::String(value.to_string()))
+    }
+}
+
+impl From<bool> for TypedFieldValue {
+    fn from(value: bool) -> Self {
+        Self::new(Value::Bool(value))
+    }
+}
+
+impl From<i64> for TypedFieldValue {
+    fn from(value: i64) -> Self {
+        Self::new(Value::Number(Number::from(value)))
+    }
+}
+
+impl From<u64> for TypedFieldValue {
+    fn from(value: u64) -> Self {
+        Self::new(Value::Number(Number::from(value)))
+    }
+}
+
+impl From<f64> for TypedFieldValue {
+    fn from(value: f64) -> Self {
+        Self::new(Value::Number(Number::from_f64(value).unwrap()))
+    }
+}
+
+impl From<Map<String, Value>> for TypedFieldValue {
+    fn from(map: Map<String, Value>) -> Self {
+        Self::new(Value::Object(map))
+    }
+}
+
+impl From<Vec<Value>> for TypedFieldValue {
+    fn from(values: Vec<Value>) -> Self {
+        Self::new(Value::Array(values))
+    }
+}
+
+impl AsRef<Value> for TypedFieldValue {
+    fn as_ref(&self) -> &Value {
+        self.as_json()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn detects_field_types_correctly() {
+        assert_eq!(FieldType::from_value(&Value::Null), FieldType::Null);
+        assert_eq!(
+            FieldType::from_value(&Value::Bool(true)),
+            FieldType::Boolean
+        );
+        assert_eq!(
+            FieldType::from_value(&Value::String("abc".into())),
+            FieldType::String
+        );
+        assert_eq!(
+            FieldType::from_value(&Value::Number(Number::from(123))),
+            FieldType::Integer
+        );
+        assert_eq!(
+            FieldType::from_value(&Value::Number(Number::from(123_u64))),
+            FieldType::Integer
+        );
+        assert_eq!(
+            FieldType::from_value(&Value::Number(Number::from(u64::MAX))),
+            FieldType::UnsignedInteger
+        );
+        assert_eq!(
+            FieldType::from_value(&Value::Number(Number::from_f64(1.5).unwrap())),
+            FieldType::Float
+        );
+        assert_eq!(
+            FieldType::from_value(&Value::Array(vec![])),
+            FieldType::Array
+        );
+        assert_eq!(
+            FieldType::from_value(&Value::Object(Map::new())),
+            FieldType::Object
+        );
+    }
+
+    #[test]
+    fn accessor_methods_return_expected_types() {
+        let string_value = TypedFieldValue::from("hello");
+        assert_eq!(string_value.as_string().unwrap(), "hello");
+
+        let bool_value = TypedFieldValue::from(true);
+        assert!(bool_value.as_bool().unwrap());
+
+        let int_value = TypedFieldValue::from(42_i64);
+        assert_eq!(int_value.as_number().unwrap().as_i64().unwrap(), 42);
+        assert_eq!(int_value.as_i64().unwrap(), 42);
+
+        let float_value = TypedFieldValue::from(3.14_f64);
+        assert_eq!(float_value.as_f64().unwrap(), 3.14_f64);
+
+        let array_value = TypedFieldValue::from(vec![json!(1), json!(2)]);
+        assert_eq!(array_value.as_array().unwrap().len(), 2);
+
+        let mut object = Map::new();
+        object.insert("key".into(), json!("value"));
+        let object_value = TypedFieldValue::from(object);
+        assert!(object_value.as_object().unwrap().contains_key("key"));
+    }
+
+    #[test]
+    fn accessor_methods_fail_with_clear_errors() {
+        let value = TypedFieldValue::from("text");
+        let err = value.as_bool().unwrap_err();
+        assert!(matches!(err, SchemaError::InvalidData(message) if message.contains("boolean")));
+
+        let number_value = TypedFieldValue::from(10_i64);
+        let err = number_value.as_array().unwrap_err();
+        assert!(matches!(err, SchemaError::InvalidData(message) if message.contains("array")));
+    }
+
+    #[test]
+    fn ensure_type_includes_context() {
+        let value = TypedFieldValue::from(json!(42));
+        let error = value
+            .ensure_type_with_context(FieldType::String, Some("user.age"))
+            .unwrap_err();
+
+        match error {
+            SchemaError::InvalidData(message) => {
+                assert!(message.contains("user.age"));
+                assert!(message.contains("string"));
+            }
+            _ => panic!("Unexpected error variant"),
+        }
+    }
+
+    #[test]
+    fn into_typed_collections_convert_recursively() {
+        let array_value = TypedFieldValue::from(json!(["a", 1]));
+        let typed_array = array_value.into_typed_array().unwrap();
+        assert_eq!(typed_array[0].as_string().unwrap(), "a");
+        assert_eq!(typed_array[1].as_i64().unwrap(), 1);
+
+        let map_value = TypedFieldValue::from(json!({"key": true}));
+        let typed_map = map_value.into_typed_object().unwrap();
+        assert!(typed_map.get("key").unwrap().as_bool().unwrap());
+    }
+}

--- a/src/fold_db_core/infrastructure/message_bus/events/request_events.rs
+++ b/src/fold_db_core/infrastructure/message_bus/events/request_events.rs
@@ -2,6 +2,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::EventType;
+use crate::field_value::{FieldType as ValueFieldType, TypedFieldValue};
+use crate::fold_db_core::infrastructure::message_bus::atom_events::MutationContext;
+use crate::schema::types::SchemaError;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AtomCreateRequest {
@@ -131,6 +134,42 @@ pub struct FieldValueSetRequest {
         Option<crate::fold_db_core::infrastructure::message_bus::atom_events::MutationContext>,
 }
 
+impl FieldValueSetRequest {
+    /// Returns the field value wrapped in a [`TypedFieldValue`] without validation.
+    pub fn typed_value(&self) -> TypedFieldValue {
+        TypedFieldValue::from(&self.value)
+    }
+
+    /// Returns the typed value after validating it against the expected [`FieldType`].
+    pub fn typed_value_with_validation(
+        &self,
+        expected: ValueFieldType,
+    ) -> Result<TypedFieldValue, SchemaError> {
+        let typed = self.typed_value();
+        typed.ensure_type_with_context(expected, Some(self.field_name.as_str()))?;
+        Ok(typed)
+    }
+
+    /// Constructs a [`FieldValueSetRequest`] directly from a [`TypedFieldValue`].
+    pub fn from_typed_value(
+        correlation_id: String,
+        schema_name: String,
+        field_name: String,
+        typed_value: TypedFieldValue,
+        source_pub_key: String,
+        mutation_context: Option<MutationContext>,
+    ) -> Self {
+        Self {
+            correlation_id,
+            schema_name,
+            field_name,
+            value: typed_value.into_inner(),
+            source_pub_key,
+            mutation_context,
+        }
+    }
+}
+
 impl EventType for FieldValueSetRequest {
     fn type_id() -> &'static str {
         "FieldValueSetRequest"
@@ -168,6 +207,40 @@ pub struct FieldUpdateRequest {
     pub field_name: String,
     pub value: Value,
     pub source_pub_key: String,
+}
+
+impl FieldUpdateRequest {
+    /// Returns the field value wrapped in a [`TypedFieldValue`] without validation.
+    pub fn typed_value(&self) -> TypedFieldValue {
+        TypedFieldValue::from(&self.value)
+    }
+
+    /// Returns the typed value after validating it against the expected [`FieldType`].
+    pub fn typed_value_with_validation(
+        &self,
+        expected: ValueFieldType,
+    ) -> Result<TypedFieldValue, SchemaError> {
+        let typed = self.typed_value();
+        typed.ensure_type_with_context(expected, Some(self.field_name.as_str()))?;
+        Ok(typed)
+    }
+
+    /// Constructs a [`FieldUpdateRequest`] directly from a [`TypedFieldValue`].
+    pub fn from_typed_value(
+        correlation_id: String,
+        schema_name: String,
+        field_name: String,
+        typed_value: TypedFieldValue,
+        source_pub_key: String,
+    ) -> Self {
+        Self {
+            correlation_id,
+            schema_name,
+            field_name,
+            value: typed_value.into_inner(),
+            source_pub_key,
+        }
+    }
 }
 
 impl EventType for FieldUpdateRequest {
@@ -448,5 +521,89 @@ pub struct SystemInitializationResponse {
 impl EventType for SystemInitializationResponse {
     fn type_id() -> &'static str {
         "SystemInitializationResponse"
+    }
+}
+
+#[cfg(test)]
+mod typed_value_request_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn field_value_set_request_enforces_expected_type() {
+        let request = FieldValueSetRequest {
+            correlation_id: "corr".into(),
+            schema_name: "schema".into(),
+            field_name: "schema.field".into(),
+            value: json!("value"),
+            source_pub_key: "pubkey".into(),
+            mutation_context: None,
+        };
+
+        let typed = request
+            .typed_value_with_validation(ValueFieldType::String)
+            .expect("string value should be accepted");
+        assert_eq!(typed.as_string().unwrap(), "value");
+
+        let error = request
+            .typed_value_with_validation(ValueFieldType::Integer)
+            .expect_err("integer validation should fail");
+        match error {
+            SchemaError::InvalidData(message) => {
+                assert!(message.contains("schema.field"));
+                assert!(message.contains("integer"));
+            }
+            other => panic!("unexpected error variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn field_value_set_request_from_typed_value_preserves_payload() {
+        let typed = TypedFieldValue::from("payload");
+        let request = FieldValueSetRequest::from_typed_value(
+            "corr".into(),
+            "schema".into(),
+            "schema.field".into(),
+            typed,
+            "pub".into(),
+            None,
+        );
+        assert_eq!(request.value, json!("payload"));
+    }
+
+    #[test]
+    fn field_update_request_enforces_expected_type() {
+        let request = FieldUpdateRequest {
+            correlation_id: "corr".into(),
+            schema_name: "schema".into(),
+            field_name: "schema.field".into(),
+            value: json!(42),
+            source_pub_key: "pubkey".into(),
+        };
+
+        request
+            .typed_value_with_validation(ValueFieldType::Integer)
+            .expect("integer value should be accepted");
+
+        let error = request
+            .typed_value_with_validation(ValueFieldType::String)
+            .expect_err("string validation should fail");
+        match error {
+            SchemaError::InvalidData(message) => assert!(message.contains("string")),
+            other => panic!("unexpected error variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn field_update_request_from_typed_value_preserves_payload() {
+        let typed = TypedFieldValue::from(99_i64);
+        let request = FieldUpdateRequest::from_typed_value(
+            "corr".into(),
+            "schema".into(),
+            "schema.field".into(),
+            typed,
+            "pub".into(),
+        );
+        assert_eq!(request.value, json!(99));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod db_operations;
 pub mod error;
 pub mod error_handling;
 pub mod fees;
+pub mod field_value;
 pub mod fold_db_core;
 pub mod ingestion;
 pub mod logging;
@@ -52,6 +53,8 @@ pub use datafold_node::DataFoldNode;
 pub use error::{FoldDbError, FoldDbResult};
 pub use fold_db_core::FoldDB;
 pub use network::{NetworkConfig, NetworkCore, NetworkError, NetworkResult, PeerId, SchemaService};
+
+pub use field_value::{FieldType as ValueFieldType, TypedFieldValue};
 
 // Re-export schema types needed for CLI
 pub use schema::types::operation::Operation;


### PR DESCRIPTION
## Summary
- introduce a `field_value` module that wraps `serde_json::Value` in the new `TypedFieldValue` helper with validation utilities
- update message bus request events to surface typed accessors/constructors and add regression tests
- document the typed wrappers, re-export them, and capture the logic requirement in the project log

## Testing
- `cargo fmt`
- `cargo test --workspace`
- `cargo clippy`
- `cd src/datafold_node/static-react && npm install`
- `cd src/datafold_node/static-react && npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_68d301f364b883278c233e226e4f2dcb