### PR TITLE
Add native word index support

### DIFF
--- a/src/db_operations/atom_operations.rs
+++ b/src/db_operations/atom_operations.rs
@@ -1,11 +1,11 @@
 use super::core::DbOperations;
 use crate::atom::{Atom, AtomStatus, Molecule, MoleculeRange};
 use crate::schema::{
-    SchemaError, 
     types::{
-        field::{FieldVariant, Field}, 
-        key_value::KeyValue
-    }
+        field::{Field, FieldVariant},
+        key_value::KeyValue,
+    },
+    SchemaError,
 };
 use serde_json::Value;
 
@@ -91,16 +91,16 @@ impl DbOperations {
         value: Value,
     ) -> Result<Atom, SchemaError> {
         let new_atom = Atom::new(schema_name.to_string(), pub_key.to_string(), value);
-        
+
         // Check if atom with this content-based UUID already exists
         let atom_key = format!("atom:{}", new_atom.uuid());
         if let Some(existing_atom) = self.get_item::<Atom>(&atom_key)? {
             return Ok(existing_atom);
         }
-        
+
         // Persist the atom to the database
         self.store_item(&atom_key, &new_atom)?;
-        
+
         Ok(new_atom)
     }
 
@@ -135,6 +135,7 @@ impl DbOperations {
     pub fn process_mutation_field(
         &self,
         schema_name: &str,
+        field_name: &str,
         pub_key: &str,
         value: Value,
         key_value: &KeyValue,
@@ -142,18 +143,26 @@ impl DbOperations {
     ) -> Result<(), SchemaError> {
         // Refresh field from database
         schema_field.refresh_from_db(self);
-        
+
+        let index_value = value.clone();
         // Create and store the atom
         let new_atom = self.create_and_store_atom_for_mutation(schema_name, pub_key, value)?;
-        
+
         // Write mutation to field (updates in-memory molecule)
         schema_field.write_mutation(key_value, new_atom, pub_key.to_string());
-        
+
         // Persist the updated molecule to the database
         if let Some(molecule_uuid) = schema_field.common().molecule_uuid() {
             self.persist_field_molecule(schema_field, molecule_uuid)?;
         }
-        
+
+        self.native_index_manager().index_field_value(
+            schema_name,
+            field_name,
+            key_value,
+            &index_value,
+        )?;
+
         Ok(())
     }
 }

--- a/src/db_operations/core.rs
+++ b/src/db_operations/core.rs
@@ -1,4 +1,4 @@
-use super::error_utils::ErrorUtils;
+use super::{error_utils::ErrorUtils, NativeIndexConfig, NativeIndexManager};
 use crate::schema::SchemaError;
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::HashMap;
@@ -19,6 +19,7 @@ pub struct DbOperations {
     /// Tree for storing public keys
     pub(crate) public_keys_tree: sled::Tree,
     pub(crate) transform_queue_tree: sled::Tree,
+    native_index_manager: NativeIndexManager,
 }
 
 impl DbOperations {
@@ -32,6 +33,9 @@ impl DbOperations {
         let schemas_tree = db.open_tree("schemas")?;
         let public_keys_tree = db.open_tree("public_keys")?;
         let transform_queue_tree = db.open_tree("transform_queue_tree")?;
+        let native_index_tree = db.open_tree("native_index")?;
+        let native_index_manager =
+            NativeIndexManager::new(native_index_tree, NativeIndexConfig::default());
 
         Ok(Self {
             db,
@@ -43,7 +47,12 @@ impl DbOperations {
             schemas_tree,
             public_keys_tree,
             transform_queue_tree,
+            native_index_manager,
         })
+    }
+
+    pub fn native_index_manager(&self) -> &NativeIndexManager {
+        &self.native_index_manager
     }
 
     /// Gets a reference to the underlying database

--- a/src/db_operations/mod.rs
+++ b/src/db_operations/mod.rs
@@ -3,6 +3,7 @@ mod atom_operations;
 pub mod core;
 pub mod error_utils;
 mod metadata_operations;
+mod native_index;
 mod orchestrator_operations;
 mod public_key_operations;
 mod schema_operations;
@@ -14,3 +15,4 @@ mod utility_operations;
 // Re-export the main DbOperations struct and error utilities
 pub use core::DbOperations;
 pub use error_utils::ErrorUtils;
+pub use native_index::{IndexResult, NativeIndexConfig, NativeIndexManager};

--- a/src/db_operations/native_index.rs
+++ b/src/db_operations/native_index.rs
@@ -1,0 +1,274 @@
+use crate::schema::types::key_value::KeyValue;
+use crate::schema::SchemaError;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sled::Tree;
+use std::collections::HashSet;
+
+const WORD_PREFIX: &str = "word:";
+const RECORD_PREFIX: &str = "record:";
+
+const STOPWORDS: &[&str] = &[
+    "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "from", "in", "is", "it", "of",
+    "on", "or", "the", "to", "with",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IndexResult {
+    pub schema_name: String,
+    pub field: String,
+    pub key_value: KeyValue,
+    pub value: Value,
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NativeIndexConfig {
+    pub enabled: bool,
+    pub min_word_length: usize,
+    pub max_word_length: usize,
+    pub excluded_fields: Vec<String>,
+    pub filter_stopwords: bool,
+}
+
+impl Default for NativeIndexConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            min_word_length: 2,
+            max_word_length: 100,
+            excluded_fields: vec![
+                "uuid".to_string(),
+                "id".to_string(),
+                "password".to_string(),
+                "token".to_string(),
+            ],
+            filter_stopwords: true,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct NativeIndexManager {
+    tree: Tree,
+    config: NativeIndexConfig,
+}
+
+impl NativeIndexManager {
+    pub fn new(tree: Tree, config: NativeIndexConfig) -> Self {
+        Self { tree, config }
+    }
+
+    pub fn search_word(&self, term: &str) -> Result<Vec<IndexResult>, SchemaError> {
+        let Some(normalized) = self.normalize_search_term(term) else {
+            return Ok(Vec::new());
+        };
+
+        let key = format!("{}{}", WORD_PREFIX, normalized);
+        let Some(bytes) = self.tree.get(key.as_bytes())? else {
+            return Ok(Vec::new());
+        };
+
+        let results: Vec<IndexResult> = serde_json::from_slice(&bytes).map_err(|e| {
+            SchemaError::InvalidData(format!("Failed to deserialize index results: {}", e))
+        })?;
+
+        Ok(results)
+    }
+
+    pub fn index_field_value(
+        &self,
+        schema_name: &str,
+        field_name: &str,
+        key_value: &KeyValue,
+        value: &Value,
+    ) -> Result<(), SchemaError> {
+        if !self.config.enabled || !self.should_index_field(field_name) {
+            return Ok(());
+        }
+
+        let record_key = self.build_record_key(schema_name, field_name, key_value)?;
+        self.remove_record_entries(&record_key, schema_name, field_name, key_value)?;
+
+        let words = self.collect_words(value);
+
+        if words.is_empty() {
+            self.tree.remove(record_key.as_bytes())?;
+            self.tree.flush()?;
+            return Ok(());
+        }
+
+        for word in &words {
+            let index_key = format!("{}{}", WORD_PREFIX, word);
+            let mut entries = self.read_entries(&index_key)?;
+            entries.retain(|entry| {
+                !(entry.schema_name == schema_name
+                    && entry.field == field_name
+                    && entry.key_value == *key_value)
+            });
+
+            let index_entry = IndexResult {
+                schema_name: schema_name.to_string(),
+                field: field_name.to_string(),
+                key_value: key_value.clone(),
+                value: value.clone(),
+                metadata: Some(json!({ "word": word })),
+            };
+
+            entries.push(index_entry);
+            self.write_entries(&index_key, &entries)?;
+        }
+
+        self.store_record_words(&record_key, &words)?;
+        self.tree.flush()?;
+        Ok(())
+    }
+
+    fn should_index_field(&self, field_name: &str) -> bool {
+        !self
+            .config
+            .excluded_fields
+            .iter()
+            .any(|excluded| excluded.eq_ignore_ascii_case(field_name))
+    }
+
+    fn build_record_key(
+        &self,
+        schema_name: &str,
+        field_name: &str,
+        key_value: &KeyValue,
+    ) -> Result<String, SchemaError> {
+        let serialized_key = serde_json::to_string(key_value).map_err(|e| {
+            SchemaError::InvalidData(format!("Failed to serialize key value for index: {}", e))
+        })?;
+        Ok(format!(
+            "{}{}:{}:{}",
+            RECORD_PREFIX, schema_name, field_name, serialized_key
+        ))
+    }
+
+    fn collect_words(&self, value: &Value) -> Vec<String> {
+        let mut words = HashSet::new();
+        self.collect_words_recursive(value, &mut words);
+        let mut result: Vec<String> = words.into_iter().collect();
+        result.sort_unstable();
+        result
+    }
+
+    fn collect_words_recursive(&self, value: &Value, acc: &mut HashSet<String>) {
+        match value {
+            Value::String(text) => {
+                for segment in text.split(|c: char| !c.is_alphanumeric()) {
+                    if let Some(word) = self.normalize_word(segment) {
+                        acc.insert(word);
+                    }
+                }
+            }
+            Value::Array(values) => {
+                for item in values {
+                    self.collect_words_recursive(item, acc);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn normalize_word(&self, raw: &str) -> Option<String> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let normalized = trimmed.to_ascii_lowercase();
+
+        if normalized.len() < self.config.min_word_length
+            || normalized.len() > self.config.max_word_length
+        {
+            return None;
+        }
+
+        if self.config.filter_stopwords && STOPWORDS.contains(&normalized.as_str()) {
+            return None;
+        }
+
+        Some(normalized)
+    }
+
+    fn normalize_search_term(&self, term: &str) -> Option<String> {
+        for segment in term.split(|c: char| !c.is_alphanumeric()) {
+            if let Some(word) = self.normalize_word(segment) {
+                return Some(word);
+            }
+        }
+        None
+    }
+
+    fn read_entries(&self, key: &str) -> Result<Vec<IndexResult>, SchemaError> {
+        let Some(bytes) = self.tree.get(key.as_bytes())? else {
+            return Ok(Vec::new());
+        };
+
+        let entries = serde_json::from_slice(&bytes).map_err(|e| {
+            SchemaError::InvalidData(format!("Failed to deserialize index entries: {}", e))
+        })?;
+        Ok(entries)
+    }
+
+    fn write_entries(&self, key: &str, entries: &[IndexResult]) -> Result<(), SchemaError> {
+        if entries.is_empty() {
+            self.tree.remove(key.as_bytes())?;
+            return Ok(());
+        }
+
+        let bytes = serde_json::to_vec(entries).map_err(|e| {
+            SchemaError::InvalidData(format!("Failed to serialize index entries: {}", e))
+        })?;
+        self.tree.insert(key.as_bytes(), bytes)?;
+        Ok(())
+    }
+
+    fn store_record_words(&self, record_key: &str, words: &[String]) -> Result<(), SchemaError> {
+        let bytes = serde_json::to_vec(words).map_err(|e| {
+            SchemaError::InvalidData(format!("Failed to serialize record index words: {}", e))
+        })?;
+        self.tree.insert(record_key.as_bytes(), bytes)?;
+        Ok(())
+    }
+
+    fn remove_record_entries(
+        &self,
+        record_key: &str,
+        schema_name: &str,
+        field_name: &str,
+        key_value: &KeyValue,
+    ) -> Result<(), SchemaError> {
+        let Some(bytes) = self.tree.get(record_key.as_bytes())? else {
+            return Ok(());
+        };
+
+        let words: Vec<String> = serde_json::from_slice(&bytes).map_err(|e| {
+            SchemaError::InvalidData(format!("Failed to deserialize record index words: {}", e))
+        })?;
+
+        for word in words {
+            let index_key = format!("{}{}", WORD_PREFIX, word);
+            let mut entries = self.read_entries(&index_key)?;
+            let initial_len = entries.len();
+
+            entries.retain(|entry| {
+                !(entry.schema_name == schema_name
+                    && entry.field == field_name
+                    && entry.key_value == *key_value)
+            });
+
+            if entries.is_empty() {
+                self.tree.remove(index_key.as_bytes())?;
+            } else if entries.len() != initial_len {
+                self.write_entries(&index_key, &entries)?;
+            }
+        }
+
+        self.tree.remove(record_key.as_bytes())?;
+        Ok(())
+    }
+}

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use log::info;
 
 // Internal crate imports
-use crate::db_operations::DbOperations;
+use crate::db_operations::{DbOperations, IndexResult};
 use crate::logging::features::{log_feature, LogFeature};
 use crate::schema::{SchemaCore, SchemaError};
 use crate::transform::manager::TransformManager;
@@ -253,6 +253,11 @@ impl FoldDB {
     pub fn schema_manager(&self) -> Arc<SchemaCore> {
         Arc::clone(&self.schema_manager)
     }
+    /// Search the native word index for a specific term
+    pub fn native_word_search(&self, term: &str) -> Result<Vec<IndexResult>, SchemaError> {
+        self.db_ops.native_index_manager().search_word(term)
+    }
+
 
     /// Get the transform orchestrator for managing transform execution
     pub fn transform_orchestrator(&self) -> Arc<TransformOrchestrator> {

--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -71,6 +71,7 @@ impl MutationManager {
                 // Use the new db_operations method to handle the entire field mutation process
                 self.db_ops.process_mutation_field(
                     &mutation.schema_name,
+                    &field_name,
                     &mutation.pub_key,
                     value,
                     &key_value,
@@ -205,6 +206,7 @@ impl MutationManager {
                 // Use the new db_operations method to handle the entire field mutation process
                 db_ops.process_mutation_field(
                     &mutation_request.mutation.schema_name,
+                    &field_name,
                     &mutation_request.mutation.pub_key,
                     value,
                     &key_value,

--- a/tests/native_word_index_test.rs
+++ b/tests/native_word_index_test.rs
@@ -1,0 +1,142 @@
+use datafold::datafold_node::DataFoldNode;
+use datafold::schema::types::key_value::KeyValue;
+use datafold::schema::types::Mutation;
+use datafold::schema::SchemaState;
+use datafold::MutationType;
+use datafold::NodeConfig;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+#[test]
+fn test_native_word_index_search_updates_with_mutations() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let db_path = temp_dir.path().to_path_buf();
+
+    let config = NodeConfig::new(db_path).with_schema_service_url("test://mock");
+    let node = DataFoldNode::new(config).expect("failed to create DataFoldNode");
+
+    {
+        let fold_db = node.get_fold_db().expect("failed to get FoldDB");
+
+        let blogpost_schema = json!({
+            "name": "BlogPost",
+            "key": {
+                "range_field": "publish_date"
+            },
+            "fields": {
+                "title": {},
+                "content": {},
+                "author": {},
+                "publish_date": {},
+                "tags": {}
+            }
+        });
+
+        let schema_str =
+            serde_json::to_string(&blogpost_schema).expect("schema serialization failed");
+        fold_db
+            .schema_manager()
+            .load_schema_from_json(&schema_str)
+            .expect("failed to load schema");
+
+        fold_db
+            .schema_manager()
+            .set_schema_state("BlogPost", SchemaState::Approved)
+            .expect("failed to approve schema");
+    }
+
+    let mut create_fields = HashMap::new();
+    create_fields.insert("title".to_string(), json!("Native Word Index Overview"));
+    create_fields.insert(
+        "content".to_string(),
+        json!("Jennifer Liu wrote about efficient Rust indexing in New York"),
+    );
+    create_fields.insert("author".to_string(), json!("Jennifer Liu"));
+    create_fields.insert("publish_date".to_string(), json!("2024-02-01"));
+    create_fields.insert("tags".to_string(), json!(["rust", "database"]));
+
+    execute_mutation(
+        &node,
+        "BlogPost",
+        create_fields,
+        KeyValue::new(None, Some("2024-02-01".to_string())),
+        MutationType::Create,
+    );
+
+    {
+        let fold_db = node.get_fold_db().expect("failed to get FoldDB");
+
+        let jennifer_results = fold_db
+            .native_word_search("Jennifer")
+            .expect("search should succeed");
+        assert!(
+            jennifer_results
+                .iter()
+                .any(|entry| entry.key_value.range.as_deref() == Some("2024-02-01")),
+            "expected Jennifer to be indexed with the publish date"
+        );
+
+        let stopword_results = fold_db
+            .native_word_search("the")
+            .expect("stopword search should succeed");
+        assert!(stopword_results.is_empty(), "stopwords should be excluded");
+    }
+
+    let mut update_fields = HashMap::new();
+    update_fields.insert(
+        "content".to_string(),
+        json!("Alice Smith explored indexing strategies while visiting Berlin"),
+    );
+    update_fields.insert("publish_date".to_string(), json!("2024-02-01"));
+
+    execute_mutation(
+        &node,
+        "BlogPost",
+        update_fields,
+        KeyValue::new(None, Some("2024-02-01".to_string())),
+        MutationType::Update,
+    );
+
+    {
+        let fold_db = node.get_fold_db().expect("failed to get FoldDB");
+
+        let jennifer_results = fold_db
+            .native_word_search("jennifer")
+            .expect("search after update should succeed");
+        assert!(
+            jennifer_results
+                .iter()
+                .all(|entry| entry.field != "content"),
+            "content entries containing 'jennifer' should be removed after update"
+        );
+
+        let alice_results = fold_db
+            .native_word_search("alice")
+            .expect("search for alice should succeed");
+        assert!(
+            alice_results.iter().any(|entry| entry.field == "content"),
+            "expected alice to appear in content results"
+        );
+    }
+}
+
+fn execute_mutation(
+    node: &DataFoldNode,
+    schema: &str,
+    fields: HashMap<String, Value>,
+    key_value: KeyValue,
+    mutation_type: MutationType,
+) {
+    let mutation = Mutation::new(
+        schema.to_string(),
+        fields,
+        key_value,
+        String::new(),
+        0,
+        mutation_type,
+    );
+
+    node.mutate(mutation)
+        .expect("mutation execution should succeed");
+}


### PR DESCRIPTION
## Summary
- add a sled-backed native word index manager with configurable filtering and record bookkeeping
- wire the index manager into DbOperations, mutation processing, and FoldDB so word queries are exposed
- add an integration test that exercises indexing behavior across create/update mutations

## Testing
- cargo test
- cargo clippy --all-targets --all-features
- npm test
- cargo test --test native_word_index_test

------
https://chatgpt.com/codex/tasks/task_e_68f943d5786c8327aa83f31bbf4a2b3f