### PR TITLE
Fix DynamoDB logger example compilation

### DIFF
--- a/examples/lambda_dynamodb_logger.rs
+++ b/examples/lambda_dynamodb_logger.rs
@@ -126,9 +126,13 @@ impl DynamoDbLogger {
             .as_secs() + (30 * 24 * 60 * 60)) as i64;
 
         // Get user_id from entry or task-local storage
-        let user_id = entry.user_id
-            .or_else(|| CURRENT_USER.try_with(|id| id.clone()).ok())
-            .unwrap_or_else(|| "system".to_string());
+        let user_id = if !entry.user_id.is_empty() {
+            entry.user_id
+        } else {
+            CURRENT_USER
+                .try_with(|id| id.clone())
+                .unwrap_or_else(|_| "system".to_string())
+        };
 
         let mut item = HashMap::new();
         item.insert("user_id".to_string(), AttributeValue::S(user_id));
@@ -178,7 +182,7 @@ impl DynamoDbLogger {
             });
 
         Some(LogEntry {
-            user_id: Some(user_id),
+            user_id,
             timestamp,
             level,
             event_type,


### PR DESCRIPTION
## Summary
- update the DynamoDB logger example to handle empty user IDs via task-local context instead of using an Option API
- ensure log entries reconstructed from DynamoDB use the expected string user_id type

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926025ed878832781a6775c8982055c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle empty `user_id` via task-local `CURRENT_USER` fallback and deserialize DynamoDB items with string `user_id`.
> 
> - **Examples/DynamoDB Logger (`examples/lambda_dynamodb_logger.rs`)**:
>   - **User ID resolution**: Use `entry.user_id` if non-empty; otherwise fetch from task-local `CURRENT_USER`, defaulting to `"system"` on error.
>   - **Deserialization**: `item_to_entry` now sets `user_id` as a string (removed wrapping), aligning with `LogEntry` expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ce369c15caeb0efa66246971f49d63900cb4871. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->