### PR TITLE
Add Claude Code CI for automated PR review handling

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,61 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      github.event_name == 'pull_request_review_comment' ||
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          use_commit_signing: true
+
+  auto-merge:
+    needs: claude
+    if: success()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=""
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER="${{ github.event.issue.number }}"
+          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          elif [ "${{ github.event_name }}" = "pull_request_review" ]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          fi
+
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr merge "$PR_NUMBER" --auto --squash || echo "Auto-merge already enabled or not eligible"
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-code.yml` that triggers Claude Code on PR review comments, `@claude` mentions, and "changes requested" reviews
- After Claude pushes fixes, auto-merge is enabled via `gh pr merge --auto --squash`
- Merge is gated by GitHub branch protection (conversation resolution + status checks)

## Setup required (one-time, manual)
1. Add `ANTHROPIC_API_KEY` secret in repo Settings → Secrets → Actions
2. Enable "Allow auto-merge" in Settings → General → Pull Requests
3. Add branch protection rule on `mainline`:
   - Require status checks (`Rust Tests`, `Frontend Tests`)
   - Require conversation resolution before merging

## Test plan
- [ ] Add `ANTHROPIC_API_KEY` secret to the repo
- [ ] Enable auto-merge and branch protection settings
- [ ] Create a test PR, leave a review comment (e.g. "rename this variable to X")
- [ ] Verify Claude Code workflow triggers and pushes a fix commit
- [ ] Resolve the conversation, verify auto-merge activates when CI passes
- [ ] Test with unresolved comment — verify merge is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)