### PR TITLE
Fix Claude Code: add actions:read for OIDC, match official example

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -20,6 +20,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,9 +28,8 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code
+        id: claude
         uses: anthropics/claude-code-action@v1
-        env:
-          OVERRIDE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true


### PR DESCRIPTION
## Summary
- Adds `actions: read` permission (matches official `examples/claude.yml`)
- Keeps `id-token: write` for OIDC token requests
- Removes custom OVERRIDE_GITHUB_TOKEN workaround — let the action handle auth natively

🤖 Generated with [Claude Code](https://claude.com/claude-code)