### PR TITLE
Refactor Tier 2: extract helpers, remove wrappers, simplify filter arms

### DIFF
--- a/src/ingestion/file_conversion.rs
+++ b/src/ingestion/file_conversion.rs
@@ -72,14 +72,6 @@ pub fn twitter_js_to_json(content: &str) -> IngestionResult<String> {
     }
 }
 
-fn is_code_ext(ext: &str) -> bool {
-    CODE_EXTS.contains(&ext)
-}
-
-fn is_config_ext(ext: &str) -> bool {
-    CONFIG_EXTS.contains(&ext)
-}
-
 /// Extract structural metadata from a source code file using regex.
 ///
 /// Returns a `Value` with function/method declarations, class/struct
@@ -161,8 +153,8 @@ fn parse_content_by_ext(content: &str, file_name: &str, ext: &str) -> IngestionR
                 .map_err(|e| IngestionError::InvalidInput(format!("Failed to parse JSON: {}", e)))
         }
         "txt" | "md" => Ok(wrap_text_content(content, file_name, ext)),
-        e if is_code_ext(e) => Ok(extract_code_metadata(content, file_name, e)),
-        e if is_config_ext(e) => Ok(wrap_text_content(content, file_name, e)),
+        e if CODE_EXTS.contains(&e) => Ok(extract_code_metadata(content, file_name, e)),
+        e if CONFIG_EXTS.contains(&e) => Ok(wrap_text_content(content, file_name, e)),
         _ => Err(IngestionError::InvalidInput(format!(
             "Unsupported file type: {}",
             ext

--- a/src/ingestion/ingestion_service/decomposition.rs
+++ b/src/ingestion/ingestion_service/decomposition.rs
@@ -98,15 +98,7 @@ impl IngestionService {
         // Children are resolved depth-first above, so their schema names are already in the cache.
         // Only do this when we actually resolved children (not at depth limit).
         if !rep_decomp.children.is_empty() && depth < MAX_DECOMPOSITION_DEPTH {
-            let schema_manager = {
-                let db_guard = node
-                    .get_fold_db()
-                    .await
-                    .map_err(super::schema_err)?;
-                let manager = db_guard.schema_manager.clone();
-                drop(db_guard);
-                manager
-            };
+            let schema_manager = super::get_schema_manager(node).await?;
 
             match schema_manager.get_schema_metadata(&schema_name) {
                 Ok(Some(mut schema)) => {
@@ -323,15 +315,7 @@ impl IngestionService {
                 .collect();
 
             // Get schema manager for key extraction
-            let schema_manager = {
-                let db_guard = node
-                    .get_fold_db()
-                    .await
-                    .map_err(super::schema_err)?;
-                let manager = db_guard.schema_manager.clone();
-                drop(db_guard);
-                manager
-            };
+            let schema_manager = super::get_schema_manager(node).await?;
 
             let keys_and_values =
                 extract_key_values_from_data(&fields_and_values, &schema_name, &schema_manager)

--- a/src/ingestion/ingestion_service/mod.rs
+++ b/src/ingestion/ingestion_service/mod.rs
@@ -22,6 +22,7 @@ use crate::ingestion::{
 use crate::log_feature;
 use crate::logging::features::LogFeature;
 use crate::schema::types::{KeyValue, Mutation};
+use crate::schema::SchemaCore;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -31,6 +32,14 @@ use decomposition::CachedSchema;
 /// Shorthand to wrap any `Display` error as a `SchemaCreationError`.
 pub(super) fn schema_err(e: impl std::fmt::Display) -> IngestionError {
     IngestionError::SchemaCreationError(e.to_string())
+}
+
+/// Acquire a clone of the SchemaCore from the node without holding the DB lock.
+async fn get_schema_manager(node: &FoldNode) -> IngestionResult<Arc<SchemaCore>> {
+    let db_guard = node.get_fold_db().await.map_err(schema_err)?;
+    let manager = db_guard.schema_manager.clone();
+    drop(db_guard);
+    Ok(manager)
 }
 
 /// AI-powered ingestion service that works with FoldNode
@@ -335,15 +344,7 @@ impl IngestionService {
         progress_id: &str,
     ) -> IngestionResult<(Vec<Mutation>, Vec<SchemaWriteRecord>)> {
         // Get schema manager for key extraction
-        let schema_manager = {
-            let db_guard = node
-                .get_fold_db()
-                .await
-                .map_err(schema_err)?;
-            let manager = db_guard.schema_manager.clone();
-            drop(db_guard);
-            manager
-        };
+        let schema_manager = get_schema_manager(node).await?;
 
         let metadata = Self::build_ingestion_metadata(&request.file_hash, progress_id);
 
@@ -669,15 +670,7 @@ impl IngestionService {
             ))
         })?;
 
-        let schema_manager = {
-            let db_guard = node
-                .get_fold_db()
-                .await
-                .map_err(schema_err)?;
-            let manager = db_guard.schema_manager.clone();
-            drop(db_guard);
-            manager
-        };
+        let schema_manager = get_schema_manager(node).await?;
 
         // Only load the schema if it doesn't already exist locally.
         // Re-loading from the schema service JSON would overwrite the cached schema's

--- a/src/schema/types/field/filter_utils.rs
+++ b/src/schema/types/field/filter_utils.rs
@@ -154,6 +154,30 @@ pub trait HashRangeOperations {
     fn get_atoms_in_hash_range(&self, start: &str, end: &str) -> Vec<(String, String, String)>;
 }
 
+fn insert_range(m: &mut HashMap<KeyValue, String>, key: String, uuid: String) {
+    m.insert(KeyValue::new(None, Some(key)), uuid);
+}
+
+fn extend_range<I: IntoIterator<Item = (String, String)>>(m: &mut HashMap<KeyValue, String>, iter: I) {
+    for (k, v) in iter {
+        insert_range(m, k, v);
+    }
+}
+
+fn insert_hash_range(m: &mut HashMap<KeyValue, String>, hash: String, range: String, uuid: String) {
+    m.insert(KeyValue::new(Some(hash), Some(range)), uuid);
+}
+
+fn extend_hash_range<I: IntoIterator<Item = (String, String)>>(
+    m: &mut HashMap<KeyValue, String>,
+    hash: &str,
+    iter: I,
+) {
+    for (rk, uuid) in iter {
+        insert_hash_range(m, hash.to_string(), rk, uuid);
+    }
+}
+
 /// Generic filter application for RangeField
 pub fn apply_range_filter<T: RangeOperations>(
     operations: &T,
@@ -164,34 +188,23 @@ pub fn apply_range_filter<T: RangeOperations>(
 
     match filter {
         HashRangeFilter::SampleN(n) => {
-            for (key, atom_uuid) in operations.get_all_atoms().into_iter().take(n) {
-                let composite_key = KeyValue::new(None, Some(key.clone()));
-                matches.insert(composite_key, atom_uuid);
-            }
+            extend_range(&mut matches, operations.get_all_atoms().into_iter().take(n));
         }
         HashRangeFilter::HashKey(key) | HashRangeFilter::RangeKey(key) => {
-            if let Some(atom_uuid) = operations.get_atom_uuid(&key) {
-                let composite_key = KeyValue::new(None, Some(key.clone()));
-                matches.insert(composite_key, atom_uuid);
+            if let Some(uuid) = operations.get_atom_uuid(&key) {
+                insert_range(&mut matches, key, uuid);
             }
         }
         HashRangeFilter::RangePrefix(prefix) => {
-            for (key, atom_uuid) in operations.get_atoms_with_prefix(&prefix) {
-                let composite_key = KeyValue::new(None, Some(key.clone()));
-                matches.insert(composite_key, atom_uuid);
-            }
+            extend_range(&mut matches, operations.get_atoms_with_prefix(&prefix));
         }
         HashRangeFilter::RangeRange { start, end } => {
-            for (key, atom_uuid) in operations.get_atoms_in_range(&start, &end) {
-                let composite_key = KeyValue::new(None, Some(key.clone()));
-                matches.insert(composite_key, atom_uuid);
-            }
+            extend_range(&mut matches, operations.get_atoms_in_range(&start, &end));
         }
         HashRangeFilter::HashRangeKeys(keys) => {
             for (_hash, range) in keys {
-                if let Some(atom_uuid) = operations.get_atom_uuid(&range) {
-                    let composite_key = KeyValue::new(None, Some(range.clone()));
-                    matches.insert(composite_key, atom_uuid);
+                if let Some(uuid) = operations.get_atom_uuid(&range) {
+                    insert_range(&mut matches, range, uuid);
                 }
             }
         }
@@ -200,22 +213,15 @@ pub fn apply_range_filter<T: RangeOperations>(
         }
         // Hash-range specific filters - RangeField only handles range keys, so ignore hash components
         HashRangeFilter::HashRangeKey { range, .. } => {
-            if let Some(atom_uuid) = operations.get_atom_uuid(&range) {
-                let composite_key = KeyValue::new(None, Some(range.clone()));
-                matches.insert(composite_key, atom_uuid);
+            if let Some(uuid) = operations.get_atom_uuid(&range) {
+                insert_range(&mut matches, range, uuid);
             }
         }
         HashRangeFilter::HashRangePrefix { prefix, .. } => {
-            for (key, atom_uuid) in operations.get_atoms_with_prefix(&prefix) {
-                let composite_key = KeyValue::new(None, Some(key.clone()));
-                matches.insert(composite_key, atom_uuid);
-            }
+            extend_range(&mut matches, operations.get_atoms_with_prefix(&prefix));
         }
         HashRangeFilter::HashRangeRange { start, end, .. } => {
-            for (key, atom_uuid) in operations.get_atoms_in_range(&start, &end) {
-                let composite_key = KeyValue::new(None, Some(key.clone()));
-                matches.insert(composite_key, atom_uuid);
-            }
+            extend_range(&mut matches, operations.get_atoms_in_range(&start, &end));
         }
         HashRangeFilter::HashRangePattern {
             pattern: _pattern, ..
@@ -253,70 +259,58 @@ pub fn apply_hash_range_filter<T: HashRangeOperations>(
             }
         }
         HashRangeFilter::HashRangeKey { hash, range } => {
-            if let Some(atom_uuid) = operations.get_atom_uuid(&hash, &range) {
-                let composite_key = KeyValue::new(Some(hash.clone()), Some(range.clone()));
-                matches.insert(composite_key, atom_uuid);
+            if let Some(uuid) = operations.get_atom_uuid(&hash, &range) {
+                insert_hash_range(&mut matches, hash, range, uuid);
             }
         }
         HashRangeFilter::HashKey(hash) => {
             if let Some(range_atoms) = operations.get_atoms_for_hash(&hash) {
-                for (range_key, atom_uuid) in range_atoms {
-                    let composite_key = KeyValue::new(Some(hash.clone()), Some(range_key.clone()));
-                    matches.insert(composite_key, atom_uuid);
-                }
+                extend_hash_range(&mut matches, &hash, range_atoms);
             }
         }
         HashRangeFilter::RangeKey(range) => {
             for hash_value in operations.get_hash_values() {
-                if let Some(atom_uuid) = operations.get_atom_uuid(&hash_value, &range) {
-                    let composite_key =
-                        KeyValue::new(Some(hash_value.clone()), Some(range.clone()));
-                    matches.insert(composite_key, atom_uuid);
+                if let Some(uuid) = operations.get_atom_uuid(&hash_value, &range) {
+                    insert_hash_range(&mut matches, hash_value, range.clone(), uuid);
                 }
             }
         }
         HashRangeFilter::HashRangePrefix { hash, prefix } => {
-            for (range_key, atom_uuid) in operations.get_atoms_with_prefix_for_hash(&hash, &prefix)
-            {
-                let composite_key = KeyValue::new(Some(hash.clone()), Some(range_key.clone()));
-                matches.insert(composite_key, atom_uuid);
-            }
+            extend_hash_range(
+                &mut matches,
+                &hash,
+                operations.get_atoms_with_prefix_for_hash(&hash, &prefix),
+            );
         }
         HashRangeFilter::RangePrefix(prefix) => {
             for hash_value in operations.get_hash_values() {
-                for (range_key, atom_uuid) in
-                    operations.get_atoms_with_prefix_for_hash(&hash_value, &prefix)
-                {
-                    let composite_key =
-                        KeyValue::new(Some(hash_value.clone()), Some(range_key.clone()));
-                    matches.insert(composite_key, atom_uuid);
-                }
+                extend_hash_range(
+                    &mut matches,
+                    &hash_value,
+                    operations.get_atoms_with_prefix_for_hash(&hash_value, &prefix),
+                );
             }
         }
         HashRangeFilter::HashRangeRange { hash, start, end } => {
-            for (range_key, atom_uuid) in
-                operations.get_atoms_in_range_for_hash(&hash, &start, &end)
-            {
-                let composite_key = KeyValue::new(Some(hash.clone()), Some(range_key.clone()));
-                matches.insert(composite_key, atom_uuid);
-            }
+            extend_hash_range(
+                &mut matches,
+                &hash,
+                operations.get_atoms_in_range_for_hash(&hash, &start, &end),
+            );
         }
         HashRangeFilter::RangeRange { start, end } => {
             for hash_value in operations.get_hash_values() {
-                for (range_key, atom_uuid) in
-                    operations.get_atoms_in_range_for_hash(&hash_value, &start, &end)
-                {
-                    let composite_key =
-                        KeyValue::new(Some(hash_value.clone()), Some(range_key.clone()));
-                    matches.insert(composite_key, atom_uuid);
-                }
+                extend_hash_range(
+                    &mut matches,
+                    &hash_value,
+                    operations.get_atoms_in_range_for_hash(&hash_value, &start, &end),
+                );
             }
         }
         HashRangeFilter::HashRangeKeys(keys) => {
             for (hash, range) in keys {
-                if let Some(atom_uuid) = operations.get_atom_uuid(&hash, &range) {
-                    let composite_key = KeyValue::new(Some(hash.clone()), Some(range.clone()));
-                    matches.insert(composite_key, atom_uuid);
+                if let Some(uuid) = operations.get_atom_uuid(&hash, &range) {
+                    insert_hash_range(&mut matches, hash, range, uuid);
                 }
             }
         }
@@ -333,12 +327,8 @@ pub fn apply_hash_range_filter<T: HashRangeOperations>(
             // Pattern matching not supported - return empty results
         }
         HashRangeFilter::HashRange { start, end } => {
-            for (hash_value, range_key, atom_uuid) in
-                operations.get_atoms_in_hash_range(&start, &end)
-            {
-                let composite_key =
-                    KeyValue::new(Some(hash_value.clone()), Some(range_key.clone()));
-                matches.insert(composite_key, atom_uuid);
+            for (hash_value, range_key, uuid) in operations.get_atoms_in_hash_range(&start, &end) {
+                insert_hash_range(&mut matches, hash_value, range_key, uuid);
             }
         }
     }

--- a/src/storage/dynamodb_backend.rs
+++ b/src/storage/dynamodb_backend.rs
@@ -35,19 +35,15 @@ impl DynamoDbKvStore {
         Self { client, table_name }
     }
 
-    fn get_current_user_id(&self) -> StorageResult<String> {
-        super::dynamodb_utils::require_user_context()
-    }
-
     fn get_partition_key_impl(&self) -> StorageResult<String> {
-        self.get_current_user_id()
+        super::dynamodb_utils::require_user_context()
     }
 
     /// Get partition key (user_id)
     /// Note: This is a change from previous implementation where PK was user_id:key
     /// This change enables Query operations with SK prefix
     fn get_partition_key_with_key(&self, _key: &[u8]) -> StorageResult<String> {
-        self.get_current_user_id()
+        super::dynamodb_utils::require_user_context()
     }
 
     /// Convert a byte key to a string for the sort key (no user_id prefixing)

--- a/src/storage/dynamodb_native_index.rs
+++ b/src/storage/dynamodb_native_index.rs
@@ -27,10 +27,6 @@ impl DynamoDbNativeIndexStore {
         Self { client, table_name }
     }
 
-    fn get_current_user_id(&self) -> StorageResult<String> {
-        super::dynamodb_utils::require_user_context()
-    }
-
     /// Parse key to extract feature and term
     /// Keys are in format: "feature:term" (e.g., "word:hello", "email:test@example.com")
     fn parse_key(&self, key: &[u8]) -> StorageResult<(String, String)> {
@@ -50,7 +46,7 @@ impl DynamoDbNativeIndexStore {
     /// Get partition key (feature) for native index
     /// Format: user_id:feature
     fn get_partition_key(&self, feature: &str) -> StorageResult<String> {
-        Ok(format!("{}:{}", self.get_current_user_id()?, feature))
+        Ok(format!("{}:{}", super::dynamodb_utils::require_user_context()?, feature))
     }
 }
 

--- a/src/storage/dynamodb_store.rs
+++ b/src/storage/dynamodb_store.rs
@@ -153,10 +153,10 @@ impl DynamoDbSchemaStore {
         Ok(Self { client, table_name })
     }
 
-    /// Get the current user_id from request context.
+    /// Get the partition key (hash key) for schemas.
     /// Falls back to "__system__" with a warning — this store is also used by the
     /// standalone schema_service binary which may not have per-user context.
-    fn get_current_user_id(&self) -> FoldDbResult<String> {
+    fn get_partition_key(&self) -> FoldDbResult<String> {
         match crate::logging::core::get_current_user_id() {
             Some(id) => Ok(id),
             None => {
@@ -167,13 +167,6 @@ impl DynamoDbSchemaStore {
                 Ok("__system__".to_string())
             }
         }
-    }
-
-    /// Get the partition key (hash key) for schemas
-    /// Format: user_id
-    /// The schema_name goes in the sort key (SK)
-    fn get_partition_key(&self) -> FoldDbResult<String> {
-        self.get_current_user_id()
     }
 
     /// Get a schema by its identity hash


### PR DESCRIPTION
## Summary

- **2.5** Extract `get_schema_manager()` free function in `ingestion_service/mod.rs`; replace 4 identical 8-line DB-lock-acquire blocks (2 in `mod.rs`, 2 in `decomposition.rs`)
- **2.2** Delete `is_code_ext`/`is_config_ext` single-line wrappers in `file_conversion.rs`; inline `CODE_EXTS.contains(&e)` / `CONFIG_EXTS.contains(&e)` at the 2 call sites
- **2.3** Add `insert_range`, `extend_range`, `insert_hash_range`, `extend_hash_range` helpers in `filter_utils.rs`; collapse verbose `KeyValue::new` + `matches.insert` patterns across all match arms in both `apply_range_filter` and `apply_hash_range_filter`
- **2.6** Remove local `get_current_user_id()` wrappers from `dynamodb_backend.rs` and `dynamodb_native_index.rs` (were single-line delegates to `dynamodb_utils::require_user_context()`); inline the `__system__` fallback logic directly into `get_partition_key` in `dynamodb_store.rs`

**Net: -56 lines** (+87 / -140 including the new helper functions)

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo check --workspace --features aws-backend` — compiles
- [x] `cargo test --workspace --all-targets` — all tests pass (378 unit + 124 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)