### PR TITLE
Fix mutation operation selection defaults

### DIFF
--- a/src/datafold_node/static-react/src/components/tabs/MutationTab.jsx
+++ b/src/datafold_node/static-react/src/components/tabs/MutationTab.jsx
@@ -4,6 +4,7 @@ import MutationEditor from './mutation/MutationEditor'
 import ResultViewer from './mutation/ResultViewer'
 import TextField from '../form/TextField'
 import { mutationClient } from '../../api'
+import { MUTATION_TYPE_API_MAP } from '../../constants/ui.js'
 // Removed hook dependencies - using Redux state management instead (TASK-003)
 // Temporarily bypass constants to break circular dependency
 const BUTTON_TEXT = { executeMutation: 'Execute Mutation', confirm: 'Confirm', cancel: 'Cancel' };
@@ -27,7 +28,7 @@ function MutationTab({ onResult }) {
   const _authState = useAppSelector(state => state.auth)
   const [selectedSchema, setSelectedSchema] = useState('')
   const [mutationData, setMutationData] = useState({})
-  const [mutationType, setMutationType] = useState('Create')
+  const [mutationType, setMutationType] = useState('')
   const [result, setResult] = useState(null)
   const [rangeKeyValue, setRangeKeyValue] = useState('')
 
@@ -37,6 +38,7 @@ function MutationTab({ onResult }) {
   const handleSchemaChange = (schemaName) => {
     setSelectedSchema(schemaName)
     setMutationData({})
+    setMutationType('')
     setRangeKeyValue('')
   }
 
@@ -61,6 +63,12 @@ function MutationTab({ onResult }) {
     if (!selectedSchema) return
     
     const selectedSchemaObj = schemas.find(s => s.name === selectedSchema)
+    const normalizedMutationType = mutationType
+      ? (MUTATION_TYPE_API_MAP[mutationType] || mutationType.toLowerCase())
+      : ''
+    if (!normalizedMutationType) {
+      return
+    }
     let mutation
 
     // Backend handles all validation
@@ -70,7 +78,7 @@ function MutationTab({ onResult }) {
       mutation = {
         type: 'mutation',
         schema: selectedSchema,
-        mutation_type: mutationType.toLowerCase(),
+        mutation_type: normalizedMutationType,
         fields_and_values: mutationType === 'Delete' ? {} : mutationData,
         key_value: { hash: null, range: null }
       }
@@ -106,6 +114,12 @@ function MutationTab({ onResult }) {
   const isCurrentSchemaRangeSchema = selectedSchemaObj ? isRangeSchema(selectedSchemaObj) : false
   const rangeKey = selectedSchemaObj ? getRangeKey(selectedSchemaObj) : null
   const selectedSchemaFields = selectedSchemaObj ? (isCurrentSchemaRangeSchema ? getNonRangeKeyFields(selectedSchemaObj) : selectedSchemaObj.fields || {}) : {}
+
+  const isMutationDisabled =
+    !selectedSchema ||
+    !mutationType ||
+    (mutationType !== 'Delete' && Object.keys(mutationData).length === 0) ||
+    (isCurrentSchemaRangeSchema && mutationType !== 'Delete' && !rangeKeyValue.trim())
 
   return (
     <div className="p-6">
@@ -151,8 +165,12 @@ function MutationTab({ onResult }) {
         <div className="flex justify-end pt-4">
           <button
             type="submit"
-            className={`inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white ${!selectedSchema || (mutationType !== 'Delete' && Object.keys(mutationData).length === 0) || (isCurrentSchemaRangeSchema && mutationType !== 'Delete' && !rangeKeyValue.trim()) ? 'bg-gray-300 cursor-not-allowed' : 'bg-primary hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary'}`}
-            disabled={!selectedSchema || (mutationType !== 'Delete' && Object.keys(mutationData).length === 0) || (isCurrentSchemaRangeSchema && mutationType !== 'Delete' && !rangeKeyValue.trim())}
+            className={`inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white ${
+              isMutationDisabled
+                ? 'bg-gray-300 cursor-not-allowed'
+                : 'bg-primary hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary'
+            }`}
+            disabled={isMutationDisabled}
           >
             {BUTTON_TEXT.executeMutation}
           </button>

--- a/src/datafold_node/static-react/src/constants/ui.js
+++ b/src/datafold_node/static-react/src/constants/ui.js
@@ -55,10 +55,18 @@ export const UI_STATES = {
 
 // Mutation Type Constants
 export const MUTATION_TYPES = [
-  { value: 'Create', label: 'Create' },
+  { value: 'Insert', label: 'Insert' },
   { value: 'Update', label: 'Update' },
   { value: 'Delete', label: 'Delete' }
 ];
+
+// Backend mutation type normalization map
+export const MUTATION_TYPE_API_MAP = {
+  Insert: 'create',
+  Create: 'create',
+  Update: 'update',
+  Delete: 'delete'
+};
 
 // Schema Badge Colors
 export const SCHEMA_BADGE_COLORS = {

--- a/src/datafold_node/static-react/src/utils/rangeSchemaHelpers.js
+++ b/src/datafold_node/static-react/src/utils/rangeSchemaHelpers.js
@@ -14,10 +14,11 @@
  * - Supports efficient range-based queries and mutations
  */
 
-import { 
-  RANGE_SCHEMA_CONFIG, 
-  VALIDATION_MESSAGES 
+import {
+  RANGE_SCHEMA_CONFIG,
+  VALIDATION_MESSAGES
 } from '../constants/schemas.js';
+import { MUTATION_TYPE_API_MAP } from '../constants/ui.js';
 
 /**
  * @typedef {Object} Schema
@@ -313,16 +314,20 @@ export function validateRangeKey(rangeKeyValue, isRequired = true) {
  * @returns {Object} Formatted mutation object
  */
 export function formatRangeMutation(schema, mutationType, rangeKeyValue, fieldData) {
+  const normalizedMutationType = typeof mutationType === 'string'
+    ? (MUTATION_TYPE_API_MAP[mutationType] || mutationType.toLowerCase())
+    : '';
+  const isDeleteOperation = normalizedMutationType === 'delete';
   const mutation = {
     type: 'mutation',
     schema: schema.name,
-    mutation_type: mutationType.toLowerCase()
+    mutation_type: normalizedMutationType
   };
   
   // Get the actual range key field name from the schema
   const rangeKeyFieldName = getRangeKey(schema);
   
-  if (mutationType === 'Delete') {
+  if (isDeleteOperation) {
     mutation.fields_and_values = {};
     mutation.key_value = { hash: null, range: null };
     // For delete operations, use the actual range key field name


### PR DESCRIPTION
## Summary
- update the mutation tab so the operation selector defaults to no choice, disables submission until a valid combination is selected, and normalizes the value sent to the API
- expose an Insert option in the shared UI constants and provide a mapping of UI labels to backend mutation type strings
- normalize range mutation formatting to reuse the shared mapping for Insert/Create/Delete handling

## Testing
- cargo test
- cargo clippy
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e96ccbf0c08327b716d752ed0bfc9f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Submit button now enables/disables based on selection, mutation type, and required inputs for safer actions.

- Bug Fixes
  - Correct handling of delete operations and range-key values when applying mutations.
  - Prevents submission when mutation type is missing or invalid, reducing errors.

- Style
  - Renamed the “Create” mutation option to “Insert” for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->