### PR TITLE
Smart folder: shell-like tab-complete and web directory browser

### DIFF
--- a/src/server/http_server.rs
+++ b/src/server/http_server.rs
@@ -475,6 +475,10 @@ impl FoldHttpServer {
         .route(
             "/system/complete-path",
             web::post().to(system_routes::complete_path),
+        )
+        .route(
+            "/system/list-directory",
+            web::post().to(system_routes::list_directory),
         );
     }
 

--- a/src/server/routes/system.rs
+++ b/src/server/routes/system.rs
@@ -582,6 +582,17 @@ pub async fn apply_setup(
     })
 }
 
+/// Expand a leading `~` or `~/` to the current user's home directory.
+fn expand_tilde(raw: &str) -> PathBuf {
+    if raw == "~" || raw.starts_with("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            let rest = raw.strip_prefix("~/").unwrap_or("");
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    PathBuf::from(raw)
+}
+
 /// Request body for filesystem path completion
 #[derive(Deserialize)]
 pub struct PathCompleteRequest {
@@ -593,14 +604,14 @@ pub struct PathCompleteRequest {
 /// This endpoint provides directory-only path completion for the folder picker UI.
 /// It lists directories matching a partial path prefix, hiding dotfiles.
 pub async fn complete_path(body: web::Json<PathCompleteRequest>) -> impl Responder {
-    let partial = &body.partial_path;
+    let partial = expand_tilde(&body.partial_path);
+    let partial_str = partial.to_string_lossy();
 
-    let (parent, prefix) = if partial.ends_with('/') || partial.ends_with('\\') {
-        (PathBuf::from(partial), String::new())
+    let (parent, prefix) = if partial_str.ends_with('/') || partial_str.ends_with('\\') {
+        (PathBuf::from(partial_str.as_ref()), String::new())
     } else {
-        let path = PathBuf::from(partial);
-        let parent = path.parent().unwrap_or(Path::new("/")).to_path_buf();
-        let prefix = path
+        let parent = partial.parent().unwrap_or(Path::new("/")).to_path_buf();
+        let prefix = partial
             .file_name()
             .map(|f| f.to_string_lossy().to_string())
             .unwrap_or_default();
@@ -646,12 +657,13 @@ pub struct ListDirectoryRequest {
 /// Returns directory **names** (not full paths), up to 200 entries, hiding dotfiles.
 /// Used by the web-based directory browser modal.
 pub async fn list_directory(body: web::Json<ListDirectoryRequest>) -> impl Responder {
-    let dir_path = PathBuf::from(&body.path);
+    let dir_path = expand_tilde(&body.path);
+    let resolved = dir_path.to_string_lossy().to_string();
 
     if !dir_path.is_dir() {
-        return HttpResponse::BadRequest().json(json!({
+        return HttpResponse::Ok().json(json!({
             "error": format!("'{}' is not a directory or is unreadable", body.path),
-            "path": body.path,
+            "path": resolved,
             "directories": Vec::<String>::new(),
         }));
     }
@@ -659,9 +671,9 @@ pub async fn list_directory(body: web::Json<ListDirectoryRequest>) -> impl Respo
     let entries = match std::fs::read_dir(&dir_path) {
         Ok(entries) => entries,
         Err(e) => {
-            return HttpResponse::BadRequest().json(json!({
+            return HttpResponse::Ok().json(json!({
                 "error": format!("Cannot read directory: {}", e),
-                "path": body.path,
+                "path": resolved,
                 "directories": Vec::<String>::new(),
             }));
         }
@@ -678,7 +690,7 @@ pub async fn list_directory(body: web::Json<ListDirectoryRequest>) -> impl Respo
     directories.truncate(200);
 
     HttpResponse::Ok().json(json!({
-        "path": body.path,
+        "path": resolved,
         "directories": directories,
     }))
 }
@@ -835,5 +847,172 @@ mod tests {
             assert!(resp.status() == 202 || resp.status() == 500);
         })
         .await;
+    }
+
+    // --- expand_tilde tests ---
+
+    #[test]
+    fn test_expand_tilde_home() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(expand_tilde("~"), PathBuf::from(&home));
+    }
+
+    #[test]
+    fn test_expand_tilde_subpath() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(
+            expand_tilde("~/Documents"),
+            PathBuf::from(&home).join("Documents")
+        );
+    }
+
+    #[test]
+    fn test_expand_tilde_noop_absolute() {
+        assert_eq!(expand_tilde("/tmp"), PathBuf::from("/tmp"));
+    }
+
+    #[test]
+    fn test_expand_tilde_noop_relative() {
+        assert_eq!(expand_tilde("foo/bar"), PathBuf::from("foo/bar"));
+    }
+
+    // --- complete_path tests ---
+
+    #[tokio::test]
+    async fn test_complete_path_with_known_dir() {
+        let req = test::TestRequest::post().to_http_request();
+        let body = web::Json(PathCompleteRequest {
+            partial_path: "/tmp".to_string(),
+        });
+        let resp = complete_path(body).await.respond_to(&req);
+        assert_eq!(resp.status(), 200);
+
+        let bytes = actix_web::body::to_bytes(resp.into_body())
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json["completions"].is_array());
+    }
+
+    #[tokio::test]
+    async fn test_complete_path_tilde_expansion() {
+        let req = test::TestRequest::post().to_http_request();
+        let body = web::Json(PathCompleteRequest {
+            partial_path: "~/".to_string(),
+        });
+        let resp = complete_path(body).await.respond_to(&req);
+        assert_eq!(resp.status(), 200);
+
+        let bytes = actix_web::body::to_bytes(resp.into_body())
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let completions = json["completions"].as_array().unwrap();
+        // Home directory should have at least one visible subdirectory
+        assert!(!completions.is_empty());
+        // Completions should be absolute paths (tilde expanded)
+        for c in completions {
+            assert!(c.as_str().unwrap().starts_with('/'));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_complete_path_nonexistent() {
+        let req = test::TestRequest::post().to_http_request();
+        let body = web::Json(PathCompleteRequest {
+            partial_path: "/nonexistent_path_abc123/".to_string(),
+        });
+        let resp = complete_path(body).await.respond_to(&req);
+        assert_eq!(resp.status(), 200);
+
+        let bytes = actix_web::body::to_bytes(resp.into_body())
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json["completions"].as_array().unwrap().is_empty());
+    }
+
+    // --- list_directory tests ---
+
+    #[tokio::test]
+    async fn test_list_directory_root() {
+        let req = test::TestRequest::post().to_http_request();
+        let body = web::Json(ListDirectoryRequest {
+            path: "/".to_string(),
+        });
+        let resp = list_directory(body).await.respond_to(&req);
+        assert_eq!(resp.status(), 200);
+
+        let bytes = actix_web::body::to_bytes(resp.into_body())
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let dirs = json["directories"].as_array().unwrap();
+        assert!(!dirs.is_empty());
+        assert!(json["error"].is_null());
+        // Should contain well-known directories
+        let names: Vec<&str> = dirs.iter().map(|d| d.as_str().unwrap()).collect();
+        assert!(names.contains(&"usr"));
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_tilde_expansion() {
+        let req = test::TestRequest::post().to_http_request();
+        let body = web::Json(ListDirectoryRequest {
+            path: "~".to_string(),
+        });
+        let resp = list_directory(body).await.respond_to(&req);
+        assert_eq!(resp.status(), 200);
+
+        let bytes = actix_web::body::to_bytes(resp.into_body())
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let dirs = json["directories"].as_array().unwrap();
+        assert!(!dirs.is_empty());
+        // Path should be the expanded home directory
+        assert!(json["path"].as_str().unwrap().starts_with('/'));
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_nonexistent() {
+        let req = test::TestRequest::post().to_http_request();
+        let body = web::Json(ListDirectoryRequest {
+            path: "/nonexistent_path_abc123".to_string(),
+        });
+        let resp = list_directory(body).await.respond_to(&req);
+        assert_eq!(resp.status(), 200);
+
+        let bytes = actix_web::body::to_bytes(resp.into_body())
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json["directories"].as_array().unwrap().is_empty());
+        assert!(json["error"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_list_directory_returns_names_not_paths() {
+        let td = tempdir().unwrap();
+        std::fs::create_dir(td.path().join("subdir_a")).unwrap();
+        std::fs::create_dir(td.path().join("subdir_b")).unwrap();
+        // Create a dotfile dir that should be hidden
+        std::fs::create_dir(td.path().join(".hidden")).unwrap();
+
+        let req = test::TestRequest::post().to_http_request();
+        let body = web::Json(ListDirectoryRequest {
+            path: td.path().to_string_lossy().to_string(),
+        });
+        let resp = list_directory(body).await.respond_to(&req);
+        assert_eq!(resp.status(), 200);
+
+        let bytes = actix_web::body::to_bytes(resp.into_body())
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let dirs = json["directories"].as_array().unwrap();
+        let names: Vec<&str> = dirs.iter().map(|d| d.as_str().unwrap()).collect();
+        assert_eq!(names, vec!["subdir_a", "subdir_b"]);
+        assert!(!names.contains(&".hidden"));
     }
 }

--- a/src/server/routes/system.rs
+++ b/src/server/routes/system.rs
@@ -635,6 +635,54 @@ pub async fn complete_path(body: web::Json<PathCompleteRequest>) -> impl Respond
     HttpResponse::Ok().json(json!({ "completions": completions }))
 }
 
+/// Request body for listing directory contents
+#[derive(Deserialize)]
+pub struct ListDirectoryRequest {
+    pub path: String,
+}
+
+/// List subdirectories inside a given directory path.
+///
+/// Returns directory **names** (not full paths), up to 200 entries, hiding dotfiles.
+/// Used by the web-based directory browser modal.
+pub async fn list_directory(body: web::Json<ListDirectoryRequest>) -> impl Responder {
+    let dir_path = PathBuf::from(&body.path);
+
+    if !dir_path.is_dir() {
+        return HttpResponse::BadRequest().json(json!({
+            "error": format!("'{}' is not a directory or is unreadable", body.path),
+            "path": body.path,
+            "directories": Vec::<String>::new(),
+        }));
+    }
+
+    let entries = match std::fs::read_dir(&dir_path) {
+        Ok(entries) => entries,
+        Err(e) => {
+            return HttpResponse::BadRequest().json(json!({
+                "error": format!("Cannot read directory: {}", e),
+                "path": body.path,
+                "directories": Vec::<String>::new(),
+            }));
+        }
+    };
+
+    let mut directories: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .filter(|e| !e.file_name().to_string_lossy().starts_with('.'))
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+
+    directories.sort();
+    directories.truncate(200);
+
+    HttpResponse::Ok().json(json!({
+        "path": body.path,
+        "directories": directories,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/static-react/src/api/clients/ingestionClient.ts
+++ b/src/server/static-react/src/api/clients/ingestionClient.ts
@@ -547,6 +547,23 @@ export class UnifiedIngestionClient {
   }
 
   /**
+   * List subdirectories inside a given directory path
+   */
+  async listDirectory(
+    path: string,
+  ): Promise<EnhancedApiResponse<{ path: string; directories: string[]; error?: string }>> {
+    return this.client.post<{ path: string; directories: string[]; error?: string }>(
+      "/system/list-directory",
+      { path },
+      {
+        timeout: API_TIMEOUTS.QUICK,
+        retries: API_RETRIES.NONE,
+        cacheable: false,
+      },
+    );
+  }
+
+  /**
    * Upload a file for AI-powered ingestion
    * UNPROTECTED - No authentication required per project preference
    *

--- a/src/server/static-react/src/components/tabs/smart-folder/DirectoryBrowserModal.jsx
+++ b/src/server/static-react/src/components/tabs/smart-folder/DirectoryBrowserModal.jsx
@@ -1,0 +1,128 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { ingestionClient } from '../../../api/clients'
+
+/**
+ * Modal for browsing and selecting a directory via the web UI.
+ *
+ * @param {Object} props
+ * @param {string} props.initialPath - Starting directory path
+ * @param {Function} props.onSelect - Called with chosen directory path
+ * @param {Function} props.onClose - Called to dismiss the modal
+ */
+export default function DirectoryBrowserModal({ initialPath, onSelect, onClose }) {
+  const [currentPath, setCurrentPath] = useState(initialPath || '/')
+  const [directories, setDirectories] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const modalRef = useRef(null)
+
+  const fetchDirectories = useCallback(async (path) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await ingestionClient.listDirectory(path)
+      if (response.data?.directories) {
+        setDirectories(response.data.directories)
+        setCurrentPath(path)
+        if (response.data.error) {
+          setError(response.data.error)
+        }
+      } else {
+        setDirectories([])
+        setError(response.data?.error || 'Failed to list directory')
+      }
+    } catch (e) {
+      setDirectories([])
+      setError('Failed to list directory')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchDirectories(currentPath)
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const navigateUp = () => {
+    const parent = currentPath.replace(/\/[^/]+\/?$/, '') || '/'
+    fetchDirectories(parent)
+  }
+
+  const navigateInto = (dirName) => {
+    const next = currentPath.endsWith('/')
+      ? currentPath + dirName
+      : currentPath + '/' + dirName
+    fetchDirectories(next)
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Escape') onClose()
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose} onKeyDown={handleKeyDown}>
+      <div
+        className="modal"
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Browse Directories"
+        onClick={(e) => e.stopPropagation()}
+        style={{ maxWidth: '36rem' }}
+      >
+        <div className="modal-header">
+          <h3 className="text-lg font-medium">Browse Directories</h3>
+          <button onClick={onClose} className="btn-secondary btn-sm p-1" aria-label="Close">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 py-3 border-b border-border">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={navigateUp}
+              disabled={currentPath === '/'}
+              className="btn-secondary btn-sm px-2"
+              title="Up one level"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+            </button>
+            <code className="text-sm text-secondary truncate flex-1">{currentPath}</code>
+          </div>
+        </div>
+
+        <div className="modal-body" style={{ minHeight: '16rem', maxHeight: '24rem' }}>
+          {loading && <p className="text-sm text-secondary">Loading...</p>}
+          {error && <p className="text-sm text-red-400">{error}</p>}
+          {!loading && !error && directories.length === 0 && (
+            <p className="text-sm text-secondary">No subdirectories found.</p>
+          )}
+          {!loading && directories.length > 0 && (
+            <ul className="space-y-0.5">
+              {directories.map((dir) => (
+                <li key={dir}>
+                  <button
+                    className="w-full text-left px-3 py-1.5 text-sm font-mono rounded hover:bg-surface-hover truncate"
+                    onClick={() => navigateInto(dir)}
+                  >
+                    {dir}/
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="modal-footer">
+          <button onClick={onClose} className="btn-secondary">Cancel</button>
+          <button onClick={() => onSelect(currentPath)} className="btn-primary">Select This Folder</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/server/static-react/src/components/tabs/smart-folder/FolderInput.jsx
+++ b/src/server/static-react/src/components/tabs/smart-folder/FolderInput.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import DirectoryBrowserModal from './DirectoryBrowserModal'
 
 const isTauri = typeof window !== 'undefined' && window.__TAURI_INTERNALS__
 
@@ -36,17 +37,26 @@ export default function FolderInput({
   } = autocomplete
 
   const [, setPickerError] = useState(null)
+  const [showBrowser, setShowBrowser] = useState(false)
 
   const openFolderPicker = async () => {
-    if (!isTauri) return
-    try {
-      const { open } = await import('@tauri-apps/plugin-dialog')
-      const selected = await open({ directory: true, multiple: false, title: 'Select folder to scan' })
-      if (selected) onFolderPathChange(selected)
-    } catch (error) {
-      setPickerError(error)
-      console.error('Failed to open folder picker:', error)
+    if (isTauri) {
+      try {
+        const { open } = await import('@tauri-apps/plugin-dialog')
+        const selected = await open({ directory: true, multiple: false, title: 'Select folder to scan' })
+        if (selected) onFolderPathChange(selected)
+      } catch (error) {
+        setPickerError(error)
+        console.error('Failed to open folder picker:', error)
+      }
+    } else {
+      setShowBrowser(true)
     }
+  }
+
+  const handleBrowserSelect = (path) => {
+    onFolderPathChange(path)
+    setShowBrowser(false)
   }
 
   return (
@@ -85,7 +95,7 @@ export default function FolderInput({
             </ul>
           )}
         </div>
-        {isTauri && <button onClick={openFolderPicker} disabled={isScanning} className="btn-secondary" title="Browse">Browse</button>}
+        <button onClick={openFolderPicker} disabled={isScanning} className="btn-secondary" title="Browse">Browse</button>
         {isScanning
           ? <button onClick={onCancelScan} className="btn-secondary">Cancel</button>
           : <button onClick={() => onScan()} disabled={!folderPath.trim()} className="btn-primary">Scan</button>
@@ -113,6 +123,13 @@ export default function FolderInput({
         >
           Try sample data
         </button>
+      )}
+      {showBrowser && (
+        <DirectoryBrowserModal
+          initialPath={folderPath.includes('/') ? folderPath : '/'}
+          onSelect={handleBrowserSelect}
+          onClose={() => setShowBrowser(false)}
+        />
       )}
     </>
   )

--- a/src/server/static-react/src/hooks/__tests__/useFolderAutocomplete.test.js
+++ b/src/server/static-react/src/hooks/__tests__/useFolderAutocomplete.test.js
@@ -1,0 +1,191 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Mock the ingestionClient before importing the hook
+vi.mock('../../api/clients', () => ({
+  ingestionClient: {
+    completePath: vi.fn(),
+  },
+}))
+
+import { useFolderAutocomplete } from '../useFolderAutocomplete.js'
+import { ingestionClient } from '../../api/clients'
+
+describe('useFolderAutocomplete', () => {
+  let onFolderPathChange
+  let onSubmit
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    onFolderPathChange = vi.fn()
+    onSubmit = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function renderAutocomplete(folderPath = '', isDisabled = false) {
+    return renderHook(
+      ({ folderPath, isDisabled }) =>
+        useFolderAutocomplete({ folderPath, isDisabled, onFolderPathChange, onSubmit }),
+      { initialProps: { folderPath, isDisabled } }
+    )
+  }
+
+  describe('debounced completions', () => {
+    it('fetches completions after debounce when path includes /', async () => {
+      ingestionClient.completePath.mockResolvedValue({
+        success: true,
+        data: { completions: ['/usr', '/Users'] },
+      })
+
+      const { rerender } = renderAutocomplete('/u')
+
+      // Completions should not fire yet
+      expect(ingestionClient.completePath).not.toHaveBeenCalled()
+
+      // Advance past debounce
+      await act(async () => { vi.advanceTimersByTime(250) })
+
+      expect(ingestionClient.completePath).toHaveBeenCalledWith('/u')
+    })
+
+    it('does not fetch when path has no slash', async () => {
+      renderAutocomplete('Documents')
+      await act(async () => { vi.advanceTimersByTime(250) })
+      expect(ingestionClient.completePath).not.toHaveBeenCalled()
+    })
+
+    it('does not fetch when disabled', async () => {
+      renderAutocomplete('/usr', true)
+      await act(async () => { vi.advanceTimersByTime(250) })
+      expect(ingestionClient.completePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Tab key handling', () => {
+    it('calls preventDefault on Tab when path has a slash', async () => {
+      ingestionClient.completePath.mockResolvedValue({
+        success: true,
+        data: { completions: ['/usr'] },
+      })
+
+      const { result } = renderAutocomplete('/u')
+
+      const event = { key: 'Tab', preventDefault: vi.fn() }
+      await act(async () => { result.current.handleInputKeyDown(event) })
+
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('auto-completes to single match on Tab', async () => {
+      ingestionClient.completePath.mockResolvedValue({
+        success: true,
+        data: { completions: ['/usr'] },
+      })
+
+      const { result } = renderAutocomplete('/u')
+
+      const event = { key: 'Tab', preventDefault: vi.fn() }
+      await act(async () => { result.current.handleInputKeyDown(event) })
+
+      // Single match → acceptSuggestion → onFolderPathChange with trailing /
+      expect(onFolderPathChange).toHaveBeenCalledWith('/usr/')
+    })
+
+    it('completes to longest common prefix with multiple matches', async () => {
+      ingestionClient.completePath.mockResolvedValue({
+        success: true,
+        data: { completions: ['/usr/local', '/usr/lib'] },
+      })
+
+      const { result } = renderAutocomplete('/us')
+
+      const event = { key: 'Tab', preventDefault: vi.fn() }
+      await act(async () => { result.current.handleInputKeyDown(event) })
+
+      // LCP of /usr/local and /usr/lib is /usr/l — longer than /us so path updates
+      expect(onFolderPathChange).toHaveBeenCalledWith('/usr/l')
+      // Suggestions should be shown
+      expect(result.current.showSuggestions).toBe(true)
+      expect(result.current.suggestions).toEqual(['/usr/local', '/usr/lib'])
+    })
+
+    it('shows suggestions without changing path when LCP equals input', async () => {
+      ingestionClient.completePath.mockResolvedValue({
+        success: true,
+        data: { completions: ['/Applications', '/Library'] },
+      })
+
+      const { result } = renderAutocomplete('/')
+
+      const event = { key: 'Tab', preventDefault: vi.fn() }
+      await act(async () => { result.current.handleInputKeyDown(event) })
+
+      // LCP is / which equals current path, so path is NOT changed
+      // but onFolderPathChange is not called for the prefix
+      // suggestions should still be shown
+      expect(result.current.showSuggestions).toBe(true)
+      expect(result.current.suggestions).toEqual(['/Applications', '/Library'])
+    })
+
+    it('does not intercept Tab when path has no slash', async () => {
+      const { result } = renderAutocomplete('Documents')
+
+      const event = { key: 'Tab', preventDefault: vi.fn() }
+      await act(async () => { result.current.handleInputKeyDown(event) })
+
+      expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(ingestionClient.completePath).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('keyboard navigation', () => {
+    it('calls onSubmit on Enter with no suggestions', async () => {
+      const { result } = renderAutocomplete('/tmp')
+
+      const event = { key: 'Enter', preventDefault: vi.fn() }
+      await act(async () => { result.current.handleInputKeyDown(event) })
+
+      expect(onSubmit).toHaveBeenCalled()
+    })
+
+    it('dismisses suggestions on Escape', async () => {
+      ingestionClient.completePath.mockResolvedValue({
+        success: true,
+        data: { completions: ['/usr', '/Users'] },
+      })
+
+      const { result } = renderAutocomplete('/u')
+      // Trigger debounce to load suggestions
+      await act(async () => { vi.advanceTimersByTime(250) })
+
+      expect(result.current.showSuggestions).toBe(true)
+
+      const event = { key: 'Escape', preventDefault: vi.fn() }
+      await act(async () => { result.current.handleInputKeyDown(event) })
+
+      expect(result.current.showSuggestions).toBe(false)
+    })
+  })
+
+  describe('acceptSuggestion', () => {
+    it('appends trailing slash to accepted path', () => {
+      const { result } = renderAutocomplete()
+
+      act(() => { result.current.acceptSuggestion('/usr/local') })
+
+      expect(onFolderPathChange).toHaveBeenCalledWith('/usr/local/')
+    })
+
+    it('does not double trailing slash', () => {
+      const { result } = renderAutocomplete()
+
+      act(() => { result.current.acceptSuggestion('/usr/local/') })
+
+      expect(onFolderPathChange).toHaveBeenCalledWith('/usr/local/')
+    })
+  })
+})

--- a/src/server/static-react/src/hooks/useFolderAutocomplete.js
+++ b/src/server/static-react/src/hooks/useFolderAutocomplete.js
@@ -2,6 +2,21 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { ingestionClient } from '../api/clients'
 
 /**
+ * Returns the longest common prefix of an array of strings.
+ */
+function longestCommonPrefix(strings) {
+  if (strings.length === 0) return ''
+  let prefix = strings[0]
+  for (let i = 1; i < strings.length; i++) {
+    while (strings[i].indexOf(prefix) !== 0) {
+      prefix = prefix.slice(0, -1)
+      if (prefix === '') return ''
+    }
+  }
+  return prefix
+}
+
+/**
  * Manages folder path autocomplete: debounced completions, keyboard nav,
  * click-outside dismiss, and suggestion acceptance.
  *
@@ -18,6 +33,10 @@ export function useFolderAutocomplete({ folderPath, isDisabled, onFolderPathChan
   const inputRef = useRef(null)
   const suggestionsRef = useRef(null)
   const debounceRef = useRef(null)
+  const folderPathRef = useRef(folderPath)
+
+  // Keep ref in sync so async handlers always see the latest value
+  useEffect(() => { folderPathRef.current = folderPath }, [folderPath])
 
   const fetchCompletions = useCallback(async (path) => {
     if (!path.includes('/')) {
@@ -75,7 +94,40 @@ export function useFolderAutocomplete({ folderPath, isDisabled, onFolderPathChan
     inputRef.current?.focus()
   }, [onFolderPathChange])
 
-  const handleInputKeyDown = useCallback((e) => {
+  const handleInputKeyDown = useCallback(async (e) => {
+    // Shell-like Tab: intercept before checking if suggestions are visible
+    if (e.key === 'Tab' && folderPathRef.current.includes('/') && !isDisabled) {
+      e.preventDefault()
+
+      // If suggestions are already loaded, accept from current list
+      if (showSuggestions && suggestions.length > 0) {
+        const idx = selectedIndex >= 0 ? selectedIndex : 0
+        acceptSuggestion(suggestions[idx])
+        return
+      }
+
+      // No suggestions yet — fetch immediately (bypass debounce)
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      try {
+        const response = await ingestionClient.completePath(folderPathRef.current)
+        if (response.success && response.data?.completions?.length) {
+          const completions = response.data.completions
+          if (completions.length === 1) {
+            acceptSuggestion(completions[0])
+          } else {
+            const prefix = longestCommonPrefix(completions)
+            if (prefix.length > folderPathRef.current.length) {
+              onFolderPathChange(prefix)
+            }
+            setSuggestions(completions)
+            setSelectedIndex(-1)
+            setShowSuggestions(true)
+          }
+        }
+      } catch { /* tab-complete is best-effort */ }
+      return
+    }
+
     if (showSuggestions && suggestions.length > 0) {
       if (e.key === 'ArrowDown') {
         e.preventDefault()
@@ -85,12 +137,6 @@ export function useFolderAutocomplete({ folderPath, isDisabled, onFolderPathChan
       if (e.key === 'ArrowUp') {
         e.preventDefault()
         setSelectedIndex((prev) => (prev > 0 ? prev - 1 : suggestions.length - 1))
-        return
-      }
-      if (e.key === 'Tab') {
-        e.preventDefault()
-        const idx = selectedIndex >= 0 ? selectedIndex : 0
-        acceptSuggestion(suggestions[idx])
         return
       }
       if (e.key === 'Enter') {
@@ -107,7 +153,7 @@ export function useFolderAutocomplete({ folderPath, isDisabled, onFolderPathChan
       }
     }
     if (e.key === 'Enter') onSubmit()
-  }, [showSuggestions, suggestions, selectedIndex, acceptSuggestion, onSubmit])
+  }, [showSuggestions, suggestions, selectedIndex, acceptSuggestion, onSubmit, isDisabled, onFolderPathChange])
 
   return {
     suggestions,

--- a/tests/dsl_heart_rate_test.rs
+++ b/tests/dsl_heart_rate_test.rs
@@ -146,7 +146,7 @@ async fn test_heart_rate_average_dsl() {
         schema.field_molecule_uuids
     );
     assert!(
-        schema.field_molecule_uuids.as_ref().map_or(false, |m| !m.is_empty()),
+        schema.field_molecule_uuids.as_ref().is_some_and(|m| !m.is_empty()),
         "Schema should have molecule UUIDs after mutations"
     );
 


### PR DESCRIPTION
## Summary
- **Shell-like tab-complete**: Tab key now works instantly in the smart folder path input — bypasses the 200ms debounce, fetches completions immediately, auto-completes single matches, and fills the longest common prefix for multiple matches
- **Web directory browser**: Browse button now appears in web mode (not just Tauri), opening a modal to navigate and select directories via a new `POST /api/system/list-directory` endpoint
- **Tilde expansion**: Both `complete-path` and `list-directory` endpoints now expand `~/` to the user's home directory

### Files changed
- `src/server/routes/system.rs` — `expand_tilde()` helper, `list_directory` endpoint, tests
- `src/server/http_server.rs` — Route registration for `/system/list-directory`
- `src/server/static-react/src/hooks/useFolderAutocomplete.js` — Immediate Tab fetch, `longestCommonPrefix` helper
- `src/server/static-react/src/api/clients/ingestionClient.ts` — `listDirectory()` method
- `src/server/static-react/src/components/tabs/smart-folder/DirectoryBrowserModal.jsx` — New modal component
- `src/server/static-react/src/components/tabs/smart-folder/FolderInput.jsx` — Browse button in web mode
- `src/server/static-react/src/hooks/__tests__/useFolderAutocomplete.test.js` — 12 Vitest tests

## Test plan
- [x] `cargo build` compiles successfully
- [x] Vitest: 12/12 tests pass for `useFolderAutocomplete` (tab-complete, LCP, keyboard nav, accept suggestion)
- [x] Rust tests written for `expand_tilde`, `complete_path`, `list_directory` (blocked by pre-existing rustc 1.89 vs 1.91 AWS SDK issue)
- [x] Manual: Tab-complete with `~/Documents` default path works
- [x] Manual: Browse button opens modal, navigates directories, selects folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added directory browser modal for browsing and selecting folders
  * Added support for tilde (~) expansion in file paths (expands to home directory)
  * Enhanced path autocomplete with improved suggestions and longer common prefix matching
  * Directory selection now available in all application environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->