### PR TITLE
Fix Claude Code auth: use github.token to bypass OIDC

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -29,7 +29,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
           track_progress: true
 
   auto-merge:


### PR DESCRIPTION
## Summary
- Changes `secrets.GITHUB_TOKEN` to `github.token` for the claude-code-action's `github_token` input
- `secrets.GITHUB_TOKEN` can resolve to empty, causing the action to fall through to OIDC
- `github.token` is always available and correctly sets `OVERRIDE_GITHUB_TOKEN` in the action

🤖 Generated with [Claude Code](https://claude.com/claude-code)