### PR TITLE
Fix Claude Code: pass OVERRIDE_GITHUB_TOKEN via env

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -28,9 +28,10 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
+        env:
+          OVERRIDE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
 
   auto-merge:


### PR DESCRIPTION
## Summary
- Sets `OVERRIDE_GITHUB_TOKEN` as step-level env var instead of via `github_token` input
- OIDC is unavailable for `pull_request_review_comment` events (`ACTIONS_ID_TOKEN_REQUEST_URL` not set)
- The `with: github_token` input wasn't propagating to the composite action's env

🤖 Generated with [Claude Code](https://claude.com/claude-code)