### PR TITLE
Simplify onboarding wizard: 3 steps, Tailwind, accessibility

### DIFF
--- a/src/server/static-react/src/components/OnboardingWizard.jsx
+++ b/src/server/static-react/src/components/OnboardingWizard.jsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { ingestionClient, llmQueryClient } from '../api/clients'
+import { ingestionClient } from '../api/clients'
 import { BROWSER_CONFIG } from '../constants/config'
 import { useAppDispatch } from '../store/hooks'
 import { fetchIngestionConfig } from '../store/ingestionSlice'
 
-const TOTAL_STEPS = 6
+const TOTAL_STEPS = 3
 
 const OPENROUTER_MODELS = [
   { value: 'google/gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
@@ -15,112 +15,20 @@ const OPENROUTER_MODELS = [
   { value: 'deepseek/deepseek-chat-v3-0324', label: 'DeepSeek V3' },
 ]
 
-// Gruvbox-warm palette matching fold_db_website
-const colors = {
-  bg: '#282828',
-  bgElevated: '#3c3836',
-  border: '#504945',
-  text: '#ebdbb2',
-  textBright: '#fbf1c7',
-  dim: '#928374',
-  orange: '#fe8019',
-  yellow: '#fabd2f',
-  green: '#b8bb26',
-  blue: '#83a598',
-  purple: '#d3869b',
-  red: '#fb4934',
-  link: '#8ec07c',
-}
-
-const styles = {
-  overlay: {
-    position: 'fixed', top: 0, left: 0, width: '100%', height: '100%',
-    background: 'rgba(0,0,0,0.7)', zIndex: 1000,
-    display: 'flex', alignItems: 'center', justifyContent: 'center',
-  },
-  modal: {
-    background: colors.bgElevated, border: `1px solid ${colors.border}`,
-    padding: 0, maxWidth: '520px', width: '90%', maxHeight: '85vh',
-    overflowY: 'auto', color: colors.text,
-    fontFamily: "'IBM Plex Mono', monospace", fontSize: '14px', lineHeight: '1.5',
-  },
-  header: {
-    padding: '24px 24px 0',
-  },
-  body: {
-    padding: '0 24px 24px',
-  },
-  footer: {
-    padding: '12px 24px', borderTop: `1px solid ${colors.border}`,
-    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-  },
-  card: {
-    border: `1px solid ${colors.border}`, padding: '12px', marginBottom: '8px',
-  },
-  label: {
-    padding: '1px 6px', fontWeight: 700, color: colors.bg, display: 'inline-block',
-    fontSize: '12px', marginBottom: '4px',
-  },
-  btnPrimary: {
-    background: 'none', border: `1px solid ${colors.orange}`, color: colors.orange,
-    padding: '6px 16px', cursor: 'pointer', fontFamily: 'inherit', fontSize: 'inherit',
-    width: '100%', textAlign: 'center',
-  },
-  btnSecondary: {
-    background: 'none', border: `1px solid ${colors.border}`, color: colors.dim,
-    padding: '6px 16px', cursor: 'pointer', fontFamily: 'inherit', fontSize: 'inherit',
-  },
-  btnLink: {
-    background: 'none', border: 'none', color: colors.dim, cursor: 'pointer',
-    fontFamily: 'inherit', fontSize: '12px', padding: 0,
-  },
-  input: {
-    background: colors.bg, border: `1px solid ${colors.border}`, color: colors.text,
-    padding: '6px 8px', width: '100%', fontFamily: 'inherit', fontSize: 'inherit',
-    outline: 'none',
-  },
-  select: {
-    background: colors.bg, border: `1px solid ${colors.border}`, color: colors.text,
-    padding: '6px 8px', width: '100%', fontFamily: 'inherit', fontSize: 'inherit',
-    outline: 'none', appearance: 'auto',
-  },
-  pre: {
-    background: colors.bg, border: `1px solid ${colors.border}`,
-    padding: '8px', margin: '8px 0', fontFamily: 'inherit', fontSize: '12px',
-  },
-}
-
 function ProgressBar({ currentStep }) {
   const segments = Array.from({ length: TOTAL_STEPS }, (_, i) => (
     <div
       key={i}
-      style={{
-        flex: 1, height: '3px',
-        background: i < currentStep ? colors.yellow : colors.border,
-      }}
+      className={i < currentStep ? 'h-[3px] flex-1 bg-gruvbox-yellow' : 'h-[3px] flex-1 bg-border'}
     />
   ))
   return (
-    <div style={styles.header}>
-      <div style={{ display: 'flex', gap: '4px' }}>{segments}</div>
-      <p style={{ fontSize: '12px', color: colors.dim, marginTop: '8px' }}>
+    <div className="px-6 pt-6">
+      <div className="flex gap-1">{segments}</div>
+      <p className="text-xs text-secondary mt-2">
         Step {currentStep} of {TOTAL_STEPS}
       </p>
     </div>
-  )
-}
-
-function PrimaryButton({ onClick, disabled, children }) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      style={{ ...styles.btnPrimary, opacity: disabled ? 0.4 : 1 }}
-      onMouseEnter={e => { if (!disabled) { e.target.style.color = colors.yellow; e.target.style.borderColor = colors.yellow } }}
-      onMouseLeave={e => { e.target.style.color = colors.orange; e.target.style.borderColor = colors.orange }}
-    >
-      {children}
-    </button>
   )
 }
 
@@ -128,32 +36,34 @@ function PrimaryButton({ onClick, disabled, children }) {
 function WelcomeStep({ onNext }) {
   return (
     <div>
-      <p style={{ fontSize: '1.4em', fontWeight: 700, color: colors.orange, margin: '0.3em 0' }}>
+      <p className="text-xl font-bold text-gruvbox-orange mt-1 mb-1">
         Welcome to FoldDB
       </p>
-      <p>
+      <p className="text-primary">
         Your personal AI database. Drop in any file, AI organizes it, search everything in plain English.
       </p>
-      <p style={{ color: colors.dim, fontSize: '12px', marginTop: '4px' }}>
-        Takes ~2 minutes to set up.
+      <p className="text-secondary text-xs mt-1">
+        One quick setup step and you&apos;re ready to go.
       </p>
 
-      <div style={{ margin: '16px 0' }}>
-        <div style={styles.card}>
-          <p><span style={{ ...styles.label, background: colors.green }}>01 AI SETUP</span></p>
-          <p style={{ margin: '4px 0' }}>Configure your AI provider for ingestion and search</p>
+      <div className="mt-4 space-y-2">
+        <div className="card p-3">
+          <p><span className="badge badge-success">AI SETUP</span></p>
+          <p className="text-primary mt-1">Configure your AI provider for ingestion and search</p>
         </div>
-        <div style={styles.card}>
-          <p><span style={{ ...styles.label, background: colors.blue }}>02 TRY IT</span></p>
-          <p style={{ margin: '4px 0' }}>Drop a file and ask it a question &mdash; see the magic</p>
+        <div className="card p-3">
+          <p><span className="badge badge-info">FILE INGESTION</span></p>
+          <p className="text-primary mt-1">Drop files in and AI structures your data automatically</p>
         </div>
-        <div style={styles.card}>
-          <p><span style={{ ...styles.label, background: colors.purple }}>03 GO</span></p>
-          <p style={{ margin: '4px 0' }}>Point FoldDB at a folder and let it work</p>
+        <div className="card p-3">
+          <p><span className="badge badge-warning">AI SEARCH</span></p>
+          <p className="text-primary mt-1">Ask questions about your data in plain English</p>
         </div>
       </div>
 
-      <PrimaryButton onClick={onNext}>[Get Started]</PrimaryButton>
+      <button className="btn-primary w-full text-center mt-4" onClick={onNext}>
+        Get Started
+      </button>
     </div>
   )
 }
@@ -173,12 +83,10 @@ function ConfigureAiStep({ onNext, onSkip }) {
   const [saving, setSaving] = useState(false)
   const [saveResult, setSaveResult] = useState(null)
   const [alreadyConfigured, setAlreadyConfigured] = useState(false)
-  const advanceTimeoutRef = useRef(null)
   const ollamaFetchTimeoutRef = useRef(null)
 
   useEffect(() => {
     return () => {
-      if (advanceTimeoutRef.current) clearTimeout(advanceTimeoutRef.current)
       if (ollamaFetchTimeoutRef.current) clearTimeout(ollamaFetchTimeoutRef.current)
     }
   }, [])
@@ -200,7 +108,6 @@ function ConfigureAiStep({ onNext, onSkip }) {
         setOllamaModelsError('No models found. Run: ollama pull <model>')
       } else {
         setOllamaModelsError(null)
-        // Auto-select first model if none currently selected
         setOllamaModel(prev => {
           if (!prev || !models.some(m => m.name === prev)) return models[0].name
           return prev
@@ -214,7 +121,6 @@ function ConfigureAiStep({ onNext, onSkip }) {
     }
   }, [])
 
-  // Fetch Ollama models when provider is Ollama and URL changes (debounced)
   useEffect(() => {
     if (provider !== 'Ollama') return
     if (ollamaFetchTimeoutRef.current) clearTimeout(ollamaFetchTimeoutRef.current)
@@ -263,7 +169,6 @@ function ConfigureAiStep({ onNext, onSkip }) {
       if (response.success) {
         setSaveResult('success')
         dispatch(fetchIngestionConfig())
-        advanceTimeoutRef.current = setTimeout(() => onNext(), 1000)
       } else {
         setSaveResult('error')
       }
@@ -275,7 +180,7 @@ function ConfigureAiStep({ onNext, onSkip }) {
   }
 
   if (loading) {
-    return <p style={{ color: colors.dim, textAlign: 'center', padding: '24px 0' }}>Loading configuration...</p>
+    return <p className="text-secondary text-center py-6">Loading configuration...</p>
   }
 
   const currentModel = provider === 'OpenRouter' ? (model || OPENROUTER_MODELS[0].value) : ollamaModel
@@ -283,25 +188,25 @@ function ConfigureAiStep({ onNext, onSkip }) {
 
   return (
     <div>
-      <h2 style={{ fontSize: 'inherit', fontWeight: 700, margin: '0 0 4px' }}>
-        <span style={{ color: colors.green }}>CONFIGURE AI</span>{' '}
-        <span style={{ color: colors.dim }}>Provider setup</span>
+      <h2 className="text-sm font-bold mb-1">
+        <span className="text-gruvbox-green">AI SETUP</span>{' '}
+        <span className="text-secondary">Provider configuration</span>
       </h2>
-      <p>FoldDB uses AI for data ingestion and search.</p>
+      <p className="text-primary">FoldDB uses AI for data ingestion and search.</p>
 
       {alreadyConfigured && (
-        <div style={{ ...styles.card, borderColor: colors.green, marginTop: '12px' }}>
-          <p><span style={{ ...styles.label, background: colors.green }}>CONFIGURED</span></p>
-          <p style={{ margin: '4px 0' }}>AI provider is already set up. Update below or skip.</p>
+        <div className="card-success p-3 mt-3">
+          <p><span className="badge badge-success">CONFIGURED</span></p>
+          <p className="text-primary mt-1">AI provider is already set up. Update below or skip.</p>
         </div>
       )}
 
-      <div style={{ marginTop: '16px' }}>
-        <p style={{ color: colors.textBright, fontWeight: 700, marginBottom: '4px' }}>Provider</p>
+      <div className="mt-4">
+        <p className="label">Provider</p>
         <select
           value={provider}
           onChange={e => setProvider(e.target.value)}
-          style={styles.select}
+          className="select"
           data-testid="provider-select"
         >
           <option value="OpenRouter">OpenRouter (Cloud)</option>
@@ -309,24 +214,24 @@ function ConfigureAiStep({ onNext, onSkip }) {
         </select>
       </div>
 
-      <div style={{ marginTop: '12px' }}>
-        <p style={{ color: colors.textBright, fontWeight: 700, marginBottom: '4px' }}>Model</p>
+      <div className="mt-3">
+        <p className="label">Model</p>
         {provider === 'OpenRouter' ? (
           <select
             value={currentModel}
             onChange={e => setModel(e.target.value)}
-            style={styles.select}
+            className="select"
             data-testid="model-select"
           >
             {OPENROUTER_MODELS.map(m => <option key={m.value} value={m.value}>{m.label}</option>)}
           </select>
         ) : ollamaModelsLoading ? (
-          <div style={{ ...styles.input, display: 'flex', alignItems: 'center', color: colors.dim }}>Loading models...</div>
+          <div className="input flex items-center text-secondary">Loading models...</div>
         ) : ollamaModels.length > 0 ? (
           <select
             value={ollamaModel}
             onChange={e => setOllamaModel(e.target.value)}
-            style={styles.select}
+            className="select"
             data-testid="model-select"
           >
             {ollamaModels.map(m => (
@@ -339,34 +244,34 @@ function ConfigureAiStep({ onNext, onSkip }) {
             value={ollamaModel}
             onChange={e => setOllamaModel(e.target.value)}
             placeholder="e.g. llama3"
-            style={styles.input}
+            className="input"
             data-testid="model-select"
           />
         )}
         {provider === 'Ollama' && ollamaModelsError && (
-          <p style={{ color: colors.red, fontSize: '12px', marginTop: '4px' }}>{ollamaModelsError}</p>
+          <p className="text-gruvbox-red text-xs mt-1">{ollamaModelsError}</p>
         )}
       </div>
 
       {provider === 'OpenRouter' && (
-        <div style={{ marginTop: '12px' }}>
-          <p style={{ color: colors.textBright, fontWeight: 700, marginBottom: '4px' }}>API Key</p>
+        <div className="mt-3">
+          <p className="label">API Key</p>
           <input
             type="password"
             value={apiKey}
             onChange={e => setApiKey(e.target.value)}
             placeholder={alreadyConfigured ? '***configured***' : 'sk-or-...'}
-            style={styles.input}
+            className="input"
             data-testid="api-key-input"
           />
-          <p style={{ marginTop: '4px' }}>
+          <p className="mt-1">
             <a
               href="https://openrouter.ai/keys"
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: colors.link, fontSize: '12px', textDecoration: 'none' }}
+              className="text-gruvbox-link text-xs hover:underline"
             >
-              [Get API key from OpenRouter]
+              Get API key from OpenRouter
             </a>
           </p>
         </div>
@@ -374,532 +279,150 @@ function ConfigureAiStep({ onNext, onSkip }) {
 
       {provider === 'Ollama' && (
         <>
-          <div style={{ marginTop: '12px' }}>
-            <p style={{ color: colors.textBright, fontWeight: 700, marginBottom: '4px' }}>Ollama URL</p>
+          <div className="mt-3">
+            <p className="label">Ollama URL</p>
             <input
               type="text"
               value={ollamaUrl}
               onChange={e => setOllamaUrl(e.target.value)}
               placeholder="http://localhost:11434"
-              style={styles.input}
+              className="input"
             />
-            <p style={{ color: colors.dim, fontSize: '12px', marginTop: '4px' }}>
+            <p className="text-secondary text-xs mt-1">
               Use a LAN address (e.g. http://192.168.1.100:11434) for a remote instance
             </p>
           </div>
-          <div style={{ ...styles.pre, marginTop: '12px' }}>
-            <p style={{ color: colors.textBright, fontWeight: 700 }}>Setup</p>
-            <p style={{ color: colors.dim }}>Make sure Ollama is running:</p>
-            <p style={{ color: colors.yellow, marginTop: '4px' }}>$ ollama pull {currentModel}</p>
+          <div className="card p-3 mt-3">
+            <p className="font-bold text-primary">Setup</p>
+            <p className="text-secondary">Make sure Ollama is running:</p>
+            <p className="text-gruvbox-yellow mt-1">$ ollama pull {currentModel}</p>
           </div>
         </>
       )}
 
       {saveResult === 'success' && (
-        <p style={{ color: colors.green, marginTop: '8px' }}>Configuration saved successfully!</p>
+        <p className="text-gruvbox-green mt-2">Configuration saved successfully!</p>
       )}
       {saveResult === 'error' && (
-        <p style={{ color: colors.red, marginTop: '8px' }}>Failed to save. Please try again.</p>
+        <p className="text-gruvbox-red mt-2">Failed to save. Please try again.</p>
       )}
 
-      <div style={{ display: 'flex', gap: '8px', marginTop: '16px' }}>
-        <button
-          onClick={handleSave}
-          disabled={canSave}
-          style={{
-            ...styles.btnPrimary, flex: 1,
-            opacity: canSave ? 0.4 : 1,
-          }}
-          onMouseEnter={e => { e.target.style.color = colors.yellow; e.target.style.borderColor = colors.yellow }}
-          onMouseLeave={e => { e.target.style.color = colors.orange; e.target.style.borderColor = colors.orange }}
-        >
-          {saving ? 'Saving...' : '[Save & Continue]'}
-        </button>
-        <button onClick={onSkip} style={{ ...styles.btnSecondary, flex: 1 }}>
-          [Skip]
-        </button>
-      </div>
-    </div>
-  )
-}
-
-// Step 3: First File (NEW - "Hello World" moment)
-function FirstFileStep({ onNext, onSkip, onFileIngested }) {
-  const [isDragging, setIsDragging] = useState(false)
-  const [selectedFile, setSelectedFile] = useState(null)
-  const [isUploading, setIsUploading] = useState(false)
-  const [uploadResult, setUploadResult] = useState(null)
-  const fileInputRef = useRef(null)
-
-  const handleDragEnter = (e) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setIsDragging(true)
-  }
-
-  const handleDragLeave = (e) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setIsDragging(false)
-  }
-
-  const handleDrop = (e) => {
-    e.preventDefault()
-    e.stopPropagation()
-    setIsDragging(false)
-    const file = e.dataTransfer.files[0]
-    if (file) {
-      setSelectedFile(file)
-      handleUpload(file)
-    }
-  }
-
-  const handleFileSelect = (e) => {
-    const file = e.target.files[0]
-    if (file) {
-      setSelectedFile(file)
-      handleUpload(file)
-    }
-  }
-
-  const handleUpload = async (file) => {
-    setIsUploading(true)
-    setUploadResult(null)
-    try {
-      const response = await ingestionClient.uploadFile(file, {
-        autoExecute: true,
-        pubKey: 'default',
-      })
-      if (response.success && response.data) {
-        const result = {
-          schemaName: response.data.schema_name,
-          newSchema: response.data.new_schema_created,
-          mutationsExecuted: response.data.mutations_executed,
-        }
-        setUploadResult({ success: true, ...result })
-        onFileIngested(result)
-      } else {
-        setUploadResult({ success: false, error: response.error || 'Upload failed' })
-      }
-    } catch (err) {
-      setUploadResult({ success: false, error: err.message || 'Upload failed' })
-    } finally {
-      setIsUploading(false)
-    }
-  }
-
-  const dropZoneStyle = {
-    border: `2px dashed ${isDragging ? colors.yellow : colors.border}`,
-    padding: '32px 16px',
-    textAlign: 'center',
-    cursor: 'pointer',
-    marginTop: '16px',
-    transition: 'border-color 0.2s',
-    background: isDragging ? 'rgba(250,189,47,0.05)' : 'transparent',
-  }
-
-  return (
-    <div>
-      <h2 style={{ fontSize: 'inherit', fontWeight: 700, margin: '0 0 4px' }}>
-        <span style={{ color: colors.blue }}>FIRST FILE</span>{' '}
-        <span style={{ color: colors.dim }}>See AI in action</span>
-      </h2>
-      <p>Drop a file and watch FoldDB&apos;s AI process it into structured data.</p>
-      <p style={{ color: colors.dim, fontSize: '12px' }}>
-        Try a PDF, text file, JSON, CSV &mdash; anything with data you care about.
-      </p>
-
-      {!uploadResult && !isUploading && (
-        <div
-          style={dropZoneStyle}
-          onDragEnter={handleDragEnter}
-          onDragOver={handleDragEnter}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
-          onClick={() => fileInputRef.current?.click()}
-        >
-          <input
-            ref={fileInputRef}
-            type="file"
-            onChange={handleFileSelect}
-            style={{ display: 'none' }}
-          />
-          <p style={{ color: isDragging ? colors.yellow : colors.textBright, fontSize: '1.1em', margin: '0 0 8px' }}>
-            {isDragging ? 'Drop it here' : 'Drag & drop a file here'}
-          </p>
-          <p style={{ color: colors.dim, fontSize: '12px', margin: 0 }}>
-            or click to browse
-          </p>
-        </div>
-      )}
-
-      {isUploading && (
-        <div style={{ ...styles.card, borderColor: colors.yellow, marginTop: '16px', textAlign: 'center' }}>
-          <p style={{ color: colors.yellow, margin: '8px 0' }}>Processing {selectedFile?.name}...</p>
-          <div style={{ display: 'flex', gap: '4px', justifyContent: 'center', margin: '12px 0' }}>
-            {[0, 1, 2].map(i => (
-              <div key={i} style={{
-                width: '8px', height: '8px', borderRadius: '50%', background: colors.yellow,
-                animation: `pulse 1.2s ease-in-out ${i * 0.2}s infinite`,
-              }} />
-            ))}
-          </div>
-          <style>{`@keyframes pulse { 0%, 100% { opacity: 0.3; } 50% { opacity: 1; } }`}</style>
-          <p style={{ color: colors.dim, fontSize: '12px', margin: '4px 0' }}>
-            AI is reading your file, detecting the schema, and structuring the data...
-          </p>
-        </div>
-      )}
-
-      {uploadResult?.success && (
-        <div style={{ ...styles.card, borderColor: colors.green, marginTop: '16px' }}>
-          <p><span style={{ ...styles.label, background: colors.green }}>INGESTED</span></p>
-          <p style={{ margin: '8px 0', color: colors.textBright }}>{selectedFile?.name}</p>
-          <div style={styles.pre}>
-            <p style={{ margin: '2px 0' }}>
-              <span style={{ color: colors.dim }}>Schema:</span>{' '}
-              <span style={{ color: colors.yellow }}>{uploadResult.schemaName}</span>
-              {uploadResult.newSchema && <span style={{ color: colors.green, marginLeft: '8px', fontSize: '12px' }}>(new)</span>}
-            </p>
-            <p style={{ margin: '2px 0' }}>
-              <span style={{ color: colors.dim }}>Records:</span>{' '}
-              <span style={{ color: colors.textBright }}>{uploadResult.mutationsExecuted || 1}</span>
-            </p>
-          </div>
-          <p style={{ color: colors.dim, fontSize: '12px', margin: '8px 0 0' }}>
-            Your data is now structured and searchable.
-          </p>
-        </div>
-      )}
-
-      {uploadResult && !uploadResult.success && (
-        <div style={{ ...styles.card, borderColor: colors.red, marginTop: '16px' }}>
-          <p><span style={{ ...styles.label, background: colors.red }}>ERROR</span></p>
-          <p style={{ margin: '4px 0', color: colors.red, fontSize: '12px' }}>{uploadResult.error}</p>
-          <button
-            onClick={() => { setUploadResult(null); setSelectedFile(null) }}
-            style={{ ...styles.btnSecondary, marginTop: '8px', width: '100%', textAlign: 'center' }}
-          >
-            [Try Another File]
+      <div className="flex gap-2 mt-4">
+        {saveResult === 'success' ? (
+          <button className="btn-primary flex-1 text-center" onClick={onNext}>
+            Continue
           </button>
-        </div>
-      )}
-
-      <div style={{ display: 'flex', gap: '8px', marginTop: '16px' }}>
-        {uploadResult?.success && (
-          <PrimaryButton onClick={onNext}>[Continue]</PrimaryButton>
-        )}
-        {!uploadResult?.success && !isUploading && (
-          <button onClick={onSkip} style={{ ...styles.btnSecondary, width: '100%', textAlign: 'center' }}>
-            [Skip for now]
-          </button>
-        )}
-      </div>
-    </div>
-  )
-}
-
-// Step 4: AI Query Demo (NEW)
-function AiQueryDemoStep({ onNext, onSkip, ingestedFile }) {
-  const [query, setQuery] = useState('')
-  const [isQuerying, setIsQuerying] = useState(false)
-  const [answer, setAnswer] = useState(null)
-  const [queryError, setQueryError] = useState(null)
-
-  useEffect(() => {
-    if (ingestedFile?.schemaName) {
-      setQuery(`What information is in my ${ingestedFile.schemaName.replace(/_/g, ' ')} data?`)
-    }
-  }, [ingestedFile])
-
-  const handleQuery = async () => {
-    if (!query.trim()) return
-    setIsQuerying(true)
-    setAnswer(null)
-    setQueryError(null)
-    try {
-      const response = await llmQueryClient.agentQuery({
-        query: query.trim(),
-        max_iterations: 10,
-      })
-      if (response.data?.answer) {
-        setAnswer(response.data.answer)
-      } else {
-        setQueryError('No answer returned. Make sure AI is configured.')
-      }
-    } catch (err) {
-      setQueryError(err.message || 'Query failed')
-    } finally {
-      setIsQuerying(false)
-    }
-  }
-
-  const hasFile = !!ingestedFile
-
-  return (
-    <div>
-      <h2 style={{ fontSize: 'inherit', fontWeight: 700, margin: '0 0 4px' }}>
-        <span style={{ color: colors.purple }}>AI QUERY</span>{' '}
-        <span style={{ color: colors.dim }}>Ask your data anything</span>
-      </h2>
-      {hasFile ? (
-        <p>Your file is ingested. Try asking it a question in plain English.</p>
-      ) : (
-        <p>Search your data using natural language. Try it out below.</p>
-      )}
-
-      <div style={{ marginTop: '16px' }}>
-        <p style={{ color: colors.textBright, fontWeight: 700, marginBottom: '4px' }}>Your question</p>
-        <input
-          type="text"
-          value={query}
-          onChange={e => setQuery(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && !isQuerying && handleQuery()}
-          placeholder={hasFile ? `Ask about your ${ingestedFile.schemaName}...` : 'Ask anything about your data...'}
-          style={styles.input}
-          disabled={isQuerying}
-        />
-      </div>
-
-      <div style={{ marginTop: '12px' }}>
-        <button
-          onClick={handleQuery}
-          disabled={isQuerying || !query.trim()}
-          style={{
-            ...styles.btnPrimary,
-            opacity: (isQuerying || !query.trim()) ? 0.4 : 1,
-          }}
-          onMouseEnter={e => { e.target.style.color = colors.yellow; e.target.style.borderColor = colors.yellow }}
-          onMouseLeave={e => { e.target.style.color = colors.orange; e.target.style.borderColor = colors.orange }}
-        >
-          {isQuerying ? 'Thinking...' : '[Ask]'}
-        </button>
-      </div>
-
-      {isQuerying && (
-        <div style={{ textAlign: 'center', margin: '16px 0' }}>
-          <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
-            {[0, 1, 2].map(i => (
-              <div key={i} style={{
-                width: '8px', height: '8px', borderRadius: '50%', background: colors.purple,
-                animation: `pulse 1.2s ease-in-out ${i * 0.2}s infinite`,
-              }} />
-            ))}
-          </div>
-          <style>{`@keyframes pulse { 0%, 100% { opacity: 0.3; } 50% { opacity: 1; } }`}</style>
-          <p style={{ color: colors.dim, fontSize: '12px', marginTop: '8px' }}>
-            AI is searching and analyzing your data...
-          </p>
-        </div>
-      )}
-
-      {answer && (
-        <div style={{ ...styles.card, borderColor: colors.green, marginTop: '16px' }}>
-          <p><span style={{ ...styles.label, background: colors.green }}>ANSWER</span></p>
-          <p style={{ margin: '8px 0', whiteSpace: 'pre-wrap', fontSize: '13px' }}>{answer}</p>
-        </div>
-      )}
-
-      {queryError && (
-        <div style={{ ...styles.card, borderColor: colors.red, marginTop: '16px' }}>
-          <p><span style={{ ...styles.label, background: colors.red }}>ERROR</span></p>
-          <p style={{ margin: '4px 0', color: colors.red, fontSize: '12px' }}>{queryError}</p>
-        </div>
-      )}
-
-      <div style={{ marginTop: '16px' }}>
-        {answer ? (
-          <PrimaryButton onClick={onNext}>[Continue]</PrimaryButton>
         ) : (
-          <button onClick={onSkip} style={{ ...styles.btnSecondary, width: '100%', textAlign: 'center' }}>
-            [Skip]
-          </button>
+          <>
+            <button
+              onClick={handleSave}
+              disabled={canSave}
+              className="btn-primary flex-1 text-center"
+            >
+              {saving ? 'Saving...' : 'Save & Continue'}
+            </button>
+            <button onClick={onSkip} className="btn-secondary flex-1 text-center">
+              Skip
+            </button>
+          </>
         )}
       </div>
     </div>
   )
 }
 
-// Step 5: Smart Folder (optional)
-function SmartFolderStep({ onNext, onSkip }) {
-  const [folderPath, setFolderPath] = useState('')
-  const [isScanning, setIsScanning] = useState(false)
-  const [scanResult, setScanResult] = useState(null)
-
-  const handleScan = async () => {
-    if (!folderPath.trim()) return
-    setIsScanning(true)
-    setScanResult(null)
-    try {
-      const response = await ingestionClient.smartFolderScan(folderPath.trim())
-      if (response.success && response.data) {
-        setScanResult({
-          success: true,
-          totalFiles: response.data.total_files,
-          personalFiles: response.data.recommendations?.filter(r => r.should_process)?.length || 0,
-        })
-      } else {
-        setScanResult({ success: false, error: response.error || 'Scan failed' })
-      }
-    } catch (err) {
-      setScanResult({ success: false, error: err.message || 'Scan failed' })
-    } finally {
-      setIsScanning(false)
-    }
-  }
-
-  return (
-    <div>
-      <h2 style={{ fontSize: 'inherit', fontWeight: 700, margin: '0 0 4px' }}>
-        <span style={{ color: colors.green }}>SMART FOLDER</span>{' '}
-        <span style={{ color: colors.dim }}>Automatic sync (optional)</span>
-      </h2>
-      <p>
-        Point FoldDB at a folder and it will automatically find and ingest your personal data files.
-      </p>
-
-      <div style={{ marginTop: '16px' }}>
-        <p style={{ color: colors.textBright, fontWeight: 700, marginBottom: '4px' }}>Folder path</p>
-        <input
-          type="text"
-          value={folderPath}
-          onChange={e => setFolderPath(e.target.value)}
-          placeholder="/Users/you/Documents"
-          style={styles.input}
-          disabled={isScanning}
-        />
-        <p style={{ color: colors.dim, fontSize: '12px', marginTop: '4px' }}>
-          AI will scan for personal data files (photos, documents, notes, etc.)
-        </p>
-      </div>
-
-      {!scanResult && (
-        <div style={{ display: 'flex', gap: '8px', marginTop: '16px' }}>
-          <button
-            onClick={handleScan}
-            disabled={isScanning || !folderPath.trim()}
-            style={{
-              ...styles.btnPrimary, flex: 1,
-              opacity: (isScanning || !folderPath.trim()) ? 0.4 : 1,
-            }}
-            onMouseEnter={e => { e.target.style.color = colors.yellow; e.target.style.borderColor = colors.yellow }}
-            onMouseLeave={e => { e.target.style.color = colors.orange; e.target.style.borderColor = colors.orange }}
-          >
-            {isScanning ? 'Scanning...' : '[Scan Folder]'}
-          </button>
-          <button onClick={onSkip} style={{ ...styles.btnSecondary, flex: 1 }}>
-            [Skip]
-          </button>
-        </div>
-      )}
-
-      {scanResult?.success && (
-        <div style={{ ...styles.card, borderColor: colors.green, marginTop: '16px' }}>
-          <p><span style={{ ...styles.label, background: colors.green }}>SCANNED</span></p>
-          <div style={styles.pre}>
-            <p style={{ margin: '2px 0' }}>
-              <span style={{ color: colors.dim }}>Total files:</span>{' '}
-              <span style={{ color: colors.textBright }}>{scanResult.totalFiles}</span>
-            </p>
-            <p style={{ margin: '2px 0' }}>
-              <span style={{ color: colors.dim }}>Personal data:</span>{' '}
-              <span style={{ color: colors.yellow }}>{scanResult.personalFiles} files</span>
-            </p>
-          </div>
-          <p style={{ color: colors.dim, fontSize: '12px', margin: '8px 0 0' }}>
-            You can start the full ingestion from the Smart Folder tab after setup.
-          </p>
-          <div style={{ marginTop: '12px' }}>
-            <PrimaryButton onClick={onNext}>[Continue]</PrimaryButton>
-          </div>
-        </div>
-      )}
-
-      {scanResult && !scanResult.success && (
-        <div style={{ ...styles.card, borderColor: colors.red, marginTop: '16px' }}>
-          <p><span style={{ ...styles.label, background: colors.red }}>ERROR</span></p>
-          <p style={{ margin: '4px 0', color: colors.red, fontSize: '12px' }}>{scanResult.error}</p>
-          <div style={{ display: 'flex', gap: '8px', marginTop: '12px' }}>
-            <button onClick={() => setScanResult(null)} style={{ ...styles.btnSecondary, flex: 1, textAlign: 'center' }}>
-              [Try Again]
-            </button>
-            <button onClick={onSkip} style={{ ...styles.btnSecondary, flex: 1, textAlign: 'center' }}>
-              [Skip]
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// Step 6: Done
+// Step 3: Done
 function DoneStep({ onComplete }) {
   return (
     <div>
-      <p style={{ fontSize: '1.4em', fontWeight: 700, color: colors.orange, margin: '0.3em 0' }}>
+      <p className="text-xl font-bold text-gruvbox-orange mt-1 mb-1">
         You&apos;re all set.
       </p>
-      <p>Your personal AI database is ready. Here&apos;s what you can do:</p>
+      <p className="text-primary">Your personal AI database is ready. Here are some things to try:</p>
 
-      <div style={{ margin: '16px 0' }}>
-        <div style={styles.card}>
-          <p><span style={{ ...styles.label, background: colors.green }}>SMART FOLDER SYNC</span></p>
-          <p style={{ margin: '4px 0' }}>Point FoldDB at a folder and let AI categorize and ingest your files.</p>
+      <div className="mt-4 space-y-2">
+        <div className="card p-3">
+          <p><span className="badge badge-success">FILE UPLOAD</span></p>
+          <p className="text-primary mt-1">Drop in a PDF, text file, CSV, or JSON to see AI-powered ingestion in action.</p>
         </div>
-        <div style={styles.card}>
-          <p><span style={{ ...styles.label, background: colors.blue }}>AI QUERY</span></p>
-          <p style={{ margin: '4px 0' }}>Search your data using natural language queries.</p>
+        <div className="card p-3">
+          <p><span className="badge badge-info">AI SEARCH</span></p>
+          <p className="text-primary mt-1">Use the AI Query tab to search your data in plain English.</p>
         </div>
-        <div style={styles.card}>
-          <p><span style={{ ...styles.label, background: colors.purple }}>FILE UPLOAD</span></p>
-          <p style={{ margin: '4px 0' }}>Drop in individual files for instant AI-powered ingestion.</p>
+        <div className="card p-3">
+          <p><span className="badge badge-warning">SMART FOLDERS</span></p>
+          <p className="text-primary mt-1">Point FoldDB at a folder and let it automatically find and ingest your files.</p>
         </div>
       </div>
 
-      <div style={{ ...styles.card, borderColor: colors.blue, marginTop: '8px' }}>
-        <p style={{ color: colors.blue, fontWeight: 700, margin: '0 0 4px', fontSize: '12px' }}>
+      <div className="card-info p-3 mt-3">
+        <p className="text-gruvbox-blue font-bold text-xs mb-1">
           WANT MORE?
         </p>
-        <p style={{ margin: '4px 0', fontSize: '13px' }}>
-          Upgrade to <span style={{ color: colors.textBright }}>Exemem Cloud</span> for sync, backup, API access, and app development.
+        <p className="text-primary text-sm">
+          Upgrade to <span className="text-gruvbox-bright">Exemem Cloud</span> for sync, backup, API access, and app development.
         </p>
-        <p style={{ margin: '4px 0' }}>
+        <p className="mt-1">
           <a
             href="https://exemem.com"
             target="_blank"
             rel="noopener noreferrer"
-            style={{ color: colors.link, fontSize: '12px', textDecoration: 'none' }}
+            className="text-gruvbox-link text-xs hover:underline"
           >
-            [Learn more about Exemem Cloud]
+            Learn more about Exemem Cloud
           </a>
         </p>
       </div>
 
-      <div style={{ marginTop: '16px' }}>
-        <PrimaryButton onClick={onComplete}>[Start Using FoldDB]</PrimaryButton>
-      </div>
+      <button className="btn-primary w-full text-center mt-4" onClick={onComplete}>
+        Start Using FoldDB
+      </button>
     </div>
   )
 }
 
 export default function OnboardingWizard({ isOpen, onClose, userHash }) {
   const [currentStep, setCurrentStep] = useState(1)
-  const [ingestedFile, setIngestedFile] = useState(null)
+  const modalRef = useRef(null)
+  const previousFocusRef = useRef(null)
 
-  const handleComplete = useCallback(() => {
+  const handleDismiss = useCallback(() => {
     if (userHash) {
       localStorage.setItem(`${BROWSER_CONFIG.STORAGE_KEYS.ONBOARDING_COMPLETED}_${userHash}`, '1')
     }
     onClose()
   }, [onClose, userHash])
 
-  const handleSkipTutorial = useCallback(() => {
-    if (userHash) {
-      localStorage.setItem(`${BROWSER_CONFIG.STORAGE_KEYS.ONBOARDING_COMPLETED}_${userHash}`, '1')
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Escape') { handleDismiss(); return }
+    if (e.key !== 'Tab') return
+    const modal = modalRef.current
+    if (!modal) return
+    const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+    if (focusable.length === 0) return
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault(); last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault(); first.focus()
     }
-    onClose()
-  }, [onClose, userHash])
+  }, [handleDismiss])
+
+  useEffect(() => {
+    if (!isOpen) return
+    previousFocusRef.current = document.activeElement
+    const modal = modalRef.current
+    if (modal) {
+      const firstFocusable = modal.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+      if (firstFocusable) firstFocusable.focus()
+    }
+    return () => {
+      if (previousFocusRef.current && typeof previousFocusRef.current.focus === 'function') {
+        previousFocusRef.current.focus()
+      }
+    }
+  }, [isOpen])
 
   if (!isOpen) return null
 
@@ -910,30 +433,34 @@ export default function OnboardingWizard({ isOpen, onClose, userHash }) {
     switch (currentStep) {
       case 1: return <WelcomeStep onNext={goNext} />
       case 2: return <ConfigureAiStep onNext={goNext} onSkip={goNext} />
-      case 3: return <FirstFileStep onNext={goNext} onSkip={goNext} onFileIngested={setIngestedFile} />
-      case 4: return <AiQueryDemoStep onNext={goNext} onSkip={goNext} ingestedFile={ingestedFile} />
-      case 5: return <SmartFolderStep onNext={goNext} onSkip={goNext} />
-      case 6: return <DoneStep onComplete={handleComplete} />
+      case 3: return <DoneStep onComplete={handleDismiss} />
       default: return null
     }
   }
 
   return (
-    <div style={styles.overlay} onClick={e => e.stopPropagation()}>
-      <div style={styles.modal} onClick={e => e.stopPropagation()}>
+    <div className="modal-overlay" onKeyDown={handleKeyDown}>
+      <div
+        className="modal max-w-lg"
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Onboarding wizard"
+        onClick={e => e.stopPropagation()}
+      >
         <ProgressBar currentStep={currentStep} />
-        <div style={styles.body}>{renderStep()}</div>
-        <div style={styles.footer}>
+        <div className="modal-body">{renderStep()}</div>
+        <div className="modal-footer justify-between">
           <div>
             {currentStep > 1 && currentStep < TOTAL_STEPS && (
-              <button onClick={goBack} style={styles.btnSecondary}>
-                [Back]
+              <button onClick={goBack} className="btn-secondary">
+                Back
               </button>
             )}
           </div>
           <div>
             {currentStep < TOTAL_STEPS && (
-              <button onClick={handleSkipTutorial} style={styles.btnLink}>
+              <button onClick={handleDismiss} className="text-secondary text-xs cursor-pointer hover:text-primary bg-transparent border-none">
                 Skip Tutorial
               </button>
             )}

--- a/src/server/static-react/src/test/components/OnboardingWizard.test.jsx
+++ b/src/server/static-react/src/test/components/OnboardingWizard.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import OnboardingWizard from '../../components/OnboardingWizard'
 import { renderWithRedux } from '../utils/testHelpers.jsx'
@@ -18,19 +18,6 @@ vi.mock('../../api/clients', () => ({
     saveConfig: vi.fn().mockResolvedValue({
       success: true,
       data: { success: true, message: 'Saved' },
-    }),
-    uploadFile: vi.fn().mockResolvedValue({
-      success: true,
-      data: { schema_name: 'TestSchema', new_schema_created: true, mutations_executed: 1 },
-    }),
-    smartFolderScan: vi.fn().mockResolvedValue({
-      success: true,
-      data: { total_files: 10, recommendations: [] },
-    }),
-  },
-  llmQueryClient: {
-    agentQuery: vi.fn().mockResolvedValue({
-      data: { answer: 'Test answer' },
     }),
   },
 }))
@@ -53,8 +40,8 @@ describe('OnboardingWizard', () => {
     await waitFor(() => {
       expect(screen.getByText('Welcome to FoldDB')).toBeInTheDocument()
     })
-    expect(screen.getByText('[Get Started]')).toBeInTheDocument()
-    expect(screen.getByText('Step 1 of 6')).toBeInTheDocument()
+    expect(screen.getByText('Get Started')).toBeInTheDocument()
+    expect(screen.getByText('Step 1 of 3')).toBeInTheDocument()
   })
 
   it('does not render when closed', () => {
@@ -63,19 +50,19 @@ describe('OnboardingWizard', () => {
     expect(screen.queryByText('Welcome to FoldDB')).not.toBeInTheDocument()
   })
 
-  it('advances from welcome to configure AI', async () => {
+  it('advances from welcome to AI setup', async () => {
     renderWithRedux(<OnboardingWizard isOpen={true} onClose={mockOnClose} userHash={testUserHash} />)
 
     await waitFor(() => {
       expect(screen.getByText('Welcome to FoldDB')).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByText('[Get Started]'))
+    fireEvent.click(screen.getByText('Get Started'))
 
     await waitFor(() => {
-      expect(screen.getByText('CONFIGURE AI')).toBeInTheDocument()
+      expect(screen.getByText('AI SETUP')).toBeInTheDocument()
     })
-    expect(screen.getByText('Step 2 of 6')).toBeInTheDocument()
+    expect(screen.getByText('Step 2 of 3')).toBeInTheDocument()
   })
 
   it('marks completed when skipping tutorial', async () => {
@@ -91,19 +78,17 @@ describe('OnboardingWizard', () => {
     expect(mockOnClose).toHaveBeenCalled()
   })
 
-  it('saves AI config and advances to first file step', async () => {
-    vi.useFakeTimers()
-
+  it('saves AI config and shows Continue button', async () => {
     renderWithRedux(<OnboardingWizard isOpen={true} onClose={mockOnClose} userHash={testUserHash} />)
 
     // Go to step 2
     await waitFor(() => {
-      expect(screen.getByText('[Get Started]')).toBeInTheDocument()
+      expect(screen.getByText('Get Started')).toBeInTheDocument()
     })
-    fireEvent.click(screen.getByText('[Get Started]'))
+    fireEvent.click(screen.getByText('Get Started'))
 
     await waitFor(() => {
-      expect(screen.getByText('CONFIGURE AI')).toBeInTheDocument()
+      expect(screen.getByText('AI SETUP')).toBeInTheDocument()
     })
 
     // Enter API key
@@ -111,27 +96,23 @@ describe('OnboardingWizard', () => {
     fireEvent.change(apiKeyInput, { target: { value: 'sk-or-test-key' } })
 
     // Click save
-    fireEvent.click(screen.getByText('[Save & Continue]'))
+    fireEvent.click(screen.getByText('Save & Continue'))
 
     await waitFor(() => {
       expect(ingestionClient.saveConfig).toHaveBeenCalled()
     })
 
-    // Should show success message
+    // Should show success message and Continue button (no auto-advance)
     await waitFor(() => {
       expect(screen.getByText('Configuration saved successfully!')).toBeInTheDocument()
     })
 
-    // Fast-forward the 1s auto-advance timer
-    act(() => {
-      vi.advanceTimersByTime(1100)
-    })
+    // Click Continue to advance
+    fireEvent.click(screen.getByText('Continue'))
 
     await waitFor(() => {
-      expect(screen.getByText('FIRST FILE')).toBeInTheDocument()
+      expect(screen.getByText("You're all set.")).toBeInTheDocument()
     })
-
-    vi.useRealTimers()
   })
 
   it('skips through all steps to done', async () => {
@@ -139,35 +120,17 @@ describe('OnboardingWizard', () => {
 
     // Step 1 -> 2
     await waitFor(() => {
-      expect(screen.getByText('[Get Started]')).toBeInTheDocument()
+      expect(screen.getByText('Get Started')).toBeInTheDocument()
     })
-    fireEvent.click(screen.getByText('[Get Started]'))
+    fireEvent.click(screen.getByText('Get Started'))
 
     // Step 2 -> 3
     await waitFor(() => {
-      expect(screen.getByText('CONFIGURE AI')).toBeInTheDocument()
+      expect(screen.getByText('AI SETUP')).toBeInTheDocument()
     })
-    fireEvent.click(screen.getByText('[Skip]'))
+    fireEvent.click(screen.getByText('Skip'))
 
-    // Step 3 -> 4
-    await waitFor(() => {
-      expect(screen.getByText('FIRST FILE')).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByText('[Skip for now]'))
-
-    // Step 4 -> 5
-    await waitFor(() => {
-      expect(screen.getByText('AI QUERY')).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByText('[Skip]'))
-
-    // Step 5 -> 6
-    await waitFor(() => {
-      expect(screen.getByText('SMART FOLDER')).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByText('[Skip]'))
-
-    // Step 6 (Done)
+    // Step 3 (Done)
     await waitFor(() => {
       expect(screen.getByText("You're all set.")).toBeInTheDocument()
     })
@@ -177,28 +140,44 @@ describe('OnboardingWizard', () => {
     renderWithRedux(<OnboardingWizard isOpen={true} onClose={mockOnClose} userHash={testUserHash} />)
 
     // Navigate through all steps to Done
-    await waitFor(() => { expect(screen.getByText('[Get Started]')).toBeInTheDocument() })
-    fireEvent.click(screen.getByText('[Get Started]'))
+    await waitFor(() => { expect(screen.getByText('Get Started')).toBeInTheDocument() })
+    fireEvent.click(screen.getByText('Get Started'))
 
-    await waitFor(() => { expect(screen.getByText('CONFIGURE AI')).toBeInTheDocument() })
-    fireEvent.click(screen.getByText('[Skip]'))
-
-    await waitFor(() => { expect(screen.getByText('FIRST FILE')).toBeInTheDocument() })
-    fireEvent.click(screen.getByText('[Skip for now]'))
-
-    await waitFor(() => { expect(screen.getByText('AI QUERY')).toBeInTheDocument() })
-    fireEvent.click(screen.getByText('[Skip]'))
-
-    await waitFor(() => { expect(screen.getByText('SMART FOLDER')).toBeInTheDocument() })
-    fireEvent.click(screen.getByText('[Skip]'))
+    await waitFor(() => { expect(screen.getByText('AI SETUP')).toBeInTheDocument() })
+    fireEvent.click(screen.getByText('Skip'))
 
     await waitFor(() => {
       expect(screen.getByText("You're all set.")).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByText('[Start Using FoldDB]'))
+    fireEvent.click(screen.getByText('Start Using FoldDB'))
 
     expect(localStorage.getItem(onboardingKey)).toBe('1')
     expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('closes wizard on Escape key', async () => {
+    renderWithRedux(<OnboardingWizard isOpen={true} onClose={mockOnClose} userHash={testUserHash} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to FoldDB')).toBeInTheDocument()
+    })
+
+    fireEvent.keyDown(screen.getByRole('dialog').parentElement, { key: 'Escape' })
+
+    expect(localStorage.getItem(onboardingKey)).toBe('1')
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it('has correct aria attributes', async () => {
+    renderWithRedux(<OnboardingWizard isOpen={true} onClose={mockOnClose} userHash={testUserHash} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to FoldDB')).toBeInTheDocument()
+    })
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAttribute('aria-label', 'Onboarding wizard')
   })
 })


### PR DESCRIPTION
## Summary

- **6 steps → 3**: Kept Welcome, AI Setup, Done. Removed FirstFile, AiQueryDemo, SmartFolder steps — users discover these features in the app itself
- **Inline styles → Tailwind CSS**: Deleted `colors`/`styles` objects and `PrimaryButton` helper. Uses existing `btn-primary`, `card`, `badge`, `modal-overlay`, `input`/`select` classes from the Gruvbox theme
- **Accessibility**: Added `role="dialog"`, `aria-modal`, `aria-label`, focus trap (Tab/Shift+Tab), Escape key dismissal, and `previousFocusRef` for focus restore (matching SettingsModal pattern)
- **UX fixes**: Replaced confusing auto-advance timer with explicit Continue button after AI config save. Removed bracket-wrapped button labels (`[Get Started]` → `Get Started`)

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors)
- [x] `npm test` passes — 481 tests, 35 files
- [ ] Manual: `./run.sh --local` → wizard opens → walk through all 3 steps
- [ ] Manual: verify Escape key closes wizard
- [ ] Manual: verify Tab cycles within modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)