### PR TITLE
Fix Claude Code workflow: remove commit signing requiring OIDC

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -19,7 +19,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,7 +30,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
-          use_commit_signing: true
 
   auto-merge:
     needs: claude


### PR DESCRIPTION
## Summary
- Removes `use_commit_signing: true` and `id-token: write` from Claude Code workflow
- OIDC tokens are not available for `pull_request_review_comment` events, causing every Claude Code run to fail
- Commit signing is nice-to-have; the core functionality (addressing review comments + auto-merge) works without it

## Test plan
- [ ] Leave a review comment on PR #348 and verify Claude Code succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)