### PR TITLE
Fix task-related tests and asset handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 test-utils = []  # Feature flag for test utilities
 ts-bindings = ["ts-rs"]  # Generate TypeScript bindings when enabled
 aws-backend = ["aws-config", "aws-sdk-dynamodb", "aws-sdk-s3", "aws-sdk-sns", "aws-sdk-sqs", "serde_dynamo"]  # AWS backends (DynamoDB, S3, SNS, SQS)
+embedded-assets = [] # Enable embedding of static React assets
 
 [dependencies]
 # Utilities
@@ -122,4 +123,3 @@ lto = "off"
 codegen-units = 16
 debug = false
 panic = "abort"
-

--- a/examples/storage_abstraction_demo.rs
+++ b/examples/storage_abstraction_demo.rs
@@ -1,12 +1,12 @@
-///! Storage Abstraction Demonstration
-///!
-///! This example shows how to use the storage abstraction layer (DbOperations)
-///! with different backends: Sled, DynamoDB, and In-Memory.
-///!
-///! Run with:
-///! ```bash
-///! cargo run --example storage_abstraction_demo
-///! ```
+//! Storage Abstraction Demonstration
+//!
+//! This example shows how to use the storage abstraction layer (DbOperations)
+//! with different backends: Sled, DynamoDB, and In-Memory.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example storage_abstraction_demo
+//! ```
 use fold_db::db_operations::DbOperations;
 use fold_db::storage::{InMemoryNamespacedStore, NamespacedStore};
 use serde::{Deserialize, Serialize};
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let keys = db_ops_sled.list_items_with_prefix("users:").await?;
     println!("✅ Keys with prefix 'users:': {:?}", keys);
 
-    println!("✅ Backend: {}", "Sled");
+    println!("✅ Backend: Sled");
     println!();
 
     // ============================================
@@ -100,7 +100,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    println!("✅ Backend: {}", "In-Memory");
+    println!("✅ Backend: In-Memory");
     println!();
 
     // ============================================
@@ -147,12 +147,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("🔄 Example 4: Same API Across All Backends");
     println!("────────────────────────────────────────────");
 
-    async fn store_and_retrieve<T>(
+    async fn store_and_retrieve(
         db_ops: &DbOperations,
         backend_name: &str,
     ) -> Result<(), Box<dyn std::error::Error>>
-    where
-        T: Serialize + for<'de> Deserialize<'de> + std::fmt::Debug + Clone,
     {
         let user = User {
             id: "demo".to_string(),
@@ -168,9 +166,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // All three backends use the exact same API!
-    store_and_retrieve::<User>(&db_ops_sled, "Sled").await?;
-    store_and_retrieve::<User>(&db_ops_mem, "In-Memory").await?;
-    // store_and_retrieve::<User>(&db_ops_dynamo, "DynamoDB").await?; // Would work too!
+    store_and_retrieve(&db_ops_sled, "Sled").await?;
+    store_and_retrieve(&db_ops_mem, "In-Memory").await?;
+    // store_and_retrieve(&db_ops_dynamo, "DynamoDB").await?; // Would work too!
 
     println!();
     println!("╔════════════════════════════════════════════╗");

--- a/src/datafold_node/schema_client.rs
+++ b/src/datafold_node/schema_client.rs
@@ -1,8 +1,9 @@
 use crate::error::{FoldDbError, FoldDbResult};
 use crate::schema::types::Schema;
-use reqwest::StatusCode;
+use reqwest::{StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::IpAddr;
 
 /// Client for communicating with the schema service
 #[derive(Clone)]
@@ -29,11 +30,15 @@ impl SchemaServiceClient {
     /// Create a new schema service client
     pub fn new(schema_service_url: &str) -> Self {
         // Create client with timeout to prevent hanging
-        let client = reqwest::Client::builder()
+        let mut builder = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
+            .connect_timeout(std::time::Duration::from_secs(10));
+
+        if is_loopback_url(schema_service_url) {
+            builder = builder.no_proxy();
+        }
+
+        let client = builder.build().unwrap_or_else(|_| reqwest::Client::new());
 
         Self {
             base_url: schema_service_url.to_string(),
@@ -312,6 +317,24 @@ impl SchemaServiceClient {
 
         Ok(())
     }
+}
+
+fn is_loopback_url(url: &str) -> bool {
+    let parsed = match Url::parse(url) {
+        Ok(parsed) => parsed,
+        Err(_) => return false,
+    };
+
+    let host = match parsed.host_str() {
+        Some(host) => host,
+        None => return false,
+    };
+
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
 }
 
 #[cfg(test)]

--- a/src/fold_db_core/infrastructure/message_bus/async_bus.rs
+++ b/src/fold_db_core/infrastructure/message_bus/async_bus.rs
@@ -314,10 +314,7 @@ mod tests {
             .unwrap();
 
         let received = consumer.recv().await;
-        match received {
-            Some(Event::MutationRequest(_)) => assert!(true),
-            _ => panic!("Expected MutationRequest event"),
-        }
+        assert!(matches!(received, Some(Event::MutationRequest(_))));
     }
 
     #[tokio::test]

--- a/src/server/static_assets.rs
+++ b/src/server/static_assets.rs
@@ -1,6 +1,12 @@
+#[cfg(feature = "embedded-assets")]
 use rust_embed::RustEmbed;
 
+#[cfg(feature = "embedded-assets")]
 #[derive(RustEmbed)]
 #[folder = "src/server/static-react/dist"]
 #[prefix = "/"]
+pub struct Asset;
+
+#[cfg(not(feature = "embedded-assets"))]
+#[derive(Debug, Clone)]
 pub struct Asset;

--- a/src/storage/dynamodb_backend.rs
+++ b/src/storage/dynamodb_backend.rs
@@ -43,7 +43,7 @@ impl DynamoDbKvStore {
 
     /// Get the partition key to use for this store
     #[cfg(test)]
-    pub fn get_partition_key(&self) -> String {
+    pub fn get_partition_key(&self) -> StorageResult<String> {
         self.get_partition_key_impl()
     }
 
@@ -963,37 +963,34 @@ mod unit_tests {
         let client = create_dummy_client().await;
 
         // Case 1: With user_id
-        let store = DynamoDbKvStore::new(
-            client.clone(),
-            "TestTable".to_string(),
-            "user123".to_string(),
-        );
-
         let key = b"my_key";
-        let pk = store.get_partition_key_with_key(key);
-        let sk = store.make_sort_key_impl(key);
+        crate::logging::core::run_with_user("user123", async {
+            let store = DynamoDbKvStore::new(client.clone(), "TestTable".to_string());
 
-        // PK should now be just user_id (or default)
-        // SK should be the key itself
-        assert_eq!(pk, "user123");
-        assert_eq!(sk, "my_key");
+            let pk = store
+                .get_partition_key_with_key(key)
+                .expect("failed to get partition key");
+            let sk = store.make_sort_key_impl(key);
+
+            // PK should now be just user_id (or default)
+            // SK should be the key itself
+            assert_eq!(pk, "user123");
+            assert_eq!(sk, "my_key");
+        })
+        .await;
 
         // Case 2: Without user_id (default)
-        let store_default = DynamoDbKvStore::new(
-            client.clone(),
-            "TestTable".to_string(),
-            "default".to_string(),
-        );
-
-        let pk_default = store_default.get_partition_key_with_key(key);
-        assert_eq!(pk_default, "default");
+        let store_default = DynamoDbKvStore::new(client.clone(), "TestTable".to_string());
+        let pk_default = store_default
+            .get_partition_key_with_key(key)
+            .expect("failed to get default partition key");
+        assert_eq!(pk_default, "__system__");
     }
 
     #[tokio::test]
     async fn test_native_index_key_parsing() {
         let client = create_dummy_client().await;
-        let store =
-            DynamoDbNativeIndexStore::new(client, "IndexTable".to_string(), "user123".to_string());
+        let store = DynamoDbNativeIndexStore::new(client, "IndexTable".to_string());
 
         // Case 1: Standard feature:term key
         let (feature, term) = store.parse_key(b"word:hello").unwrap();
@@ -1020,20 +1017,20 @@ mod unit_tests {
         let client = create_dummy_client().await;
 
         // Case 1: With user_id
-        let store = DynamoDbNativeIndexStore::new(
-            client.clone(),
-            "IndexTable".to_string(),
-            "user123".to_string(),
-        );
-
-        let pk = store.get_partition_key("word");
-        assert_eq!(pk, "user123:word");
+        crate::logging::core::run_with_user("user123", async {
+            let store = DynamoDbNativeIndexStore::new(client.clone(), "IndexTable".to_string());
+            let pk = store
+                .get_partition_key("word")
+                .expect("failed to get partition key");
+            assert_eq!(pk, "user123:word");
+        })
+        .await;
 
         // Case 2: Without user_id
-        let store_default =
-            DynamoDbNativeIndexStore::new(client, "IndexTable".to_string(), "default".to_string());
-
-        let pk_default = store_default.get_partition_key("email");
-        assert_eq!(pk_default, "default:email");
+        let store_default = DynamoDbNativeIndexStore::new(client, "IndexTable".to_string());
+        let pk_default = store_default
+            .get_partition_key("email")
+            .expect("failed to get default partition key");
+        assert_eq!(pk_default, "__system__:email");
     }
 }

--- a/src/storage/dynamodb_store.rs
+++ b/src/storage/dynamodb_store.rs
@@ -36,7 +36,7 @@ impl DynamoDbSchemaStore {
         let table_name = config.tables.schemas.clone();
 
         // Require user_id
-        let user_id = config.user_id.ok_or_else(|| {
+        let _user_id = config.user_id.ok_or_else(|| {
             FoldDbError::Config("Missing user_id for DynamoDbSchemaStore".to_string())
         })?;
 

--- a/tests/dynamodb_mock_test.rs
+++ b/tests/dynamodb_mock_test.rs
@@ -40,6 +40,12 @@ impl MockHttpClient {
     }
 }
 
+impl Default for MockHttpClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HttpClient for MockHttpClient {
     fn http_connector(
         &self,
@@ -104,34 +110,34 @@ fn create_mock_client(mock: MockHttpClient) -> aws_sdk_dynamodb::Client {
 #[tokio::test]
 async fn test_dynamodb_put_mock() {
     let mock = MockHttpClient::new();
-    let client = create_mock_client(mock.clone());
-    let store = DynamoDbKvStore::new(
-        Arc::new(client),
-        "TestTable".to_string(),
-        "user1".to_string(),
-    );
+    let client = Arc::new(create_mock_client(mock.clone()));
 
-    let key = b"test_key";
-    let value = b"test_value";
+    fold_db::logging::core::run_with_user("user1", async {
+        let store = DynamoDbKvStore::new(client.clone(), "TestTable".to_string());
 
-    store.put(key, value.to_vec()).await.expect("put failed");
+        let key = b"test_key";
+        let value = b"test_value";
 
-    // Verify request
-    let request = mock.get_last_request().expect("no request sent");
-    let body_str = std::str::from_utf8(&request.body).expect("invalid utf8");
+        store.put(key, value.to_vec()).await.expect("put failed");
 
-    // DynamoDB uses JSON
-    // We expect a PutItem request
-    // {"TableName":"TestTable","Item":{"PK":{"S":"user1:test_key"},"SK":{"S":"test_key"},"Value":{"S":"test_value"}}}
+        // Verify request
+        let request = mock.get_last_request().expect("no request sent");
+        let body_str = std::str::from_utf8(&request.body).expect("invalid utf8");
 
-    println!("Request body: {}", body_str);
-    // assert!(body_str.contains("PutItem")); // The action is in headers
-    assert!(body_str.contains("TestTable"));
-    // PK should be just "user1"
-    assert!(body_str.contains("\"PK\":{\"S\":\"user1\"}"));
-    // SK should be "test_key"
-    assert!(body_str.contains("\"SK\":{\"S\":\"test_key\"}"));
-    assert!(body_str.contains("test_value"));
+        // DynamoDB uses JSON
+        // We expect a PutItem request
+        // {"TableName":"TestTable","Item":{"PK":{"S":"user1:test_key"},"SK":{"S":"test_key"},"Value":{"S":"test_value"}}}
+
+        println!("Request body: {}", body_str);
+        // assert!(body_str.contains("PutItem")); // The action is in headers
+        assert!(body_str.contains("TestTable"));
+        // PK should be just "user1"
+        assert!(body_str.contains("\"PK\":{\"S\":\"user1\"}"));
+        // SK should be "test_key"
+        assert!(body_str.contains("\"SK\":{\"S\":\"test_key\"}"));
+        assert!(body_str.contains("test_value"));
+    })
+    .await;
 }
 
 #[tokio::test]
@@ -149,88 +155,83 @@ async fn test_dynamodb_get_mock() {
     "#;
 
     let mock = MockHttpClient::new().with_response(200, response_body);
-    let client = create_mock_client(mock.clone());
-    let store = DynamoDbKvStore::new(
-        Arc::new(client),
-        "TestTable".to_string(),
-        "user1".to_string(),
-    );
+    let client = Arc::new(create_mock_client(mock.clone()));
 
-    let key = b"test_key";
-    let result = store.get(key).await.expect("get failed");
+    fold_db::logging::core::run_with_user("user1", async {
+        let store = DynamoDbKvStore::new(client.clone(), "TestTable".to_string());
 
-    assert_eq!(result, Some(b"test_value".to_vec()));
+        let key = b"test_key";
+        let result = store.get(key).await.expect("get failed");
 
-    // Verify request
-    let request = mock.get_last_request().expect("no request sent");
-    let body_str = std::str::from_utf8(&request.body).expect("invalid utf8");
+        assert_eq!(result, Some(b"test_value".to_vec()));
 
-    println!("Request body: {}", body_str);
-    // Note: GetItem body might be empty if using query params, or JSON if using POST
-    // AWS SDK usually uses POST for DynamoDB
-    assert!(body_str.contains("TestTable"));
-    // PK should be just "user1"
-    assert!(body_str.contains("\"PK\":{\"S\":\"user1\"}"));
+        // Verify request
+        let request = mock.get_last_request().expect("no request sent");
+        let body_str = std::str::from_utf8(&request.body).expect("invalid utf8");
+
+        println!("Request body: {}", body_str);
+        // Note: GetItem body might be empty if using query params, or JSON if using POST
+        // AWS SDK usually uses POST for DynamoDB
+        assert!(body_str.contains("TestTable"));
+        // PK should be just "user1"
+        assert!(body_str.contains("\"PK\":{\"S\":\"user1\"}"));
+    })
+    .await;
 }
 
 #[tokio::test]
 async fn test_dynamodb_namespace_isolation_mock() {
     let mock = MockHttpClient::new();
-    let client = create_mock_client(mock.clone());
+    let client = Arc::new(create_mock_client(mock.clone()));
 
-    // Create two stores with different table names (simulating namespaces)
-    let store1 = DynamoDbKvStore::new(
-        Arc::new(client.clone()),
-        "Namespace1".to_string(),
-        "user1".to_string(),
-    );
-    let store2 = DynamoDbKvStore::new(
-        Arc::new(client),
-        "Namespace2".to_string(),
-        "user1".to_string(),
-    );
+    fold_db::logging::core::run_with_user("user1", async {
+        // Create two stores with different table names (simulating namespaces)
+        let store1 = DynamoDbKvStore::new(client.clone(), "Namespace1".to_string());
+        let store2 = DynamoDbKvStore::new(client.clone(), "Namespace2".to_string());
 
-    let key = b"key";
-    let value = b"value";
+        let key = b"key";
+        let value = b"value";
 
-    // Put to store1
-    store1.put(key, value.to_vec()).await.expect("put failed");
-    let req1 = mock.get_last_request().expect("req1 missing");
-    let body1 = std::str::from_utf8(&req1.body).expect("utf8");
-    assert!(body1.contains("Namespace1"));
-    assert!(!body1.contains("Namespace2"));
+        // Put to store1
+        store1.put(key, value.to_vec()).await.expect("put failed");
+        let req1 = mock.get_last_request().expect("req1 missing");
+        let body1 = std::str::from_utf8(&req1.body).expect("utf8");
+        assert!(body1.contains("Namespace1"));
+        assert!(!body1.contains("Namespace2"));
 
-    // Put to store2
-    store2.put(key, value.to_vec()).await.expect("put failed");
-    let req2 = mock.get_last_request().expect("req2 missing");
-    let body2 = std::str::from_utf8(&req2.body).expect("utf8");
-    assert!(body2.contains("Namespace2"));
-    assert!(!body2.contains("Namespace1"));
+        // Put to store2
+        store2.put(key, value.to_vec()).await.expect("put failed");
+        let req2 = mock.get_last_request().expect("req2 missing");
+        let body2 = std::str::from_utf8(&req2.body).expect("utf8");
+        assert!(body2.contains("Namespace2"));
+        assert!(!body2.contains("Namespace1"));
+    })
+    .await;
 }
 
 #[tokio::test]
 async fn test_dynamodb_special_chars_mock() {
     let mock = MockHttpClient::new();
-    let client = create_mock_client(mock.clone());
-    let store = DynamoDbKvStore::new(
-        Arc::new(client),
-        "TestTable".to_string(),
-        "user1".to_string(),
-    );
+    let client = Arc::new(create_mock_client(mock.clone()));
 
-    // Test key with special chars: colon, slash, space, unicode
-    let key = "key:with/special chars_and_🚀".as_bytes();
-    let value = b"value";
+    fold_db::logging::core::run_with_user("user1", async {
+        let store = DynamoDbKvStore::new(client.clone(), "TestTable".to_string());
 
-    store.put(key, value.to_vec()).await.expect("put failed");
+        // Test key with special chars: colon, slash, space, unicode
+        let key = "key:with/special chars_and_🚀".as_bytes();
+        let value = b"value";
 
-    let request = mock.get_last_request().expect("request missing");
-    let body_str = std::str::from_utf8(&request.body).expect("utf8");
+        store.put(key, value.to_vec()).await.expect("put failed");
 
-    // Verify SK contains the special chars (JSON escaped)
-    // "key:with/special chars_and_🚀"
-    assert!(body_str.contains("key:with/special chars_and_"));
-    // Unicode might be escaped or raw depending on serde, but usually raw in UTF-8
-    // We'll check for the prefix to be safe
-    assert!(body_str.contains("key:with/special"));
+        let request = mock.get_last_request().expect("request missing");
+        let body_str = std::str::from_utf8(&request.body).expect("utf8");
+
+        // Verify SK contains the special chars (JSON escaped)
+        // "key:with/special chars_and_🚀"
+        assert!(body_str.contains("key:with/special chars_and_"));
+        // Unicode might be escaped or raw depending on serde, but usually raw in UTF-8
+        // We'll check for the prefix to be safe
+        assert!(body_str.contains("key:with/special"));
+    })
+    .await;
 }

--- a/tests/mutation_perf_investigation.rs
+++ b/tests/mutation_perf_investigation.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use fold_db::datafold_node::{DataFoldNode, NodeConfig};
-use fold_db::ingestion::mutation_generator::MutationGenerator;
+use fold_db::ingestion::mutation_generator::generate_mutations;
 
 mod common;
 use common::create_test_mutation;
@@ -31,7 +31,6 @@ async fn test_mutation_performance_investigation() {
 async fn _test_mutation_generation_performance() {
     println!("\n--- Phase 1: Mutation Generation Performance ---");
 
-    let generator = MutationGenerator::new();
     let schema_name = "PerformanceTestSchema";
 
     // Prepare sample data (1000 items)
@@ -61,32 +60,27 @@ async fn _test_mutation_generation_performance() {
         all_data.push(fields);
     }
 
-    let mut mappers = HashMap::new();
-    // Assuming simple mapping where fields map to themselves if not specified,
-    // or we can leave empty for default behavior if MutationGenerator supports it.
-    // Correct mapping: JSON field -> Schema field
-    mappers.insert("id".to_string(), "PerformanceTestSchema.id".to_string());
+    let mappers = HashMap::new();
 
     let start = Instant::now();
 
     let mut total_mutations = 0;
     for fields in &all_data {
         let keys_values = HashMap::from([(
-            "id".to_string(),
+            "hash_field".to_string(),
             fields.get("id").unwrap().as_str().unwrap().to_string(),
         )]);
 
-        let mutations = generator
-            .generate_mutations(
-                schema_name,
-                &keys_values,
-                fields,
-                &mappers,
-                0,
-                "test_pub_key".to_string(),
-                None,
-            )
-            .expect("Failed to generate mutations");
+        let mutations = generate_mutations(
+            schema_name,
+            &keys_values,
+            fields,
+            &mappers,
+            0,
+            "test_pub_key".to_string(),
+            None,
+        )
+        .expect("Failed to generate mutations");
 
         total_mutations += mutations.len();
     }

--- a/tests/mutation_triggers_transform.rs
+++ b/tests/mutation_triggers_transform.rs
@@ -120,10 +120,8 @@ async fn test_blogpost_mutation_triggers_transforms() {
     let start = std::time::Instant::now();
 
     while start.elapsed() < timeout {
-        if let Ok(event) = transform_triggered_consumer.try_recv() {
-            if let Event::TransformTriggered(e) = event {
-                triggered_transform_ids.push(e.transform_id);
-            }
+        if let Ok(Event::TransformTriggered(e)) = transform_triggered_consumer.try_recv() {
+            triggered_transform_ids.push(e.transform_id);
         }
         tokio::time::sleep(Duration::from_millis(5)).await;
     }
@@ -155,10 +153,8 @@ async fn test_blogpost_mutation_triggers_transforms() {
     let execution_start = std::time::Instant::now();
 
     while execution_start.elapsed() < execution_timeout {
-        if let Ok(event) = transform_executed_consumer.try_recv() {
-            if let Event::TransformExecuted(e) = event {
-                executed_transform_ids.push(e.transform_id);
-            }
+        if let Ok(Event::TransformExecuted(e)) = transform_executed_consumer.try_recv() {
+            executed_transform_ids.push(e.transform_id);
         }
         tokio::time::sleep(Duration::from_millis(5)).await;
     }
@@ -277,10 +273,8 @@ async fn test_partial_mutation_triggers_subset_of_transforms() {
     let start = std::time::Instant::now();
 
     while start.elapsed() < timeout {
-        if let Ok(event) = transform_triggered_consumer.try_recv() {
-            if let Event::TransformTriggered(e) = event {
-                triggered_transform_ids.push(e.transform_id);
-            }
+        if let Ok(Event::TransformTriggered(e)) = transform_triggered_consumer.try_recv() {
+            triggered_transform_ids.push(e.transform_id);
         }
         tokio::time::sleep(Duration::from_millis(5)).await;
     }
@@ -397,10 +391,8 @@ async fn test_content_mutation_triggers_word_transform() {
     let start = std::time::Instant::now();
 
     while start.elapsed() < timeout {
-        if let Ok(event) = transform_triggered_consumer.try_recv() {
-            if let Event::TransformTriggered(e) = event {
-                triggered_transform_ids.push(e.transform_id);
-            }
+        if let Ok(Event::TransformTriggered(e)) = transform_triggered_consumer.try_recv() {
+            triggered_transform_ids.push(e.transform_id);
         }
         tokio::time::sleep(Duration::from_millis(5)).await;
     }

--- a/tests/unified_progress_test.rs
+++ b/tests/unified_progress_test.rs
@@ -3,7 +3,6 @@
 async fn test_dynamo_progress_persistence_and_backfill_integration() {
     use fold_db::fold_db_core::infrastructure::backfill_tracker::BackfillTracker;
     use fold_db::progress::{DynamoDbProgressStore, Job, JobType, ProgressStore};
-    use fold_db::storage::config::CloudConfig;
     use std::sync::Arc;
 
     println!("Starting DynamoDB Progress Tracker Test...");


### PR DESCRIPTION
### Motivation
- Make local testing and CI robust by fixing failing tests that assumed removed/changed APIs and by avoiding build failures when frontend assets are missing.
- Ensure schema service calls to loopback URLs aren't blocked by proxy settings during tests.
- Simplify event checks in message-bus tests and bring DynamoDB test helpers in line with the current runtime context (task-local user id).

### Description
- Updated the schema service client to detect loopback URLs and disable proxies when appropriate via `is_loopback_url` and `reqwest` builder tweaks in `src/datafold_node/schema_client.rs`.
- Guarded embedded React static assets behind a new Cargo feature `embedded-assets` and added a no-op fallback `Asset` type to avoid build-time failures when `dist` is absent in `src/server/static_assets.rs`, and added the feature flag to `Cargo.toml`.
- Refactored DynamoDB backend tests and helpers to use task-local user context (`run_with_user`) and the updated `DynamoDbKvStore` constructor, changed `get_partition_key` test API to return `StorageResult<String>`, and added `Default` for the mock HTTP client in `tests/dynamodb_mock_test.rs` and `src/storage/dynamodb_backend.rs`.
- Reworked mutation-related tests and helpers to match current ingestion APIs by replacing the removed `MutationGenerator` type with the `generate_mutations` function in `tests/mutation_perf_investigation.rs` and updated example code in `examples/storage_abstraction_demo.rs`.
- Simplified pattern matching in several event-driven tests (e.g., `src/fold_db_core/infrastructure/message_bus/async_bus.rs` and `tests/mutation_triggers_transform.rs`) for clearer intent and to avoid unnecessary nested `if let` checks.

### Testing
- Ran the full test suite with `cargo test`, which completed successfully with all tests passing (`268` library tests plus binaries and integration tests as part of the run) and no failing tests.
- Ran `cargo clippy --all-targets --all-features`; it completed but emitted unrelated warnings (notably `ts-rs` warnings about parsing some `serde` attributes and a few minor clippy suggestions), none of which are regressions introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69878d564ed883279a253f0a91cb9c8a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `embedded-assets` feature flag for static asset configuration.

* **Refactor**
  * Simplified function signatures and improved code structure across example files and tests.
  * Enhanced schema client with improved loopback URL handling.
  * Refactored mutation generation to use function-based approach.

* **Chores**
  * Test infrastructure improvements and code cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->