### PR TITLE
Expose schema state in schema list endpoint

### DIFF
--- a/src/datafold_node/schema_routes.rs
+++ b/src/datafold_node/schema_routes.rs
@@ -1,7 +1,7 @@
 use super::http_server::AppState;
 use crate::log_feature;
 use crate::logging::features::LogFeature;
-use crate::schema::SchemaState;
+use crate::schema::{SchemaError, SchemaState, SchemaWithState};
 use actix_web::{web, HttpResponse, Responder};
 use serde_json::json;
 
@@ -29,7 +29,8 @@ where
 )]
 pub async fn list_schemas(state: web::Data<AppState>) -> impl Responder {
     log_feature!(LogFeature::Schema, info, "Received request to list schemas");
-    let result = with_schema_manager(&state, |db| db.schema_manager.get_schemas()).await;
+    let result =
+        with_schema_manager(&state, |db| db.schema_manager.get_schemas_with_states()).await;
     match result {
         Ok(schemas) => HttpResponse::Ok().json(json!({"data": schemas})),
         Err(e) => HttpResponse::InternalServerError()
@@ -53,7 +54,19 @@ pub async fn list_schemas(state: web::Data<AppState>) -> impl Responder {
 )]
 pub async fn get_schema(path: web::Path<String>, state: web::Data<AppState>) -> impl Responder {
     let name = path.into_inner();
-    let result = with_schema_manager(&state, |db| db.schema_manager.get_schema(&name)).await;
+    let result: Result<Option<SchemaWithState>, SchemaError> =
+        with_schema_manager(&state, |db| {
+            let schema = db.schema_manager.get_schema(&name)?;
+            if let Some(schema) = schema {
+                let state = db.schema_manager.get_schema_states()?;
+                let schema_state = state.get(&name).copied().unwrap_or_default();
+                Ok(Some(SchemaWithState::new(schema, schema_state)))
+            } else {
+                Ok(None)
+            }
+        })
+        .await;
+
     match result {
         Ok(Some(schema)) => HttpResponse::Ok().json(schema),
         Ok(None) => HttpResponse::NotFound().json(json!({"error": "Schema not found"})),

--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -4,6 +4,7 @@ use crate::logging::features::{log_feature, LogFeature};
 use crate::schema::types::{Schema, SchemaError, FieldVariant, Field};
 use crate::schema::{
     SchemaState,
+    SchemaWithState,
 };
 use log::{info};
 use serde::{Serialize};
@@ -58,7 +59,24 @@ impl SchemaCore {
     }
 
     pub fn get_schema_states(&self) -> Result<HashMap<String, SchemaState>, SchemaError> {
-        Ok(self.schema_states.lock().map_err(|_| SchemaError::InvalidData("Failed to acquire schema_states lock".to_string()))?.clone())
+        Ok(self
+            .schema_states
+            .lock()
+            .map_err(|_| SchemaError::InvalidData("Failed to acquire schema_states lock".to_string()))?
+            .clone())
+    }
+
+    pub fn get_schemas_with_states(&self) -> Result<Vec<SchemaWithState>, SchemaError> {
+        let schemas = self.get_schemas()?;
+        let schema_states = self.get_schema_states()?;
+
+        let mut with_states = Vec::with_capacity(schemas.len());
+        for (name, schema) in schemas {
+            let state = schema_states.get(&name).copied().unwrap_or_default();
+            with_states.push(SchemaWithState::new(schema, state));
+        }
+
+        Ok(with_states)
     }
 
     pub fn set_schema_state(&self, schema_name: &str, schema_state: SchemaState) -> Result<(), SchemaError> {
@@ -222,6 +240,20 @@ mod tests {
 
         let states = core.get_schema_states().expect("get states");
         assert_eq!(states.get("BlogPost"), Some(&SchemaState::Available));
+    }
+
+    #[test]
+    fn get_schemas_with_states_returns_default_available() {
+        let core = SchemaCore::new_for_testing().expect("init core");
+        core.load_schema_from_json(&blogpost_schema_json()).expect("load blogpost");
+
+        let schemas_with_states = core.get_schemas_with_states().expect("get with states");
+        assert_eq!(schemas_with_states.len(), 1);
+        let schema_entry = schemas_with_states
+            .iter()
+            .find(|entry| entry.name() == "BlogPost")
+            .expect("BlogPost entry");
+        assert_eq!(schema_entry.state, SchemaState::Available);
     }
 
     #[test]

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -44,7 +44,7 @@ pub use duplicate_detection::SchemaDuplicateDetector;
 pub use file_operations::SchemaFileOperations;
 pub use hasher::SchemaHasher;
 pub use molecule_variants::MoleculeVariant;
-pub use schema_types::{SchemaLoadingReport, SchemaSource, SchemaState};
+pub use schema_types::{SchemaLoadingReport, SchemaSource, SchemaState, SchemaWithState};
 pub use types::*;
 
 /// Public prelude module containing types needed by tests and external code

--- a/src/schema/schema_types.rs
+++ b/src/schema/schema_types.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::schema::types::schema::Schema;
+
 /// Report of schema discovery and loading operations
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SchemaLoadingReport {
@@ -39,4 +41,26 @@ pub enum SchemaState {
     Approved,
     /// Schema blocked by user, cannot be queried or mutated but field-mapping and transforms still run
     Blocked,
+}
+
+/// Schema definition bundled with its current state for UI/API responses
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchemaWithState {
+    /// All schema fields serialized at the top level
+    #[serde(flatten)]
+    pub schema: Schema,
+    /// Current state of the schema
+    pub state: SchemaState,
+}
+
+impl SchemaWithState {
+    /// Create a new [`SchemaWithState`] from components
+    pub fn new(schema: Schema, state: SchemaState) -> Self {
+        Self { schema, state }
+    }
+
+    /// Access the schema name (helper to avoid cloning when only the name is needed)
+    pub fn name(&self) -> &str {
+        &self.schema.name
+    }
 }


### PR DESCRIPTION
## Summary
- add a SchemaWithState wrapper so schema payloads include their current state
- expose a SchemaCore::get_schemas_with_states helper and verify it with a unit test
- update the schema listing and fetch endpoints to return schemas together with their states

## Testing
- `cargo test --workspace`
- `cargo clippy`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dc4dd8b728832799457ef2ec426152