### PR TITLE
Fix Claude Code OIDC permission for commit signing

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -19,6 +19,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds missing `id-token: write` permission to the Claude Code workflow
- Required for `use_commit_signing: true` which uses OIDC tokens
- Was lost during the squash merge of PR #345

## Test plan
- [ ] Claude Code workflow succeeds on PR review comments (no OIDC error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)