### PR TITLE
Fix DynamoDB logger example compile errors

### DIFF
--- a/examples/lambda_dynamodb_logger.rs
+++ b/examples/lambda_dynamodb_logger.rs
@@ -178,7 +178,7 @@ impl DynamoDbLogger {
             });
 
         Some(LogEntry {
-            user_id,
+            user_id: Some(user_id),
             timestamp,
             level,
             event_type,
@@ -186,6 +186,17 @@ impl DynamoDbLogger {
             metadata,
         })
     }
+}
+
+/// Minimal example entrypoint so the example builds during `cargo test`.
+///
+/// The logger requires AWS credentials and a DynamoDB table to be useful, so
+/// the main function only prints a message indicating how to run the example
+/// in a real environment.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Configure AWS credentials and run this example inside AWS Lambda to see DynamoDB logging in action.");
+    Ok(())
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- wrap DynamoDB logger example deserialized user IDs in an option to match the `LogEntry` type
- add a minimal async `main` so the lambda DynamoDB logger example builds during tests

## Testing
- cargo test -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925d6fb3adc832783e56d050588bd31)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap `user_id` in `Some(...)` when building `LogEntry` and add a minimal async `main` so the DynamoDB logger example builds.
> 
> - **Examples**:
>   - **DynamoDB Logger (`examples/lambda_dynamodb_logger.rs`)**:
>     - Wrap deserialized `user_id` in `Some(...)` when constructing `LogEntry`.
>     - Add minimal async `main` that prints usage guidance so the example builds during tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7390b83895512261f672f5773cc7a67ef3f02a98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->