### PR TITLE
fix: use PAT for auto-update-branches so CI triggers on updated PRs

### DIFF
--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -28,4 +28,8 @@ jobs:
               2>&1 && echo "  Updated." || echo "  Skipped (already up to date or conflict)"
           done
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Must use a PAT (not github.token) so that the resulting push
+          # triggers the pull_request: synchronize event and CI runs.
+          # Create a fine-grained PAT with Contents: read/write and
+          # Pull requests: read/write, then store it as secret GH_PAT.
+          GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Problem

When `auto-update-branches` merges mainline into a PR branch, it uses `GITHUB_TOKEN` to push the merge commit. GitHub explicitly suppresses `pull_request: synchronize` events for pushes made by `GITHUB_TOKEN`, so CI never triggers on the resulting commit — and the PR gets permanently blocked waiting for checks that can never appear.

## Fix

Replace `GH_TOKEN: ${{ github.token }}` with `GH_TOKEN: ${{ secrets.GH_PAT }}`. A push authenticated with a user PAT is treated as a normal push and triggers the `synchronize` event → CI runs normally.

## Required setup

Before merging, add a repository secret named **`GH_PAT`**:

1. Go to GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
2. Create a token scoped to `shiba4life/fold_db` with:
   - **Contents**: Read and write
   - **Pull requests**: Read and write
3. Add it at: `https://github.com/shiba4life/fold_db/settings/secrets/actions` → New repository secret → name `GH_PAT`

## Test plan

- [ ] Add the `GH_PAT` secret
- [ ] Merge a commit to mainline and verify CI runs on all open PR branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)