### PR TITLE
Fix system route test compilation errors

### DIFF
--- a/src/server/routes/system.rs
+++ b/src/server/routes/system.rs
@@ -1095,14 +1095,14 @@ mod tests {
 
     // --- expand_tilde tests ---
 
-    #[test]
-    fn test_expand_tilde_home() {
+    #[tokio::test]
+    async fn test_expand_tilde_home() {
         let home = std::env::var("HOME").unwrap();
         assert_eq!(expand_tilde("~"), PathBuf::from(&home));
     }
 
-    #[test]
-    fn test_expand_tilde_subpath() {
+    #[tokio::test]
+    async fn test_expand_tilde_subpath() {
         let home = std::env::var("HOME").unwrap();
         assert_eq!(
             expand_tilde("~/Documents"),
@@ -1110,13 +1110,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_expand_tilde_noop_absolute() {
+    #[tokio::test]
+    async fn test_expand_tilde_noop_absolute() {
         assert_eq!(expand_tilde("/tmp"), PathBuf::from("/tmp"));
     }
 
-    #[test]
-    fn test_expand_tilde_noop_relative() {
+    #[tokio::test]
+    async fn test_expand_tilde_noop_relative() {
         assert_eq!(expand_tilde("foo/bar"), PathBuf::from("foo/bar"));
     }
 
@@ -1133,6 +1133,7 @@ mod tests {
 
         let bytes = actix_web::body::to_bytes(resp.into_body())
             .await
+            .ok()
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert!(json["completions"].is_array());
@@ -1149,6 +1150,7 @@ mod tests {
 
         let bytes = actix_web::body::to_bytes(resp.into_body())
             .await
+            .ok()
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         let completions = json["completions"].as_array().unwrap();
@@ -1171,6 +1173,7 @@ mod tests {
 
         let bytes = actix_web::body::to_bytes(resp.into_body())
             .await
+            .ok()
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert!(json["completions"].as_array().unwrap().is_empty());
@@ -1189,6 +1192,7 @@ mod tests {
 
         let bytes = actix_web::body::to_bytes(resp.into_body())
             .await
+            .ok()
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         let dirs = json["directories"].as_array().unwrap();
@@ -1210,6 +1214,7 @@ mod tests {
 
         let bytes = actix_web::body::to_bytes(resp.into_body())
             .await
+            .ok()
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         let dirs = json["directories"].as_array().unwrap();
@@ -1229,6 +1234,7 @@ mod tests {
 
         let bytes = actix_web::body::to_bytes(resp.into_body())
             .await
+            .ok()
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert!(json["directories"].as_array().unwrap().is_empty());
@@ -1252,6 +1258,7 @@ mod tests {
 
         let bytes = actix_web::body::to_bytes(resp.into_body())
             .await
+            .ok()
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         let dirs = json["directories"].as_array().unwrap();

--- a/tests/sort_order_test.rs
+++ b/tests/sort_order_test.rs
@@ -96,7 +96,7 @@ async fn test_sort_order_desc_range_schema() {
 
     assert_eq!(results.len(), 4, "Should return all 4 posts");
 
-    let ranges: Vec<String> = results.iter().map(|r| range_of(r)).collect();
+    let ranges: Vec<String> = results.iter().map(range_of).collect();
     assert_eq!(
         ranges,
         vec!["2024-12-25", "2024-06-15", "2024-03-10", "2024-01-01"],
@@ -144,7 +144,7 @@ async fn test_sort_order_asc_range_schema() {
 
     assert_eq!(results.len(), 4, "Should return all 4 posts");
 
-    let ranges: Vec<String> = results.iter().map(|r| range_of(r)).collect();
+    let ranges: Vec<String> = results.iter().map(range_of).collect();
     assert_eq!(
         ranges,
         vec!["2024-01-01", "2024-03-10", "2024-06-15", "2024-12-25"],
@@ -247,7 +247,7 @@ async fn test_sort_order_desc_hashrange_schema() {
 
     assert_eq!(results.len(), 4, "Should return all 4 messages");
 
-    let ranges: Vec<String> = results.iter().map(|r| range_of(r)).collect();
+    let ranges: Vec<String> = results.iter().map(range_of).collect();
     assert_eq!(
         ranges,
         vec![
@@ -308,7 +308,7 @@ async fn test_sort_order_asc_hashrange_schema() {
 
     assert_eq!(results.len(), 3, "Should return all 3 messages");
 
-    let ranges: Vec<String> = results.iter().map(|r| range_of(r)).collect();
+    let ranges: Vec<String> = results.iter().map(range_of).collect();
     assert_eq!(
         ranges,
         vec![
@@ -368,7 +368,7 @@ async fn test_sort_order_via_json_deserialization() {
 
     assert_eq!(results.len(), 3, "Should return all 3 posts");
 
-    let ranges: Vec<String> = results.iter().map(|r| range_of(r)).collect();
+    let ranges: Vec<String> = results.iter().map(range_of).collect();
     assert_eq!(
         ranges,
         vec!["2024-12-25", "2024-06-15", "2024-01-01"],


### PR DESCRIPTION
## Summary
- Fix `#[test]` being shadowed by `use actix_web::test` — the import causes `#[test]` to resolve to `#[actix_web::test]` which requires async. Changed sync tests to `#[tokio::test] async fn`.
- Fix `to_bytes(resp.into_body()).await.unwrap()` where the body error type from `impl Responder` doesn't implement `Debug`. Changed to `.ok().unwrap()`.

These are pre-existing issues that broke `Rust Tests` CI on mainline.

## Test plan
- [x] `cargo clippy --workspace` passes clean
- [x] `cargo test --workspace` — all 560+ tests pass, 0 failures
- [ ] CI `Rust Tests` and `Frontend Tests` pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with async support for system route tests.
  * Enhanced test error handling patterns.
  * Refactored test code syntax for improved readability.

**Note:** These are internal testing improvements with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->