### PR TITLE
Fix NodeConfig test setup and update storage demo

### DIFF
--- a/examples/storage_abstraction_demo.rs
+++ b/examples/storage_abstraction_demo.rs
@@ -1,6 +1,6 @@
 ///! Storage Abstraction Demonstration
 ///!
-///! This example shows how to use the new storage abstraction layer (DbOperationsV2)
+///! This example shows how to use the storage abstraction layer (DbOperations)
 ///! with different backends: Sled, DynamoDB, and In-Memory.
 ///!
 ///! Run with:
@@ -8,8 +8,8 @@
 ///! cargo run --example storage_abstraction_demo
 ///! ```
 
-use datafold::db_operations::DbOperationsV2;
-use datafold::storage::{SledNamespacedStore, InMemoryNamespacedStore, NamespacedStore};
+use datafold::db_operations::DbOperations;
+use datafold::storage::{InMemoryNamespacedStore, NamespacedStore};
 use serde::{Serialize, Deserialize};
 use std::sync::Arc;
 
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     let temp_dir = tempfile::tempdir()?;
     let sled_db = sled::open(temp_dir.path())?;
-    let db_ops_sled = DbOperationsV2::from_sled(sled_db).await?;
+    let db_ops_sled = DbOperations::from_sled(sled_db).await?;
     
     // Store data
     let user = User {
@@ -65,7 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("────────────────────────────────────────────");
     
     let mem_store = Arc::new(InMemoryNamespacedStore::new());
-    let db_ops_mem = DbOperationsV2::from_namespaced_store(mem_store).await?;
+    let db_ops_mem = DbOperations::from_namespaced_store(mem_store).await?;
     
     // Batch insert
     let users = vec![
@@ -105,7 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("────────────────────────────────────────────");
     
     let store = Arc::new(InMemoryNamespacedStore::new());
-    let db_ops = DbOperationsV2::from_namespaced_store(store.clone()).await?;
+    let db_ops = DbOperations::from_namespaced_store(store.clone()).await?;
     
     // Store in different namespaces
     db_ops.store_in_namespace("users", "alice", &User {
@@ -135,7 +135,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("────────────────────────────────────────────");
     
     async fn store_and_retrieve<T>(
-        db_ops: &DbOperationsV2,
+        db_ops: &DbOperations,
         backend_name: &str
     ) -> Result<(), Box<dyn std::error::Error>>
     where

--- a/tests/node_startup_schema_loading.rs
+++ b/tests/node_startup_schema_loading.rs
@@ -10,14 +10,8 @@ async fn test_node_starts_without_schema_service() {
     let test_db_path = temp_dir.path().join("test_db");
     
     // Create node configuration WITHOUT schema service URL
-    let config = NodeConfig {
-        database: datafold::datafold_node::config::DatabaseConfig::Local { path: test_db_path.to_path_buf() },
-        storage_path: test_db_path.to_path_buf(),
-        default_trust_distance: 1,
-        network_listen_address: "/ip4/127.0.0.1/tcp/9002".to_string(),
-        security_config: Default::default(),
-        schema_service_url: None,
-    };
+    let config = NodeConfig::new(test_db_path.to_path_buf())
+        .with_network_listen_address("/ip4/127.0.0.1/tcp/9002");
     
     // Attempt to create the node - should succeed without schema service URL
     let result = DataFoldNode::new(config).await;


### PR DESCRIPTION
## Summary
- construct the node startup test config with the NodeConfig helper instead of assigning nonexistent fields
- update the storage abstraction example to use the current DbOperations API and bring required traits into scope

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c9b8013d48327bc0cf0e7ad01fbbe)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update storage abstraction example to the current DbOperations API and construct node startup test config via NodeConfig builder methods.
> 
> - **Examples**:
>   - `examples/storage_abstraction_demo.rs`:
>     - Migrate from `DbOperationsV2` to `DbOperations`.
>     - Update constructors (`from_sled`, `from_namespaced_store`) and related type signatures/usages.
>     - Clean up imports to remove unused backends.
> - **Tests**:
>   - `tests/node_startup_schema_loading.rs`:
>     - Build `NodeConfig` using `NodeConfig::new(...).with_network_listen_address(...)` instead of manual struct fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92c80167ebbb1f4bec1d74aee6757d307c2f21f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->