### PR TITLE
Use bundled OpenAPI spec in CI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -89,6 +89,9 @@ jobs:
     name: Frontend Tests
     runs-on: ubuntu-latest
 
+    env:
+      OPENAPI_URL: ${{ github.workspace }}/src/datafold_node/static-react/target/openapi.json
+
     defaults:
       run:
         working-directory: src/datafold_node/static-react
@@ -106,6 +109,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Generate API endpoints
+        run: npm run generate:endpoints
 
       - name: Run npm test
         id: npm-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,11 @@ jobs:
             arch: aarch64
           - os: macos-15-large  # Intel
             arch: x86_64
-    
+
     runs-on: ${{ matrix.os }}
+
+    env:
+      OPENAPI_URL: ${{ github.workspace }}/src/datafold_node/static-react/target/openapi.json
     
     steps:
       - name: Checkout repository

--- a/src/datafold_node/static-react/scripts/generate-endpoints.js
+++ b/src/datafold_node/static-react/scripts/generate-endpoints.js
@@ -32,11 +32,11 @@ function fetchJsonFromHttp(url) {
           try {
             resolve(JSON.parse(data));
           } catch (e) {
-            reject(e);
+            reject(new Error(`Failed to parse JSON from ${url}: ${e.message}`));
           }
         });
       })
-      .on('error', reject);
+      .on('error', (err) => reject(new Error(`Failed to fetch ${url}: ${err.message}`)));
   });
 }
 
@@ -47,8 +47,18 @@ function loadSpec(input) {
   // file path or file:// URL
   const p = input.startsWith('file://') ? input.slice('file://'.length) : input;
   const abs = path.isAbsolute(p) ? p : path.join(process.cwd(), p);
-  const raw = fs.readFileSync(abs, 'utf8');
-  return Promise.resolve(JSON.parse(raw));
+
+  if (!fs.existsSync(abs)) {
+    const hint = 'Set OPENAPI_URL to a local openapi.json file (for example ./target/openapi.json).';
+    throw new Error(`OpenAPI spec not found at ${abs}. ${hint}`);
+  }
+
+  try {
+    const raw = fs.readFileSync(abs, 'utf8');
+    return Promise.resolve(JSON.parse(raw));
+  } catch (e) {
+    throw new Error(`Failed to load OpenAPI spec from ${abs}: ${e.message}`);
+  }
 }
 
 function emit(filePath, content) {
@@ -178,6 +188,7 @@ async function main() {
     console.log(`[generate-endpoints] Wrote ${outputFile}`);
   } catch (e) {
     console.error('[generate-endpoints] Failed:', e.message);
+    console.error('[generate-endpoints] Provide OPENAPI_URL to a local spec file (e.g. ./target/openapi.json).');
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- make the endpoint generator fail with clearer errors when the OpenAPI spec is missing or unreadable
- set OPENAPI_URL to the bundled openapi.json for frontend CI and release workflows, and run endpoint generation during CI
- rely on the committed schema file instead of localhost when building frontend artifacts in automation

## Testing
- cargo test --workspace *(hung; terminated manually after an extended wait)*
- cargo clippy --workspace
- npm test (in src/datafold_node/static-react)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d226d13d08327a2f3cef3f34bedfd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling with more descriptive messages during the API endpoint generation process
  * Improved CI/CD pipeline configuration for better build reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->