### PR TITLE
Add 28 regression tests for ingestion pipeline

### DIFF
--- a/src/ingestion/ai_helpers.rs
+++ b/src/ingestion/ai_helpers.rs
@@ -608,4 +608,75 @@ That should work."###;
         let value = serde_json::json!({"x": 1});
         assert!(pretty_json(&value).contains("\"x\": 1"));
     }
+
+    // ---- extract_json_from_response edge cases ----
+
+    #[test]
+    fn test_extract_json_array_in_markdown_fence() {
+        let response = r#"Here are the results:
+```json
+[{"path": "a.txt", "should_ingest": true}]
+```
+Done."#;
+        let result = extract_json_from_response(response).unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed.is_array());
+        assert_eq!(parsed.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_extract_nested_json_with_trailing_prose() {
+        let response = r#"{"outer": {"inner": {"value": 42}}} And here is some extra explanation."#;
+        let result = extract_json_from_response(response).unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["outer"]["inner"]["value"], 42);
+    }
+
+    #[test]
+    fn test_extract_first_json_object_from_multiple() {
+        let response = r#"{"first": 1} {"second": 2}"#;
+        let result = extract_json_from_response(response).unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["first"], 1);
+    }
+
+    #[test]
+    fn test_extract_only_prose_returns_error() {
+        let response = "This response contains no JSON at all, just plain text.";
+        let result = extract_json_from_response(response);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_empty_string_returns_error() {
+        let result = extract_json_from_response("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_json_with_unicode() {
+        let response = r#"{"name": "日本語テスト", "emoji": "🎉"}"#;
+        let result = extract_json_from_response(response).unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["name"], "日本語テスト");
+        assert_eq!(parsed["emoji"], "🎉");
+    }
+
+    #[test]
+    fn test_extract_unclosed_markdown_fence() {
+        let response = "```json\n{\"key\": \"value\"}\nsome trailing text without closing fence";
+        let result = extract_json_from_response(response).unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["key"], "value");
+    }
+
+    #[test]
+    fn test_extract_brace_matching_fallback() {
+        // JSON with invalid trailing content that stream parser may choke on,
+        // but brace-matching should rescue
+        let response = "prefix {\"a\": 1, \"b\": [2, 3]} suffix with } brace";
+        let result = extract_json_from_response(response).unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["a"], 1);
+    }
 }

--- a/src/ingestion/file_conversion.rs
+++ b/src/ingestion/file_conversion.rs
@@ -165,3 +165,122 @@ pub fn read_file_with_hash(file_path: &Path) -> IngestionResult<(Value, String, 
 
     Ok((value, hash_hex, raw_bytes))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+    use std::io::Write;
+
+    #[test]
+    fn test_read_file_with_hash_json() {
+        let mut tmp = tempfile::Builder::new()
+            .suffix(".json")
+            .tempfile()
+            .unwrap();
+        let json_content = r#"{"name": "Alice", "age": 30}"#;
+        write!(tmp, "{}", json_content).unwrap();
+
+        let (value, hash, raw) = read_file_with_hash(tmp.path()).unwrap();
+        assert_eq!(value["name"], "Alice");
+        assert_eq!(value["age"], 30);
+
+        let expected_hash = format!("{:x}", Sha256::digest(json_content.as_bytes()));
+        assert_eq!(hash, expected_hash);
+        assert_eq!(raw, json_content.as_bytes());
+    }
+
+    #[test]
+    fn test_read_file_with_hash_twitter_js() {
+        let mut tmp = tempfile::Builder::new()
+            .suffix(".js")
+            .tempfile()
+            .unwrap();
+        let content = r#"window.YTD.tweet.part0 = [{"id": "123", "text": "hello"}]"#;
+        write!(tmp, "{}", content).unwrap();
+
+        let (value, hash, _raw) = read_file_with_hash(tmp.path()).unwrap();
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["id"], "123");
+
+        let expected_hash = format!("{:x}", Sha256::digest(content.as_bytes()));
+        assert_eq!(hash, expected_hash);
+    }
+
+    #[test]
+    fn test_read_file_with_hash_csv() {
+        let mut tmp = tempfile::Builder::new()
+            .suffix(".csv")
+            .tempfile()
+            .unwrap();
+        let content = "name,age\nAlice,30\nBob,25\n";
+        write!(tmp, "{}", content).unwrap();
+
+        let (value, hash, _raw) = read_file_with_hash(tmp.path()).unwrap();
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["name"], "Alice");
+
+        let expected_hash = format!("{:x}", Sha256::digest(content.as_bytes()));
+        assert_eq!(hash, expected_hash);
+    }
+
+    #[test]
+    fn test_read_file_with_hash_txt() {
+        let mut tmp = tempfile::Builder::new()
+            .suffix(".txt")
+            .tempfile()
+            .unwrap();
+        let content = "Hello, this is a text file.";
+        write!(tmp, "{}", content).unwrap();
+
+        let (value, hash, _raw) = read_file_with_hash(tmp.path()).unwrap();
+        assert_eq!(value["content"], content);
+        assert_eq!(value["file_type"], "txt");
+        assert!(value["source_file"].as_str().unwrap().ends_with(".txt"));
+
+        let expected_hash = format!("{:x}", Sha256::digest(content.as_bytes()));
+        assert_eq!(hash, expected_hash);
+    }
+
+    #[test]
+    fn test_read_file_with_hash_md() {
+        let mut tmp = tempfile::Builder::new()
+            .suffix(".md")
+            .tempfile()
+            .unwrap();
+        let content = "# Heading\n\nSome markdown content.";
+        write!(tmp, "{}", content).unwrap();
+
+        let (value, hash, _raw) = read_file_with_hash(tmp.path()).unwrap();
+        assert_eq!(value["content"], content);
+        assert_eq!(value["file_type"], "md");
+        assert!(value["source_file"].as_str().unwrap().ends_with(".md"));
+
+        let expected_hash = format!("{:x}", Sha256::digest(content.as_bytes()));
+        assert_eq!(hash, expected_hash);
+    }
+
+    #[test]
+    fn test_read_file_with_hash_unsupported_extension() {
+        let mut tmp = tempfile::Builder::new()
+            .suffix(".xyz")
+            .tempfile()
+            .unwrap();
+        write!(tmp, "some content").unwrap();
+
+        let result = read_file_with_hash(tmp.path());
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("Unsupported file type"));
+    }
+
+    #[test]
+    fn test_read_file_with_hash_nonexistent_file() {
+        let result = read_file_with_hash(Path::new("/tmp/nonexistent_file_abc123.json"));
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("Failed to read file"));
+    }
+}

--- a/src/ingestion/smart_folder_classifier.rs
+++ b/src/ingestion/smart_folder_classifier.rs
@@ -166,3 +166,159 @@ pub fn apply_heuristic_filtering(file_tree: &[String]) -> Vec<FileRecommendation
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- parse_llm_file_recommendations tests ----
+
+    #[test]
+    fn test_parse_llm_valid_json_with_matching_paths() {
+        let response = r#"```json
+[
+  {"path": "docs/notes.txt", "should_ingest": true, "category": "personal_data", "reason": "Personal notes"},
+  {"path": "photos/pic.jpg", "should_ingest": true, "category": "media", "reason": "Photo"}
+]
+```"#;
+        let file_tree = vec![
+            "docs/notes.txt".to_string(),
+            "photos/pic.jpg".to_string(),
+        ];
+        let result = parse_llm_file_recommendations(response, &file_tree).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].path, "docs/notes.txt");
+        assert_eq!(result[1].path, "photos/pic.jpg");
+    }
+
+    #[test]
+    fn test_parse_llm_hallucinated_paths_filtered() {
+        let response = r#"[
+  {"path": "docs/notes.txt", "should_ingest": true, "category": "personal_data", "reason": "ok"},
+  {"path": "fake/hallucinated.txt", "should_ingest": true, "category": "unknown", "reason": "nope"}
+]"#;
+        let file_tree = vec!["docs/notes.txt".to_string()];
+        let result = parse_llm_file_recommendations(response, &file_tree).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, "docs/notes.txt");
+    }
+
+    #[test]
+    fn test_parse_llm_empty_response_returns_error() {
+        let file_tree = vec!["a.txt".to_string()];
+        let result = parse_llm_file_recommendations("", &file_tree);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_llm_mixed_valid_invalid_paths() {
+        let response = r#"[
+  {"path": "a.txt", "should_ingest": true, "category": "personal_data", "reason": "ok"},
+  {"path": "b.txt", "should_ingest": false, "category": "unknown", "reason": "nope"},
+  {"path": "c.txt", "should_ingest": true, "category": "work", "reason": "work file"}
+]"#;
+        let file_tree = vec!["a.txt".to_string(), "c.txt".to_string()];
+        let result = parse_llm_file_recommendations(response, &file_tree).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].path, "a.txt");
+        assert_eq!(result[1].path, "c.txt");
+    }
+
+    #[test]
+    fn test_parse_llm_empty_file_tree_returns_empty() {
+        let response = r#"[
+  {"path": "a.txt", "should_ingest": true, "category": "personal_data", "reason": "ok"}
+]"#;
+        let file_tree: Vec<String> = vec![];
+        let result = parse_llm_file_recommendations(response, &file_tree).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_llm_malformed_json_returns_error() {
+        let response = r#"This is not JSON at all, just some text."#;
+        let file_tree = vec!["a.txt".to_string()];
+        let result = parse_llm_file_recommendations(response, &file_tree);
+        assert!(result.is_err());
+    }
+
+    // ---- create_smart_folder_prompt tests ----
+
+    #[test]
+    fn test_prompt_contains_tree_and_file_paths() {
+        let tree = "docs/\n  notes.txt\n  report.pdf";
+        let files = vec![
+            "docs/notes.txt".to_string(),
+            "docs/report.pdf".to_string(),
+        ];
+        let prompt = create_smart_folder_prompt(tree, &files);
+        assert!(prompt.contains(tree));
+        assert!(prompt.contains("docs/notes.txt"));
+        assert!(prompt.contains("docs/report.pdf"));
+    }
+
+    #[test]
+    fn test_prompt_contains_categories_and_instructions() {
+        let prompt = create_smart_folder_prompt("tree", &["f.txt".to_string()]);
+        assert!(prompt.contains("personal_data"));
+        assert!(prompt.contains("media"));
+        assert!(prompt.contains("website_scaffolding"));
+        assert!(prompt.contains("should_ingest"));
+        assert!(prompt.contains("JSON array"));
+    }
+
+    // ---- apply_heuristic_filtering tests ----
+
+    #[test]
+    fn test_heuristic_mixed_file_types() {
+        let files = vec![
+            "report.pdf".to_string(),
+            "photo.jpg".to_string(),
+            "script.py".to_string(),
+            "data.csv".to_string(),
+            "export/backup.json".to_string(),
+        ];
+        let recs = apply_heuristic_filtering(&files);
+        assert_eq!(recs.len(), 5);
+
+        // PDF → personal_data, should_ingest
+        assert!(recs[0].should_ingest);
+        assert_eq!(recs[0].category, "personal_data");
+
+        // JPG without export context → media, should_ingest = false
+        assert!(!recs[1].should_ingest);
+        assert_eq!(recs[1].category, "media");
+
+        // .py → unknown, should_ingest = false
+        assert!(!recs[2].should_ingest);
+
+        // CSV → personal_data, should_ingest
+        assert!(recs[3].should_ingest);
+        assert_eq!(recs[3].category, "personal_data");
+
+        // backup path → personal_data, should_ingest
+        assert!(recs[4].should_ingest);
+    }
+
+    #[test]
+    fn test_heuristic_case_insensitive_extensions() {
+        let files = vec![
+            "REPORT.PDF".to_string(),
+            "Data.Csv".to_string(),
+            "photo.JPG".to_string(),
+        ];
+        let recs = apply_heuristic_filtering(&files);
+
+        // .PDF → personal_data (extension lowercased internally)
+        assert!(recs[0].should_ingest);
+        assert_eq!(recs[0].category, "personal_data");
+
+        // .Csv → personal_data
+        assert!(recs[1].should_ingest);
+        assert_eq!(recs[1].category, "personal_data");
+
+        // .JPG without export → media, not ingested
+        assert!(!recs[2].should_ingest);
+        assert_eq!(recs[2].category, "media");
+    }
+}

--- a/src/ingestion/smart_folder_scanner.rs
+++ b/src/ingestion/smart_folder_scanner.rs
@@ -262,3 +262,44 @@ pub fn is_never_personal_data(path: &str) -> bool {
         .to_lowercase();
     BINARY_SKIP_EXTS.contains(&ext.as_str())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+    use std::io::Write;
+
+    #[test]
+    fn test_compute_file_hash_known_content() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = b"hello world";
+        tmp.write_all(content).unwrap();
+
+        let hash = compute_file_hash(tmp.path()).unwrap();
+        let expected = format!("{:x}", Sha256::digest(content));
+        assert_eq!(hash, expected);
+    }
+
+    #[test]
+    fn test_compute_file_hash_same_content_identical() {
+        let content = b"identical content for hashing";
+
+        let mut tmp1 = tempfile::NamedTempFile::new().unwrap();
+        tmp1.write_all(content).unwrap();
+
+        let mut tmp2 = tempfile::NamedTempFile::new().unwrap();
+        tmp2.write_all(content).unwrap();
+
+        let hash1 = compute_file_hash(tmp1.path()).unwrap();
+        let hash2 = compute_file_hash(tmp2.path()).unwrap();
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_file_hash_nonexistent_file() {
+        let result = compute_file_hash(Path::new("/tmp/nonexistent_hash_test_abc.txt"));
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("Failed to read file for hashing"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add 28 new unit tests covering previously untested functions in the ingestion & smart folder pipeline
- **`smart_folder_classifier.rs`** (10 tests): `parse_llm_file_recommendations`, `create_smart_folder_prompt`, `apply_heuristic_filtering`
- **`file_conversion.rs`** (7 tests): `read_file_with_hash` for JSON, Twitter JS, CSV, TXT, MD, unsupported ext, nonexistent file
- **`ai_helpers.rs`** (8 tests): `extract_json_from_response` edge cases — markdown fence arrays, nested JSON, multiple objects, prose-only, empty, unicode, unclosed fence, brace-matching fallback
- **`smart_folder_scanner.rs`** (3 tests): `compute_file_hash` — known content, identical hashes, nonexistent file

## Test plan
- [x] All 28 new tests pass (`cargo test --lib`)
- [x] Full test suite passes (430/430)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for file ingestion and conversion operations, including edge cases for JSON extraction, file hashing, and smart folder classification. All changes are internal testing improvements with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->