### PR TITLE
Handle missing results in ResultsSection

### DIFF
--- a/src/datafold_node/static-react/src/components/ResultsSection.jsx
+++ b/src/datafold_node/static-react/src/components/ResultsSection.jsx
@@ -3,11 +3,15 @@ import StructuredResults from './StructuredResults'
 import { isHashRangeFieldsShape } from '../utils/hashRangeResults'
 
 function ResultsSection({ results }) {
-  const hasResults = Boolean(results)
+  const hasResults = results != null
   const isError = hasResults && (Boolean(results.error) || (results.status && results.status >= 400))
   const hasData = hasResults && results.data !== undefined
   const defaultStructured = useMemo(() => hasResults && !isError && isHashRangeFieldsShape(hasData ? results.data : results), [hasResults, results, isError, hasData])
   const [structured, setStructured] = useState(defaultStructured)
+
+  if (!hasResults) {
+    return null
+  }
 
   return (
     <div className="bg-white rounded-lg shadow-sm p-6 mt-6">


### PR DESCRIPTION
## Summary
- avoid rendering the results container when no results are provided
- keep existing structured/JSON toggles by returning early only after hook initialization

## Testing
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc4d89238c832788b631eeedbc7608