### PR TITLE
Harden CI and fix all clippy warnings

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -65,12 +65,12 @@ jobs:
       - name: Run clippy
         id: clippy
         continue-on-error: true
-        run: cargo clippy --workspace
+        run: cargo clippy --all-targets --workspace -- -D warnings
 
       - name: Run cargo test
         id: cargo-test
         continue-on-error: true
-        run: cargo test --workspace
+        run: cargo test --workspace --all-targets
 
       - name: Run tweets ingestion integration test
         id: ingestion-test

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK_SRC="$SCRIPT_DIR/pre-commit"
+HOOK_DST="$REPO_DIR/.git/hooks/pre-commit"
+
+if [ ! -f "$HOOK_SRC" ]; then
+    echo "Error: pre-commit script not found at $HOOK_SRC"
+    exit 1
+fi
+
+cp "$HOOK_SRC" "$HOOK_DST"
+chmod +x "$HOOK_DST"
+echo "Pre-commit hook installed at $HOOK_DST"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+echo "Running pre-commit checks..."
+
+# Build frontend dist if missing (needed for RustEmbed)
+if [ ! -d "src/server/static-react/dist" ]; then
+    mkdir -p src/server/static-react/dist
+    touch src/server/static-react/dist/index.html
+fi
+
+cargo clippy --all-targets -- -D warnings
+echo "Pre-commit checks passed."


### PR DESCRIPTION
## Summary
- Fix all clippy warnings across the codebase (tests, examples, main code) and remove dead example file
- Deduplicate route handler boilerplate with shared `parse_user_hash()` helper
- Harden CI: clippy now uses `--all-targets -- -D warnings` so any warning fails the build
- Add `scripts/pre-commit` hook and `scripts/install-hooks.sh` for local pre-commit checks

## Test plan
- [ ] CI passes with the new `--all-targets -- -D warnings` flags
- [ ] `cargo clippy --all-targets -- -D warnings` is clean locally
- [ ] `cargo test --workspace --all-targets` passes
- [ ] Run `./scripts/install-hooks.sh` and verify hook triggers on `git commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to enforce stricter code quality checks across all workspace targets and tests.
  * Added pre-commit hook infrastructure to automate validation checks before commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->