### PR TITLE
Remove unused aggregation helper utilities

### DIFF
--- a/src/transform/aggregation.rs
+++ b/src/transform/aggregation.rs
@@ -427,48 +427,6 @@ fn resolve_field_value(
     }
 }
 
-/// Extracts the final segment from an expression for use as a field name.
-///
-/// # Arguments
-///
-/// * `expression` - The expression to parse
-///
-/// # Returns
-///
-/// The final segment if valid, None otherwise
-#[cfg(test)]
-fn extract_expression_final_segment(expression: &str) -> Option<String> {
-    expression.split('.').rev().find_map(|segment| {
-        let trimmed = segment.trim();
-        if trimmed.is_empty() || 
-           trimmed.eq_ignore_ascii_case("input") || 
-           trimmed.ends_with("()") {
-            None
-        } else {
-            Some(trimmed.trim_matches(|c| "\"'".contains(c)).to_string())
-        }
-    })
-}
-
-/// Sanitizes a field name by removing leading underscores.
-///
-/// # Arguments
-///
-/// * `field_name` - The field name to sanitize
-///
-/// # Returns
-///
-/// The sanitized field name
-#[cfg(test)]
-fn sanitize_field_name(field_name: &str) -> String {
-    let sanitized = field_name.trim_start_matches('_');
-    if sanitized.is_empty() {
-        field_name.to_string()
-    } else {
-        sanitized.to_string()
-    }
-}
-
 /// Converts a JSON value to a string representation.
 ///
 /// # Arguments
@@ -702,23 +660,6 @@ mod tests {
         let row = arr[0].as_object().unwrap();
         assert!(row.contains_key("key"));
         assert_eq!(row["fields"]["field1"], json!(["value1", "value2"]));
-    }
-
-    #[test]
-    fn test_field_name_sanitization() {
-        assert_eq!(sanitize_field_name("normal_field"), "normal_field");
-        assert_eq!(sanitize_field_name("_internal_field"), "internal_field");
-        assert_eq!(sanitize_field_name("__double_underscore"), "double_underscore");
-        assert_eq!(sanitize_field_name("_"), "_");
-    }
-
-    #[test]
-    fn test_expression_final_segment_extraction() {
-        assert_eq!(extract_expression_final_segment("input.field1"), Some("field1".to_string()));
-        assert_eq!(extract_expression_final_segment("input.user.name"), Some("name".to_string()));
-        assert_eq!(extract_expression_final_segment("input"), None);
-        assert_eq!(extract_expression_final_segment("input."), None);
-        assert_eq!(extract_expression_final_segment("input.func()"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- delete the unused `extract_expression_final_segment` and `sanitize_field_name` helpers from the aggregation module
- remove the self-referential unit tests that only exercised the deleted helpers

## Testing
- `cargo test`
- `cargo clippy --all-targets`
- `npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_68e041709f108327be6494cb22bb6512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed obsolete internal test helpers and their related unit tests in the aggregation module, simplifying the test suite and reducing maintenance overhead.
  * Minor improvements to test clarity and potential test execution time.
  * No changes to app behavior, features, or public API; end users will not see any functional differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->