### PR TITLE
Simplify log handlers: remove fallbacks, inline processors

### DIFF
--- a/LOG_HANDLERS.md
+++ b/LOG_HANDLERS.md
@@ -16,7 +16,7 @@
 
 ## How it fits in the architecture
 
-```
+```text
 HTTP route / Lambda handler
         │
         ▼

--- a/LOG_HANDLERS.md
+++ b/LOG_HANDLERS.md
@@ -1,0 +1,53 @@
+# Log Handlers
+
+## What it does
+
+`src/handlers/logs.rs` is the **framework-agnostic handler layer for log management**. It exposes five operations that are shared between the HTTP server and the Lambda runtime — neither caller needs to know where the data comes from.
+
+## Operations
+
+| Function | What it does |
+|---|---|
+| `list_logs(since, user_hash, node)` | Returns up to 1,000 log entries, optionally filtered by timestamp |
+| `get_log_config(user_hash, node)` | Returns the current `LogConfig` (levels, feature map) |
+| `get_log_features(user_hash, node)` | Returns the per-feature log levels plus the list of valid level strings |
+| `update_log_feature_level(feature, level, user_hash, node)` | Sets one feature's log level at runtime (e.g. `"ingestion"` → `"DEBUG"`) |
+| `reload_log_config(config_path, user_hash, node)` | Reloads `LogConfig` from a file on disk |
+
+## How it fits in the architecture
+
+```
+HTTP route / Lambda handler
+        │
+        ▼
+  handlers/logs.rs          ← this file
+        │  delegates to
+        ▼
+  OperationProcessor         (fold_node layer)
+        │  calls
+        ▼
+  LoggingSystem              (global singleton backed by OnceLock)
+```
+
+Every handler follows the same three-step pattern:
+1. Create an `OperationProcessor` from the `FoldNode`
+2. Call the appropriate `LoggingSystem` method through the processor
+3. Wrap the result in `ApiResponse::success_with_user` or propagate a `HandlerError::Internal`
+
+## Response types
+
+- **`LogListResponse`** — `{ logs: Value, count: usize, timestamp: u64 }`
+- **`LogConfigResponse`** — `{ config: Value }` (the full `LogConfig` serialized)
+- **`LogFeaturesResponse`** — `{ features: Value, available_levels: Vec<String> }`
+- Simple mutations use the shared **`SuccessResponse`** — `{ success: bool, message: Option<String> }`
+
+## What the original code had that the rewrite removes
+
+| Original pattern | Why removed |
+|---|---|
+| `if let Some(x) = ... { ok } else { hardcoded fallback }` | Fallbacks hide the fact that `LoggingSystem` isn't initialized — violates "no fallbacks" rule |
+| `match result { Ok(_) => success, Err(e) => Err(...) }` | Replaced with `map_err(...)?` + explicit `Ok(...)` — same semantics, less nesting |
+| Hardcoded feature-name list in the `None` branch of `get_log_features` | Removed with the fallback; the list of valid features comes from the live config |
+| `vec!["TRACE"..., "ERROR".to_string()]` repeated inline | Replaced with a `const` array |
+| `let processor = OperationProcessor::new(node.clone())` intermediate variable | Inlined where the processor is used only once |
+| Section banner comments (`// ====...====`) | Removed — the function names and types are self-documenting |

--- a/src/handlers/logs.rs
+++ b/src/handlers/logs.rs
@@ -37,8 +37,8 @@ pub async fn list_logs(
         .list_logs(since, Some(1000))
         .await;
     let count = logs.len();
-    let logs_json =
-        serde_json::to_value(&logs).unwrap_or_else(|_| serde_json::Value::Array(vec![]));
+    let logs_json = serde_json::to_value(&logs)
+        .map_err(|e| HandlerError::Internal(format!("Failed to serialize logs: {}", e)))?;
     Ok(ApiResponse::success_with_user(
         LogListResponse {
             logs: logs_json,
@@ -94,7 +94,7 @@ pub async fn update_log_feature_level(
     OperationProcessor::new(node.clone())
         .update_log_feature_level(feature, level)
         .await
-        .map_err(|e| HandlerError::Internal(format!("Failed to update log level: {}", e)))?;
+        .map_err(HandlerError::from)?;
     Ok(ApiResponse::success_with_user(
         SuccessResponse {
             success: true,
@@ -112,7 +112,7 @@ pub async fn reload_log_config(
     OperationProcessor::new(node.clone())
         .reload_log_config(config_path)
         .await
-        .map_err(|e| HandlerError::Internal(format!("Failed to reload configuration: {}", e)))?;
+        .map_err(HandlerError::from)?;
     Ok(ApiResponse::success_with_user(
         SuccessResponse {
             success: true,

--- a/src/handlers/logs.rs
+++ b/src/handlers/logs.rs
@@ -1,18 +1,13 @@
 //! Shared Log Handlers
 //!
 //! Framework-agnostic handlers for logging operations.
-//! These can be called by both HTTP server routes and Lambda handlers.
+//! Shared between HTTP server routes and Lambda handlers.
 
 use crate::fold_node::node::FoldNode;
 use crate::fold_node::OperationProcessor;
 use crate::handlers::response::{ApiResponse, HandlerError, HandlerResult, SuccessResponse};
 use serde::{Deserialize, Serialize};
 
-// ============================================================================
-// Response Types
-// ============================================================================
-
-/// Response for log list
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogListResponse {
     pub logs: serde_json::Value,
@@ -20,38 +15,30 @@ pub struct LogListResponse {
     pub timestamp: u64,
 }
 
-/// Response for log config
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogConfigResponse {
     pub config: serde_json::Value,
 }
 
-/// Response for log features
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogFeaturesResponse {
     pub features: serde_json::Value,
     pub available_levels: Vec<String>,
 }
 
-// ============================================================================
-// Node-based Handlers (for HTTP server using OperationProcessor)
-// ============================================================================
+const LOG_LEVELS: &[&str] = &["TRACE", "DEBUG", "INFO", "WARN", "ERROR"];
 
-/// List logs using OperationProcessor
 pub async fn list_logs(
     since: Option<i64>,
     user_hash: &str,
     node: &FoldNode,
 ) -> HandlerResult<LogListResponse> {
-    let processor = OperationProcessor::new(node.clone());
-
-    let logs = processor.list_logs(since, Some(1000)).await;
+    let logs = OperationProcessor::new(node.clone())
+        .list_logs(since, Some(1000))
+        .await;
     let count = logs.len();
-
-    // Convert to JSON Value
     let logs_json =
         serde_json::to_value(&logs).unwrap_or_else(|_| serde_json::Value::Array(vec![]));
-
     Ok(ApiResponse::success_with_user(
         LogListResponse {
             logs: logs_json,
@@ -65,123 +52,72 @@ pub async fn list_logs(
     ))
 }
 
-/// Get log configuration
 pub async fn get_log_config(
     user_hash: &str,
     node: &FoldNode,
 ) -> HandlerResult<LogConfigResponse> {
-    let processor = OperationProcessor::new(node.clone());
-
-    if let Some(config) = processor.get_log_config().await {
-        Ok(ApiResponse::success_with_user(
-            LogConfigResponse {
-                config: serde_json::to_value(config).unwrap_or(serde_json::Value::Null),
-            },
-            user_hash,
-        ))
-    } else {
-        let current_level = log::max_level().to_string();
-        Ok(ApiResponse::success_with_user(
-            LogConfigResponse {
-                config: serde_json::json!({
-                    "message": "Basic logging configuration",
-                    "current_level": current_level
-                }),
-            },
-            user_hash,
-        ))
-    }
+    let config = OperationProcessor::new(node.clone())
+        .get_log_config()
+        .await
+        .ok_or_else(|| HandlerError::Internal("Log configuration not available".to_string()))?;
+    Ok(ApiResponse::success_with_user(
+        LogConfigResponse {
+            config: serde_json::to_value(config).unwrap_or(serde_json::Value::Null),
+        },
+        user_hash,
+    ))
 }
 
-/// Get available log features
 pub async fn get_log_features(
     user_hash: &str,
     node: &FoldNode,
 ) -> HandlerResult<LogFeaturesResponse> {
-    let processor = OperationProcessor::new(node.clone());
-    let available_levels = vec![
-        "TRACE".to_string(),
-        "DEBUG".to_string(),
-        "INFO".to_string(),
-        "WARN".to_string(),
-        "ERROR".to_string(),
-    ];
-
-    if let Some(features) = processor.get_log_features().await {
-        Ok(ApiResponse::success_with_user(
-            LogFeaturesResponse {
-                features: serde_json::to_value(features).unwrap_or(serde_json::Value::Null),
-                available_levels,
-            },
-            user_hash,
-        ))
-    } else {
-        let current_level = log::max_level().to_string();
-        Ok(ApiResponse::success_with_user(
-            LogFeaturesResponse {
-                features: serde_json::json!({
-                    "transform": current_level,
-                    "network": current_level,
-                    "database": current_level,
-                    "schema": current_level,
-                    "query": current_level,
-                    "mutation": current_level,
-                    "permissions": current_level,
-                    "http_server": current_level,
-                    "tcp_server": current_level,
-                    "ingestion": current_level
-                }),
-                available_levels,
-            },
-            user_hash,
-        ))
-    }
+    let features = OperationProcessor::new(node.clone())
+        .get_log_features()
+        .await
+        .ok_or_else(|| HandlerError::Internal("Log features not available".to_string()))?;
+    Ok(ApiResponse::success_with_user(
+        LogFeaturesResponse {
+            features: serde_json::to_value(features).unwrap_or(serde_json::Value::Null),
+            available_levels: LOG_LEVELS.iter().map(|s| s.to_string()).collect(),
+        },
+        user_hash,
+    ))
 }
 
-/// Update log feature level
 pub async fn update_log_feature_level(
     feature: &str,
     level: &str,
     user_hash: &str,
     node: &FoldNode,
 ) -> HandlerResult<SuccessResponse> {
-    let processor = OperationProcessor::new(node.clone());
-
-    match processor.update_log_feature_level(feature, level).await {
-        Ok(_) => Ok(ApiResponse::success_with_user(
-            SuccessResponse {
-                success: true,
-                message: Some(format!("Updated {} log level to {}", feature, level)),
-            },
-            user_hash,
-        )),
-        Err(e) => Err(HandlerError::Internal(format!(
-            "Failed to update log level: {}",
-            e
-        ))),
-    }
+    OperationProcessor::new(node.clone())
+        .update_log_feature_level(feature, level)
+        .await
+        .map_err(|e| HandlerError::Internal(format!("Failed to update log level: {}", e)))?;
+    Ok(ApiResponse::success_with_user(
+        SuccessResponse {
+            success: true,
+            message: Some(format!("Updated {} log level to {}", feature, level)),
+        },
+        user_hash,
+    ))
 }
 
-/// Reload log configuration
 pub async fn reload_log_config(
     config_path: &str,
     user_hash: &str,
     node: &FoldNode,
 ) -> HandlerResult<SuccessResponse> {
-    let processor = OperationProcessor::new(node.clone());
-
-    match processor.reload_log_config(config_path).await {
-        Ok(_) => Ok(ApiResponse::success_with_user(
-            SuccessResponse {
-                success: true,
-                message: Some("Configuration reloaded successfully".to_string()),
-            },
-            user_hash,
-        )),
-        Err(e) => Err(HandlerError::Internal(format!(
-            "Failed to reload configuration: {}",
-            e
-        ))),
-    }
+    OperationProcessor::new(node.clone())
+        .reload_log_config(config_path)
+        .await
+        .map_err(|e| HandlerError::Internal(format!("Failed to reload configuration: {}", e)))?;
+    Ok(ApiResponse::success_with_user(
+        SuccessResponse {
+            success: true,
+            message: Some("Configuration reloaded successfully".to_string()),
+        },
+        user_hash,
+    ))
 }
-


### PR DESCRIPTION
## Summary

- Removes fake `None` fallbacks from `get_log_config` and `get_log_features` — `None` means `LoggingSystem` is uninitialized, which is a programming error that should return a 500, not synthetic data
- Replaces `match { Ok(_) => success_response, Err(e) => Err(...) }` with `map_err(...)? + Ok(...)` — same semantics, less nesting
- Inlines single-use `OperationProcessor` variables
- Extracts `LOG_LEVELS` const instead of repeating the vec
- Removes section banner comments
- Adds `LOG_HANDLERS.md` documenting the system

**187 → 123 lines (34% reduction)**

## Test plan

- [ ] `cargo build --lib` passes
- [ ] CI Rust Tests pass
- [ ] CI Frontend Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive logging handler documentation describing available operations and system architecture.

* **Refactor**
  * Streamlined internal log handler implementation while preserving existing API behavior and response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->