### PR TITLE
Add Word Graph tab for visualizing indexed words and schema connections

### DIFF
--- a/src/server/static-react/package-lock.json
+++ b/src/server/static-react/package-lock.json
@@ -18,6 +18,7 @@
         "buffer": "^6.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-force-graph-2d": "^1.29.1",
         "react-redux": "^9.2.0"
       },
       "devDependencies": {
@@ -2213,6 +2214,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2795,6 +2802,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3088,6 +3104,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3274,6 +3300,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -3520,6 +3558,222 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "4.0.0",
@@ -4266,6 +4520,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -4300,6 +4568,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.1.tgz",
+      "integrity": "sha512-uEEX8iRzgq1IKRISOw6RrB2RLMhcI25xznQYrCTVvxZHZZ+A2jH6qIolYuwavVxAMi64pFp2yZm4KFVdD993cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/form-data": {
@@ -4701,6 +4995,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/index-to-position": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
@@ -4727,6 +5030,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arguments": {
@@ -5109,6 +5421,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -5238,6 +5559,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5297,6 +5630,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5616,7 +5955,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6116,6 +6454,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.28.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.4.tgz",
+      "integrity": "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6160,6 +6508,17 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -6243,11 +6602,43 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -6985,6 +7376,12 @@
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
     "node_modules/tinyexec": {

--- a/src/server/static-react/package.json
+++ b/src/server/static-react/package.json
@@ -49,6 +49,7 @@
     "buffer": "^6.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-force-graph-2d": "^1.29.1",
     "react-redux": "^9.2.0"
   },
   "overrides": {

--- a/src/server/static-react/src/App.jsx
+++ b/src/server/static-react/src/App.jsx
@@ -14,6 +14,7 @@ import FileUploadTab from './components/tabs/FileUploadTab'
 import NativeIndexTab from './components/tabs/NativeIndexTab'
 import SmartFolderTab from './components/tabs/SmartFolderTab'
 import DataBrowserTab from './components/tabs/DataBrowserTab'
+import WordGraphTab from './components/tabs/WordGraphTab'
 import SettingsModal from './components/SettingsModal'
 import OnboardingWizard from './components/OnboardingWizard'
 import LogSidebar from './components/LogSidebar'
@@ -43,6 +44,7 @@ const HASH_TO_TAB = {
   'llm-query': 'llm-query', 'ai-query': 'llm-query',
   'smart-folder': 'smart-folder',
   'data-browser': 'data-browser',
+  'word-graph': 'word-graph',
 }
 
 function resolveTabFromHash() {
@@ -212,6 +214,8 @@ export function AppContent() {
         return <NativeIndexTab onResult={handleOperationResult} />
       case 'data-browser':
         return <DataBrowserTab />
+      case 'word-graph':
+        return <WordGraphTab />
       default:
         return null
     }

--- a/src/server/static-react/src/components/tabs/WordGraphTab.jsx
+++ b/src/server/static-react/src/components/tabs/WordGraphTab.jsx
@@ -1,0 +1,469 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import ForceGraph2D from 'react-force-graph-2d'
+import { useApprovedSchemas } from '../../hooks/useApprovedSchemas.js'
+import { nativeIndexClient, mutationClient, schemaClient } from '../../api/clients'
+import { getFieldNames, toErrorMessage } from '../../utils/schemaUtils'
+
+// Gruvbox-inspired palette
+const COLORS = {
+  schema:    '#83a598',
+  word:      '#b8bb26',
+  key:       '#fe8019',
+  link:      '#504945',
+  linkHover: '#928374',
+  bg:        '#282828',
+  text:      '#ebdbb2',
+}
+
+const STOPWORDS = new Set([
+  'the','and','for','are','but','not','you','all','can','her','was','one',
+  'our','out','get','has','him','his','how','new','now','old','see','two',
+  'way','who','did','its','let','put','say','she','too','use','that','this',
+  'with','from','they','been','have','will','more','also','than','then',
+  'when','just','over','into','some','what','your','would','could','which',
+])
+
+const MAX_WORDS     = 300  // cap on unique words to search
+const MAX_RECORDS   = 20   // records to query per schema
+const SEARCH_BATCH  = 8    // concurrent searches at a time
+
+function makeSchemaId(name) { return `schema:${name}` }
+function makeWordId(term)   { return `word:${term}` }
+
+function formatKey(kv) {
+  const parts = []
+  if (kv?.hash)  parts.push(kv.hash.slice(0, 12))
+  if (kv?.range) parts.push(kv.range.slice(0, 12))
+  return parts.join(' / ') || '—'
+}
+
+function mergeGraphData(prev, newNodes, newLinks) {
+  const nodeMap = new Map(prev.nodes.map(n => [n.id, n]))
+  const linkMap = new Map(prev.links.map(l => [l.id, l]))
+  for (const n of newNodes) if (!nodeMap.has(n.id)) nodeMap.set(n.id, n)
+  for (const l of newLinks) if (!linkMap.has(l.id)) linkMap.set(l.id, l)
+  return { nodes: Array.from(nodeMap.values()), links: Array.from(linkMap.values()) }
+}
+
+function extractWordsFromRecord(record) {
+  const words = new Set()
+  const fields = record?.fields ?? (typeof record === 'object' ? record : {})
+  for (const value of Object.values(fields ?? {})) {
+    if (typeof value !== 'string') continue
+    for (const w of value.toLowerCase().split(/[^a-z0-9]+/)) {
+      if (w.length >= 3 && !STOPWORDS.has(w)) words.add(w)
+    }
+  }
+  return words
+}
+
+function buildFromResults(results) {
+  const nodes = []
+  const links = []
+  const seenWords = new Set()
+  for (const r of results) {
+    const schemaId = makeSchemaId(r.schema_name)
+    const wordLabel = String(r.value ?? r.field ?? '')
+    if (!wordLabel) continue
+    const wordId = makeWordId(wordLabel)
+    const linkId = `${wordId}-->${schemaId}:${r.key_value?.hash}:${r.key_value?.range}:${r.field}`
+    if (!seenWords.has(wordId)) {
+      seenWords.add(wordId)
+      nodes.push({ id: wordId, label: wordLabel, type: 'word', field: r.field })
+    }
+    links.push({
+      id: linkId,
+      source: wordId,
+      target: schemaId,
+      keyLabel: formatKey(r.key_value),
+      field: r.field,
+      hash: r.key_value?.hash ?? '',
+      range: r.key_value?.range ?? '',
+    })
+  }
+  return { nodes, links }
+}
+
+async function searchBatch(words, onBatchResult) {
+  const pending = [...words]
+  while (pending.length > 0) {
+    const batch = pending.splice(0, SEARCH_BATCH)
+    await Promise.all(batch.map(async (word) => {
+      const res = await nativeIndexClient.search(word)
+      if (res.success) {
+        const results = res.data?.results ?? []
+        if (results.length) onBatchResult(results)
+      }
+    }))
+  }
+}
+
+function NodeDetail({ node, links }) {
+  if (!node) return null
+  const connected = links.filter(l => {
+    const src = typeof l.source === 'object' ? l.source?.id : l.source
+    const tgt = typeof l.target === 'object' ? l.target?.id : l.target
+    return src === node.id || tgt === node.id
+  })
+  return (
+    <div className="space-y-3">
+      <div>
+        <span className={`text-xs uppercase font-bold tracking-widest ${node.type === 'schema' ? 'text-[#83a598]' : 'text-[#b8bb26]'}`}>
+          {node.type}
+        </span>
+        <div className="text-primary font-mono mt-1 text-sm break-all">{node.label}</div>
+      </div>
+      {connected.length > 0 && (
+        <div>
+          <div className="text-xs uppercase tracking-widest text-tertiary mb-2">
+            Connections ({connected.length})
+          </div>
+          <div className="space-y-1 max-h-56 overflow-y-auto pr-1">
+            {connected.map((l, i) => {
+              const src = typeof l.source === 'object' ? l.source?.id : l.source
+              const tgt = typeof l.target === 'object' ? l.target?.id : l.target
+              const other = src === node.id ? tgt : src
+              const otherLabel = String(other ?? '').replace(/^(schema:|word:)/, '')
+              return (
+                <div key={i} className="text-xs bg-surface-secondary border border-border p-2 space-y-0.5">
+                  <div className="text-primary font-mono truncate">{otherLabel}</div>
+                  <div className="text-tertiary">field: <span className="text-secondary">{l.field}</span></div>
+                  <div className="text-tertiary">key: <span className="text-secondary font-mono">{l.keyLabel}</span></div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function WordGraphTab() {
+  const { approvedSchemas } = useApprovedSchemas()
+  const [graphData, setGraphData] = useState({ nodes: [], links: [] })
+  const [searchTerm, setSearchTerm] = useState('')
+  const [isSearching, setIsSearching] = useState(false)
+  const [loadStatus, setLoadStatus] = useState(null) // { phase, progress, total } | null
+  const [error, setError] = useState(null)
+  const [selectedNode, setSelectedNode] = useState(null)
+  const [highlightNodes, setHighlightNodes] = useState(new Set())
+  const [highlightLinks, setHighlightLinks] = useState(new Set())
+  const graphRef = useRef(null)
+  const containerRef = useRef(null)
+  const [dimensions, setDimensions] = useState({ width: 800, height: 550 })
+  const prepopulatedRef = useRef(false)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    const ro = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setDimensions({ width: entry.contentRect.width, height: entry.contentRect.height })
+      }
+    })
+    ro.observe(containerRef.current)
+    return () => ro.disconnect()
+  }, [])
+
+  // Seed schema nodes whenever approved schemas change
+  useEffect(() => {
+    if (!approvedSchemas?.length) return
+    const schemaNodes = approvedSchemas.map(s => ({ id: makeSchemaId(s.name), label: s.name, type: 'schema' }))
+    setGraphData(prev => mergeGraphData(prev, schemaNodes, []))
+  }, [approvedSchemas])
+
+  const addResults = useCallback((results) => {
+    const { nodes, links } = buildFromResults(results)
+    setGraphData(prev => mergeGraphData(prev, nodes, links))
+  }, [])
+
+  // Auto-populate on first schema load
+  const prepopulate = useCallback(async (schemas) => {
+    if (prepopulatedRef.current || !schemas?.length) return
+    prepopulatedRef.current = true
+
+    setError(null)
+    const allWords = new Set()
+
+    // Phase 1: query records from each schema to extract real words
+    setLoadStatus({ phase: 'Reading records…', progress: 0, total: schemas.length })
+    for (let i = 0; i < schemas.length; i++) {
+      const schema = schemas[i]
+      setLoadStatus({ phase: `Reading ${schema.name}…`, progress: i, total: schemas.length })
+      try {
+        const fields = getFieldNames(schema)
+        const res = await mutationClient.executeQuery({ schema_name: schema.name, fields })
+        const records = Array.isArray(res.data?.results) ? res.data.results : []
+        for (const record of records.slice(0, MAX_RECORDS)) {
+          for (const w of extractWordsFromRecord(record)) {
+            if (allWords.size < MAX_WORDS) allWords.add(w)
+          }
+        }
+      } catch {
+        // schema query failure is non-fatal
+      }
+    }
+
+    if (allWords.size === 0) {
+      // Fallback: list keys and use their hashes as seed terms
+      for (const schema of schemas) {
+        if (allWords.size >= MAX_WORDS) break
+        try {
+          const res = await schemaClient.listSchemaKeys(schema.name, 0, 50)
+          for (const kv of (res.data?.keys ?? [])) {
+            if (kv.hash && allWords.size < MAX_WORDS) allWords.add(kv.hash)
+            if (kv.range && allWords.size < MAX_WORDS) allWords.add(kv.range)
+          }
+        } catch { /* non-fatal */ }
+      }
+    }
+
+    if (allWords.size === 0) {
+      setLoadStatus(null)
+      return
+    }
+
+    // Phase 2: search each word in the native index
+    const wordList = Array.from(allWords)
+    let done = 0
+    setLoadStatus({ phase: 'Indexing words…', progress: 0, total: wordList.length })
+    await searchBatch(wordList, (results) => {
+      addResults(results)
+      done += SEARCH_BATCH
+      setLoadStatus({ phase: 'Indexing words…', progress: Math.min(done, wordList.length), total: wordList.length })
+    })
+
+    setLoadStatus(null)
+  }, [addResults])
+
+  useEffect(() => {
+    if (approvedSchemas?.length) {
+      prepopulate(approvedSchemas)
+    }
+  }, [approvedSchemas, prepopulate])
+
+  const handleSearch = useCallback(async () => {
+    const q = searchTerm.trim()
+    if (!q) return
+    setIsSearching(true)
+    setError(null)
+    try {
+      const res = await nativeIndexClient.search(q)
+      if (res.success) {
+        const results = res.data?.results ?? []
+        addResults(results)
+        if (results.length === 0) setError(`No index entries for "${q}"`)
+      } else {
+        setError(res.error || 'Search failed')
+      }
+    } catch (e) {
+      setError(toErrorMessage(e) || 'Network error')
+    } finally {
+      setIsSearching(false)
+    }
+  }, [searchTerm, addResults])
+
+  const handleNodeHover = useCallback((node) => {
+    if (!node) { setHighlightNodes(new Set()); setHighlightLinks(new Set()); return }
+    const hl = new Set([node.id])
+    const hlLinks = new Set()
+    for (const l of graphData.links) {
+      const src = typeof l.source === 'object' ? l.source?.id : l.source
+      const tgt = typeof l.target === 'object' ? l.target?.id : l.target
+      if (src === node.id || tgt === node.id) {
+        hlLinks.add(l.id); hl.add(src); hl.add(tgt)
+      }
+    }
+    setHighlightNodes(hl)
+    setHighlightLinks(hlLinks)
+  }, [graphData.links])
+
+  const handleNodeClick = useCallback((node) => {
+    setSelectedNode(prev => prev?.id === node.id ? null : node)
+  }, [])
+
+  const nodeCanvasObject = useCallback((node, ctx, globalScale) => {
+    const isHighlighted = highlightNodes.has(node.id)
+    const isSelected = selectedNode?.id === node.id
+    const isSchema = node.type === 'schema'
+    const baseColor = isSchema ? COLORS.schema : COLORS.word
+    const r = isSchema ? 8 : 5
+
+    ctx.beginPath()
+    if (isSchema) {
+      ctx.rect(node.x - r, node.y - r, r * 2, r * 2)
+    } else {
+      ctx.arc(node.x, node.y, r, 0, 2 * Math.PI)
+    }
+    ctx.fillStyle = isHighlighted || isSelected ? baseColor : `${baseColor}99`
+    ctx.fill()
+    if (isSelected) { ctx.strokeStyle = COLORS.key; ctx.lineWidth = 2; ctx.stroke() }
+
+    const fontSize = Math.max(10 / globalScale, isSchema ? 11 : 9)
+    ctx.font = `${isSchema ? 'bold ' : ''}${fontSize}px monospace`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillStyle = isHighlighted || isSelected ? COLORS.text : `${COLORS.text}99`
+    const lbl = node.label.length > 20 ? node.label.slice(0, 18) + '…' : node.label
+    ctx.fillText(lbl, node.x, node.y + r + fontSize)
+  }, [highlightNodes, selectedNode])
+
+  const linkCanvasObject = useCallback((link, ctx) => {
+    const src = link.source
+    const tgt = link.target
+    if (!src?.x || !tgt?.x) return
+    const isHighlighted = highlightLinks.has(link.id)
+    ctx.beginPath()
+    ctx.moveTo(src.x, src.y)
+    ctx.lineTo(tgt.x, tgt.y)
+    ctx.strokeStyle = isHighlighted ? COLORS.linkHover : COLORS.link
+    ctx.lineWidth = isHighlighted ? 1.5 : 0.8
+    ctx.stroke()
+    if (isHighlighted) {
+      const mx = (src.x + tgt.x) / 2
+      const my = (src.y + tgt.y) / 2
+      ctx.font = '8px monospace'
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'middle'
+      ctx.fillStyle = COLORS.key
+      ctx.fillText(link.keyLabel, mx, my - 5)
+    }
+  }, [highlightLinks])
+
+  const handleClear = () => {
+    const schemaNodes = (approvedSchemas ?? []).map(s => ({ id: makeSchemaId(s.name), label: s.name, type: 'schema' }))
+    setGraphData({ nodes: schemaNodes, links: [] })
+    setSelectedNode(null)
+    setHighlightNodes(new Set())
+    setHighlightLinks(new Set())
+    prepopulatedRef.current = false
+  }
+
+  const wordNodeCount   = graphData.nodes.filter(n => n.type === 'word').length
+  const schemaNodeCount = graphData.nodes.filter(n => n.type === 'schema').length
+  const isLoading = !!loadStatus
+
+  return (
+    <div className="flex gap-4" style={{ height: '600px' }}>
+      {/* Sidebar */}
+      <div className="w-56 flex-shrink-0 flex flex-col gap-3 overflow-y-auto">
+        <div>
+          <div className="text-xs uppercase tracking-widest text-tertiary mb-2">Search Word</div>
+          <div className="flex flex-col gap-2">
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={e => setSearchTerm(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleSearch()}
+              placeholder="e.g. alice"
+              className="input text-sm"
+              disabled={isLoading}
+            />
+            <button
+              onClick={handleSearch}
+              disabled={isSearching || isLoading || !searchTerm.trim()}
+              className="btn-primary text-sm"
+            >
+              {isSearching ? 'Searching…' : 'Add to Graph'}
+            </button>
+          </div>
+        </div>
+
+        {/* Load status */}
+        {loadStatus && (
+          <div className="border border-border p-2 text-xs space-y-1">
+            <div className="text-secondary">{loadStatus.phase}</div>
+            <div className="w-full bg-surface-secondary h-1.5 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-[#83a598] transition-all duration-300"
+                style={{ width: `${loadStatus.total ? (loadStatus.progress / loadStatus.total) * 100 : 0}%` }}
+              />
+            </div>
+            <div className="text-tertiary">{loadStatus.progress} / {loadStatus.total}</div>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1 text-xs text-secondary border border-border p-2">
+          <div>Schemas: <span className="text-primary font-mono">{schemaNodeCount}</span></div>
+          <div>Words: <span className="text-primary font-mono">{wordNodeCount}</span></div>
+          <div>Links: <span className="text-primary font-mono">{graphData.links.length}</span></div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2 text-xs text-secondary">
+            <span className="inline-block w-3 h-3" style={{ background: COLORS.schema }} />
+            Schema (square)
+          </div>
+          <div className="flex items-center gap-2 text-xs text-secondary">
+            <span className="inline-block w-3 h-3 rounded-full" style={{ background: COLORS.word }} />
+            Word (circle)
+          </div>
+          <div className="flex items-center gap-2 text-xs text-secondary">
+            <span className="inline-block w-8 h-px" style={{ background: COLORS.key }} />
+            Key (hover)
+          </div>
+        </div>
+
+        <button
+          onClick={handleClear}
+          disabled={isLoading}
+          className="btn-secondary text-xs"
+        >
+          Clear & Reload
+        </button>
+
+        {error && (
+          <div className="text-xs text-gruvbox-red border border-gruvbox-red/30 p-2">
+            {error}
+          </div>
+        )}
+
+        {selectedNode && (
+          <div className="border border-border p-2">
+            <div className="text-xs uppercase tracking-widest text-tertiary mb-2">Selected</div>
+            <NodeDetail node={selectedNode} links={graphData.links} />
+          </div>
+        )}
+      </div>
+
+      {/* Graph Canvas */}
+      <div
+        ref={containerRef}
+        className="flex-1 border border-border overflow-hidden relative"
+        style={{ background: COLORS.bg }}
+      >
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
+            <div className="text-xs text-[#928374] bg-[#282828]/80 px-3 py-1.5 border border-[#504945]">
+              {loadStatus.phase}
+            </div>
+          </div>
+        )}
+        <ForceGraph2D
+          ref={graphRef}
+          width={dimensions.width}
+          height={dimensions.height}
+          graphData={graphData}
+          nodeCanvasObject={nodeCanvasObject}
+          nodeCanvasObjectMode={() => 'replace'}
+          linkCanvasObject={linkCanvasObject}
+          linkCanvasObjectMode={() => 'replace'}
+          onNodeHover={handleNodeHover}
+          onNodeClick={handleNodeClick}
+          cooldownTicks={100}
+          nodePointerAreaPaint={(node, color, ctx) => {
+            const r = node.type === 'schema' ? 10 : 7
+            ctx.fillStyle = color
+            if (node.type === 'schema') {
+              ctx.fillRect(node.x - r, node.y - r, r * 2, r * 2)
+            } else {
+              ctx.beginPath(); ctx.arc(node.x, node.y, r, 0, 2 * Math.PI); ctx.fill()
+            }
+          }}
+          d3AlphaDecay={0.02}
+          d3VelocityDecay={0.3}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/server/static-react/src/constants/ui.js
+++ b/src/server/static-react/src/constants/ui.js
@@ -29,6 +29,7 @@ export const DEFAULT_TABS = [
     group: "advanced",
   },
   { id: "data-browser", label: "Data Browser", icon: "🗄️", group: "advanced" },
+  { id: "word-graph", label: "Word Graph", icon: "🕸️", group: "advanced" },
 ];
 
 // Button Text Constants

--- a/src/server/static-react/src/test/components/tabs/WordGraphTab.test.jsx
+++ b/src/server/static-react/src/test/components/tabs/WordGraphTab.test.jsx
@@ -1,0 +1,377 @@
+import React from 'react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import WordGraphTab from '../../../components/tabs/WordGraphTab'
+import { renderWithRedux, createTestSchemaState } from '../../utils/testStore.jsx'
+
+// react-force-graph-2d uses canvas/WebGL — replace with a testable stub
+vi.mock('react-force-graph-2d', () => ({
+  default: vi.fn(({ graphData, onNodeClick, onNodeHover }) => (
+    <div data-testid="force-graph">
+      <span data-testid="graph-node-count">{graphData?.nodes?.length ?? 0}</span>
+      <span data-testid="graph-link-count">{graphData?.links?.length ?? 0}</span>
+      {graphData?.nodes?.map(n => (
+        <button
+          key={n.id}
+          data-testid={`node-${n.id}`}
+          onClick={() => onNodeClick?.(n)}
+          onMouseEnter={() => onNodeHover?.(n)}
+          onMouseLeave={() => onNodeHover?.(null)}
+        >
+          {n.label}
+        </button>
+      ))}
+    </div>
+  ))
+}))
+
+vi.mock('../../../api/clients/nativeIndexClient', () => ({
+  nativeIndexClient: { search: vi.fn() },
+  NativeIndexClient: vi.fn()
+}))
+
+vi.mock('../../../api/clients/mutationClient', () => ({
+  mutationClient: { executeQuery: vi.fn() }
+}))
+
+vi.mock('../../../api/clients/schemaClient', () => ({
+  default:      { listSchemaKeys: vi.fn() },
+  schemaClient: { listSchemaKeys: vi.fn() }
+}))
+
+vi.mock('../../../store/schemaSlice', async () => {
+  const actual = await vi.importActual('../../../store/schemaSlice')
+  const thunk = vi.fn(() => {
+    const fn = () => Promise.resolve({ type: 'schemas/fetchSchemas/fulfilled', payload: undefined })
+    fn.fulfilled = { match: () => true }
+    return fn
+  })
+  return { ...actual, fetchSchemas: thunk }
+})
+
+import { nativeIndexClient } from '../../../api/clients/nativeIndexClient'
+import { mutationClient }    from '../../../api/clients/mutationClient'
+import { schemaClient }      from '../../../api/clients/schemaClient'
+
+const APPROVED_SCHEMA_STATE = createTestSchemaState({
+  schemas: {
+    UserProfile: { name: 'UserProfile', state: 'Approved', fields: ['name', 'bio'] },
+    TweetData:   { name: 'TweetData',   state: 'Approved', fields: ['text', 'author'] },
+  }
+})
+
+function makeSearchResult(word, schema, hash = 'abc123') {
+  return { schema_name: schema, field: 'name', key_value: { hash, range: null }, value: word }
+}
+
+async function renderTab(schemaState = APPROVED_SCHEMA_STATE) {
+  return renderWithRedux(<WordGraphTab />, { preloadedState: schemaState })
+}
+
+// Wait for schema nodes to appear AND for the search input to be enabled.
+// The input is disabled={isLoading} — it becomes enabled once auto-populate completes.
+async function waitForReady() {
+  await waitFor(() => {
+    expect(screen.getByTestId('graph-node-count').textContent).toBe('2')
+    expect(screen.getByPlaceholderText('e.g. alice')).not.toBeDisabled()
+  }, { timeout: 5000 })
+}
+
+describe('WordGraphTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: no-op responses so prepopulate finishes immediately
+    nativeIndexClient.search.mockResolvedValue({ success: true, data: { results: [] } })
+    mutationClient.executeQuery.mockResolvedValue({ success: true, data: { results: [] } })
+    schemaClient.listSchemaKeys.mockResolvedValue({ success: true, data: { keys: [], total_count: 0 } })
+  })
+
+  describe('initial render', () => {
+    it('renders search input and Add to Graph button', async () => {
+      await renderTab()
+      expect(screen.getByPlaceholderText('e.g. alice')).toBeInTheDocument()
+      expect(screen.getByText('Add to Graph')).toBeInTheDocument()
+    })
+
+    it('renders force graph canvas', async () => {
+      await renderTab()
+      expect(screen.getByTestId('force-graph')).toBeInTheDocument()
+    })
+
+    it('renders legend items', async () => {
+      await renderTab()
+      expect(screen.getByText(/Schema \(square\)/)).toBeInTheDocument()
+      expect(screen.getByText(/Word \(circle\)/)).toBeInTheDocument()
+    })
+
+    it('renders Clear & Reload button', async () => {
+      await renderTab()
+      expect(screen.getByText('Clear & Reload')).toBeInTheDocument()
+    })
+  })
+
+  describe('schema nodes', () => {
+    it('shows schema nodes from approved schemas', async () => {
+      await renderTab()
+      await waitFor(() => {
+        expect(screen.getByTestId('graph-node-count').textContent).toBe('2')
+      }, { timeout: 5000 })
+    })
+  })
+
+  describe('manual search', () => {
+    it('calls nativeIndexClient.search with the entered term', async () => {
+      await renderTab()
+      await waitForReady()
+
+      fireEvent.change(screen.getByPlaceholderText('e.g. alice'), { target: { value: 'alice' } })
+      fireEvent.click(screen.getByText('Add to Graph'))
+
+      await waitFor(() => {
+        expect(nativeIndexClient.search).toHaveBeenCalledWith('alice')
+      }, { timeout: 3000 })
+    })
+
+    it('triggers search on Enter key', async () => {
+      await renderTab()
+      await waitForReady()
+
+      const input = screen.getByPlaceholderText('e.g. alice')
+      fireEvent.change(input, { target: { value: 'bob' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(nativeIndexClient.search).toHaveBeenCalledWith('bob')
+      }, { timeout: 3000 })
+    })
+
+    it('adds word node and link from search result', async () => {
+      nativeIndexClient.search.mockResolvedValue({
+        success: true,
+        data: { results: [makeSearchResult('alice', 'UserProfile', 'h1')] }
+      })
+
+      await renderTab()
+      await waitForReady()
+
+      fireEvent.change(screen.getByPlaceholderText('e.g. alice'), { target: { value: 'alice' } })
+      fireEvent.click(screen.getByText('Add to Graph'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('graph-node-count').textContent).toBe('3')
+        expect(screen.getByTestId('graph-link-count').textContent).toBe('1')
+      }, { timeout: 3000 })
+    })
+
+    it('shows error message when search returns no results', async () => {
+      await renderTab()
+      await waitForReady()
+
+      fireEvent.change(screen.getByPlaceholderText('e.g. alice'), { target: { value: 'xyz' } })
+      fireEvent.click(screen.getByText('Add to Graph'))
+
+      await waitFor(() => {
+        expect(screen.getByText(/No index entries for "xyz"/)).toBeInTheDocument()
+      }, { timeout: 3000 })
+    })
+
+    it('shows error message on search API failure', async () => {
+      nativeIndexClient.search.mockResolvedValue({ success: false, error: 'Server error' })
+
+      await renderTab()
+      await waitForReady()
+
+      fireEvent.change(screen.getByPlaceholderText('e.g. alice'), { target: { value: 'fail' } })
+      fireEvent.click(screen.getByText('Add to Graph'))
+
+      await waitFor(() => {
+        expect(screen.getByText('Server error')).toBeInTheDocument()
+      }, { timeout: 3000 })
+    })
+
+    it('disables Add to Graph button when input is empty', async () => {
+      await renderTab()
+      // Wait for loading to finish — button stays disabled due to empty input
+      await waitFor(() => expect(screen.getByPlaceholderText('e.g. alice')).not.toBeDisabled(), { timeout: 5000 })
+      expect(screen.getByText('Add to Graph')).toBeDisabled()
+    })
+  })
+
+  describe('auto-populate on mount', () => {
+    it('queries records for each approved schema on mount', async () => {
+      mutationClient.executeQuery.mockResolvedValue({
+        success: true,
+        data: { results: [{ fields: { name: 'Alice Smith' } }] }
+      })
+
+      await renderTab()
+
+      await waitFor(() => {
+        expect(mutationClient.executeQuery).toHaveBeenCalledWith(
+          expect.objectContaining({ schema_name: 'UserProfile' })
+        )
+      }, { timeout: 5000 })
+    })
+
+    it('searches words extracted from record field values', async () => {
+      mutationClient.executeQuery.mockResolvedValue({
+        success: true,
+        data: { results: [{ fields: { name: 'uniquewordxyz' } }] }
+      })
+
+      await renderTab()
+
+      await waitFor(() => {
+        expect(nativeIndexClient.search).toHaveBeenCalledWith('uniquewordxyz')
+      }, { timeout: 5000 })
+    })
+
+    it('filters out stopwords and short words', async () => {
+      mutationClient.executeQuery.mockResolvedValue({
+        success: true,
+        data: { results: [{ fields: { bio: 'the and for realword' } }] }
+      })
+
+      await renderTab()
+
+      await waitFor(() => {
+        expect(nativeIndexClient.search).toHaveBeenCalledWith('realword')
+      }, { timeout: 5000 })
+
+      expect(nativeIndexClient.search).not.toHaveBeenCalledWith('the')
+      expect(nativeIndexClient.search).not.toHaveBeenCalledWith('and')
+      expect(nativeIndexClient.search).not.toHaveBeenCalledWith('for')
+    })
+
+    it('adds word nodes from auto-populate results', async () => {
+      mutationClient.executeQuery.mockResolvedValue({
+        success: true,
+        data: { results: [{ fields: { name: 'graphword' } }] }
+      })
+      nativeIndexClient.search.mockImplementation(async (term) => {
+        if (term === 'graphword') {
+          return { success: true, data: { results: [makeSearchResult('graphword', 'UserProfile', 'h1')] } }
+        }
+        return { success: true, data: { results: [] } }
+      })
+
+      await renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('graph-node-count').textContent).toBe('3')
+      }, { timeout: 5000 })
+    })
+  })
+
+  describe('graph deduplication', () => {
+    it('does not add duplicate word nodes on repeated searches', async () => {
+      nativeIndexClient.search.mockResolvedValue({
+        success: true,
+        data: { results: [makeSearchResult('alice', 'UserProfile', 'h1')] }
+      })
+
+      await renderTab()
+      await waitForReady()
+
+      fireEvent.change(screen.getByPlaceholderText('e.g. alice'), { target: { value: 'alice' } })
+      fireEvent.click(screen.getByText('Add to Graph'))
+      await waitFor(() => expect(screen.getByTestId('graph-node-count').textContent).toBe('3'), { timeout: 3000 })
+
+      fireEvent.click(screen.getByText('Add to Graph'))
+      await waitFor(() => {
+        expect(screen.getByTestId('graph-node-count').textContent).toBe('3')
+      }, { timeout: 3000 })
+    })
+  })
+
+  describe('node selection', () => {
+    it('shows selected node detail panel when a word node is clicked', async () => {
+      nativeIndexClient.search.mockResolvedValue({
+        success: true,
+        data: { results: [makeSearchResult('alice', 'UserProfile', 'h1')] }
+      })
+
+      await renderTab()
+      await waitForReady()
+
+      fireEvent.change(screen.getByPlaceholderText('e.g. alice'), { target: { value: 'alice' } })
+      fireEvent.click(screen.getByText('Add to Graph'))
+      await waitFor(() => expect(screen.getByTestId('graph-node-count').textContent).toBe('3'), { timeout: 3000 })
+
+      fireEvent.click(screen.getByTestId('node-word:alice'))
+
+      await waitFor(() => {
+        expect(screen.getByText('Selected')).toBeInTheDocument()
+        expect(screen.getByText('word')).toBeInTheDocument()
+      }, { timeout: 3000 })
+    })
+
+    it('deselects node when clicked again', async () => {
+      nativeIndexClient.search.mockResolvedValue({
+        success: true,
+        data: { results: [makeSearchResult('alice', 'UserProfile', 'h1')] }
+      })
+
+      await renderTab()
+      await waitForReady()
+
+      fireEvent.change(screen.getByPlaceholderText('e.g. alice'), { target: { value: 'alice' } })
+      fireEvent.click(screen.getByText('Add to Graph'))
+      await waitFor(() => expect(screen.getByTestId('graph-node-count').textContent).toBe('3'), { timeout: 3000 })
+
+      fireEvent.click(screen.getByTestId('node-word:alice'))
+      await waitFor(() => expect(screen.getByText('Selected')).toBeInTheDocument(), { timeout: 3000 })
+
+      fireEvent.click(screen.getByTestId('node-word:alice'))
+      await waitFor(() => expect(screen.queryByText('Selected')).not.toBeInTheDocument(), { timeout: 3000 })
+    })
+  })
+
+  describe('clear & reload', () => {
+    it('removes word nodes and links, keeps schema nodes', async () => {
+      nativeIndexClient.search.mockResolvedValue({
+        success: true,
+        data: { results: [makeSearchResult('alice', 'UserProfile', 'h1')] }
+      })
+
+      await renderTab()
+      await waitForReady()
+
+      fireEvent.change(screen.getByPlaceholderText('e.g. alice'), { target: { value: 'alice' } })
+      fireEvent.click(screen.getByText('Add to Graph'))
+      await waitFor(() => expect(screen.getByTestId('graph-node-count').textContent).toBe('3'), { timeout: 3000 })
+
+      fireEvent.click(screen.getByText('Clear & Reload'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('graph-node-count').textContent).toBe('2')
+        expect(screen.getByTestId('graph-link-count').textContent).toBe('0')
+      }, { timeout: 3000 })
+    })
+  })
+
+  describe('stats panel', () => {
+    it('shows correct link count when one word connects to two schemas', async () => {
+      nativeIndexClient.search.mockResolvedValue({
+        success: true,
+        data: {
+          results: [
+            makeSearchResult('alice', 'UserProfile', 'h1'),
+            makeSearchResult('alice', 'TweetData',   'h2'),
+          ]
+        }
+      })
+
+      await renderTab()
+      await waitForReady()
+
+      fireEvent.change(screen.getByPlaceholderText('e.g. alice'), { target: { value: 'alice' } })
+      fireEvent.click(screen.getByText('Add to Graph'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('graph-node-count').textContent).toBe('3')
+        expect(screen.getByTestId('graph-link-count').textContent).toBe('2')
+      }, { timeout: 3000 })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a new **🕸️ Word Graph** tab in the advanced section of the FoldDB UI
- Renders a force-directed graph (via `react-force-graph-2d`) where **word nodes** (circles) connect to **schema nodes** (squares) via edges labeled with record keys
- Auto-populates on mount by querying records from each approved schema, extracting text field values, tokenizing into words (with stopword filtering), and searching the native index
- Supports incremental search — type any term to add it and its schema connections to the graph
- Hover a node to highlight connections and show key labels on edges; click to open a detail panel

## Test plan

- [x] 20 unit tests added in `WordGraphTab.test.jsx` covering:
  - Initial render (search input, graph canvas, legend, clear button)
  - Schema node seeding from approved schemas
  - Manual search — API calls, node/link creation, error states, deduplication
  - Auto-populate — record querying, word extraction, stopword filtering, node population
  - Node selection and deselection via click
  - Clear & Reload resets word nodes and links while keeping schema nodes
  - Stats panel link counts
- [x] All 434 existing tests continue to pass (no regressions)
- [x] Production build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Word Graph tab with an interactive visualization displaying word and schema relationships as a graph.
  * Supports word search, auto-population from approved schemas, and node selection with detailed connection information.
  * Includes Clear & Reload button to reset the graph and status display during indexing.

* **Tests**
  * Added comprehensive test coverage for Word Graph functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->