### PR TITLE
Add Playwright E2E smoke tests for UI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -146,3 +146,55 @@ jobs:
       - name: Fail if npm tests failed
         if: steps.npm-test.outcome == 'failure'
         run: exit 1
+
+  e2e-tests:
+    name: E2E UI Tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: src/server/static-react
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: src/server/static-react/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E smoke tests
+        id: e2e-test
+        continue-on-error: true
+        run: npx playwright test
+
+      - name: Upload test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: src/server/static-react/test-results/
+          retention-days: 7
+
+      - name: E2E test summary
+        if: always()
+        run: |
+          status="${{ steps.e2e-test.outcome }}"
+          if [ "$status" = "success" ]; then
+            echo "✅ **E2E UI Tests** — passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **E2E UI Tests** — failed" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Fail if E2E tests failed
+        if: steps.e2e-test.outcome == 'failure'
+        run: exit 1

--- a/src/server/static-react/.gitignore
+++ b/src/server/static-react/.gitignore
@@ -13,6 +13,10 @@ dist/*
 dist-ssr
 *.local
 
+# Playwright
+test-results/
+playwright-report/
+
 # Coverage reports
 coverage/
 .nyc_output

--- a/src/server/static-react/e2e/helpers.js
+++ b/src/server/static-react/e2e/helpers.js
@@ -1,0 +1,120 @@
+/**
+ * Shared helpers for E2E tests.
+ * Sets up API mocking and pre-seeds localStorage so the app
+ * renders the main dashboard without needing a real backend.
+ *
+ * NOTE: The ApiClient wraps all responses in { success, data, status, ... }.
+ * Mocks return the raw backend response — the client adds the wrapper.
+ */
+
+/** Seed localStorage so the app skips the login screen. */
+export function seedAuth(page) {
+  return page.addInitScript(() => {
+    localStorage.setItem('fold_user_id', 'e2e-test-user');
+    localStorage.setItem('fold_user_hash', 'e2e-test-hash');
+    // Mark onboarding completed so the wizard doesn't appear
+    localStorage.setItem('folddb_onboarding_completed_e2e-test-hash', '1');
+    // Dismiss AI setup banner
+    localStorage.setItem('folddb_setup_dismissed', '1');
+  });
+}
+
+/** Helper: fulfill with JSON and correct content-type header. */
+function json(route, body) {
+  return route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+/** Mock all backend API routes so the app renders without a real server. */
+export async function mockApi(page) {
+  // System endpoints
+  await page.route('**/api/system/auto-identity', route =>
+    json(route, { user_id: 'e2e-test-user', user_hash: 'e2e-test-hash' }),
+  );
+  await page.route('**/api/system/status', route =>
+    json(route, { status: 'ok', version: '0.1.0', storage_mode: 'local' }),
+  );
+  await page.route('**/api/system/database-status', route =>
+    json(route, { initialized: true, has_saved_config: true }),
+  );
+  await page.route('**/api/system/database-config', route =>
+    json(route, { storage_mode: 'local' }),
+  );
+  await page.route('**/api/system/public-key', route =>
+    json(route, { public_key: 'e2e-mock-key' }),
+  );
+  await page.route('**/api/system/private-key', route =>
+    json(route, null),
+  );
+  await page.route('**/api/security/system-key', route =>
+    json(route, { public_key: 'e2e-mock-system-key' }),
+  );
+
+  // Schema endpoints — backend returns { schemas: [...] }
+  const mockSchema = {
+    name: 'test_schema',
+    state: 'approved',
+    fields: {
+      title: { field_type: 'Single', permission: { owner_read: true, owner_write: true } },
+      body: { field_type: 'Single', permission: { owner_read: true, owner_write: true } },
+    },
+  };
+  await page.route('**/api/schemas', route =>
+    json(route, { schemas: [mockSchema], count: 1 }),
+  );
+  await page.route('**/api/schema/*', route =>
+    json(route, mockSchema),
+  );
+
+  // Ingestion config (AI settings)
+  await page.route('**/api/ingestion/config', route =>
+    json(route, { openrouter_api_key: null, ollama_url: null, model: null, provider: null }),
+  );
+
+  // Query / mutation / search — return empty results
+  await page.route('**/api/query', route =>
+    json(route, { results: [] }),
+  );
+  await page.route('**/api/mutation', route =>
+    json(route, {}),
+  );
+  await page.route('**/api/native-index/search', route =>
+    json(route, { results: [] }),
+  );
+  await page.route('**/api/ingestion/process', route =>
+    json(route, { schemas_written: [] }),
+  );
+  await page.route('**/api/ingestion/upload', route =>
+    json(route, {}),
+  );
+  await page.route('**/api/llm-query/**', route =>
+    json(route, { response: 'mock reply', results: [] }),
+  );
+  await page.route('**/api/logs/**', route =>
+    json(route, []),
+  );
+  await page.route('**/api/logs', route =>
+    json(route, []),
+  );
+  await page.route('**/api/indexing/**', route =>
+    json(route, {}),
+  );
+  await page.route('**/api/ingestion/progress', route =>
+    json(route, { active: false, progress: null }),
+  );
+  await page.route('**/api/system/complete-path', route =>
+    json(route, { completions: [] }),
+  );
+
+  // Log stream (EventSource — return empty event stream to avoid errors)
+  await page.route('**/api/logs/stream', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: 'data: []\n\n',
+    }),
+  );
+}

--- a/src/server/static-react/e2e/smoke.spec.js
+++ b/src/server/static-react/e2e/smoke.spec.js
@@ -1,0 +1,163 @@
+import { test, expect } from '@playwright/test';
+import { seedAuth, mockApi } from './helpers.js';
+
+// All tabs defined in the app (label matches aria-label="${label} tab")
+const TABS = [
+  { id: 'smart-folder', label: 'Smart Folder' },
+  { id: 'file-upload', label: 'File Upload' },
+  { id: 'llm-query', label: 'AI Query' },
+  { id: 'schemas', label: 'Schema' },
+  { id: 'query', label: 'Query' },
+  { id: 'mutation', label: 'Mutation' },
+  { id: 'ingestion', label: 'JSON Ingestion' },
+  { id: 'native-index', label: 'Native Index' },
+  { id: 'data-browser', label: 'Data Browser' },
+  { id: 'word-graph', label: 'Word Graph' },
+];
+
+/** Locate a tab button by its label (uses aria-label="${label} tab"). */
+function tabButton(page, label) {
+  return page.getByLabel(`${label} tab`, { exact: true });
+}
+
+/** Wait for the app to finish loading by checking a tab is visible. */
+async function waitForApp(page) {
+  await expect(tabButton(page, 'Smart Folder')).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe('UI Smoke Tests', () => {
+  let consoleErrors;
+
+  test.beforeEach(async ({ page }) => {
+    consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', err => consoleErrors.push(err.message));
+
+    await seedAuth(page);
+    await mockApi(page);
+  });
+
+  test.afterEach(async () => {
+    const realErrors = consoleErrors.filter(
+      e =>
+        !e.includes('EventSource') &&
+        !e.includes('net::ERR') &&
+        !e.includes('Failed to fetch') &&
+        !e.includes('Failed to load resource') &&
+        !e.includes('WebSocket') &&
+        !e.includes('MIME type') &&
+        !e.includes('validateDOMNesting'),
+    );
+    expect(realErrors, `Unexpected console errors:\n${realErrors.join('\n')}`).toHaveLength(0);
+  });
+
+  test('app loads and shows the dashboard', async ({ page }) => {
+    await page.goto('/');
+    await waitForApp(page);
+    // Default tab should have aria-current="page"
+    await expect(tabButton(page, 'Smart Folder')).toHaveAttribute('aria-current', 'page');
+  });
+
+  // Click every tab and verify it renders without crashing
+  for (const tab of TABS) {
+    test(`navigate to "${tab.label}" tab`, async ({ page }) => {
+      await page.goto('/');
+      await waitForApp(page);
+
+      await tabButton(page, tab.label).click();
+
+      // URL hash should update
+      await expect(page).toHaveURL(new RegExp(`#${tab.id}`));
+
+      // The clicked tab should now be active
+      await expect(tabButton(page, tab.label)).toHaveAttribute('aria-current', 'page');
+
+      // Section title should reflect the tab
+      const sectionTitle = tab.id.replace('-', ' ');
+      await expect(page.locator('.text-xs.uppercase').first()).toContainText(new RegExp(sectionTitle, 'i'));
+    });
+  }
+
+  test('settings modal opens and cycles through sub-tabs', async ({ page }) => {
+    await page.goto('/');
+    await waitForApp(page);
+
+    // Open settings via the Settings button
+    await page.getByRole('button', { name: /settings/i }).click();
+
+    // Modal should be visible
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    // Click through each settings sub-tab
+    const settingsTabs = ['AI', 'Key', 'Schema', 'Database'];
+    for (const label of settingsTabs) {
+      const btn = modal.getByRole('button', { name: new RegExp(label, 'i') }).first();
+      if (await btn.isVisible()) {
+        await btn.click();
+        await page.waitForTimeout(200);
+      }
+    }
+
+    // Close with Escape
+    await page.keyboard.press('Escape');
+    await expect(modal).not.toBeVisible();
+  });
+
+  test('Schema tab shows mock schema', async ({ page }) => {
+    await page.goto('/#schemas');
+    await waitForApp(page);
+    await expect(page.getByText('test_schema')).toBeVisible();
+  });
+
+  test('Query tab has execute button', async ({ page }) => {
+    await page.goto('/#query');
+    await waitForApp(page);
+    await expect(page.getByText(/schema/i).first()).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /execute|run|query/i }).first(),
+    ).toBeVisible();
+  });
+
+  test('Mutation tab has schema selector', async ({ page }) => {
+    await page.goto('/#mutation');
+    await waitForApp(page);
+    // Should have schema and operation type selectors
+    await expect(page.locator('select').first()).toBeVisible();
+  });
+
+  test('JSON Ingestion tab loads sample data', async ({ page }) => {
+    await page.goto('/#ingestion');
+    await waitForApp(page);
+
+    // Click the first visible sample-data button
+    for (const label of ['Blog', 'Twitter', 'Instagram', 'LinkedIn', 'TikTok']) {
+      const btn = page.getByRole('button', { name: new RegExp(label, 'i') });
+      if (await btn.isVisible()) {
+        await btn.click();
+        break;
+      }
+    }
+  });
+
+  test('Native Index tab accepts search input', async ({ page }) => {
+    await page.goto('/#native-index');
+    await waitForApp(page);
+    const searchInput = page.getByPlaceholder(/search/i).first();
+    await expect(searchInput).toBeVisible();
+    await searchInput.fill('hello');
+  });
+
+  test('rapid tab switching causes no errors', async ({ page }) => {
+    await page.goto('/');
+    await waitForApp(page);
+
+    for (const tab of TABS) {
+      await tabButton(page, tab.label).click();
+    }
+
+    await page.waitForTimeout(500);
+  });
+});

--- a/src/server/static-react/package-lock.json
+++ b/src/server/static-react/package-lock.json
@@ -22,6 +22,7 @@
         "react-redux": "^9.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/forms": "^0.5.10",
         "@tauri-apps/api": "~2.10.0",
         "@tauri-apps/cli": "~2.10.0",
@@ -1334,6 +1335,22 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -6269,6 +6286,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/src/server/static-react/package.json
+++ b/src/server/static-react/package.json
@@ -28,6 +28,9 @@
     "test:coverage:threshold": "vitest --coverage --run --reporter=json --outputFile.json=./coverage/coverage-summary.json",
     "coverage:open": "open coverage/index.html",
     "coverage:serve": "npx http-server coverage -p 8080 -o",
+    "test:e2e": "npx playwright test",
+    "test:e2e:headed": "npx playwright test --headed",
+    "test:e2e:ui": "npx playwright test --ui",
     "lint": "eslint . --ext ts,tsx,js,jsx",
     "lint:fix": "eslint . --ext ts,tsx,js,jsx --fix",
     "ci:test": "npm run lint && npm run test:coverage:threshold",
@@ -57,6 +60,7 @@
     "js-yaml": "4.1.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/forms": "^0.5.10",
     "@tauri-apps/api": "~2.10.0",
     "@tauri-apps/cli": "~2.10.0",

--- a/src/server/static-react/playwright.config.js
+++ b/src/server/static-react/playwright.config.js
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
+const E2E_PORT = 5174;
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 1,
+  use: {
+    baseURL: `http://localhost:${E2E_PORT}`,
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+  webServer: {
+    command: `npx vite --port ${E2E_PORT}`,
+    url: `http://localhost:${E2E_PORT}`,
+    reuseExistingServer: false,
+    timeout: 30_000,
+  },
+});

--- a/src/server/static-react/vitest.config.js
+++ b/src/server/static-react/vitest.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.js'],
+    exclude: ['e2e/**', 'node_modules/**'],
     css: true,
     testTimeout: 1000, // 1 second timeout - fast but allows for legitimate delays
     define: {


### PR DESCRIPTION
## Summary
- Add Playwright E2E smoke tests that verify the fold_db React UI loads and all tabs/modals render without errors
- 18 tests covering: app loading, all 10 tab navigations, settings modal, schema display, query/mutation forms, ingestion, native index search, and rapid tab switching
- Tests mock all backend API routes so no running server is needed
- Add `e2e-tests` job to CI pipeline running in parallel with existing test jobs

## Test plan
- [x] All 18 E2E tests pass locally (~10s)
- [ ] CI `e2e-tests` job passes on this PR
- [ ] Existing `rust-tests` and `frontend-tests` jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)