### PR TITLE
Fix 10 architectural issues in React UI

### DIFF
--- a/src/server/static-react/src/App.jsx
+++ b/src/server/static-react/src/App.jsx
@@ -21,7 +21,7 @@ import ErrorBoundary from './components/ErrorBoundary'
 import { useApprovedSchemas } from './hooks/useApprovedSchemas.js'
 import { useIngestionStatus } from './hooks/useIngestionStatus'
 import { useAppSelector, useAppDispatch } from './store/hooks'
-import { initializeSystemKey, fetchNodePrivateKey, restoreSession } from './store/authSlice'
+import { initializeSystemKey, restoreSession } from './store/authSlice'
 import LoginPage from './components/LoginPage'
 import { DEFAULT_TAB } from './constants'
 import { BROWSER_CONFIG } from './constants/config'
@@ -106,13 +106,6 @@ export function AppContent() {
   useEffect(() => {
     if (isAuthenticated) {
       dispatch(initializeSystemKey())
-    }
-  }, [dispatch, isAuthenticated])
-
-  // Fetch node private key ONLY after authenticated
-  useEffect(() => {
-    if (isAuthenticated) {
-      dispatch(fetchNodePrivateKey())
     }
   }, [dispatch, isAuthenticated])
 

--- a/src/server/static-react/src/api/clients/index.ts
+++ b/src/server/static-react/src/api/clients/index.ts
@@ -71,7 +71,7 @@ export { llmQueryClient } from "./llmQueryClient";
 // Native Index Client
 export { nativeIndexClient, NativeIndexClient } from "./nativeIndexClient";
 // Indexing Status Client
-export { getIndexingStatus, useIndexingStatus } from "./indexingClient";
+export { getIndexingStatus } from "./indexingClient";
 export type { IndexingStatus } from "./indexingClient";
 
 // Type exports for convenience

--- a/src/server/static-react/src/api/clients/indexingClient.ts
+++ b/src/server/static-react/src/api/clients/indexingClient.ts
@@ -4,7 +4,6 @@
  * Provides methods for querying the background indexing system status.
  */
 
-import { useState, useEffect } from 'react';
 import { defaultApiClient } from '../core/client';
 import { API_ENDPOINTS } from '../endpoints';
 
@@ -31,54 +30,4 @@ export async function getIndexingStatus(): Promise<IndexingStatus> {
   return response.data;
 }
 
-/**
- * Hook to poll indexing status at regular intervals
- */
-export function useIndexingStatus(pollInterval: number = 1000) {
-  const [status, setStatus] = useState<IndexingStatus | null>(null);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    let mounted = true;
-    let timeoutId: NodeJS.Timeout;
-
-    const fetchStatus = async () => {
-      try {
-        const newStatus = await getIndexingStatus();
-        if (mounted) {
-          setStatus(newStatus);
-          setError(null);
-        }
-      } catch (err) {
-        if (mounted) {
-          setError(err instanceof Error ? err : new Error('Failed to fetch indexing status'));
-        }
-      }
-    };
-
-    // Initial fetch
-    fetchStatus();
-
-    // Set up polling
-    const poll = async () => {
-      await fetchStatus();
-      if (mounted) {
-        // Adjust polling based on state
-        const interval = status?.state === 'Indexing' ? pollInterval : pollInterval * 5;
-        timeoutId = setTimeout(poll, interval);
-      }
-    };
-
-    timeoutId = setTimeout(poll, pollInterval);
-
-    return () => {
-      mounted = false;
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [pollInterval, status?.state]);
-
-  return { status, error };
-}
 

--- a/src/server/static-react/src/api/clients/mutationClient.ts
+++ b/src/server/static-react/src/api/clients/mutationClient.ts
@@ -76,7 +76,6 @@ export class UnifiedMutationClient implements MutationApiClient {
       API_ENDPOINTS.EXECUTE_MUTATION,
       _mutation,
       {
-        validateSchema: false, // Skip schema validation for mutations
         timeout: 15000, // Longer timeout for mutation operations
         retries: 0, // No retries for mutations to prevent duplicate operations
         cacheable: false, // Never cache mutation results
@@ -95,10 +94,6 @@ export class UnifiedMutationClient implements MutationApiClient {
     query: Record<string, unknown>,
   ): Promise<EnhancedApiResponse<Record<string, unknown>>> {
     return this.client.post<QueryResponse>(API_ENDPOINTS.EXECUTE_QUERY, query, {
-      validateSchema: {
-        operation: "read" as const,
-        requiresApproved: true, // SCHEMA-002: Only approved schemas for queries
-      },
       timeout: 10000, // Standard timeout for queries
       retries: 2, // Limited retries for read operations
       cacheable: true, // Query results can be cached
@@ -125,11 +120,6 @@ export class UnifiedMutationClient implements MutationApiClient {
       API_ENDPOINTS.EXECUTE_QUERY,
       queryParams,
       {
-        validateSchema: {
-          schemaName: queryParams.schema,
-          operation: "read" as const,
-          requiresApproved: true,
-        },
         timeout: 15000,
         retries: 2,
         cacheable: true,

--- a/src/server/static-react/src/api/clients/schemaClient.ts
+++ b/src/server/static-react/src/api/clients/schemaClient.ts
@@ -135,11 +135,6 @@ export class UnifiedSchemaClient {
    */
   async getSchema(name: string): Promise<EnhancedApiResponse<Schema>> {
     return this.client.get<Schema>(API_ENDPOINTS.GET_SCHEMA(name), {
-      validateSchema: {
-        schemaName: name,
-        operation: 'read' as const,
-        requiresApproved: false // Allow reading any schema for inspection
-      },
       cacheable: true,
       cacheKey: `schema:${name}`,
       cacheTtl: 300000 // 5 minutes
@@ -263,11 +258,6 @@ export class UnifiedSchemaClient {
       API_ENDPOINTS.APPROVE_SCHEMA(name),
       {}, // Empty body, schema name is in URL
       {
-        validateSchema: {
-          schemaName: name,
-          operation: 'approve' as const,
-          requiresApproved: false // Can approve non-approved schemas
-        },
         timeout: 10000, // Longer timeout for state changes
         retries: 1 // Limited retries for state-changing operations
       }
@@ -286,11 +276,6 @@ export class UnifiedSchemaClient {
       API_ENDPOINTS.BLOCK_SCHEMA(name),
       {}, // Empty body, schema name is in URL
       {
-        validateSchema: {
-          schemaName: name,
-          operation: 'block' as const,
-          requiresApproved: true // Only approved schemas can be blocked
-        },
         timeout: 10000, // Longer timeout for state changes
         retries: 1 // Limited retries for state-changing operations
       }

--- a/src/server/static-react/src/api/core/client.ts
+++ b/src/server/static-react/src/api/core/client.ts
@@ -35,7 +35,6 @@ import type {
   RequestMetrics,
   BatchRequest,
   BatchResponse,
-  SchemaValidationOptions,
   ApiClientInstance,
 } from "./types";
 
@@ -294,15 +293,6 @@ export class ApiClient implements ApiClientInstance {
         config = await interceptor(config);
       }
 
-      // Schema validation (SCHEMA-002 compliance)
-      if (config.validateSchema) {
-        await this.validateSchemaAccess(
-          endpoint,
-          method,
-          options.validateSchema || true,
-        );
-      }
-
       // Check cache for GET requests
       if (
         method === "GET" &&
@@ -546,33 +536,6 @@ export class ApiClient implements ApiClientInstance {
         fromCache: false,
       },
     };
-  }
-
-  /**
-   * Add authentication headers using the authentication wrapper
-   */
-  private async addAuthHeaders(
-    _headers: Record<string, string>,
-    _body?: unknown,
-  ): Promise<void> {
-    // No-op: UI does not perform authentication
-    return;
-  }
-
-  /**
-   * Validate schema access according to SCHEMA-002 rules
-   * Note: Schema validation is enforced at the component/hook level (useApprovedSchemas)
-   * This method is kept for API compatibility but validation should be done before API calls
-   */
-  private async validateSchemaAccess(
-    _endpoint: string,
-    _method: HttpMethod,
-    _options: SchemaValidationOptions | boolean,
-  ): Promise<void> {
-    // Schema validation is now handled at the component/hook level
-    // using useApprovedSchemas hook which has access to Redux state
-    // This avoids circular dependency between ApiClient and Redux store
-    return;
   }
 
   /**

--- a/src/server/static-react/src/api/core/types.ts
+++ b/src/server/static-react/src/api/core/types.ts
@@ -40,7 +40,7 @@ export interface RequestOptions {
   requiresAuth?: boolean;
   timeout?: number;
   retries?: number;
-  validateSchema?: boolean | SchemaValidationOptions;
+  validateSchema?: boolean;
   cacheable?: boolean;
   cacheKey?: string;
   cacheTtl?: number;
@@ -106,13 +106,6 @@ export interface RetryConfig {
   backoffMultiplier: number;
   maxDelay: number;
   retryableStatusCodes: number[];
-}
-
-// Schema Validation Interface
-export interface SchemaValidationOptions {
-  requiresApproved?: boolean;
-  operation?: 'read' | 'write' | 'approve' | 'block';
-  schemaName?: string;
 }
 
 // Request Metrics Interface

--- a/src/server/static-react/src/api/index.ts
+++ b/src/server/static-react/src/api/index.ts
@@ -22,7 +22,6 @@ export type {
   RequestMetrics,
   BatchRequest,
   BatchResponse,
-  SchemaValidationOptions,
   ApiClientInstance
 } from './core/types';
 

--- a/src/server/static-react/src/components/tabs/SchemaTab.jsx
+++ b/src/server/static-react/src/components/tabs/SchemaTab.jsx
@@ -4,11 +4,11 @@ import { getRangeSchemaInfo, getHashRangeSchemaInfo } from '../../utils/rangeSch
 import { useAppSelector, useAppDispatch } from '../../store/hooks'
 import {
   selectAllSchemas,
+  selectApprovedSchemas,
   approveSchema as approveSchemaAction,
   blockSchema as blockSchemaAction,
   fetchSchemas
 } from '../../store/schemaSlice'
-import schemaClient from '../../api/clients/schemaClient'
 import SchemaName from '../shared/SchemaName'
 import { SCHEMA_BADGE_COLORS } from '../../constants/ui'
 import { toErrorMessage } from '../../utils/schemaUtils'
@@ -33,7 +33,7 @@ function SchemaTab({ onResult, onSchemaUpdated }) {
 
   const toggleSchema = async (schemaName) => {
     const isCurrentlyExpanded = expandedSchemas[schemaName]
-    
+
     setExpandedSchemas(prev => ({
       ...prev,
       [schemaName]: !prev[schemaName]
@@ -43,17 +43,9 @@ function SchemaTab({ onResult, onSchemaUpdated }) {
     if (!isCurrentlyExpanded) {
       const schema = schemas.find(s => s.name === schemaName)
       if (schema && (!schema.fields || Object.keys(schema.fields).length === 0)) {
-        try {
-          const response = await schemaClient.getSchema(schemaName)
-          if (response.success) {
-            // Refresh the schema list to get updated details
-            dispatch(fetchSchemas({ forceRefresh: true }))
-            if (onSchemaUpdated) {
-              onSchemaUpdated()
-            }
-          }
-        } catch (err) {
-          console.error(`Failed to fetch schema details for ${schemaName}:`, err)
+        dispatch(fetchSchemas({ forceRefresh: true }))
+        if (onSchemaUpdated) {
+          onSchemaUpdated()
         }
       }
     }
@@ -311,20 +303,7 @@ function SchemaTab({ onResult, onSchemaUpdated }) {
     )
   }
 
-  // Filter schemas by state - safely handle non-string states
-  const getStateString = (state) => {
-    if (typeof state === 'string') return state.toLowerCase()
-    if (typeof state === 'object' && state !== null) return String(state).toLowerCase()
-    return String(state || '').toLowerCase()
-  }
-  
-
-
-  // Derive approved schemas from the full schema list so newly fetched field
-  // details are reflected when a schema is expanded.
-  const approvedSchemas = schemas.filter(
-    (schema) => getStateString(schema.state) === 'approved'
-  )
+  const approvedSchemas = useAppSelector(selectApprovedSchemas)
 
 
 

--- a/src/server/static-react/src/constants/index.js
+++ b/src/server/static-react/src/constants/index.js
@@ -92,7 +92,7 @@ export {
   API_CONFIG,
   SCHEMA_STATES as API_SCHEMA_STATES,
   SCHEMA_OPERATIONS,
-} from "./api.ts";
+} from "./api";
 
 // ============================================================================
 // SCHEMA EXPORTS (from existing files)
@@ -105,7 +105,6 @@ export {
   RANGE_SCHEMA_FIELD_PREFIX,
   SCHEMA_STATES,
   SCHEMA_API_ENDPOINTS,
-  VALIDATION_MESSAGES as SCHEMA_VALIDATION_MESSAGES,
   RANGE_SCHEMA_CONFIG,
   FIELD_TYPES,
 } from "./schemas";

--- a/src/server/static-react/src/constants/redux.js
+++ b/src/server/static-react/src/constants/redux.js
@@ -201,12 +201,8 @@ export const SCHEMA_ERROR_MESSAGES = {
 /**
  * Valid schema states - extends base SCHEMA_STATES with Redux-specific UI states
  */
-import { SCHEMA_STATES as BASE_SCHEMA_STATES } from "./schemas";
-export const SCHEMA_STATES = {
-  ...BASE_SCHEMA_STATES,
-  LOADING: "loading",
-  ERROR: "error",
-};
+import { SCHEMA_STATES } from "./schemas";
+export { SCHEMA_STATES };
 
 /**
  * Schema operations that require specific states

--- a/src/server/static-react/src/constants/schemas.js
+++ b/src/server/static-react/src/constants/schemas.js
@@ -9,18 +9,13 @@ export const SCHEMA_CACHE_DURATION_MS = 300000; // 5 minutes
 export const FORM_VALIDATION_DEBOUNCE_MS = 500;
 export const RANGE_SCHEMA_FIELD_PREFIX = 'range_';
 
-// Testing constants (TASK-006 requirements)
-export const TEST_TIMEOUT_MS = 10000;
-export const MOCK_DELAY_MS = 100;
-export const COVERAGE_THRESHOLD_PERCENT = 80;
-export const INTEGRATION_TEST_BATCH_SIZE = 5;
-export const DOCUMENTATION_VERSION = '2.0.0';
-
 // Schema state constants
 export const SCHEMA_STATES = {
   AVAILABLE: 'available',
   APPROVED: 'approved',
-  BLOCKED: 'blocked'
+  BLOCKED: 'blocked',
+  LOADING: 'loading',
+  ERROR: 'error'
 };
 
 // API endpoints - Use centralized endpoints for API-STD-1 compliance
@@ -30,15 +25,6 @@ export const SCHEMA_API_ENDPOINTS = {
   AVAILABLE: API_ENDPOINTS.LIST_SCHEMAS,
   PERSISTED: API_ENDPOINTS.LIST_SCHEMAS,
   SCHEMA_DETAIL: API_ENDPOINTS.LIST_SCHEMAS
-};
-
-// Validation error messages
-export const VALIDATION_MESSAGES = {
-  RANGE_KEY_REQUIRED: 'Range key is required for range schema mutations',
-  RANGE_KEY_EMPTY: 'Range key cannot be empty',
-  SCHEMA_NOT_APPROVED: 'Only approved schemas can be used for this operation',
-  FIELD_REQUIRED: 'This field is required',
-  INVALID_TYPE: 'Invalid value type for this field'
 };
 
 // Range schema constants

--- a/src/server/static-react/src/hooks/__tests__/useQueryState.test.jsx
+++ b/src/server/static-react/src/hooks/__tests__/useQueryState.test.jsx
@@ -9,10 +9,10 @@ import { renderHook, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { useQueryState } from '../useQueryState.js';
 import { createTestStore } from '../../test/utils/testUtilities.jsx';
-import { selectFetchLoading, selectAllSchemas } from '../../store/schemaSlice.ts';
+import { selectFetchLoading, selectAllSchemas, selectApprovedSchemas } from '../../store/schemaSlice';
 
 // Mock the Redux store hooks
-vi.mock('../../store/hooks.ts', () => ({
+vi.mock('../../store/hooks', () => ({
   useAppSelector: vi.fn(),
   useAppDispatch: vi.fn(() => vi.fn())
 }));
@@ -47,7 +47,7 @@ describe('useQueryState Hook', () => {
     mockStore = await createTestStore();
     
     // Import the mocked hook
-    const { useAppSelector } = await import('../../store/hooks.ts');
+    const { useAppSelector } = await import('../../store/hooks');
     mockUseAppSelector = useAppSelector;
 
     // Set up default mock implementation
@@ -57,6 +57,9 @@ describe('useQueryState Hook', () => {
       }
       if (selector === selectAllSchemas) {
         return mockSchemas;
+      }
+      if (selector === selectApprovedSchemas) {
+        return mockSchemas.filter(s => s.state === 'approved');
       }
       if (selector === selectFetchLoading) {
         return false;
@@ -420,6 +423,8 @@ describe('useQueryState Hook', () => {
         { name: 'Schema1', state: 'APPROVED', fields: {} },
         { name: 'Schema2', state: 'BLOCKED', fields: {} }
       ];
+      // selectApprovedSchemas normalizes case, so APPROVED matches
+      const approvedOnly = [schemasWithUppercaseState[0]];
 
       mockUseAppSelector.mockImplementation((selector) => {
         if (selector.toString().includes('auth')) {
@@ -427,6 +432,9 @@ describe('useQueryState Hook', () => {
         }
         if (selector === selectAllSchemas) {
           return schemasWithUppercaseState;
+        }
+        if (selector === selectApprovedSchemas) {
+          return approvedOnly;
         }
         return false;
       });
@@ -439,10 +447,10 @@ describe('useQueryState Hook', () => {
 
     it('should handle schema state objects with toString', () => {
       const schemasWithObjectState = [
-        { 
-          name: 'Schema1', 
-          state: { toString: () => 'approved' }, 
-          fields: {} 
+        {
+          name: 'Schema1',
+          state: { toString: () => 'approved' },
+          fields: {}
         }
       ];
 
@@ -451,6 +459,9 @@ describe('useQueryState Hook', () => {
           return { isAuthenticated: true };
         }
         if (selector === selectAllSchemas) {
+          return schemasWithObjectState;
+        }
+        if (selector === selectApprovedSchemas) {
           return schemasWithObjectState;
         }
         return false;

--- a/src/server/static-react/src/hooks/__tests__/useRangeSchema.test.js
+++ b/src/server/static-react/src/hooks/__tests__/useRangeSchema.test.js
@@ -1,7 +1,8 @@
 import { renderHook } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useRangeSchema } from '../useRangeSchema.js';
-import { RANGE_SCHEMA_CONFIG, VALIDATION_MESSAGES } from '../../constants/schemas.js';
+import { RANGE_SCHEMA_CONFIG } from '../../constants/schemas.js';
+import { VALIDATION_MESSAGES } from '../../constants/validation.js';
 
 describe('useRangeSchema Hook', () => {
   let mockConsole;

--- a/src/server/static-react/src/hooks/useApprovedSchemas.js
+++ b/src/server/static-react/src/hooks/useApprovedSchemas.js
@@ -14,7 +14,7 @@
  */
 
 import { useEffect, useCallback } from "react";
-import { useAppSelector, useAppDispatch } from "../store/hooks.ts";
+import { useAppSelector, useAppDispatch } from "../store/hooks";
 import {
   fetchSchemas,
   selectApprovedSchemas,

--- a/src/server/static-react/src/hooks/useQueryState.js
+++ b/src/server/static-react/src/hooks/useQueryState.js
@@ -13,10 +13,8 @@
  */
 
 import { useState, useCallback, useMemo } from 'react';
-import { useAppSelector, useAppDispatch } from '../store/hooks.ts';
-import { selectAllSchemas, selectFetchLoading } from '../store/schemaSlice';
-import { fetchSchemas } from '../store/schemaSlice';
-import { SCHEMA_STATES } from '../constants/redux.js';
+import { useAppSelector, useAppDispatch } from '../store/hooks';
+import { selectApprovedSchemas, selectAllSchemas, selectFetchLoading, fetchSchemas } from '../store/schemaSlice';
 import { isHashRangeSchema, isRangeSchema, getRangeKey } from '../utils/rangeSchemaHelpers.js';
 
 /**
@@ -93,15 +91,8 @@ function useQueryState() {
   const [hashKeyValue, setHashKeyValue] = useState('');
   const [rangeSchemaFilter, setRangeSchemaFilter] = useState({});
 
-  // Memoized approved schemas - following QueryTab.jsx pattern (lines 265-271)
-  const approvedSchemas = useMemo(() => {
-    return (schemas || []).filter(schema => {
-      const state = typeof schema.state === 'string'
-        ? schema.state.toLowerCase()
-        : String(schema.state || '').toLowerCase();
-      return state === SCHEMA_STATES.APPROVED;
-    });
-  }, [schemas]);
+  // Approved schemas from Redux selector (SCHEMA-002 compliant)
+  const approvedSchemas = useAppSelector(selectApprovedSchemas);
 
   // Memoized selected schema object
   const selectedSchemaObj = useMemo(() => {

--- a/src/server/static-react/src/index.js
+++ b/src/server/static-react/src/index.js
@@ -56,7 +56,6 @@ export {
   initializeSystemKey,
   validatePrivateKey,
   refreshSystemKey,
-  fetchNodePrivateKey,
   loginUser,
   clearAuthentication,
   setError,

--- a/src/server/static-react/src/store/authSlice.ts
+++ b/src/server/static-react/src/store/authSlice.ts
@@ -171,31 +171,6 @@ export const refreshSystemKey = createAsyncThunk(
   },
 );
 
-// Async thunk for fetching node private key from backend
-export const fetchNodePrivateKey = createAsyncThunk(
-  "auth/fetchNodePrivateKey",
-  async (_, { rejectWithValue }) => {
-    try {
-      const response = await getNodePrivateKey();
-
-      if (response.success && response.data && response.data.private_key) {
-        return {
-          privateKey: response.data.private_key, // Store as base64 string (serializable)
-          publicKeyId: "node-private-key", // Use a consistent identifier
-          isSystemReady: true,
-        };
-      } else {
-        return rejectWithValue("Failed to fetch private key from backend");
-      }
-    } catch (err) {
-      console.error("Failed to fetch node private key:", err);
-      return rejectWithValue(
-        err instanceof Error ? err.message : "Failed to fetch node private key",
-      );
-    }
-  },
-);
-
 // Async thunk for user login and hash generation
 export const loginUser = createAsyncThunk(
   "auth/loginUser",
@@ -319,22 +294,6 @@ const authSlice = createSlice({
         state.isLoading = false;
         state.systemPublicKey = null;
         state.systemKeyId = null;
-        state.error = action.payload as string;
-      })
-      // fetchNodePrivateKey cases
-      .addCase(fetchNodePrivateKey.pending, (state) => {
-        state.isLoading = true;
-        state.error = null;
-      })
-      .addCase(fetchNodePrivateKey.fulfilled, (state, action) => {
-        state.isLoading = false;
-        state.privateKey = action.payload.privateKey;
-        state.publicKeyId = action.payload.publicKeyId;
-        state.error = null;
-      })
-      .addCase(fetchNodePrivateKey.rejected, (state, action) => {
-        state.isLoading = false;
-        // Don't log out just because key fetch failed, might be network
         state.error = action.payload as string;
       })
       // loginUser cases

--- a/src/server/static-react/src/store/schemaSlice.ts
+++ b/src/server/static-react/src/store/schemaSlice.ts
@@ -37,9 +37,7 @@ import {
   SCHEMA_OPERATION_REQUIREMENTS,
   READABLE_SCHEMA_STATES,
 } from "../constants/redux";
-import { createApiClient } from "../api/core/client";
-import { UnifiedSchemaClient } from "../api/clients/schemaClient";
-import { API_CONFIG } from "../constants/api";
+import { schemaClient as sharedSchemaClient } from "../api/clients/schemaClient";
 import {
   SCHEMA_OPERATION_TYPES,
   isCacheValid,
@@ -98,20 +96,9 @@ export const fetchSchemas = createAsyncThunk<
       };
     }
 
-    // Create schema client with main API base URL (not schema service)
-    // The schema endpoints are on the main API server, not a separate service
-    const schemaClient = new UnifiedSchemaClient(
-      createApiClient({
-        baseUrl: API_CONFIG.BASE_URL, // Use main API base URL (/api)
-        enableCache: true,
-        enableLogging: true,
-        enableMetrics: true,
-      }),
-    );
-
     // Clear API client cache when force refresh is requested
     if (params.forceRefresh) {
-      schemaClient.clearCache();
+      sharedSchemaClient.clearCache();
     }
 
     // Fetch with retry logic
@@ -120,7 +107,7 @@ export const fetchSchemas = createAsyncThunk<
     for (let attempt = 1; attempt <= SCHEMA_FETCH_RETRY_ATTEMPTS; attempt++) {
       try {
         // Fetch schemas with their states from the backend
-        const availableResponse = await schemaClient.getSchemas();
+        const availableResponse = await sharedSchemaClient.getSchemas();
 
         if (!availableResponse.success) {
           const error = new Error(
@@ -212,45 +199,33 @@ export const fetchSchemas = createAsyncThunk<
   },
 );
 
-// Create a shared schema client instance for operations
-const getMainApiSchemaClient = () => {
-  return new UnifiedSchemaClient(
-    createApiClient({
-      baseUrl: API_CONFIG.BASE_URL, // Use main API base URL (/api)
-      enableCache: true,
-      enableLogging: true,
-      enableMetrics: true,
-    }),
-  );
-};
-
 /**
  * Schema operation thunks using the factory function
  */
 export const approveSchema = createSchemaOperationThunk(
   SCHEMA_ACTION_TYPES.APPROVE_SCHEMA,
-  (name: string) => getMainApiSchemaClient().approveSchema(name),
+  (name: string) => sharedSchemaClient.approveSchema(name),
   SCHEMA_STATES.APPROVED as SchemaStateType,
   SCHEMA_ERROR_MESSAGES.APPROVE_FAILED,
 );
 
 export const blockSchema = createSchemaOperationThunk(
   SCHEMA_ACTION_TYPES.BLOCK_SCHEMA,
-  (name: string) => getMainApiSchemaClient().blockSchema(name),
+  (name: string) => sharedSchemaClient.blockSchema(name),
   SCHEMA_STATES.BLOCKED as SchemaStateType,
   SCHEMA_ERROR_MESSAGES.BLOCK_FAILED,
 );
 
 export const unloadSchema = createSchemaOperationThunk(
   SCHEMA_ACTION_TYPES.UNLOAD_SCHEMA,
-  (name: string) => getMainApiSchemaClient().unloadSchema(name),
+  (name: string) => sharedSchemaClient.unloadSchema(name),
   SCHEMA_STATES.AVAILABLE as SchemaStateType,
   SCHEMA_ERROR_MESSAGES.UNLOAD_FAILED,
 );
 
 export const loadSchema = createSchemaOperationThunk(
   SCHEMA_ACTION_TYPES.LOAD_SCHEMA,
-  (name: string) => getMainApiSchemaClient().loadSchema(name),
+  (name: string) => sharedSchemaClient.loadSchema(name),
   SCHEMA_STATES.APPROVED as SchemaStateType,
   SCHEMA_ERROR_MESSAGES.LOAD_FAILED,
 );

--- a/src/server/static-react/src/test/components/App.test.jsx
+++ b/src/server/static-react/src/test/components/App.test.jsx
@@ -23,7 +23,6 @@ vi.mock('../../store/authSlice', async () => {
     ...actual,
     // Mock async thunks to be no-ops that don't trigger reducers
     initializeSystemKey: createMockThunk('initializeSystemKey'),
-    fetchNodePrivateKey: createMockThunk('fetchNodePrivateKey'),
     restoreSession: (payload) => ({ type: 'auth/restoreSession/noop', payload }),
   };
 });

--- a/src/server/static-react/src/test/utils/testUtilities.jsx
+++ b/src/server/static-react/src/test/utils/testUtilities.jsx
@@ -23,15 +23,9 @@ import {
 } from '../config/constants';
 import authReducer from '../../store/authSlice';
 import schemaReducer from '../../store/schemaSlice';
+import { SCHEMA_STATES } from '../../constants/schemas';
 
-// Schema states for testing
-export const SCHEMA_STATES = {
-  APPROVED: 'approved',
-  AVAILABLE: 'available', 
-  BLOCKED: 'blocked',
-  LOADING: 'loading',
-  ERROR: 'error'
-};
+export { SCHEMA_STATES };
 
 /**
  * Creates a test store with optional initial state

--- a/src/server/static-react/src/utils/rangeSchemaHelpers.js
+++ b/src/server/static-react/src/utils/rangeSchemaHelpers.js
@@ -14,10 +14,8 @@
  * - Supports efficient range-based queries and mutations
  */
 
-import {
-  RANGE_SCHEMA_CONFIG,
-  VALIDATION_MESSAGES
-} from '../constants/schemas.js';
+import { RANGE_SCHEMA_CONFIG } from '../constants/schemas.js';
+import { VALIDATION_MESSAGES } from '../constants/validation.js';
 import { MUTATION_TYPE_API_MAP } from '../constants/ui.js';
 
 /**


### PR DESCRIPTION
## Summary

### Commit 1: Fix 10 architectural issues (3 critical, 7 high)
- **C1**: Use singleton `schemaClient` in `schemaSlice` instead of creating a new `UnifiedSchemaClient` on every thunk dispatch, making caching/dedup infrastructure actually work
- **C2**: Consolidate `SCHEMA_STATES` to a single definition in `schemas.js` (with `LOADING`/`ERROR`), eliminating 3 divergent copies
- **C3**: Replace 4 independent "filter to approved" implementations with the shared `selectApprovedSchemas` Redux selector
- **H1**: Remove duplicate `fetchNodePrivateKey` thunk — `initializeSystemKey` already fetches the key and derives the public key
- **H3**: Delete unused `useIndexingStatus` React hook from `indexingClient.ts` (no component imports it)
- **H4**: Remove direct `schemaClient.getSchema()` call from `SchemaTab`; use Redux `fetchSchemas` dispatch only
- **H5**: Delete duplicate `VALIDATION_MESSAGES` from `schemas.js`; consumers now import from canonical `validation.js`
- **H6**: Remove no-op `addAuthHeaders()`/`validateSchemaAccess()` methods and `SchemaValidationOptions` type from API pipeline
- **H7**: Remove explicit `.ts` extensions from JS imports (3 files)
- **Cleanup**: Remove misplaced test constants (`TEST_TIMEOUT_MS`, `COVERAGE_THRESHOLD_PERCENT`, etc.) from `schemas.js`

### Commit 2: Fix 6 high/medium severity issues
- **Consolidate test utilities**: Remove duplicate `renderWithRedux`/`createTestStore` from `testHelpers.jsx`, import from canonical `testUtilities.jsx`
- **Fix stale closure**: Reorder `poll()` after `setInterval` in `useBatchMonitor` so `pollTimer` is set when first async poll resolves
- **Consolidate normalization**: Replace 2 inline schema state normalization blocks in `schemaSlice.ts` with shared `normalizeSchemaState()`
- **Fix unstable key**: Replace `Math.random()` with `useId()` in `FieldWrapper` for stable React keys and correct accessibility
- **Fix unmounted setState**: Add mounted guard in `Header.jsx` to prevent setState after unmount
- **Respect cache**: Remove `forceRefresh: true` from `SchemaTab` mount effect to use Redux cache

28 files changed across both commits.

## Test plan

- [x] `npm run build` — succeeds with no errors
- [x] `npm test` — 29/29 test suites, 414/414 tests pass
- [x] `npm run lint` — no new errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)