### PR TITLE
Fix ingestion prompt tests for updated signature

### DIFF
--- a/src/ingestion/ollama_service.rs
+++ b/src/ingestion/ollama_service.rs
@@ -485,7 +485,7 @@ That should work."###;
         let sample = serde_json::json!({"a": 1});
         let schemas = serde_json::json!({"test": {"field": "string"}});
 
-        let prompt = service.create_prompt(&sample, &schemas);
+        let prompt = service.create_prompt(&sample, &schemas, false);
         assert!(prompt.contains("Sample JSON Data:"));
         assert!(prompt.contains("\"a\": 1"));
         assert!(prompt.contains("Available Schemas:"));

--- a/src/ingestion/openrouter_service.rs
+++ b/src/ingestion/openrouter_service.rs
@@ -534,7 +534,7 @@ That should work."###;
         let sample = serde_json::json!({"a": 1});
         let schemas = serde_json::json!({"test": {"field": "string"}});
 
-        let prompt = service.create_prompt(&sample, &schemas);
+        let prompt = service.create_prompt(&sample, &schemas, false);
         assert!(prompt.contains("Sample JSON Data:"));
         assert!(prompt.contains("\"a\": 1"));
         assert!(prompt.contains("Available Schemas:"));


### PR DESCRIPTION
## Summary
- update the Ollama and OpenRouter prompt creation unit tests to match the current `create_prompt` signature

## Testing
- cargo test
- cargo clippy --all-targets --all-features
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e3d7f452bc83278fda8175eaa83760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved AI prompt generation now detects and adapts to array (list) inputs, delivering more accurate schema recommendations and responses across ingestion workflows.
  * Harmonized behavior across providers for array inputs, reducing ambiguity and enhancing result consistency.

* **Bug Fixes**
  * Corrected prompt handling edge cases for list-based data, minimizing misclassification and improving reliability of generated recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->