### PR TITLE
Remove unused DynamoDB partition key test helper

### DIFF
--- a/src/storage/dynamodb_backend.rs
+++ b/src/storage/dynamodb_backend.rs
@@ -39,12 +39,6 @@ impl DynamoDbKvStore {
         super::dynamodb_utils::require_user_context()
     }
 
-    /// Get the partition key to use for this store
-    #[cfg(test)]
-    pub fn get_partition_key(&self) -> String {
-        self.get_partition_key_impl()
-    }
-
     fn get_partition_key_impl(&self) -> StorageResult<String> {
         self.get_current_user_id()
     }


### PR DESCRIPTION
### Motivation
- Remove an unused `#[cfg(test)]` helper that duplicated `get_partition_key_impl` and caused a stale type/usage path in test builds to simplify the code in `src/storage/dynamodb_backend.rs`.

### Description
- Deleted the `pub fn get_partition_key(&self) -> String` test helper from `src/storage/dynamodb_backend.rs` so tests and production code use the existing `get_partition_key_impl` (`StorageResult<String>`) consistently.

### Testing
- Ran `cargo clippy --lib -- -W dead_code` and `cargo test --lib test_typed_store_operations` which passed, while `cargo clippy --all-targets --all-features -- -W dead_code` failed due to a pre-existing unrelated test compile error in `tests/dynamodb_mutation_perf.rs`, and `cargo fmt --check` reported pre-existing formatting diffs unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6613aa50883279509486a72ca61ef)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-visible changes. Internal code maintenance was performed to optimize the storage backend architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->