### PR TITLE
Fix Claude Code: add id-token permission for OIDC auth

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -19,6 +19,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -29,7 +30,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ github.token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
 
   auto-merge:


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission so the OIDC flow can obtain a GitHub App token
- Also provides `secrets.GITHUB_TOKEN` as explicit fallback via `github_token` input

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to enhance security and authentication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->