### PR TITLE
Enhance query execution to include metadata in response records

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ utoipa = { version = "4", features = ["actix_extras"] }
 reqwest = { version = "0.11", features = ["json", "multipart"] }
 
 # File to JSON conversion
-file_to_json = "0.1.3"
+file_to_json = "0.1.4"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "full"] }

--- a/src/datafold_node/llm_query/routes.rs
+++ b/src/datafold_node/llm_query/routes.rs
@@ -314,7 +314,7 @@ pub async fn execute_query_plan(
             let records_map = records_from_field_map(&result_map);
             records_map
                 .into_iter()
-                .map(|(key, record)| json!({"key": key, "fields": record.fields}))
+                .map(|(key, record)| json!({"key": key, "fields": record.fields, "metadata": record.metadata}))
                 .collect::<Vec<Value>>()
         }
         Err(e) => {
@@ -555,7 +555,7 @@ pub async fn chat(
                         let records_map = records_from_field_map(&result_map);
                         let new_results: Vec<Value> = records_map
                             .into_iter()
-                            .map(|(key, record)| json!({"key": key, "fields": record.fields}))
+                            .map(|(key, record)| json!({"key": key, "fields": record.fields, "metadata": record.metadata}))
                             .collect();
 
                         if !new_results.is_empty() {
@@ -905,7 +905,7 @@ pub async fn run_query(
                 let records_map = records_from_field_map(&result_map);
                 results = records_map
                     .into_iter()
-                    .map(|(key, record)| json!({"key": key, "fields": record.fields}))
+                    .map(|(key, record)| json!({"key": key, "fields": record.fields, "metadata": record.metadata}))
                     .collect();
 
                 if !results.is_empty() {

--- a/src/datafold_node/operation_processor.rs
+++ b/src/datafold_node/operation_processor.rs
@@ -75,9 +75,9 @@ impl OperationProcessor {
 
         // Parse each mutation from the input data
         for mutation_data in mutations_data {
-            let (schema, fields_and_values, key_value, mutation_type) = match serde_json::from_value::<Operation>(mutation_data) {
-                Ok(Operation::Mutation { schema, fields_and_values, key_value, mutation_type }) => {
-                    (schema, fields_and_values, key_value, mutation_type)
+            let (schema, fields_and_values, key_value, mutation_type, source_file_name) = match serde_json::from_value::<Operation>(mutation_data) {
+                Ok(Operation::Mutation { schema, fields_and_values, key_value, mutation_type, source_file_name }) => {
+                    (schema, fields_and_values, key_value, mutation_type, source_file_name)
                 },
                 Err(e) => {
                     return Err(FoldDbError::Config(format!("Failed to parse mutation: {}", e)));
@@ -88,7 +88,7 @@ impl OperationProcessor {
                 return Err(FoldDbError::Config("No fields to mutate".to_string()));
             }
 
-            let mutation = Mutation::new(
+            let mut mutation = Mutation::new(
                 schema,
                 fields_and_values,
                 key_value,
@@ -96,6 +96,11 @@ impl OperationProcessor {
                 0,
                 mutation_type,
             );
+
+            // Add source_file_name if provided
+            if let Some(filename) = source_file_name {
+                mutation = mutation.with_source_file_name(filename);
+            }
 
             mutations.push(mutation);
         }

--- a/src/datafold_node/query_routes.rs
+++ b/src/datafold_node/query_routes.rs
@@ -68,7 +68,7 @@ pub async fn execute_mutation(
 ) -> impl Responder {
 
     let (schema, fields_and_values, key_value, mutation_type) = match serde_json::from_value::<Operation>(mutation_data.into_inner()) {
-        Ok(Operation::Mutation { schema, fields_and_values, key_value, mutation_type }) => (schema, fields_and_values, key_value, mutation_type),
+        Ok(Operation::Mutation { schema, fields_and_values, key_value, mutation_type, source_file_name: _ }) => (schema, fields_and_values, key_value, mutation_type),
         Err(e) => {
             return HttpResponse::BadRequest()
                 .json(json!({"error": format!("Failed to parse mutation: {}", e)}))

--- a/src/datafold_node/query_routes.rs
+++ b/src/datafold_node/query_routes.rs
@@ -41,7 +41,7 @@ pub async fn execute_query(query: web::Json<Query>, state: web::Data<AppState>) 
             let records_map = records_from_field_map(&result_map);
             let data: Vec<Value> = records_map
                 .into_iter()
-                .map(|(key, record)| json!({"key": key, "fields": record.fields}))
+                .map(|(key, record)| json!({"key": key, "fields": record.fields, "metadata": record.metadata}))
                 .collect();
             HttpResponse::Ok().json(data)
         },

--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -262,38 +262,26 @@ impl MutationManager {
             *timing_breakdown.entry("  - write_molecules").or_insert(std::time::Duration::ZERO) += molecule_time;
             *timing_breakdown.entry("  - index_fields").or_insert(std::time::Duration::ZERO) += index_time;
             
-            // Publish batch index request for background processing
+            // Process batch index operations synchronously
             if !index_operations.is_empty() {
                 let index_start = std::time::Instant::now();
                 debug!(
-                    "MutationManager: Publishing BatchIndexRequest with {} operations for schema '{}'",
+                    "MutationManager: Processing batch index with {} operations for schema '{}'",
                     index_operations.len(),
                     schema_name
                 );
                 
-                let index_requests: Vec<_> = index_operations.into_iter().map(|(schema_name, field_name, key_value, value, classifications)| {
-                    super::infrastructure::message_bus::request_events::IndexRequest {
-                        schema_name,
-                        field_name,
-                        key_value,
-                        value,
-                        classifications,
-                    }
-                }).collect();
+                // Call batch indexing directly for synchronous processing
+                self.db_ops.native_index_manager().batch_index_field_values_with_classifications(&index_operations)?;
                 
-                let batch_request = super::infrastructure::message_bus::request_events::BatchIndexRequest {
-                    operations: index_requests,
-                };
-                
-                self.message_bus.publish(batch_request)?;
                 debug!(
-                    "MutationManager: Successfully published BatchIndexRequest for schema '{}'",
+                    "MutationManager: Successfully processed batch index for schema '{}'",
                     schema_name
                 );
                 index_time += index_start.elapsed();
             } else {
                 debug!(
-                    "MutationManager: No index operations to publish for schema '{}'",
+                    "MutationManager: No index operations to process for schema '{}'",
                     schema_name
                 );
             }
@@ -333,6 +321,11 @@ impl MutationManager {
                 mutation_ids.push(mutation_id.clone());
             }
         }
+
+        // Flush native index after all mutations in the batch
+        let native_index_flush_start = std::time::Instant::now();
+        self.db_ops.native_index_manager().flush()?;
+        timing_breakdown.insert("native_index_flush", native_index_flush_start.elapsed());
 
         // Single flush for entire batch
         let flush_start = std::time::Instant::now();

--- a/src/fold_db_core/query/formatter.rs
+++ b/src/fold_db_core/query/formatter.rs
@@ -36,11 +36,20 @@ pub fn format_hash_range_fields(
     Value::Object(top)
 }
 
+/// Metadata associated with a field value
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct FieldMetadata {
+    pub atom_uuid: String,
+    pub source_file_name: Option<String>,
+}
+
 /// Represents a single logical record keyed by `KeyValue`.
-/// The `fields` map stores field_name -> value. Atom metadata is omitted here.
+/// The `fields` map stores field_name -> value.
+/// The `metadata` map stores field_name -> atom metadata.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Record {
     pub fields: HashMap<String, Value>,
+    pub metadata: HashMap<String, FieldMetadata>,
 }
 
 /// Represents a query result record with its key and fields
@@ -56,17 +65,30 @@ pub fn records_from_field_map(
     results: &HashMap<String, HashMap<KeyValue, FieldValue>>,
 ) -> HashMap<KeyValue, Record> {
     let mut by_key: HashMap<KeyValue, HashMap<String, Value>> = HashMap::new();
+    let mut metadata_by_key: HashMap<KeyValue, HashMap<String, FieldMetadata>> = HashMap::new();
 
     for (field_name, key_map) in results.iter() {
         for (key_value, field_val) in key_map.iter() {
             let entry = by_key.entry(key_value.clone()).or_default();
             entry.insert(field_name.clone(), field_val.value.clone());
+            
+            let metadata_entry = metadata_by_key.entry(key_value.clone()).or_default();
+            metadata_entry.insert(
+                field_name.clone(),
+                FieldMetadata {
+                    atom_uuid: field_val.atom_uuid.clone(),
+                    source_file_name: field_val.source_file_name.clone(),
+                },
+            );
         }
     }
 
     by_key
         .into_iter()
-        .map(|(k, fields)| (k, Record { fields }))
+        .map(|(k, fields)| {
+            let metadata = metadata_by_key.get(&k).cloned().unwrap_or_default();
+            (k, Record { fields, metadata })
+        })
         .collect()
 }
 
@@ -82,11 +104,11 @@ mod tests {
         let key2 = KeyValue::new(Some("h2".to_string()), None);
 
         let mut f1_map = HashMap::new();
-        f1_map.insert(key1.clone(), FieldValue { value: Value::from(1), atom_uuid: "a1".to_string() });
-        f1_map.insert(key2.clone(), FieldValue { value: Value::from(2), atom_uuid: "a2".to_string() });
+        f1_map.insert(key1.clone(), FieldValue { value: Value::from(1), atom_uuid: "a1".to_string(), source_file_name: None });
+        f1_map.insert(key2.clone(), FieldValue { value: Value::from(2), atom_uuid: "a2".to_string(), source_file_name: None });
 
         let mut f2_map = HashMap::new();
-        f2_map.insert(key1.clone(), FieldValue { value: Value::from("x"), atom_uuid: "b1".to_string() });
+        f2_map.insert(key1.clone(), FieldValue { value: Value::from("x"), atom_uuid: "b1".to_string(), source_file_name: None });
 
         results.insert("f1".to_string(), f1_map);
         results.insert("f2".to_string(), f2_map);
@@ -100,6 +122,114 @@ mod tests {
         let rec2 = records.get(&key2).expect("record for key2");
         assert_eq!(rec2.fields.get("f1").cloned().unwrap(), Value::from(2));
         assert!(!rec2.fields.contains_key("f2"));
+    }
+
+    #[test]
+    fn records_include_metadata() {
+        let mut results: HashMap<String, HashMap<KeyValue, FieldValue>> = HashMap::new();
+
+        let key1 = KeyValue::new(Some("user1".to_string()), Some("post1".to_string()));
+
+        let mut f1_map = HashMap::new();
+        f1_map.insert(
+            key1.clone(), 
+            FieldValue { 
+                value: Value::from("Hello World"), 
+                atom_uuid: "atom-123".to_string(), 
+                source_file_name: Some("tweets.json".to_string()),
+            }
+        );
+
+        let mut f2_map = HashMap::new();
+        f2_map.insert(
+            key1.clone(), 
+            FieldValue { 
+                value: Value::from(42), 
+                atom_uuid: "atom-456".to_string(), 
+                source_file_name: None,
+            }
+        );
+
+        results.insert("content".to_string(), f1_map);
+        results.insert("likes".to_string(), f2_map);
+
+        let records = records_from_field_map(&results);
+
+        let rec1 = records.get(&key1).expect("record for key1");
+        
+        // Check fields
+        assert_eq!(rec1.fields.get("content").cloned().unwrap(), Value::from("Hello World"));
+        assert_eq!(rec1.fields.get("likes").cloned().unwrap(), Value::from(42));
+        
+        // Check metadata for content field
+        let content_meta = rec1.metadata.get("content").expect("content metadata");
+        assert_eq!(content_meta.atom_uuid, "atom-123");
+        assert_eq!(content_meta.source_file_name, Some("tweets.json".to_string()));
+        
+        // Check metadata for likes field
+        let likes_meta = rec1.metadata.get("likes").expect("likes metadata");
+        assert_eq!(likes_meta.atom_uuid, "atom-456");
+        assert_eq!(likes_meta.source_file_name, None);
+    }
+
+    #[test]
+    fn metadata_preserved_for_multiple_keys() {
+        let mut results: HashMap<String, HashMap<KeyValue, FieldValue>> = HashMap::new();
+
+        let key1 = KeyValue::new(Some("user1".to_string()), Some("post1".to_string()));
+        let key2 = KeyValue::new(Some("user2".to_string()), Some("post2".to_string()));
+
+        let mut field_map = HashMap::new();
+        field_map.insert(
+            key1.clone(), 
+            FieldValue { 
+                value: Value::from("First post"), 
+                atom_uuid: "atom-1".to_string(), 
+                source_file_name: Some("file1.json".to_string()),
+            }
+        );
+        field_map.insert(
+            key2.clone(), 
+            FieldValue { 
+                value: Value::from("Second post"), 
+                atom_uuid: "atom-2".to_string(), 
+                source_file_name: Some("file2.json".to_string()),
+            }
+        );
+
+        results.insert("content".to_string(), field_map);
+
+        let records = records_from_field_map(&results);
+
+        // Verify key1 metadata
+        let rec1 = records.get(&key1).expect("record for key1");
+        let meta1 = rec1.metadata.get("content").expect("content metadata for key1");
+        assert_eq!(meta1.atom_uuid, "atom-1");
+        assert_eq!(meta1.source_file_name, Some("file1.json".to_string()));
+        
+        // Verify key2 metadata
+        let rec2 = records.get(&key2).expect("record for key2");
+        let meta2 = rec2.metadata.get("content").expect("content metadata for key2");
+        assert_eq!(meta2.atom_uuid, "atom-2");
+        assert_eq!(meta2.source_file_name, Some("file2.json".to_string()));
+    }
+
+    #[test]
+    fn field_metadata_is_serializable() {
+        let metadata = FieldMetadata {
+            atom_uuid: "test-atom".to_string(),
+            source_file_name: Some("test.json".to_string()),
+        };
+        
+        // Test serialization
+        let json = serde_json::to_string(&metadata).expect("should serialize");
+        assert!(json.contains("test-atom"));
+        assert!(json.contains("test.json"));
+        
+        // Test deserialization
+        let deserialized: FieldMetadata = serde_json::from_str(&json).expect("should deserialize");
+        assert_eq!(deserialized.atom_uuid, "test-atom");
+        assert_eq!(deserialized.source_file_name, Some("test.json".to_string()));
     }
 }
 

--- a/src/fold_db_core/query/mod.rs
+++ b/src/fold_db_core/query/mod.rs
@@ -10,4 +10,4 @@ pub mod formatter;
 // Re-export main query functionality
 pub use hash_range_query::HashRangeQueryProcessor;
 pub use query_executor::QueryExecutor;
-pub use formatter::{format_hash_range_fields, records_from_field_map, Record, QueryResultRecord};
+pub use formatter::{format_hash_range_fields, records_from_field_map, FieldMetadata, Record, QueryResultRecord};

--- a/src/ingestion/file_upload.rs
+++ b/src/ingestion/file_upload.rs
@@ -39,6 +39,18 @@ pub async fn upload_file(
         Err(response) => return response,
     };
 
+    // Check if file already exists (duplicate upload) BEFORE converting to JSON
+    if form_data.already_exists {
+        log_feature!(
+            LogFeature::Ingestion,
+            info,
+            "File already exists, skipping ingestion (no JSON conversion needed): {}",
+            form_data.original_filename
+        );
+        
+        return build_duplicate_response(&form_data.file_path, &form_data.original_filename);
+    }
+
     // Convert file to JSON using file_to_json
     let json_value = match convert_file_to_json(&form_data.file_path).await {
         Ok(json) => json,
@@ -58,6 +70,13 @@ pub async fn upload_file(
     let temp_json_path = save_json_debug_file(&flattened_json);
 
     // Spawn background ingestion and get progress_id
+    log_feature!(
+        LogFeature::Ingestion,
+        info,
+        "Creating mutations with source_file_name: {}",
+        form_data.original_filename
+    );
+    
     let spawn_config = IngestionSpawnConfig {
         json_data: flattened_json,
         auto_execute: form_data.auto_execute,
@@ -117,7 +136,8 @@ fn build_upload_response(
         "success": true,
         "progress_id": progress_id,
         "message": "File upload and ingestion started. Use progress_id to track status.",
-        "file_path": file_path.to_string_lossy().to_string()
+        "file_path": file_path.to_string_lossy().to_string(),
+        "duplicate": false
     });
 
     if let Some(json_path) = temp_json_path {
@@ -125,4 +145,18 @@ fn build_upload_response(
     }
 
     HttpResponse::Accepted().json(response)
+}
+
+/// Build the HTTP response for duplicate file upload
+fn build_duplicate_response(
+    file_path: &std::path::Path,
+    filename: &str,
+) -> HttpResponse {
+    HttpResponse::Ok().json(json!({
+        "success": true,
+        "message": "File already exists - no ingestion needed (content-based deduplication)",
+        "file_path": file_path.to_string_lossy().to_string(),
+        "filename": filename,
+        "duplicate": true
+    }))
 }

--- a/src/ingestion/multipart_parser.rs
+++ b/src/ingestion/multipart_parser.rs
@@ -158,21 +158,24 @@ async fn save_uploaded_file(
     let unique_filename = format!("{}_{}", short_hash, &filename);
     let filepath = uploads_dir.join(&unique_filename);
 
-    // Check if file already exists
-    if filepath.exists() {
-        log_feature!(
-            LogFeature::Ingestion,
-            info,
-            "File already exists (duplicate upload): {} at {:?}",
-            unique_filename,
-            filepath
-        );
-        return Ok((filepath, unique_filename, true));
-    }
-
-    // Save file to disk
-    let mut f = match std::fs::File::create(&filepath) {
+    // Atomically create file only if it doesn't exist (prevents race condition)
+    let mut f = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&filepath)
+    {
         Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            // File already exists (duplicate upload detected atomically)
+            log_feature!(
+                LogFeature::Ingestion,
+                info,
+                "File already exists (duplicate upload): {} at {:?}",
+                unique_filename,
+                filepath
+            );
+            return Ok((filepath, unique_filename, true));
+        }
         Err(e) => {
             log_feature!(
                 LogFeature::Ingestion,

--- a/src/ingestion/multipart_parser.rs
+++ b/src/ingestion/multipart_parser.rs
@@ -13,16 +13,21 @@ use crate::logging::features::LogFeature;
 #[derive(Debug)]
 pub struct UploadFormData {
     pub file_path: PathBuf,
+    /// The unique filename as saved to disk (HASH_originalname format).
+    /// This matches the filename in data/uploads/ directory.
     pub original_filename: String,
     pub auto_execute: bool,
     pub trust_distance: u32,
     pub pub_key: String,
+    /// Whether this file already existed (true = duplicate upload)
+    pub already_exists: bool,
 }
 
 /// Extract and parse multipart form data
 pub async fn parse_multipart(mut payload: Multipart) -> Result<UploadFormData, HttpResponse> {
     let mut file_path: Option<PathBuf> = None;
     let mut original_filename: Option<String> = None;
+    let mut already_exists = false;
     let mut auto_execute = true;
     let mut trust_distance = 0;
     let mut pub_key = "default".to_string();
@@ -48,9 +53,10 @@ pub async fn parse_multipart(mut payload: Multipart) -> Result<UploadFormData, H
 
         match field_name.as_deref() {
             Some("file") => {
-                let (path, filename) = save_uploaded_file(field).await?;
+                let (path, filename, exists) = save_uploaded_file(field).await?;
                 file_path = Some(path);
                 original_filename = Some(filename);
+                already_exists = exists;
             }
             Some("autoExecute") => {
                 auto_execute = parse_field_as_bool(&mut field).await.unwrap_or(true);
@@ -84,14 +90,18 @@ pub async fn parse_multipart(mut payload: Multipart) -> Result<UploadFormData, H
         auto_execute,
         trust_distance,
         pub_key,
+        already_exists,
     })
 }
 
-/// Save uploaded file from multipart field
-/// Returns (file_path, original_filename)
+/// Save uploaded file from multipart field with content-based hash
+/// Returns (file_path, unique_filename, already_exists) where:
+/// - unique_filename has format: HASH_originalname (first 16 chars of SHA256)
+/// - already_exists is true if this exact file was already uploaded
 async fn save_uploaded_file(
     mut field: actix_multipart::Field,
-) -> Result<(PathBuf, String), HttpResponse> {
+) -> Result<(PathBuf, String, bool), HttpResponse> {
+    use sha2::{Sha256, Digest};
     use std::io::Write;
     use tokio::fs;
 
@@ -116,9 +126,49 @@ async fn save_uploaded_file(
         })));
     }
 
-    // Generate unique filename
-    let unique_filename = format!("{}_{}", uuid::Uuid::new_v4(), &filename);
+    // Read file contents and compute hash simultaneously
+    let mut hasher = Sha256::new();
+    let mut file_data = Vec::new();
+
+    while let Some(chunk) = field.next().await {
+        let data = match chunk {
+            Ok(data) => data,
+            Err(e) => {
+                log_feature!(
+                    LogFeature::Ingestion,
+                    error,
+                    "Failed to read file chunk: {}",
+                    e
+                );
+                return Err(HttpResponse::InternalServerError().json(json!({
+                    "success": false,
+                    "error": format!("Failed to read file: {}", e)
+                })));
+            }
+        };
+        
+        hasher.update(&data);
+        file_data.extend_from_slice(&data);
+    }
+
+    // Generate hash-based filename (use first 16 chars of hex for readability)
+    let hash_result = hasher.finalize();
+    let hash_hex = format!("{:x}", hash_result);
+    let short_hash = &hash_hex[..16]; // First 16 characters provides plenty of uniqueness
+    let unique_filename = format!("{}_{}", short_hash, &filename);
     let filepath = uploads_dir.join(&unique_filename);
+
+    // Check if file already exists
+    if filepath.exists() {
+        log_feature!(
+            LogFeature::Ingestion,
+            info,
+            "File already exists (duplicate upload): {} at {:?}",
+            unique_filename,
+            filepath
+        );
+        return Ok((filepath, unique_filename, true));
+    }
 
     // Save file to disk
     let mut f = match std::fs::File::create(&filepath) {
@@ -137,46 +187,62 @@ async fn save_uploaded_file(
         }
     };
 
-    // Write file contents
-    while let Some(chunk) = field.next().await {
-        let data = match chunk {
-            Ok(data) => data,
-            Err(e) => {
-                log_feature!(
-                    LogFeature::Ingestion,
-                    error,
-                    "Failed to read file chunk: {}",
-                    e
-                );
-                return Err(HttpResponse::InternalServerError().json(json!({
-                    "success": false,
-                    "error": format!("Failed to read file: {}", e)
-                })));
-            }
-        };
+    // Write all file data at once
+    if let Err(e) = f.write_all(&file_data) {
+        log_feature!(
+            LogFeature::Ingestion,
+            error,
+            "Failed to write file: {}",
+            e
+        );
+        return Err(HttpResponse::InternalServerError().json(json!({
+            "success": false,
+            "error": format!("Failed to write file: {}", e)
+        })));
+    }
 
-        if let Err(e) = f.write_all(&data) {
-            log_feature!(
-                LogFeature::Ingestion,
-                error,
-                "Failed to write file chunk: {}",
-                e
-            );
-            return Err(HttpResponse::InternalServerError().json(json!({
-                "success": false,
-                "error": format!("Failed to write file: {}", e)
-            })));
-        }
+    // Ensure file is flushed to disk before returning
+    if let Err(e) = f.flush() {
+        log_feature!(
+            LogFeature::Ingestion,
+            error,
+            "Failed to flush file to disk: {}",
+            e
+        );
+        return Err(HttpResponse::InternalServerError().json(json!({
+            "success": false,
+            "error": format!("Failed to flush file to disk: {}", e)
+        })));
+    }
+
+    // Verify the filename matches what we saved
+    let saved_filename = filepath.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    
+    if saved_filename != unique_filename {
+        log_feature!(
+            LogFeature::Ingestion,
+            error,
+            "Filename mismatch: saved as '{}' but returning '{}'",
+            saved_filename,
+            unique_filename
+        );
+        return Err(HttpResponse::InternalServerError().json(json!({
+            "success": false,
+            "error": "Internal error: filename mismatch"
+        })));
     }
 
     log_feature!(
         LogFeature::Ingestion,
         info,
-        "File saved to: {:?}",
+        "File saved successfully (new upload): {} at {:?}",
+        unique_filename,
         filepath
     );
 
-    Ok((filepath, filename))
+    Ok((filepath, unique_filename, false))
 }
 
 /// Parse multipart field as boolean
@@ -210,5 +276,67 @@ async fn parse_field_as_string(field: &mut actix_multipart::Field) -> Option<Str
         }
     }
     String::from_utf8(bytes).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use sha2::{Sha256, Digest};
+
+    #[test]
+    fn test_unique_filename_format() {
+        // Verify the unique filename format matches HASH_originalname pattern
+        let test_content = b"test file content";
+        let mut hasher = Sha256::new();
+        hasher.update(test_content);
+        let hash_result = hasher.finalize();
+        let hash_hex = format!("{:x}", hash_result);
+        let short_hash = &hash_hex[..16];
+        
+        let original = "tweets.js";
+        let unique = format!("{}_{}", short_hash, original);
+        
+        // Verify format
+        assert!(unique.contains('_'));
+        assert!(unique.ends_with("tweets.js"));
+        
+        // Verify we can extract the original name if needed
+        let parts: Vec<&str> = unique.splitn(2, '_').collect();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0].len(), 16); // Short hash is 16 chars
+        assert_eq!(parts[1], original);
+    }
+
+    #[test]
+    fn test_hash_consistency() {
+        // Same content should produce same hash
+        let content = b"identical content";
+        
+        let mut hasher1 = Sha256::new();
+        hasher1.update(content);
+        let hash1 = format!("{:x}", hasher1.finalize());
+        
+        let mut hasher2 = Sha256::new();
+        hasher2.update(content);
+        let hash2 = format!("{:x}", hasher2.finalize());
+        
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_hash_uniqueness() {
+        // Different content should produce different hashes
+        let content1 = b"content one";
+        let content2 = b"content two";
+        
+        let mut hasher1 = Sha256::new();
+        hasher1.update(content1);
+        let hash1 = format!("{:x}", hasher1.finalize());
+        
+        let mut hasher2 = Sha256::new();
+        hasher2.update(content2);
+        let hash2 = format!("{:x}", hasher2.finalize());
+        
+        assert_ne!(hash1, hash2);
+    }
 }
 

--- a/src/ingestion/simple_service.rs
+++ b/src/ingestion/simple_service.rs
@@ -880,6 +880,7 @@ impl SimpleIngestionService {
                     fields_and_values: mutation.fields_and_values.clone(),
                     key_value: mutation.key_value.clone(),
                     mutation_type: mutation.mutation_type.clone(),
+                    source_file_name: mutation.source_file_name.clone(),
                 };
                 serde_json::to_value(operation).expect("Failed to serialize operation")
             })
@@ -918,6 +919,7 @@ impl SimpleIngestionService {
                     fields_and_values: mutation.fields_and_values.clone(),
                     key_value: mutation.key_value.clone(),
                     mutation_type: mutation.mutation_type.clone(),
+                    source_file_name: mutation.source_file_name.clone(),
                 };
                 serde_json::to_value(operation).expect("Failed to serialize operation")
             })

--- a/src/schema/types/field/filter_utils.rs
+++ b/src/schema/types/field/filter_utils.rs
@@ -49,7 +49,11 @@ pub fn fetch_atoms_for_matches(
             Ok(Some(atom)) => {
                 resolved_values.insert(
                     key,
-                    FieldValue { value: atom.content().clone(), atom_uuid: atom_uuid.clone() },
+                    FieldValue { 
+                        value: atom.content().clone(), 
+                        atom_uuid: atom_uuid.clone(),
+                        source_file_name: atom.source_file_name().cloned(),
+                    },
                 );
             }
             Ok(None) => {

--- a/src/schema/types/field/variant.rs
+++ b/src/schema/types/field/variant.rs
@@ -26,6 +26,7 @@ pub enum FieldVariant {
 pub struct FieldValue {
     pub value: JsonValue,
     pub atom_uuid: String,
+    pub source_file_name: Option<String>,
 }
 
 // Macro to reduce boilerplate for Field trait implementation

--- a/src/schema/types/operations.rs
+++ b/src/schema/types/operations.rs
@@ -76,7 +76,69 @@ pub enum Operation {
         fields_and_values: HashMap<String, Value>,
         key_value: KeyValue,
         mutation_type: MutationType,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source_file_name: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_operation_mutation_preserves_source_file_name() {
+        let operation = Operation::Mutation {
+            schema: "TestSchema".to_string(),
+            fields_and_values: HashMap::new(),
+            key_value: KeyValue::new(None, None),
+            mutation_type: MutationType::Create,
+            source_file_name: Some("test_file.json".to_string()),
+        };
+
+        // Serialize to JSON
+        let json = serde_json::to_value(&operation).unwrap();
+        
+        // Verify source_file_name is in the JSON
+        assert_eq!(json["source_file_name"], json!("test_file.json"));
+
+        // Deserialize back
+        let deserialized: Operation = serde_json::from_value(json).unwrap();
+        
+        // Verify source_file_name is preserved
+        match deserialized {
+            Operation::Mutation { source_file_name, .. } => {
+                assert_eq!(source_file_name, Some("test_file.json".to_string()));
+            }
+        }
+    }
+
+    #[test]
+    fn test_operation_mutation_without_source_file_name() {
+        let operation = Operation::Mutation {
+            schema: "TestSchema".to_string(),
+            fields_and_values: HashMap::new(),
+            key_value: KeyValue::new(None, None),
+            mutation_type: MutationType::Create,
+            source_file_name: None,
+        };
+
+        // Serialize to JSON
+        let json = serde_json::to_value(&operation).unwrap();
+        
+        // Verify source_file_name is NOT in the JSON (due to skip_serializing_if)
+        assert!(json.get("source_file_name").is_none());
+
+        // Deserialize back
+        let deserialized: Operation = serde_json::from_value(json).unwrap();
+        
+        // Verify source_file_name is None
+        match deserialized {
+            Operation::Mutation { source_file_name, .. } => {
+                assert_eq!(source_file_name, None);
+            }
+        }
+    }
 }
 
 

--- a/src/transform/functions/comprehensive_tests.rs
+++ b/src/transform/functions/comprehensive_tests.rs
@@ -19,6 +19,7 @@ fn create_text_item(text: &str, key: &str) -> IterationItem {
         value: FieldValue {
             value: serde_json::Value::String(text.to_string()),
             atom_uuid: format!("atom-{}", key),
+            source_file_name: None,
         },
         is_text_token: false,
     }
@@ -30,6 +31,7 @@ fn create_numeric_item(value: f64, key: &str) -> IterationItem {
         value: FieldValue {
             value: serde_json::Value::Number(serde_json::Number::from_f64(value).unwrap()),
             atom_uuid: format!("atom-{}", key),
+            source_file_name: None,
         },
         is_text_token: false,
     }
@@ -41,6 +43,7 @@ fn create_array_item(values: Vec<serde_json::Value>, key: &str) -> IterationItem
         value: FieldValue {
             value: serde_json::Value::Array(values),
             atom_uuid: format!("atom-{}", key),
+            source_file_name: None,
         },
         is_text_token: false,
     }
@@ -489,6 +492,7 @@ fn test_functions_with_null_values() {
         value: FieldValue {
             value: serde_json::Value::Null,
             atom_uuid: "atom-null".to_string(),
+            source_file_name: None,
         },
         is_text_token: false,
     };
@@ -523,6 +527,7 @@ fn test_functions_with_complex_json() {
         value: FieldValue {
             value: serde_json::Value::Object(obj),
             atom_uuid: "atom-complex".to_string(),
+            source_file_name: None,
         },
         is_text_token: false,
     };

--- a/src/transform/functions/integration_tests.rs
+++ b/src/transform/functions/integration_tests.rs
@@ -5,99 +5,11 @@
 
 use super::*;
 use crate::transform::chain_parser::parser::ChainParser;
-use crate::transform::iterator_stack_typed::adapter::map_chain_to_specs;
 use crate::transform::iterator_stack_typed::engine::TypedEngine;
 use crate::transform::iterator_stack_typed::types::{IteratorSpec, TypedInput};
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::field::FieldValue;
 use std::collections::HashMap;
-
-/// Helper to create test input data
-fn create_test_input() -> TypedInput {
-    let mut input: TypedInput = HashMap::new();
-    
-    // Add blog post data - each KeyValue represents a unique item
-    let mut blogpost_data = HashMap::new();
-    blogpost_data.insert(
-        KeyValue::new(Some("content".to_string()), None),
-        FieldValue {
-            value: serde_json::Value::String("hello world test".to_string()),
-            atom_uuid: "atom-1".to_string(),
-            source_file_name: None,
-        }
-    );
-    input.insert("BlogPost.content".to_string(), blogpost_data);
-    
-    input
-}
-
-fn create_numeric_input() -> TypedInput {
-    let mut input: TypedInput = HashMap::new();
-    
-    // Create multiple numeric items
-    let mut scores_data = HashMap::new();
-    scores_data.insert(
-        KeyValue::new(Some("values".to_string()), Some("item1".to_string())),
-        FieldValue {
-            value: serde_json::Value::Number(serde_json::Number::from(10)),
-            atom_uuid: "atom-1".to_string(),
-            source_file_name: None,
-        }
-    );
-    scores_data.insert(
-        KeyValue::new(Some("values".to_string()), Some("item2".to_string())),
-        FieldValue {
-            value: serde_json::Value::Number(serde_json::Number::from(20)),
-            atom_uuid: "atom-2".to_string(),
-            source_file_name: None,
-        }
-    );
-    scores_data.insert(
-        KeyValue::new(Some("values".to_string()), Some("item3".to_string())),
-        FieldValue {
-            value: serde_json::Value::Number(serde_json::Number::from(30)),
-            atom_uuid: "atom-3".to_string(),
-            source_file_name: None,
-        }
-    );
-    input.insert("Scores.values".to_string(), scores_data);
-    
-    input
-}
-
-fn create_array_input() -> TypedInput {
-    let mut input: TypedInput = HashMap::new();
-    
-    // Create multiple string items
-    let mut tags_data = HashMap::new();
-    tags_data.insert(
-        KeyValue::new(Some("values".to_string()), Some("tag1".to_string())),
-        FieldValue {
-            value: serde_json::Value::String("rust".to_string()),
-            atom_uuid: "atom-1".to_string(),
-            source_file_name: None,
-        }
-    );
-    tags_data.insert(
-        KeyValue::new(Some("values".to_string()), Some("tag2".to_string())),
-        FieldValue {
-            value: serde_json::Value::String("database".to_string()),
-            atom_uuid: "atom-2".to_string(),
-            source_file_name: None,
-        }
-    );
-    tags_data.insert(
-        KeyValue::new(Some("values".to_string()), Some("tag3".to_string())),
-        FieldValue {
-            value: serde_json::Value::String("transforms".to_string()),
-            atom_uuid: "atom-3".to_string(),
-            source_file_name: None,
-        }
-    );
-    input.insert("Scores.values".to_string(), tags_data);
-    
-    input
-}
 
 // ============================================================================
 // Chain Parser Integration Tests

--- a/src/transform/functions/integration_tests.rs
+++ b/src/transform/functions/integration_tests.rs
@@ -23,6 +23,7 @@ fn create_test_input() -> TypedInput {
         FieldValue {
             value: serde_json::Value::String("hello world test".to_string()),
             atom_uuid: "atom-1".to_string(),
+            source_file_name: None,
         }
     );
     input.insert("BlogPost.content".to_string(), blogpost_data);
@@ -40,6 +41,7 @@ fn create_numeric_input() -> TypedInput {
         FieldValue {
             value: serde_json::Value::Number(serde_json::Number::from(10)),
             atom_uuid: "atom-1".to_string(),
+            source_file_name: None,
         }
     );
     scores_data.insert(
@@ -47,6 +49,7 @@ fn create_numeric_input() -> TypedInput {
         FieldValue {
             value: serde_json::Value::Number(serde_json::Number::from(20)),
             atom_uuid: "atom-2".to_string(),
+            source_file_name: None,
         }
     );
     scores_data.insert(
@@ -54,6 +57,7 @@ fn create_numeric_input() -> TypedInput {
         FieldValue {
             value: serde_json::Value::Number(serde_json::Number::from(30)),
             atom_uuid: "atom-3".to_string(),
+            source_file_name: None,
         }
     );
     input.insert("Scores.values".to_string(), scores_data);
@@ -71,6 +75,7 @@ fn create_array_input() -> TypedInput {
         FieldValue {
             value: serde_json::Value::String("rust".to_string()),
             atom_uuid: "atom-1".to_string(),
+            source_file_name: None,
         }
     );
     tags_data.insert(
@@ -78,6 +83,7 @@ fn create_array_input() -> TypedInput {
         FieldValue {
             value: serde_json::Value::String("database".to_string()),
             atom_uuid: "atom-2".to_string(),
+            source_file_name: None,
         }
     );
     tags_data.insert(
@@ -85,6 +91,7 @@ fn create_array_input() -> TypedInput {
         FieldValue {
             value: serde_json::Value::String("transforms".to_string()),
             atom_uuid: "atom-3".to_string(),
+            source_file_name: None,
         }
     );
     input.insert("Scores.values".to_string(), tags_data);
@@ -226,6 +233,7 @@ fn test_engine_executes_iterator_functions() {
         FieldValue {
             value: serde_json::Value::String("hello world test".to_string()),
             atom_uuid: "atom-1".to_string(),
+            source_file_name: None,
         }
     );
     input.insert("BlogPost.content".to_string(), field_map);

--- a/src/transform/functions/registry.rs
+++ b/src/transform/functions/registry.rs
@@ -430,6 +430,7 @@ mod tests {
             value: FieldValue {
                 value: serde_json::Value::String(text.to_string()),
                 atom_uuid: "test-uuid".to_string(),
+                source_file_name: None,
             },
             is_text_token: false,
         }
@@ -505,6 +506,7 @@ mod tests {
                 value: FieldValue {
                     value: serde_json::Value::Number(serde_json::Number::from(10)),
                     atom_uuid: "test-uuid".to_string(),
+                    source_file_name: None,
                 },
                 is_text_token: false,
             },
@@ -513,6 +515,7 @@ mod tests {
                 value: FieldValue {
                     value: serde_json::Value::Number(serde_json::Number::from(20)),
                     atom_uuid: "test-uuid".to_string(),
+                    source_file_name: None,
                 },
                 is_text_token: false,
             },

--- a/src/transform/iterator_stack_typed/engine.rs
+++ b/src/transform/iterator_stack_typed/engine.rs
@@ -155,6 +155,7 @@ impl TypedEngine {
                                         value: FieldValue {
                                             value: serde_json::Value::String(token.clone()),
                                             atom_uuid: item.value.atom_uuid.clone(),
+                                            source_file_name: item.value.source_file_name.clone(),
                                         },
                                         is_text_token: true,
                                     })

--- a/src/transform/iterator_stack_typed/tests.rs
+++ b/src/transform/iterator_stack_typed/tests.rs
@@ -16,7 +16,7 @@ mod typed_engine_tests {
     fn test_passthrough_emits_atom_uuid() {
         let mut input: TypedInput = HashMap::new();
         let mut field_map: HashMap<KeyValue, FieldValue> = HashMap::new();
-        field_map.insert(kv("h1", "r1"), FieldValue { value: serde_json::json!("hello world"), atom_uuid: "atom-1".to_string() });
+        field_map.insert(kv("h1", "r1"), FieldValue { value: serde_json::json!("hello world"), atom_uuid: "atom-1".to_string(), source_file_name: None });
         input.insert("BlogPost.content".to_string(), field_map);
 
         let engine = TypedEngine::new();
@@ -32,7 +32,7 @@ mod typed_engine_tests {
     fn test_word_split_emits_words_with_atom_uuid() {
         let mut input: TypedInput = HashMap::new();
         let mut field_map: HashMap<KeyValue, FieldValue> = HashMap::new();
-        field_map.insert(kv("h1", "r1"), FieldValue { value: serde_json::json!("alpha beta gamma"), atom_uuid: "atom-2".to_string() });
+        field_map.insert(kv("h1", "r1"), FieldValue { value: serde_json::json!("alpha beta gamma"), atom_uuid: "atom-2".to_string(), source_file_name: None });
         input.insert("BlogPost.content".to_string(), field_map);
 
         let engine = TypedEngine::new();
@@ -60,9 +60,9 @@ mod typed_engine_tests {
     fn test_count_reducer_execution() {
         let mut input: TypedInput = HashMap::new();
         let mut field_map: HashMap<KeyValue, FieldValue> = HashMap::new();
-        field_map.insert(kv("h1", "r1"), FieldValue { value: serde_json::json!("one"), atom_uuid: "atom-1".to_string() });
-        field_map.insert(kv("h1", "r2"), FieldValue { value: serde_json::json!("two"), atom_uuid: "atom-2".to_string() });
-        field_map.insert(kv("h1", "r3"), FieldValue { value: serde_json::json!("three"), atom_uuid: "atom-3".to_string() });
+        field_map.insert(kv("h1", "r1"), FieldValue { value: serde_json::json!("one"), atom_uuid: "atom-1".to_string(), source_file_name: None });
+        field_map.insert(kv("h1", "r2"), FieldValue { value: serde_json::json!("two"), atom_uuid: "atom-2".to_string(), source_file_name: None });
+        field_map.insert(kv("h1", "r3"), FieldValue { value: serde_json::json!("three"), atom_uuid: "atom-3".to_string(), source_file_name: None });
         input.insert("BlogPost.content".to_string(), field_map);
 
         let engine = TypedEngine::new();
@@ -86,8 +86,8 @@ mod typed_engine_tests {
     fn test_join_reducer_execution() {
         let mut input: TypedInput = HashMap::new();
         let mut field_map: HashMap<KeyValue, FieldValue> = HashMap::new();
-        field_map.insert(kv("h1", "r1"), FieldValue { value: serde_json::json!("hello"), atom_uuid: "atom-1".to_string() });
-        field_map.insert(kv("h1", "r2"), FieldValue { value: serde_json::json!("world"), atom_uuid: "atom-2".to_string() });
+        field_map.insert(kv("h1", "r1"), FieldValue { value: serde_json::json!("hello"), atom_uuid: "atom-1".to_string(), source_file_name: None });
+        field_map.insert(kv("h1", "r2"), FieldValue { value: serde_json::json!("world"), atom_uuid: "atom-2".to_string(), source_file_name: None });
         input.insert("BlogPost.content".to_string(), field_map);
 
         let engine = TypedEngine::new();
@@ -113,7 +113,7 @@ mod typed_engine_tests {
     fn test_iterator_then_reducer_chain() {
         let mut input: TypedInput = HashMap::new();
         let mut field_map: HashMap<KeyValue, FieldValue> = HashMap::new();
-        field_map.insert(kv("h1", "r1"), FieldValue { value: serde_json::json!("alpha beta gamma"), atom_uuid: "atom-1".to_string() });
+        field_map.insert(kv("h1", "r1"), FieldValue { value: serde_json::json!("alpha beta gamma"), atom_uuid: "atom-1".to_string(), source_file_name: None });
         input.insert("BlogPost.content".to_string(), field_map);
 
         let engine = TypedEngine::new();

--- a/src/transform/manager/transform_runner.rs
+++ b/src/transform/manager/transform_runner.rs
@@ -206,7 +206,7 @@ fn convert_execution_result_to_records(execution_result: &ExecutionResult) -> Re
             };
             record_fields.insert(field_name, value);
         }
-        records.push(Record { fields: record_fields });
+        records.push(Record { fields: record_fields, metadata: HashMap::new() });
     }
     
     Ok(records)

--- a/src/transform/manager/types.rs
+++ b/src/transform/manager/types.rs
@@ -31,7 +31,7 @@ impl TransformResult {
     /// Convert to a single Record by merging all records (for backward compatibility)
     pub fn to_single_record(&self) -> Record {
         if self.records.is_empty() {
-            return Record { fields: HashMap::new() };
+            return Record { fields: HashMap::new(), metadata: HashMap::new() };
         }
         
         if self.records.len() == 1 {
@@ -40,6 +40,7 @@ impl TransformResult {
 
         // Merge all records into a single record
         let mut merged_fields = HashMap::new();
+        let mut merged_metadata = HashMap::new();
         for (i, record) in self.records.iter().enumerate() {
             for (key, value) in &record.fields {
                 // Add index suffix to avoid field name conflicts
@@ -48,11 +49,16 @@ impl TransformResult {
                 } else {
                     key.clone()
                 };
-                merged_fields.insert(indexed_key, value.clone());
+                merged_fields.insert(indexed_key.clone(), value.clone());
+                
+                // Merge metadata with the same indexed key
+                if let Some(meta) = record.metadata.get(key) {
+                    merged_metadata.insert(indexed_key, meta.clone());
+                }
             }
         }
         
-        Record { fields: merged_fields }
+        Record { fields: merged_fields, metadata: merged_metadata }
     }
 }
 

--- a/tests/mutation_performance_test.rs
+++ b/tests/mutation_performance_test.rs
@@ -54,16 +54,18 @@ async fn test_mutation_performance_direct() {
     let schema_path = Path::new("./tests/schemas_for_testing/BlogPost.json");
     let schema_json = std::fs::read_to_string(schema_path).expect("Failed to read schema file");
     
-    let mut db_guard = node.get_fold_db().expect("Failed to get database");
-    db_guard.load_schema_from_json(&schema_json)
-        .expect("Failed to load BlogPost schema");
-    drop(db_guard);
+    {
+        let mut db_guard = node.get_fold_db().expect("Failed to get database");
+        db_guard.load_schema_from_json(&schema_json)
+            .expect("Failed to load BlogPost schema");
+    }
     
     // Approve the schema
-    let db_guard = node.get_fold_db().expect("Failed to get database");
-    db_guard.schema_manager().approve("BlogPost")
-        .expect("Failed to approve BlogPost schema");
-    drop(db_guard);
+    {
+        let db_guard = node.get_fold_db().expect("Failed to get database");
+        db_guard.schema_manager().approve("BlogPost")
+            .expect("Failed to approve BlogPost schema");
+    }
 
     println!("\n{}", "=".repeat(80));
     println!("Test Configuration");
@@ -146,7 +148,7 @@ async fn execute_single_mutations_direct(node: &DataFoldNode, count: usize) -> V
         let mutation = create_blogpost_mutation(i);
         
         let start = Instant::now();
-        let result = node.mutate(mutation);
+        let result = node.mutate_batch(vec![mutation]);
         let duration = start.elapsed();
         times.push(duration.as_millis() as u64);
         

--- a/tests/native_word_index_test.rs
+++ b/tests/native_word_index_test.rs
@@ -156,6 +156,6 @@ fn execute_mutation(
         mutation_type,
     );
 
-    node.mutate(mutation)
+    node.mutate_batch(vec![mutation])
         .expect("mutation execution should succeed");
 }

--- a/tests/transform_integration.rs
+++ b/tests/transform_integration.rs
@@ -27,7 +27,7 @@ fn convert_execution_result_to_records(execution_result: &datafold::transform::r
             };
             record_fields.insert(field_name, value);
         }
-        records.push(datafold::fold_db_core::query::formatter::Record { fields: record_fields });
+        records.push(datafold::fold_db_core::query::formatter::Record { fields: record_fields, metadata: HashMap::new() });
     }
     
     Ok(records)
@@ -94,8 +94,8 @@ fn execute_engine_and_convert_to_records() {
     // Helper to insert a field map
     let mut insert_field = |name: &str, v1: serde_json::Value, v2: serde_json::Value| {
         let mut m: HashMap<KV, FV> = HashMap::new();
-        m.insert(k1.clone(), FV { value: v1, atom_uuid: "a1".to_string() });
-        m.insert(k2.clone(), FV { value: v2, atom_uuid: "a2".to_string() });
+        m.insert(k1.clone(), FV { value: v1, atom_uuid: "a1".to_string(), source_file_name: None });
+        m.insert(k2.clone(), FV { value: v2, atom_uuid: "a2".to_string(), source_file_name: None });
         typed_input.insert(name.to_string(), m);
     };
 


### PR DESCRIPTION
- Updated the `execute_query` and related functions to include a `metadata` field in the response records, providing additional context for each field.
- Introduced a new `FieldMetadata` struct to encapsulate metadata details, including `atom_uuid` and `source_file_name`.
- Modified the `records_from_field_map` function to construct records with both fields and metadata.
- Ensured all changes adhere to coding standards, including organized imports and comprehensive testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds per-field metadata to query outputs and introduces hash-based upload deduplication while propagating source_file_name through mutations and synchronizing native index batching.
> 
> - **Query/Results**:
>   - Add `FieldMetadata` and extend `Record` with `metadata` per field; update `records_from_field_map` and re-exports.
>   - Update API responses in `llm_query/routes.rs` and `query_routes.rs` to include `metadata` alongside `key` and `fields`.
> - **Schema/Operations**:
>   - Extend `FieldValue` with optional `source_file_name`; propagate through filters (`filter_utils`), variants, and tests.
>   - Extend `Operation::Mutation` to carry `source_file_name`; `OperationProcessor::execute_mutations_batch` sets it on `Mutation`.
> - **Ingestion**:
>   - Implement content-hash-based upload naming and atomic duplicate detection; skip JSON conversion on duplicates and return `duplicate: true`.
>   - Include `duplicate` flag in upload responses; pass `source_file_name` into ingestion/mutation generation; bump `file_to_json` to `0.1.4`.
> - **Mutation/Indexing**:
>   - Process batch index operations synchronously via native index manager and flush after batch (replace message-bus publish path); add timing tracking.
> - **Transforms/Engine**:
>   - Preserve `source_file_name` through iterator engine; adapt record construction to include empty `metadata` where applicable.
> - **Tests/Perf**:
>   - Update tests to new structs/fields and switch to `mutate_batch` where used; add ingestion filename hash tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f63cde78aa38f3026745e95fca88bec28292d15e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query and chat results now include per-field metadata (atomic IDs and optional source filenames).
  * Field values carry an optional source filename through processing and follow-up workflows.
  * File uploads use hash-based unique names and return a duplicate flag for identical files.
  * Mutations propagate an optional source filename so ingested files are tracked with records.

* **Bug Fixes / Reliability**
  * Batch indexing now performs synchronous native index processing and an explicit native-index flush for more reliable indexing.

* **Tests**
  * Tests and integrations updated to validate metadata, source-file propagation, and upload deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->