### PR TITLE
Add S3 sync module and remove encryption-at-rest

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -9,6 +9,7 @@ use crate::progress::{DynamoDbProgressStore as DynamoDbJobStore, ProgressStore a
 use crate::storage::config::DatabaseConfig;
 #[cfg(feature = "aws-backend")]
 use crate::storage::TableNameResolver;
+use crate::sync::SyncSetup;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -17,191 +18,233 @@ use crate::log_feature;
 
 /// Creates a fully initialized FoldDB instance based on the database configuration.
 ///
-/// This factory handles the creation of backend-specific components like:
-/// - Storage operations (DbOperations)
-/// - Progress tracking (ProgressStore)
-/// - Connection pooling and configuration
-/// - E2E encryption (atom content via EncryptingNamespacedStore, index keywords via HMAC)
+/// - **Local**: Sled backend with E2E encryption.
+/// - **Exemem**: Local Sled + E2E encryption + S3 sync via the Exemem platform.
+///   Uses the same `api_url` and `api_key` for sync auth — no extra config needed.
+/// - **Cloud** (aws-backend feature): DynamoDB backend with E2E encryption.
 pub async fn create_fold_db(
     config: &DatabaseConfig,
     e2e_keys: &E2eKeys,
 ) -> FoldDbResult<Arc<Mutex<FoldDB>>> {
     match config {
         DatabaseConfig::Local { path } => {
-            let path_str = path
-                .to_str()
-                .ok_or_else(|| FoldDbError::Config("Invalid storage path".to_string()))?;
-
-            // Open sled database
-            let db = sled::open(path)
-                .map_err(|e| FoldDbError::Config(format!("Failed to open sled database: {}", e)))?;
-            let progress_tree = db
-                .open_tree("progress")
-                .map_err(|e| FoldDbError::Config(format!("Failed to open progress tree: {}", e)))?;
-
-            // Build base namespaced store from sled
-            let base_store: Arc<dyn crate::storage::traits::NamespacedStore> =
-                Arc::new(crate::storage::SledNamespacedStore::new(db));
-
-            // Wrap with E2E encryption (atom content via AES-256-GCM)
-            let crypto = Arc::new(
-                crate::crypto::LocalCryptoProvider::from_key(e2e_keys.encryption_key()),
-            );
-            let enc_store = crate::storage::EncryptingNamespacedStore::new(
-                base_store,
-                crypto,
-                true, // migration_mode: tolerate existing plaintext data
-            );
-            let store = Arc::new(enc_store) as Arc<dyn crate::storage::traits::NamespacedStore>;
-
-            let db_ops = DbOperations::from_namespaced_store(store)
-            .await
-            .map_err(|e| FoldDbError::Config(e.to_string()))?;
-
-            let job_store = crate::progress::create_tracker_with_sled(progress_tree);
-
-            Ok(Arc::new(Mutex::new(
-                FoldDB::initialize_from_db_ops(
-                    Arc::new(db_ops),
-                    path_str,
-                    Some(job_store),
-                    "local".to_string(),
-                )
-                .await
-                .map_err(|e| FoldDbError::Config(e.to_string()))?,
-            )))
+            create_local_fold_db(path, e2e_keys, None).await
         }
         DatabaseConfig::Exemem { api_url, api_key } => {
-            let auth = crate::storage::ExememAuth::ApiKey(api_key.clone());
-            let store: Arc<dyn crate::storage::traits::NamespacedStore> = Arc::new(
-                crate::storage::ExememNamespacedStore::new(api_url.clone(), auth),
+            // Exemem mode: local Sled + S3 sync via the Exemem platform.
+            // The sync auth Lambda shares the same API URL and API key.
+            let sync_setup = SyncSetup::from_exemem(api_url, api_key);
+            let path = std::path::PathBuf::from(
+                std::env::var("FOLD_STORAGE_PATH").unwrap_or_else(|_| "data".to_string()),
             );
-            create_fold_db_from_store(store, e2e_keys).await
+            create_local_fold_db(&path, e2e_keys, Some(sync_setup)).await
         }
         #[cfg(feature = "aws-backend")]
         DatabaseConfig::Cloud(cloud_config) => {
-            log_feature!(
-                LogFeature::Database,
-                info,
-                "Initializing Cloud backend: region={}",
-                cloud_config.region
-            );
-
-            let aws_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-                .region(aws_sdk_dynamodb::config::Region::new(
-                    cloud_config.region.clone(),
-                ))
-                .load()
-                .await;
-
-            let client = aws_sdk_dynamodb::Client::new(&aws_config);
-
-            // Convert ExplicitTables to TableNameResolver
-            let map = std::collections::HashMap::from([
-                ("main".to_string(), cloud_config.tables.main.clone()),
-                ("metadata".to_string(), cloud_config.tables.metadata.clone()),
-                (
-                    "node_id_schema_permissions".to_string(),
-                    cloud_config.tables.permissions.clone(),
-                ),
-                (
-                    "schema_states".to_string(),
-                    cloud_config.tables.schema_states.clone(),
-                ),
-                ("schemas".to_string(), cloud_config.tables.schemas.clone()),
-                (
-                    "public_keys".to_string(),
-                    cloud_config.tables.public_keys.clone(),
-                ),
-                (
-                    "native_index".to_string(),
-                    cloud_config.tables.native_index.clone(),
-                ),
-                ("process".to_string(), cloud_config.tables.process.clone()),
-                (
-                    "idempotency".to_string(),
-                    cloud_config.tables.idempotency.clone(),
-                ),
-            ]);
-
-            let resolver = TableNameResolver::Explicit(map);
-
-            // Require user_id for DynamoDB backend
-            let user_id = cloud_config.user_id.clone().ok_or_else(|| {
-                FoldDbError::Config("Missing user_id for Cloud config".to_string())
-            })?;
-
-            // Build the base namespaced store
-            let base_store: Arc<dyn crate::storage::traits::NamespacedStore> =
-                Arc::new(crate::storage::CloudNamespacedStore::new(
-                    client.clone(),
-                    resolver,
-                    cloud_config.auto_create,
-                ));
-
-            // Wrap with E2E encryption (atom content via AES-256-GCM)
-            let e2e_crypto = Arc::new(
-                crate::crypto::LocalCryptoProvider::from_key(e2e_keys.encryption_key()),
-            );
-            let e2e_store = crate::storage::EncryptingNamespacedStore::new(
-                base_store,
-                e2e_crypto,
-                true, // migration_mode: tolerate existing plaintext data
-            );
-            let final_store =
-                Arc::new(e2e_store) as Arc<dyn crate::storage::traits::NamespacedStore>;
-
-            let db_ops = Arc::new(
-                DbOperations::from_namespaced_store(final_store)
-                    .await
-                    .map_err(|e| {
-                        FoldDbError::Config(format!("Failed to initialize DynamoDB backend: {}", e))
-                    })?,
-            );
-
-            // Generate path string for compatibility
-            let path_str = "data";
-
-            // Initialize JobStore (Generic)
-            let job_store: Option<Arc<dyn JobStore>> = {
-                let table_name = cloud_config.tables.process.clone();
-                let store = DynamoDbJobStore::new(client.clone(), table_name);
-                Some(Arc::new(store))
-            };
-
-            // Use the new constructor that accepts components
-            Ok(Arc::new(Mutex::new(
-                FoldDB::new_with_components(db_ops, path_str, job_store, Some(user_id))
-                    .await
-                    .map_err(|e| FoldDbError::Config(e.to_string()))?,
-            )))
+            create_cloud_fold_db(cloud_config, e2e_keys).await
         }
     }
 }
 
-/// Creates a FoldDB instance from a pre-built NamespacedStore.
+/// Creates a local Sled-backed FoldDB with optional S3 sync.
 ///
-/// This is the generic factory for use when the caller already has a
-/// NamespacedStore (e.g. `ExememNamespacedStore` backed by the Storage API).
-/// It wraps the store with E2E encryption and initialises DbOperations.
-pub async fn create_fold_db_from_store(
-    store: Arc<dyn crate::storage::traits::NamespacedStore>,
+/// When `sync_setup` is provided, the storage stack becomes:
+/// ```text
+/// EncryptingNamespacedStore  (E2E AES-256-GCM)
+///       ↓
+/// SyncingNamespacedStore     (records ops for S3 sync)
+///       ↓
+/// SledNamespacedStore        (local persistence)
+/// ```
+async fn create_local_fold_db(
+    path: &std::path::Path,
+    e2e_keys: &E2eKeys,
+    sync_setup: Option<SyncSetup>,
+) -> FoldDbResult<Arc<Mutex<FoldDB>>> {
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| FoldDbError::Config("Invalid storage path".to_string()))?;
+
+    let db = sled::open(path)
+        .map_err(|e| FoldDbError::Config(format!("Failed to open sled database: {}", e)))?;
+    let progress_tree = db
+        .open_tree("progress")
+        .map_err(|e| FoldDbError::Config(format!("Failed to open progress tree: {}", e)))?;
+
+    let base_store: Arc<dyn crate::storage::traits::NamespacedStore> =
+        Arc::new(crate::storage::SledNamespacedStore::new(db));
+
+    // Build the store stack, optionally inserting sync layer
+    let (store, sync_engine, sync_interval_ms): (
+        Arc<dyn crate::storage::traits::NamespacedStore>,
+        Option<Arc<crate::sync::SyncEngine>>,
+        u64,
+    ) = if let Some(setup) = sync_setup {
+        let sync_config = setup.config.unwrap_or_default();
+        let interval_ms = sync_config.sync_interval_ms;
+
+        let sync_crypto: Arc<dyn crate::crypto::CryptoProvider> = Arc::new(
+            crate::crypto::LocalCryptoProvider::from_key(e2e_keys.encryption_key()),
+        );
+        let http = Arc::new(reqwest::Client::new());
+        let s3 = crate::sync::s3::S3Client::new(http.clone());
+        let auth = crate::sync::auth::AuthClient::new(
+            http,
+            setup.auth_url,
+            setup.auth,
+        );
+
+        let engine = Arc::new(crate::sync::SyncEngine::new(
+            setup.device_id,
+            sync_crypto,
+            s3,
+            auth,
+            base_store.clone(),
+            sync_config,
+        ));
+
+        // Sled → SyncingNamespacedStore → EncryptingNamespacedStore
+        let syncing_store = crate::storage::SyncingNamespacedStore::new(
+            base_store,
+            engine.clone(),
+        );
+        let mid_store: Arc<dyn crate::storage::traits::NamespacedStore> =
+            Arc::new(syncing_store);
+
+        let crypto = Arc::new(
+            crate::crypto::LocalCryptoProvider::from_key(e2e_keys.encryption_key()),
+        );
+        let enc_store = crate::storage::EncryptingNamespacedStore::new(
+            mid_store,
+            crypto,
+            true,
+        );
+
+        (Arc::new(enc_store), Some(engine), interval_ms)
+    } else {
+        // No sync — Sled → EncryptingNamespacedStore
+        let crypto = Arc::new(
+            crate::crypto::LocalCryptoProvider::from_key(e2e_keys.encryption_key()),
+        );
+        let enc_store = crate::storage::EncryptingNamespacedStore::new(
+            base_store,
+            crypto,
+            true,
+        );
+        (Arc::new(enc_store), None, 0)
+    };
+
+    let db_ops = DbOperations::from_namespaced_store(store)
+        .await
+        .map_err(|e| FoldDbError::Config(e.to_string()))?;
+
+    let job_store = crate::progress::create_tracker_with_sled(progress_tree);
+
+    let mut fold_db = FoldDB::initialize_from_db_ops(
+        Arc::new(db_ops),
+        path_str,
+        Some(job_store),
+        "local".to_string(),
+    )
+    .await
+    .map_err(|e| FoldDbError::Config(e.to_string()))?;
+
+    if let Some(engine) = sync_engine {
+        fold_db.set_sync_engine(engine);
+        fold_db.start_sync(sync_interval_ms);
+    }
+
+    Ok(Arc::new(Mutex::new(fold_db)))
+}
+
+#[cfg(feature = "aws-backend")]
+async fn create_cloud_fold_db(
+    cloud_config: &crate::storage::config::CloudConfig,
     e2e_keys: &E2eKeys,
 ) -> FoldDbResult<Arc<Mutex<FoldDB>>> {
-    let crypto = Arc::new(crate::crypto::LocalCryptoProvider::from_key(
-        e2e_keys.encryption_key(),
-    ));
-    let enc_store = crate::storage::EncryptingNamespacedStore::new(store, crypto, true);
-    let final_store = Arc::new(enc_store) as Arc<dyn crate::storage::traits::NamespacedStore>;
+    log_feature!(
+        LogFeature::Database,
+        info,
+        "Initializing Cloud backend: region={}",
+        cloud_config.region
+    );
+
+    let aws_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(aws_sdk_dynamodb::config::Region::new(
+            cloud_config.region.clone(),
+        ))
+        .load()
+        .await;
+
+    let client = aws_sdk_dynamodb::Client::new(&aws_config);
+
+    let map = std::collections::HashMap::from([
+        ("main".to_string(), cloud_config.tables.main.clone()),
+        ("metadata".to_string(), cloud_config.tables.metadata.clone()),
+        (
+            "node_id_schema_permissions".to_string(),
+            cloud_config.tables.permissions.clone(),
+        ),
+        (
+            "schema_states".to_string(),
+            cloud_config.tables.schema_states.clone(),
+        ),
+        ("schemas".to_string(), cloud_config.tables.schemas.clone()),
+        (
+            "public_keys".to_string(),
+            cloud_config.tables.public_keys.clone(),
+        ),
+        (
+            "native_index".to_string(),
+            cloud_config.tables.native_index.clone(),
+        ),
+        ("process".to_string(), cloud_config.tables.process.clone()),
+        (
+            "idempotency".to_string(),
+            cloud_config.tables.idempotency.clone(),
+        ),
+    ]);
+
+    let resolver = TableNameResolver::Explicit(map);
+
+    let user_id = cloud_config.user_id.clone().ok_or_else(|| {
+        FoldDbError::Config("Missing user_id for Cloud config".to_string())
+    })?;
+
+    let base_store: Arc<dyn crate::storage::traits::NamespacedStore> =
+        Arc::new(crate::storage::CloudNamespacedStore::new(
+            client.clone(),
+            resolver,
+            cloud_config.auto_create,
+        ));
+
+    let e2e_crypto = Arc::new(
+        crate::crypto::LocalCryptoProvider::from_key(e2e_keys.encryption_key()),
+    );
+    let e2e_store = crate::storage::EncryptingNamespacedStore::new(
+        base_store,
+        e2e_crypto,
+        true,
+    );
+    let final_store =
+        Arc::new(e2e_store) as Arc<dyn crate::storage::traits::NamespacedStore>;
 
     let db_ops = Arc::new(
         DbOperations::from_namespaced_store(final_store)
             .await
-            .map_err(|e| FoldDbError::Config(e.to_string()))?,
+            .map_err(|e| {
+                FoldDbError::Config(format!("Failed to initialize DynamoDB backend: {}", e))
+            })?,
     );
 
+    let job_store: Option<Arc<dyn JobStore>> = {
+        let table_name = cloud_config.tables.process.clone();
+        let store = DynamoDbJobStore::new(client.clone(), table_name);
+        Some(Arc::new(store))
+    };
+
     Ok(Arc::new(Mutex::new(
-        FoldDB::new_with_components(db_ops, "remote", None, None)
+        FoldDB::new_with_components(db_ops, "data", job_store, Some(user_id))
             .await
             .map_err(|e| FoldDbError::Config(e.to_string()))?,
     )))

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -41,6 +41,11 @@ pub struct FoldDB {
     /// Unified progress tracker for all job types (ingestion, indexing, etc.)
     /// This is the single source of truth for progress - local uses Sled, cloud uses DynamoDB
     pub progress_tracker: ProgressTracker,
+    /// Optional sync engine for S3 replication.
+    /// Present when sync is configured (local mode only).
+    sync_engine: Option<Arc<crate::sync::SyncEngine>>,
+    /// Handle for the background sync timer task.
+    sync_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl FoldDB {
@@ -67,6 +72,69 @@ impl FoldDB {
         );
 
         Ok(())
+    }
+
+    /// Graceful async shutdown: flush pending sync, stop background timer, then close.
+    pub async fn shutdown(&mut self) -> Result<(), StorageError> {
+        if let Err(e) = self.stop_sync().await {
+            log::warn!("sync flush on shutdown failed: {e}");
+        }
+        self.flush().await?;
+        self.close().map_err(|e| StorageError::IoError(std::io::Error::other(e.to_string())))
+    }
+
+    /// Set the sync engine (called by the factory when sync is configured).
+    pub fn set_sync_engine(&mut self, engine: Arc<crate::sync::SyncEngine>) {
+        self.sync_engine = Some(engine);
+    }
+
+    /// Start the background sync timer.
+    ///
+    /// Spawns a tokio task that calls `sync()` every `interval_ms` when the
+    /// engine is dirty. Does nothing if no sync engine is configured.
+    pub fn start_sync(&mut self, interval_ms: u64) {
+        let engine = match &self.sync_engine {
+            Some(e) => Arc::clone(e),
+            None => return,
+        };
+
+        let handle = tokio::spawn(async move {
+            let interval = tokio::time::Duration::from_millis(interval_ms);
+            loop {
+                tokio::time::sleep(interval).await;
+                if engine.state().await == crate::sync::SyncState::Dirty {
+                    if let Err(e) = engine.sync().await {
+                        log::warn!("sync cycle failed: {e}");
+                    }
+                }
+            }
+        });
+
+        self.sync_task = Some(handle);
+    }
+
+    /// Force an immediate sync (e.g. on shutdown).
+    pub async fn force_sync(&self) -> Result<(), crate::sync::SyncError> {
+        if let Some(engine) = &self.sync_engine {
+            engine.sync().await?;
+        }
+        Ok(())
+    }
+
+    /// Stop the background sync timer and run a final sync.
+    pub async fn stop_sync(&mut self) -> Result<(), crate::sync::SyncError> {
+        if let Some(handle) = self.sync_task.take() {
+            handle.abort();
+        }
+        self.force_sync().await
+    }
+
+    /// Get the sync engine state, if sync is configured.
+    pub async fn sync_state(&self) -> Option<crate::sync::SyncState> {
+        match &self.sync_engine {
+            Some(engine) => Some(engine.state().await),
+            None => None,
+        }
     }
 
     /// Creates a new FoldDB instance with the specified storage path.
@@ -202,6 +270,8 @@ impl FoldDB {
             mutation_manager,
             pending_tasks,
             progress_tracker,
+            sync_engine: None,
+            sync_task: None,
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod progress;
 pub mod schema;
 pub mod security;
 pub mod storage;
+pub mod sync;
 pub mod testing_utils;
 
 // Re-export main types for convenience

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -141,10 +141,10 @@ pub enum DatabaseConfig {
     #[cfg(feature = "aws-backend")]
     #[serde(rename = "cloud")]
     Cloud(Box<CloudConfig>),
-    /// Exemem Cloud storage (remote API-backed)
+    /// Exemem Cloud storage (local Sled + encrypted S3 sync)
     #[serde(rename = "exemem")]
     Exemem {
-        /// Exemem Storage API URL
+        /// Exemem API URL (sync routes at /api/sync/*)
         api_url: String,
         /// API key for authentication
         api_key: String,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -18,6 +18,8 @@ pub mod inmemory_backend;
 #[cfg(feature = "aws-backend")]
 pub mod reset_manager;
 pub mod sled_backend;
+pub mod syncing_namespaced_store;
+pub mod syncing_store;
 pub mod traits;
 pub mod upload_storage;
 
@@ -44,5 +46,7 @@ pub use encrypting_store::EncryptingKvStore;
 pub use exemem_api_store::{ExememApiStore, ExememAuth};
 pub use exemem_namespaced_store::ExememNamespacedStore;
 pub use sled_backend::SledNamespacedStore;
+pub use syncing_namespaced_store::SyncingNamespacedStore;
+pub use syncing_store::SyncingKvStore;
 pub use traits::{NamespacedStore, TypedKvStore};
 pub use upload_storage::UploadStorage;

--- a/src/storage/syncing_namespaced_store.rs
+++ b/src/storage/syncing_namespaced_store.rs
@@ -1,0 +1,118 @@
+use super::error::StorageResult;
+use super::syncing_store::SyncingKvStore;
+use super::traits::{KvStore, NamespacedStore};
+use crate::sync::SyncEngine;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// A NamespacedStore decorator that wraps each opened namespace with a SyncingKvStore.
+///
+/// Every namespace opened through this store will automatically record
+/// write operations to the SyncEngine for S3 sync.
+///
+/// ```text
+/// SyncingNamespacedStore
+///   └── open_namespace("main")
+///         └── SyncingKvStore("main")  ← records ops
+///               └── inner KvStore     ← actual backend
+/// ```
+pub struct SyncingNamespacedStore {
+    inner: Arc<dyn NamespacedStore>,
+    sync_engine: Arc<SyncEngine>,
+}
+
+impl SyncingNamespacedStore {
+    pub fn new(
+        inner: Arc<dyn NamespacedStore>,
+        sync_engine: Arc<SyncEngine>,
+    ) -> Self {
+        Self {
+            inner,
+            sync_engine,
+        }
+    }
+}
+
+#[async_trait]
+impl NamespacedStore for SyncingNamespacedStore {
+    async fn open_namespace(&self, name: &str) -> StorageResult<Arc<dyn KvStore>> {
+        let inner_kv = self.inner.open_namespace(name).await?;
+        let syncing = SyncingKvStore::new(
+            inner_kv,
+            self.sync_engine.clone(),
+            name.to_string(),
+        );
+        Ok(Arc::new(syncing))
+    }
+
+    async fn list_namespaces(&self) -> StorageResult<Vec<String>> {
+        self.inner.list_namespaces().await
+    }
+
+    async fn delete_namespace(&self, name: &str) -> StorageResult<bool> {
+        self.inner.delete_namespace(name).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::provider::LocalCryptoProvider;
+    use crate::storage::inmemory_backend::InMemoryNamespacedStore;
+    use crate::sync::auth::{AuthClient, SyncAuth};
+    use crate::sync::s3::S3Client;
+    use crate::sync::SyncConfig;
+
+    async fn test_setup() -> (SyncingNamespacedStore, Arc<SyncEngine>) {
+        let inner = Arc::new(InMemoryNamespacedStore::new());
+        let crypto: Arc<dyn crate::crypto::CryptoProvider> =
+            Arc::new(LocalCryptoProvider::from_key([0x42u8; 32]));
+        let http = Arc::new(reqwest::Client::new());
+        let s3 = S3Client::new(http.clone());
+        let auth = AuthClient::new(
+            http,
+            "http://localhost:0".to_string(),
+            SyncAuth::ApiKey("test".to_string()),
+        );
+
+        let engine = Arc::new(SyncEngine::new(
+            "test-device".to_string(),
+            crypto,
+            s3,
+            auth,
+            inner.clone(),
+            SyncConfig::default(),
+        ));
+
+        let syncing = SyncingNamespacedStore::new(inner, engine.clone());
+        (syncing, engine)
+    }
+
+    #[tokio::test]
+    async fn writes_through_namespace_are_recorded() {
+        let (store, engine) = test_setup().await;
+
+        let main = store.open_namespace("main").await.unwrap();
+        assert_eq!(engine.pending_count().await, 0);
+
+        main.put(b"atom:1", b"data1".to_vec()).await.unwrap();
+        assert_eq!(engine.pending_count().await, 1);
+
+        let meta = store.open_namespace("metadata").await.unwrap();
+        meta.put(b"schema:foo", b"schema".to_vec()).await.unwrap();
+        assert_eq!(engine.pending_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn list_namespaces_passthrough() {
+        let (store, _engine) = test_setup().await;
+
+        // Open some namespaces
+        store.open_namespace("main").await.unwrap();
+        store.open_namespace("metadata").await.unwrap();
+
+        let names = store.list_namespaces().await.unwrap();
+        assert!(names.contains(&"main".to_string()));
+        assert!(names.contains(&"metadata".to_string()));
+    }
+}

--- a/src/storage/syncing_store.rs
+++ b/src/storage/syncing_store.rs
@@ -1,0 +1,227 @@
+use super::error::StorageResult;
+use super::traits::{ExecutionModel, FlushBehavior, KvStore};
+use crate::sync::SyncEngine;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// A KvStore decorator that records all write operations to the SyncEngine.
+///
+/// Sits between EncryptingKvStore and the backend (Sled/DynamoDB):
+///
+/// ```text
+/// TypedKvStore (JSON serialization)
+///       ↓
+/// EncryptingKvStore (AES-256-GCM)
+///       ↓
+/// SyncingKvStore (records ops for S3 sync)  ← THIS
+///       ↓
+/// SledKvStore (actual persistence)
+/// ```
+///
+/// Write operations are recorded non-blocking — the sync engine queues them
+/// and uploads on its timer cycle. Reads pass through directly.
+pub struct SyncingKvStore {
+    inner: Arc<dyn KvStore>,
+    sync_engine: Arc<SyncEngine>,
+    namespace: String,
+}
+
+impl SyncingKvStore {
+    pub fn new(
+        inner: Arc<dyn KvStore>,
+        sync_engine: Arc<SyncEngine>,
+        namespace: String,
+    ) -> Self {
+        Self {
+            inner,
+            sync_engine,
+            namespace,
+        }
+    }
+}
+
+#[async_trait]
+impl KvStore for SyncingKvStore {
+    async fn get(&self, key: &[u8]) -> StorageResult<Option<Vec<u8>>> {
+        self.inner.get(key).await
+    }
+
+    async fn put(&self, key: &[u8], value: Vec<u8>) -> StorageResult<()> {
+        // Write to backend first
+        self.inner.put(key, value.clone()).await?;
+        // Record for sync (non-blocking, just queues)
+        self.sync_engine
+            .record_put(&self.namespace, key, &value)
+            .await;
+        Ok(())
+    }
+
+    async fn delete(&self, key: &[u8]) -> StorageResult<bool> {
+        let existed = self.inner.delete(key).await?;
+        if existed {
+            self.sync_engine
+                .record_delete(&self.namespace, key)
+                .await;
+        }
+        Ok(existed)
+    }
+
+    async fn exists(&self, key: &[u8]) -> StorageResult<bool> {
+        self.inner.exists(key).await
+    }
+
+    async fn scan_prefix(&self, prefix: &[u8]) -> StorageResult<Vec<(Vec<u8>, Vec<u8>)>> {
+        self.inner.scan_prefix(prefix).await
+    }
+
+    async fn batch_put(&self, items: Vec<(Vec<u8>, Vec<u8>)>) -> StorageResult<()> {
+        // Write to backend first
+        self.inner.batch_put(items.clone()).await?;
+        // Record for sync
+        self.sync_engine
+            .record_batch_put(&self.namespace, &items)
+            .await;
+        Ok(())
+    }
+
+    async fn batch_delete(&self, keys: Vec<Vec<u8>>) -> StorageResult<()> {
+        self.inner.batch_delete(keys.clone()).await?;
+        self.sync_engine
+            .record_batch_delete(&self.namespace, &keys)
+            .await;
+        Ok(())
+    }
+
+    async fn flush(&self) -> StorageResult<()> {
+        self.inner.flush().await
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "syncing"
+    }
+
+    fn execution_model(&self) -> ExecutionModel {
+        self.inner.execution_model()
+    }
+
+    fn flush_behavior(&self) -> FlushBehavior {
+        self.inner.flush_behavior()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::provider::LocalCryptoProvider;
+    use crate::storage::inmemory_backend::InMemoryNamespacedStore;
+    use crate::storage::traits::NamespacedStore;
+    use crate::sync::auth::{AuthClient, SyncAuth};
+    use crate::sync::s3::S3Client;
+    use crate::sync::SyncConfig;
+
+    async fn test_store_with_sync() -> (Arc<dyn KvStore>, Arc<SyncEngine>) {
+        let ns_store = InMemoryNamespacedStore::new();
+        let inner = ns_store.open_namespace("main").await.unwrap();
+
+        let crypto: Arc<dyn crate::crypto::CryptoProvider> =
+            Arc::new(LocalCryptoProvider::from_key([0x42u8; 32]));
+        let http = Arc::new(reqwest::Client::new());
+        let s3 = S3Client::new(http.clone());
+        let auth = AuthClient::new(
+            http,
+            "http://localhost:0".to_string(),
+            SyncAuth::ApiKey("test".to_string()),
+        );
+        let ns_store_arc: Arc<dyn NamespacedStore> = Arc::new(ns_store);
+
+        let engine = Arc::new(SyncEngine::new(
+            "test-device".to_string(),
+            crypto,
+            s3,
+            auth,
+            ns_store_arc,
+            SyncConfig::default(),
+        ));
+
+        let syncing = Arc::new(SyncingKvStore::new(
+            inner,
+            engine.clone(),
+            "main".to_string(),
+        ));
+
+        (syncing, engine)
+    }
+
+    #[tokio::test]
+    async fn put_records_to_sync_engine() {
+        let (store, engine) = test_store_with_sync().await;
+
+        assert_eq!(engine.pending_count().await, 0);
+
+        store.put(b"key1", b"val1".to_vec()).await.unwrap();
+        assert_eq!(engine.pending_count().await, 1);
+
+        store.put(b"key2", b"val2".to_vec()).await.unwrap();
+        assert_eq!(engine.pending_count().await, 2);
+
+        // Verify data is still readable
+        let val = store.get(b"key1").await.unwrap();
+        assert_eq!(val, Some(b"val1".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn delete_records_to_sync_engine() {
+        let (store, engine) = test_store_with_sync().await;
+
+        store.put(b"key1", b"val1".to_vec()).await.unwrap();
+        assert_eq!(engine.pending_count().await, 1);
+
+        store.delete(b"key1").await.unwrap();
+        assert_eq!(engine.pending_count().await, 2); // put + delete
+
+        let val = store.get(b"key1").await.unwrap();
+        assert_eq!(val, None);
+    }
+
+    #[tokio::test]
+    async fn batch_put_records_to_sync_engine() {
+        let (store, engine) = test_store_with_sync().await;
+
+        let items = vec![
+            (b"k1".to_vec(), b"v1".to_vec()),
+            (b"k2".to_vec(), b"v2".to_vec()),
+        ];
+
+        store.batch_put(items).await.unwrap();
+        assert_eq!(engine.pending_count().await, 1); // one batch op
+
+        let val = store.get(b"k1").await.unwrap();
+        assert_eq!(val, Some(b"v1".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn reads_dont_record() {
+        let (store, engine) = test_store_with_sync().await;
+
+        store.put(b"key1", b"val1".to_vec()).await.unwrap();
+        assert_eq!(engine.pending_count().await, 1);
+
+        // These should not add to pending
+        store.get(b"key1").await.unwrap();
+        store.exists(b"key1").await.unwrap();
+        store.scan_prefix(b"key").await.unwrap();
+
+        assert_eq!(engine.pending_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn state_transitions_to_dirty() {
+        let (store, engine) = test_store_with_sync().await;
+
+        assert_eq!(engine.state().await, crate::sync::SyncState::Idle);
+
+        store.put(b"key1", b"val1".to_vec()).await.unwrap();
+
+        assert_eq!(engine.state().await, crate::sync::SyncState::Dirty);
+    }
+}

--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -1,0 +1,282 @@
+use super::error::{SyncError, SyncResult};
+use super::s3::PresignedUrl;
+use reqwest::Client;
+use serde::Deserialize;
+use std::sync::Arc;
+
+/// Authentication method for the sync auth Lambda.
+#[derive(Clone, Debug)]
+pub enum SyncAuth {
+    ApiKey(String),
+    BearerToken(String),
+}
+
+/// Response from the auth Lambda listing available S3 objects.
+#[derive(Debug, Deserialize)]
+pub struct ListObjectsResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub objects: Vec<S3ObjectInfo>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct S3ObjectInfo {
+    pub key: String,
+    pub size: u64,
+    pub last_modified: String,
+}
+
+/// Response from the auth Lambda with presigned URLs.
+#[derive(Debug, Deserialize)]
+pub struct PresignedResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub urls: Vec<PresignedUrl>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Response from the auth Lambda for lock operations.
+#[derive(Debug, Deserialize)]
+pub struct LockResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub locked_by: Option<String>,
+    #[serde(default)]
+    pub expires_at: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Client for the sync auth Lambda.
+///
+/// The auth Lambda:
+/// 1. Validates authentication (API key or bearer token)
+/// 2. Returns presigned S3 URLs scoped to the user's prefix
+/// 3. Manages device locks
+///
+/// The client never gets AWS credentials — only time-limited presigned URLs.
+pub struct AuthClient {
+    http: Arc<Client>,
+    base_url: String,
+    auth: SyncAuth,
+}
+
+impl AuthClient {
+    pub fn new(http: Arc<Client>, base_url: String, auth: SyncAuth) -> Self {
+        Self {
+            http,
+            base_url,
+            auth,
+        }
+    }
+
+    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.auth {
+            SyncAuth::ApiKey(key) => req.header("X-API-Key", key),
+            SyncAuth::BearerToken(token) => {
+                req.header("Authorization", format!("Bearer {token}"))
+            }
+        }
+    }
+
+    async fn post(&self, path: &str, body: serde_json::Value) -> SyncResult<serde_json::Value> {
+        let url = format!("{}{}", self.base_url, path);
+        let req = self.http.post(&url).json(&body);
+        let req = self.apply_auth(req);
+
+        let response = req.send().await.map_err(|e| {
+            if e.is_timeout() {
+                SyncError::Network(format!("auth Lambda timeout: {e}"))
+            } else if e.is_connect() {
+                SyncError::Network(format!("auth Lambda unreachable: {e}"))
+            } else {
+                SyncError::Network(e.to_string())
+            }
+        })?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED
+            || status == reqwest::StatusCode::FORBIDDEN
+        {
+            return Err(SyncError::Auth("authentication failed — re-authenticate".to_string()));
+        }
+
+        if status.is_server_error() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(SyncError::Auth(format!("auth Lambda error: HTTP {status}: {body}")));
+        }
+
+        let json: serde_json::Value = response.json().await.map_err(|e| {
+            SyncError::Auth(format!("invalid JSON from auth Lambda: {e}"))
+        })?;
+
+        Ok(json)
+    }
+
+    /// Request presigned URLs for uploading log entries.
+    pub async fn presign_log_upload(&self, seq_numbers: &[u64]) -> SyncResult<Vec<PresignedUrl>> {
+        let body = serde_json::json!({
+            "action": "presign_log_upload",
+            "seq_numbers": seq_numbers,
+        });
+
+        let resp = self.post("/api/sync/presign", body).await?;
+        let parsed: PresignedResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed.error.unwrap_or_else(|| "presign failed".to_string()),
+            ));
+        }
+
+        Ok(parsed.urls)
+    }
+
+    /// Request a presigned URL for uploading a snapshot.
+    pub async fn presign_snapshot_upload(&self, snapshot_name: &str) -> SyncResult<PresignedUrl> {
+        let body = serde_json::json!({
+            "action": "presign_snapshot_upload",
+            "snapshot_name": snapshot_name,
+        });
+
+        let resp = self.post("/api/sync/presign", body).await?;
+        let parsed: PresignedResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed.error.unwrap_or_else(|| "presign failed".to_string()),
+            ));
+        }
+
+        parsed.urls.into_iter().next().ok_or_else(|| {
+            SyncError::Auth("no presigned URL returned".to_string())
+        })
+    }
+
+    /// Request a presigned URL for downloading a snapshot.
+    pub async fn presign_snapshot_download(&self, snapshot_name: &str) -> SyncResult<PresignedUrl> {
+        let body = serde_json::json!({
+            "action": "presign_snapshot_download",
+            "snapshot_name": snapshot_name,
+        });
+
+        let resp = self.post("/api/sync/presign", body).await?;
+        let parsed: PresignedResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed.error.unwrap_or_else(|| "presign failed".to_string()),
+            ));
+        }
+
+        parsed.urls.into_iter().next().ok_or_else(|| {
+            SyncError::Auth("no presigned URL returned".to_string())
+        })
+    }
+
+    /// Request presigned URLs for downloading log entries.
+    pub async fn presign_log_download(&self, seq_numbers: &[u64]) -> SyncResult<Vec<PresignedUrl>> {
+        let body = serde_json::json!({
+            "action": "presign_log_download",
+            "seq_numbers": seq_numbers,
+        });
+
+        let resp = self.post("/api/sync/presign", body).await?;
+        let parsed: PresignedResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed.error.unwrap_or_else(|| "presign failed".to_string()),
+            ));
+        }
+
+        Ok(parsed.urls)
+    }
+
+    /// List objects in the user's S3 prefix.
+    pub async fn list_objects(&self, prefix: &str) -> SyncResult<Vec<S3ObjectInfo>> {
+        let body = serde_json::json!({
+            "action": "list_objects",
+            "prefix": prefix,
+        });
+
+        let resp = self.post("/api/sync/list", body).await?;
+        let parsed: ListObjectsResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed.error.unwrap_or_else(|| "list failed".to_string()),
+            ));
+        }
+
+        Ok(parsed.objects)
+    }
+
+    /// Acquire the device lock.
+    pub async fn acquire_lock(&self, device_id: &str, ttl_secs: u64) -> SyncResult<bool> {
+        let body = serde_json::json!({
+            "action": "acquire_lock",
+            "device_id": device_id,
+            "ttl_secs": ttl_secs,
+        });
+
+        let resp = self.post("/api/sync/lock", body).await?;
+        let parsed: LockResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            if let Some(locked_by) = parsed.locked_by {
+                return Err(SyncError::DeviceLocked {
+                    device_id: locked_by,
+                    expires_at: parsed.expires_at.unwrap_or_default(),
+                });
+            }
+            return Err(SyncError::Auth(
+                parsed.error.unwrap_or_else(|| "lock failed".to_string()),
+            ));
+        }
+
+        Ok(true)
+    }
+
+    /// Release the device lock.
+    pub async fn release_lock(&self, device_id: &str) -> SyncResult<()> {
+        let body = serde_json::json!({
+            "action": "release_lock",
+            "device_id": device_id,
+        });
+
+        let resp = self.post("/api/sync/lock", body).await?;
+        let parsed: LockResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed.error.unwrap_or_else(|| "unlock failed".to_string()),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Renew the device lock (extend TTL).
+    pub async fn renew_lock(&self, device_id: &str, ttl_secs: u64) -> SyncResult<()> {
+        let body = serde_json::json!({
+            "action": "renew_lock",
+            "device_id": device_id,
+            "ttl_secs": ttl_secs,
+        });
+
+        let resp = self.post("/api/sync/lock", body).await?;
+        let parsed: LockResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed.error.unwrap_or_else(|| "renew failed".to_string()),
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1,0 +1,497 @@
+use super::auth::AuthClient;
+use super::error::{SyncError, SyncResult};
+use super::log::{LogEntry, LogOp};
+use super::s3::S3Client;
+use super::snapshot::Snapshot;
+use crate::crypto::CryptoProvider;
+use crate::storage::traits::NamespacedStore;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Sync engine state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncState {
+    /// No unsynced changes.
+    Idle,
+    /// Local changes not yet uploaded.
+    Dirty,
+    /// Upload in progress.
+    Syncing,
+    /// Network unavailable, will retry.
+    Offline,
+}
+
+/// Configuration for the sync engine.
+#[derive(Debug, Clone)]
+pub struct SyncConfig {
+    /// How often to sync when dirty (milliseconds).
+    pub sync_interval_ms: u64,
+    /// Number of log entries before triggering compaction (snapshot + delete old logs).
+    pub compaction_threshold: u64,
+    /// Device lock TTL in seconds.
+    pub lock_ttl_secs: u64,
+    /// Maximum retries for network operations.
+    pub max_retries: u32,
+}
+
+impl Default for SyncConfig {
+    fn default() -> Self {
+        Self {
+            sync_interval_ms: 30_000,
+            compaction_threshold: 100,
+            lock_ttl_secs: 300,
+            max_retries: 2,
+        }
+    }
+}
+
+/// Callback for sync status changes.
+pub type StatusCallback = Box<dyn Fn(SyncState, Option<&str>) + Send + Sync>;
+
+/// The sync engine manages replication of a local Sled database to S3.
+///
+/// Architecture:
+/// ```text
+/// fold_db (local) ──▶ SyncEngine ──▶ Auth Lambda ──▶ S3 (encrypted blobs)
+///
+/// State machine:
+///   IDLE ──mutation──▶ DIRTY ──timer──▶ SYNCING ──success──▶ IDLE
+///                       ▲                  │
+///                       └──── failure ─────┘
+/// ```
+///
+/// The engine:
+/// 1. Records KvStore operations as encrypted log entries
+/// 2. Uploads log entries to S3 via presigned URLs
+/// 3. Periodically compacts logs into snapshots
+/// 4. Manages single-device write lock
+/// 5. Supports bootstrap (download snapshot + replay logs) for new devices
+pub struct SyncEngine {
+    state: Arc<Mutex<SyncState>>,
+    /// Pending log entries not yet uploaded.
+    pending: Arc<Mutex<Vec<LogEntry>>>,
+    /// Current sequence number.
+    seq: Arc<Mutex<u64>>,
+    /// Device identifier (unique per device).
+    device_id: String,
+    /// Encryption provider for sealing log entries and snapshots.
+    crypto: Arc<dyn CryptoProvider>,
+    /// S3 client for uploads/downloads.
+    s3: S3Client,
+    /// Auth client for presigned URLs and lock management.
+    auth: AuthClient,
+    /// The local namespaced store (for snapshot creation).
+    store: Arc<dyn NamespacedStore>,
+    /// Configuration.
+    config: SyncConfig,
+    /// Optional callback for status changes.
+    status_callback: Option<StatusCallback>,
+}
+
+impl SyncEngine {
+    pub fn new(
+        device_id: String,
+        crypto: Arc<dyn CryptoProvider>,
+        s3: S3Client,
+        auth: AuthClient,
+        store: Arc<dyn NamespacedStore>,
+        config: SyncConfig,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(SyncState::Idle)),
+            pending: Arc::new(Mutex::new(Vec::new())),
+            seq: Arc::new(Mutex::new(0)),
+            device_id,
+            crypto,
+            s3,
+            auth,
+            store,
+            config,
+            status_callback: None,
+        }
+    }
+
+    /// Set a callback that fires on state changes.
+    pub fn set_status_callback(&mut self, cb: StatusCallback) {
+        self.status_callback = Some(cb);
+    }
+
+    /// Get the device identifier.
+    pub fn device_id(&self) -> &str {
+        &self.device_id
+    }
+
+    /// Get the current sync state.
+    pub async fn state(&self) -> SyncState {
+        *self.state.lock().await
+    }
+
+    /// Get the number of pending (unsynced) log entries.
+    pub async fn pending_count(&self) -> usize {
+        self.pending.lock().await.len()
+    }
+
+    async fn set_state(&self, new_state: SyncState, message: Option<&str>) {
+        let mut state = self.state.lock().await;
+        *state = new_state;
+        if let Some(cb) = &self.status_callback {
+            cb(new_state, message);
+        }
+    }
+
+    // =========================================================================
+    // Recording operations
+    // =========================================================================
+
+    /// Record a put operation for sync.
+    pub async fn record_put(&self, namespace: &str, key: &[u8], value: &[u8]) {
+        let entry = self.make_entry(LogOp::Put {
+            namespace: namespace.to_string(),
+            key: LogOp::encode_bytes(key),
+            value: LogOp::encode_bytes(value),
+        }).await;
+
+        self.pending.lock().await.push(entry);
+        self.set_state(SyncState::Dirty, None).await;
+    }
+
+    /// Record a delete operation for sync.
+    pub async fn record_delete(&self, namespace: &str, key: &[u8]) {
+        let entry = self.make_entry(LogOp::Delete {
+            namespace: namespace.to_string(),
+            key: LogOp::encode_bytes(key),
+        }).await;
+
+        self.pending.lock().await.push(entry);
+        self.set_state(SyncState::Dirty, None).await;
+    }
+
+    /// Record a batch put operation for sync.
+    pub async fn record_batch_put(&self, namespace: &str, items: &[(Vec<u8>, Vec<u8>)]) {
+        let encoded_items: Vec<(String, String)> = items
+            .iter()
+            .map(|(k, v)| (LogOp::encode_bytes(k), LogOp::encode_bytes(v)))
+            .collect();
+
+        let entry = self.make_entry(LogOp::BatchPut {
+            namespace: namespace.to_string(),
+            items: encoded_items,
+        }).await;
+
+        self.pending.lock().await.push(entry);
+        self.set_state(SyncState::Dirty, None).await;
+    }
+
+    /// Record a batch delete operation for sync.
+    pub async fn record_batch_delete(&self, namespace: &str, keys: &[Vec<u8>]) {
+        let encoded_keys: Vec<String> = keys.iter().map(|k| LogOp::encode_bytes(k)).collect();
+
+        let entry = self.make_entry(LogOp::BatchDelete {
+            namespace: namespace.to_string(),
+            keys: encoded_keys,
+        }).await;
+
+        self.pending.lock().await.push(entry);
+        self.set_state(SyncState::Dirty, None).await;
+    }
+
+    async fn make_entry(&self, op: LogOp) -> LogEntry {
+        let mut seq = self.seq.lock().await;
+        *seq += 1;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        LogEntry {
+            seq: *seq,
+            timestamp_ms: now,
+            device_id: self.device_id.clone(),
+            op,
+        }
+    }
+
+    // =========================================================================
+    // Sync cycle
+    // =========================================================================
+
+    /// Run one sync cycle: upload pending log entries, compact if needed.
+    ///
+    /// Returns Ok(true) if all pending entries were uploaded,
+    /// Ok(false) if there was nothing to sync.
+    pub async fn sync(&self) -> SyncResult<bool> {
+        let current_state = self.state().await;
+        if current_state == SyncState::Syncing {
+            return Ok(false);
+        }
+        if current_state == SyncState::Idle {
+            return Ok(false);
+        }
+
+        self.set_state(SyncState::Syncing, Some("uploading")).await;
+
+        match self.do_sync().await {
+            Ok(synced) => {
+                self.set_state(SyncState::Idle, None).await;
+                Ok(synced)
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                match &e {
+                    SyncError::Network(_) => {
+                        self.set_state(SyncState::Offline, Some(&msg)).await;
+                    }
+                    SyncError::Auth(_) => {
+                        self.set_state(SyncState::Dirty, Some(&msg)).await;
+                    }
+                    _ => {
+                        self.set_state(SyncState::Dirty, Some(&msg)).await;
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
+
+    async fn do_sync(&self) -> SyncResult<bool> {
+        let entries = {
+            let pending = self.pending.lock().await;
+            if pending.is_empty() {
+                return Ok(false);
+            }
+            pending.clone()
+        };
+
+        // Seal each entry individually
+        let mut sealed_entries = Vec::with_capacity(entries.len());
+        for entry in &entries {
+            let sealed = entry.seal(&self.crypto).await?;
+            sealed_entries.push((entry.seq, sealed));
+        }
+
+        // Get presigned URLs for all entries
+        let seq_numbers: Vec<u64> = sealed_entries.iter().map(|(seq, _)| *seq).collect();
+        let urls = self.auth.presign_log_upload(&seq_numbers).await?;
+
+        if urls.len() != sealed_entries.len() {
+            return Err(SyncError::Auth(format!(
+                "expected {} presigned URLs, got {}",
+                sealed_entries.len(),
+                urls.len()
+            )));
+        }
+
+        // Upload each sealed entry
+        for ((_seq, sealed), url) in sealed_entries.into_iter().zip(urls.iter()) {
+            self.s3.upload(url, sealed.bytes).await?;
+        }
+
+        // Clear uploaded entries from pending
+        {
+            let mut pending = self.pending.lock().await;
+            let uploaded_count = entries.len();
+            let count = uploaded_count.min(pending.len());
+            pending.drain(..count);
+        }
+
+        // Check if compaction is needed
+        let current_seq = *self.seq.lock().await;
+        if current_seq > 0 && current_seq % self.config.compaction_threshold == 0 {
+            if let Err(e) = self.compact(current_seq).await {
+                log::warn!("compaction failed (non-fatal): {e}");
+            }
+        }
+
+        Ok(true)
+    }
+
+    // =========================================================================
+    // Compaction (snapshot + delete old logs)
+    // =========================================================================
+
+    async fn compact(&self, last_seq: u64) -> SyncResult<()> {
+        log::info!("compacting: creating snapshot at seq {last_seq}");
+
+        let snapshot = Snapshot::create(
+            self.store.as_ref(),
+            &self.device_id,
+            last_seq,
+        ).await?;
+
+        let sealed = snapshot.seal(&self.crypto).await?;
+
+        let snapshot_name = format!("{last_seq}.enc");
+        let url = self.auth.presign_snapshot_upload(&snapshot_name).await?;
+        self.s3.upload(&url, sealed).await?;
+
+        // Also upload as "latest.enc" for quick bootstrap
+        let latest_url = self.auth.presign_snapshot_upload("latest.enc").await?;
+        let sealed_again = Snapshot::create(
+            self.store.as_ref(),
+            &self.device_id,
+            last_seq,
+        ).await?.seal(&self.crypto).await?;
+        self.s3.upload(&latest_url, sealed_again).await?;
+
+        log::info!("compaction complete: snapshot at seq {last_seq}");
+        Ok(())
+    }
+
+    // =========================================================================
+    // Bootstrap (download snapshot + replay logs)
+    // =========================================================================
+
+    /// Bootstrap this device from S3.
+    ///
+    /// Downloads the latest snapshot, restores it to the local store,
+    /// then replays any log entries after the snapshot's sequence number.
+    pub async fn bootstrap(&self) -> SyncResult<u64> {
+        log::info!("bootstrapping from S3");
+
+        // Download latest snapshot
+        let snapshot_url = self.auth.presign_snapshot_download("latest.enc").await?;
+        let snapshot_data = self.s3.download(&snapshot_url).await?;
+
+        let last_seq = match snapshot_data {
+            Some(data) => {
+                let snapshot = Snapshot::unseal(&data, &self.crypto).await?;
+                let last_seq = snapshot.last_seq;
+
+                log::info!(
+                    "restoring snapshot: {} namespaces, last_seq={}",
+                    snapshot.namespaces.len(),
+                    last_seq
+                );
+
+                snapshot.restore(self.store.as_ref()).await?;
+                last_seq
+            }
+            None => {
+                log::info!("no snapshot found — starting fresh");
+                0
+            }
+        };
+
+        // List and replay log entries after the snapshot
+        let log_objects = self.auth.list_objects("log/").await?;
+        let mut log_seqs: Vec<u64> = log_objects
+            .iter()
+            .filter_map(|obj| {
+                obj.key
+                    .rsplit('/')
+                    .next()
+                    .and_then(|name| name.strip_suffix(".enc"))
+                    .and_then(|s| s.parse::<u64>().ok())
+            })
+            .filter(|seq| *seq > last_seq)
+            .collect();
+
+        log_seqs.sort();
+
+        if !log_seqs.is_empty() {
+            log::info!("replaying {} log entries (seq {}..={})", log_seqs.len(), log_seqs[0], log_seqs[log_seqs.len() - 1]);
+
+            let urls = self.auth.presign_log_download(&log_seqs).await?;
+
+            for (seq, url) in log_seqs.iter().zip(urls.iter()) {
+                let data = self.s3.download(url).await?;
+                match data {
+                    Some(bytes) => {
+                        match LogEntry::unseal(&bytes, &self.crypto).await {
+                            Ok(entry) => {
+                                self.replay_entry(&entry).await?;
+                            }
+                            Err(e) => {
+                                log::warn!("skipping corrupt log entry seq={seq}: {e}");
+                            }
+                        }
+                    }
+                    None => {
+                        log::warn!("log entry seq={seq} not found in S3, skipping");
+                    }
+                }
+            }
+        }
+
+        // Update local sequence counter
+        let final_seq = log_seqs.last().copied().unwrap_or(last_seq);
+        *self.seq.lock().await = final_seq;
+
+        log::info!("bootstrap complete at seq {final_seq}");
+        Ok(final_seq)
+    }
+
+    /// Replay a single log entry by executing the operation against the local store.
+    async fn replay_entry(&self, entry: &LogEntry) -> SyncResult<()> {
+        match &entry.op {
+            LogOp::Put { namespace, key, value } => {
+                let kv = self.store.open_namespace(namespace).await?;
+                let key_bytes = LogOp::decode_bytes(key)?;
+                let value_bytes = LogOp::decode_bytes(value)?;
+                kv.put(&key_bytes, value_bytes).await?;
+            }
+            LogOp::Delete { namespace, key } => {
+                let kv = self.store.open_namespace(namespace).await?;
+                let key_bytes = LogOp::decode_bytes(key)?;
+                kv.delete(&key_bytes).await?;
+            }
+            LogOp::BatchPut { namespace, items } => {
+                let kv = self.store.open_namespace(namespace).await?;
+                let decoded: Vec<(Vec<u8>, Vec<u8>)> = items
+                    .iter()
+                    .map(|(k, v)| {
+                        Ok((LogOp::decode_bytes(k)?, LogOp::decode_bytes(v)?))
+                    })
+                    .collect::<SyncResult<Vec<_>>>()?;
+                kv.batch_put(decoded).await?;
+            }
+            LogOp::BatchDelete { namespace, keys } => {
+                let kv = self.store.open_namespace(namespace).await?;
+                let decoded: Vec<Vec<u8>> = keys
+                    .iter()
+                    .map(|k| LogOp::decode_bytes(k))
+                    .collect::<SyncResult<Vec<_>>>()?;
+                kv.batch_delete(decoded).await?;
+            }
+        }
+        Ok(())
+    }
+
+    // =========================================================================
+    // Lock management
+    // =========================================================================
+
+    /// Acquire the write lock for this device.
+    pub async fn acquire_lock(&self) -> SyncResult<()> {
+        self.auth
+            .acquire_lock(&self.device_id, self.config.lock_ttl_secs)
+            .await?;
+        Ok(())
+    }
+
+    /// Release the write lock.
+    pub async fn release_lock(&self) -> SyncResult<()> {
+        self.auth.release_lock(&self.device_id).await
+    }
+
+    /// Renew the write lock (extend TTL).
+    pub async fn renew_lock(&self) -> SyncResult<()> {
+        self.auth
+            .renew_lock(&self.device_id, self.config.lock_ttl_secs)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config() {
+        let config = SyncConfig::default();
+        assert_eq!(config.sync_interval_ms, 30_000);
+        assert_eq!(config.compaction_threshold, 100);
+        assert_eq!(config.lock_ttl_secs, 300);
+        assert_eq!(config.max_retries, 2);
+    }
+}

--- a/src/sync/error.rs
+++ b/src/sync/error.rs
@@ -1,0 +1,69 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SyncError {
+    #[error("encryption error: {0}")]
+    Crypto(String),
+
+    #[error("serialization error: {0}")]
+    Serialization(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("network error: {0}")]
+    Network(String),
+
+    #[error("auth error: {0}")]
+    Auth(String),
+
+    #[error("S3 error: {0}")]
+    S3(String),
+
+    #[error("corrupt log entry at seq {seq}: {reason}")]
+    CorruptEntry { seq: u64, reason: String },
+
+    #[error("sequence gap: expected {expected}, found {found}")]
+    SequenceGap { expected: u64, found: u64 },
+
+    #[error("device locked by {device_id}, expires at {expires_at}")]
+    DeviceLocked {
+        device_id: String,
+        expires_at: String,
+    },
+
+    #[error("snapshot too large: {size_bytes} bytes")]
+    SnapshotTooLarge { size_bytes: u64 },
+
+    #[error("wrong encryption key")]
+    WrongKey,
+
+    #[error("storage error: {0}")]
+    Storage(String),
+}
+
+pub type SyncResult<T> = Result<T, SyncError>;
+
+impl From<crate::crypto::CryptoError> for SyncError {
+    fn from(e: crate::crypto::CryptoError) -> Self {
+        SyncError::Crypto(e.to_string())
+    }
+}
+
+impl From<crate::storage::error::StorageError> for SyncError {
+    fn from(e: crate::storage::error::StorageError) -> Self {
+        SyncError::Storage(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for SyncError {
+    fn from(e: serde_json::Error) -> Self {
+        SyncError::Serialization(e.to_string())
+    }
+}
+
+impl From<reqwest::Error> for SyncError {
+    fn from(e: reqwest::Error) -> Self {
+        SyncError::Network(e.to_string())
+    }
+}

--- a/src/sync/log.rs
+++ b/src/sync/log.rs
@@ -1,0 +1,245 @@
+use super::error::{SyncError, SyncResult};
+use crate::crypto::CryptoProvider;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+
+/// A single KvStore operation recorded for sync.
+///
+/// Each entry captures one write operation (put, delete, batch_put, batch_delete)
+/// along with its sequence number for ordered replay.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogEntry {
+    /// Monotonically increasing sequence number.
+    pub seq: u64,
+    /// Client timestamp (millis since epoch).
+    pub timestamp_ms: u64,
+    /// Device ID that produced this entry.
+    pub device_id: String,
+    /// The operation.
+    pub op: LogOp,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum LogOp {
+    Put {
+        namespace: String,
+        /// Base64-encoded key (keys are arbitrary bytes).
+        key: String,
+        /// Base64-encoded value.
+        value: String,
+    },
+    Delete {
+        namespace: String,
+        key: String,
+    },
+    BatchPut {
+        namespace: String,
+        /// Vec of (base64 key, base64 value).
+        items: Vec<(String, String)>,
+    },
+    BatchDelete {
+        namespace: String,
+        keys: Vec<String>,
+    },
+}
+
+/// Serialized + encrypted log entry with integrity hash.
+///
+/// Wire format:
+/// ```text
+/// [sha256: 32 bytes] [encrypted_payload: variable]
+/// ```
+///
+/// The SHA-256 is computed over the plaintext JSON before encryption,
+/// allowing the reader to verify integrity after decryption.
+pub struct SealedLogEntry {
+    pub bytes: Vec<u8>,
+}
+
+const HASH_SIZE: usize = 32;
+
+impl LogEntry {
+    /// Serialize, hash, encrypt.
+    pub async fn seal(
+        &self,
+        crypto: &Arc<dyn CryptoProvider>,
+    ) -> SyncResult<SealedLogEntry> {
+        let json = serde_json::to_vec(self)?;
+
+        let mut hasher = Sha256::new();
+        hasher.update(&json);
+        let hash: [u8; 32] = hasher.finalize().into();
+
+        let mut plaintext = Vec::with_capacity(HASH_SIZE + json.len());
+        plaintext.extend_from_slice(&hash);
+        plaintext.extend_from_slice(&json);
+
+        let ciphertext = crypto.encrypt(&plaintext).await?;
+
+        Ok(SealedLogEntry { bytes: ciphertext })
+    }
+
+    /// Decrypt, verify hash, deserialize.
+    pub async fn unseal(
+        sealed: &[u8],
+        crypto: &Arc<dyn CryptoProvider>,
+    ) -> SyncResult<Self> {
+        let plaintext = crypto.decrypt(sealed).await.map_err(|e| {
+            SyncError::Crypto(format!("failed to decrypt log entry: {e}"))
+        })?;
+
+        if plaintext.len() < HASH_SIZE {
+            return Err(SyncError::CorruptEntry {
+                seq: 0,
+                reason: "plaintext too short for hash".to_string(),
+            });
+        }
+
+        let (stored_hash, json_bytes) = plaintext.split_at(HASH_SIZE);
+
+        let mut hasher = Sha256::new();
+        hasher.update(json_bytes);
+        let computed_hash: [u8; 32] = hasher.finalize().into();
+
+        if stored_hash != computed_hash.as_slice() {
+            return Err(SyncError::CorruptEntry {
+                seq: 0,
+                reason: "hash mismatch — data corrupted".to_string(),
+            });
+        }
+
+        let entry: LogEntry = serde_json::from_slice(json_bytes)?;
+        Ok(entry)
+    }
+}
+
+impl LogOp {
+    /// Encode key bytes to base64 for storage in the log entry.
+    pub fn encode_bytes(bytes: &[u8]) -> String {
+        BASE64.encode(bytes)
+    }
+
+    /// Decode base64 key back to bytes for replay.
+    pub fn decode_bytes(encoded: &str) -> SyncResult<Vec<u8>> {
+        BASE64.decode(encoded).map_err(|e| {
+            SyncError::Serialization(format!("invalid base64: {e}"))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::provider::LocalCryptoProvider;
+
+    fn test_crypto() -> Arc<dyn CryptoProvider> {
+        Arc::new(LocalCryptoProvider::from_key([0x42u8; 32]))
+    }
+
+    fn sample_entry(seq: u64) -> LogEntry {
+        LogEntry {
+            seq,
+            timestamp_ms: 1700000000000,
+            device_id: "device-abc".to_string(),
+            op: LogOp::Put {
+                namespace: "main".to_string(),
+                key: LogOp::encode_bytes(b"atom:123"),
+                value: LogOp::encode_bytes(b"{\"name\":\"test\"}"),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn seal_unseal_roundtrip() {
+        let crypto = test_crypto();
+        let entry = sample_entry(1);
+
+        let sealed = entry.seal(&crypto).await.unwrap();
+        let unsealed = LogEntry::unseal(&sealed.bytes, &crypto).await.unwrap();
+
+        assert_eq!(unsealed.seq, 1);
+        assert_eq!(unsealed.device_id, "device-abc");
+    }
+
+    #[tokio::test]
+    async fn tampered_ciphertext_fails() {
+        let crypto = test_crypto();
+        let entry = sample_entry(2);
+
+        let mut sealed = entry.seal(&crypto).await.unwrap();
+        let last = sealed.bytes.len() - 1;
+        sealed.bytes[last] ^= 0x01;
+
+        let result = LogEntry::unseal(&sealed.bytes, &crypto).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn wrong_key_fails() {
+        let crypto1 = test_crypto();
+        let crypto2: Arc<dyn CryptoProvider> =
+            Arc::new(LocalCryptoProvider::from_key([0x99u8; 32]));
+
+        let entry = sample_entry(3);
+        let sealed = entry.seal(&crypto1).await.unwrap();
+
+        let result = LogEntry::unseal(&sealed.bytes, &crypto2).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_op_roundtrip() {
+        let crypto = test_crypto();
+        let entry = LogEntry {
+            seq: 4,
+            timestamp_ms: 1700000000000,
+            device_id: "device-abc".to_string(),
+            op: LogOp::Delete {
+                namespace: "main".to_string(),
+                key: LogOp::encode_bytes(b"atom:456"),
+            },
+        };
+
+        let sealed = entry.seal(&crypto).await.unwrap();
+        let unsealed = LogEntry::unseal(&sealed.bytes, &crypto).await.unwrap();
+
+        assert_eq!(unsealed.seq, 4);
+        matches!(unsealed.op, LogOp::Delete { .. });
+    }
+
+    #[tokio::test]
+    async fn batch_put_roundtrip() {
+        let crypto = test_crypto();
+        let entry = LogEntry {
+            seq: 5,
+            timestamp_ms: 1700000000000,
+            device_id: "device-abc".to_string(),
+            op: LogOp::BatchPut {
+                namespace: "metadata".to_string(),
+                items: vec![
+                    (LogOp::encode_bytes(b"k1"), LogOp::encode_bytes(b"v1")),
+                    (LogOp::encode_bytes(b"k2"), LogOp::encode_bytes(b"v2")),
+                ],
+            },
+        };
+
+        let sealed = entry.seal(&crypto).await.unwrap();
+        let unsealed = LogEntry::unseal(&sealed.bytes, &crypto).await.unwrap();
+
+        if let LogOp::BatchPut { items, .. } = &unsealed.op {
+            assert_eq!(items.len(), 2);
+        } else {
+            panic!("expected BatchPut");
+        }
+    }
+
+    #[test]
+    fn encode_decode_bytes() {
+        let original = b"hello world";
+        let encoded = LogOp::encode_bytes(original);
+        let decoded = LogOp::decode_bytes(&encoded).unwrap();
+        assert_eq!(decoded, original);
+    }
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,0 +1,94 @@
+//! S3-based sync for encrypted Sled databases.
+//!
+//! The sync module replicates a local Sled database to S3 as encrypted blobs.
+//! The server never sees plaintext data — only opaque ciphertext.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! fold_db (local Sled)
+//!       │
+//!       ▼
+//! SyncEngine
+//!   ├── Records KvStore ops as encrypted log entries
+//!   ├── Uploads log entries to S3 via presigned URLs
+//!   ├── Compacts logs into snapshots every 100 entries
+//!   └── Manages single-device write lock
+//!       │
+//!       ▼
+//! Auth Lambda (thin)
+//!   ├── Validates API key / bearer token
+//!   ├── Returns presigned S3 URLs scoped to /{user_hash}/*
+//!   └── Manages device lock (S3 object)
+//!       │
+//!       ▼
+//! S3 Bucket
+//!   /{user_hash}/
+//!     snapshots/
+//!       latest.enc          — most recent snapshot
+//!       {seq}.enc           — historical snapshots
+//!     log/
+//!       {seq}.enc           — individual encrypted log entries
+//!     lock.json             — device lock file
+//! ```
+//!
+//! ## Data Flow
+//!
+//! **Write path:** mutation → Sled write → SyncEngine records op →
+//!   timer fires → seal entries → get presigned URLs → upload to S3
+//!
+//! **Read path (bootstrap):** download latest.enc → decrypt → restore to Sled →
+//!   list log entries after snapshot seq → download + replay each
+//!
+//! ## Security
+//!
+//! - All data encrypted client-side with AES-256-GCM before upload
+//! - E2E key never leaves the client device
+//! - Server sees only opaque encrypted blobs
+//! - Presigned URLs expire after 15 minutes
+//! - No AWS credentials on the client
+
+pub mod auth;
+pub mod engine;
+pub mod error;
+pub mod log;
+pub mod s3;
+pub mod snapshot;
+
+pub use engine::{SyncConfig, SyncEngine, SyncState};
+pub use error::{SyncError, SyncResult};
+
+/// Configuration needed to enable S3 sync.
+///
+/// Derived automatically from the Exemem credentials — no extra config needed.
+/// The sync auth Lambda shares the same API URL and API key as the Exemem platform.
+#[derive(Clone, Debug)]
+pub struct SyncSetup {
+    /// Exemem API base URL (sync routes live at /api/sync/*).
+    pub auth_url: String,
+    /// Authentication credential (same as Exemem auth).
+    pub auth: auth::SyncAuth,
+    /// Unique identifier for this device (auto-generated if not set).
+    pub device_id: String,
+    /// Sync tuning parameters. Uses defaults if None.
+    pub config: Option<SyncConfig>,
+}
+
+impl SyncSetup {
+    /// Create SyncSetup from Exemem credentials.
+    ///
+    /// The sync auth Lambda is part of the Exemem platform, so the same
+    /// `api_url` and `api_key` are reused. Device ID is auto-generated
+    /// and persisted in the local database.
+    pub fn from_exemem(api_url: &str, api_key: &str) -> Self {
+        let device_id = std::env::var("FOLD_SYNC_DEVICE_ID")
+            .unwrap_or_else(|_| uuid::Uuid::new_v4().to_string());
+
+        Self {
+            auth_url: api_url.to_string(),
+            auth: auth::SyncAuth::ApiKey(api_key.to_string()),
+            device_id,
+            config: None,
+        }
+    }
+}

--- a/src/sync/s3.rs
+++ b/src/sync/s3.rs
@@ -1,0 +1,99 @@
+use super::error::{SyncError, SyncResult};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Client for interacting with S3 via presigned URLs.
+///
+/// This client never has AWS credentials — it only uses presigned URLs
+/// obtained from the auth Lambda. Each URL is scoped to a single S3 object
+/// and a single operation (GET or PUT), expiring after a short window.
+pub struct S3Client {
+    http: Arc<Client>,
+}
+
+/// A presigned URL for a specific S3 operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PresignedUrl {
+    pub url: String,
+    pub method: String,
+    pub expires_in_secs: u64,
+}
+
+impl S3Client {
+    pub fn new(http: Arc<Client>) -> Self {
+        Self { http }
+    }
+
+    /// Upload bytes to S3 using a presigned PUT URL.
+    pub async fn upload(&self, presigned: &PresignedUrl, data: Vec<u8>) -> SyncResult<()> {
+        let response = self
+            .http
+            .put(&presigned.url)
+            .header("Content-Type", "application/octet-stream")
+            .body(data)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(SyncError::S3(format!(
+                "upload failed: HTTP {status}: {body}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Download bytes from S3 using a presigned GET URL.
+    ///
+    /// Returns `None` if the object doesn't exist (404).
+    pub async fn download(&self, presigned: &PresignedUrl) -> SyncResult<Option<Vec<u8>>> {
+        let response = self.http.get(&presigned.url).send().await?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(SyncError::S3(format!(
+                "download failed: HTTP {status}: {body}"
+            )));
+        }
+
+        let bytes = response.bytes().await?;
+        Ok(Some(bytes.to_vec()))
+    }
+
+    /// Delete an S3 object using a presigned DELETE URL.
+    pub async fn delete(&self, presigned: &PresignedUrl) -> SyncResult<()> {
+        let response = self.http.delete(&presigned.url).send().await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(SyncError::S3(format!(
+                "delete failed: HTTP {status}: {body}"
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presigned_url_deserialize() {
+        let json = r#"{"url":"https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc","method":"PUT","expires_in_secs":900}"#;
+        let url: PresignedUrl = serde_json::from_str(json).unwrap();
+        assert_eq!(url.method, "PUT");
+        assert_eq!(url.expires_in_secs, 900);
+        assert!(url.url.contains("X-Amz-Signature"));
+    }
+}

--- a/src/sync/snapshot.rs
+++ b/src/sync/snapshot.rs
@@ -1,0 +1,315 @@
+use super::error::{SyncError, SyncResult};
+use crate::crypto::CryptoProvider;
+use crate::storage::traits::NamespacedStore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+
+/// A serialized snapshot of the entire database.
+///
+/// The snapshot format is backend-agnostic: a list of namespaces,
+/// each containing a list of key-value pairs. Keys and values are
+/// base64-encoded bytes.
+///
+/// For streaming, the snapshot is written namespace-by-namespace to
+/// a temp file, then encrypted and uploaded.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Snapshot {
+    /// Format version for forward compatibility.
+    pub version: u32,
+    /// Timestamp when the snapshot was created (millis since epoch).
+    pub created_at_ms: u64,
+    /// Device ID that created this snapshot.
+    pub device_id: String,
+    /// The log sequence number this snapshot covers up to (inclusive).
+    pub last_seq: u64,
+    /// All namespaces and their key-value pairs.
+    pub namespaces: Vec<NamespaceData>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NamespaceData {
+    pub name: String,
+    /// Key-value pairs, both base64-encoded.
+    pub entries: Vec<SnapshotEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SnapshotEntry {
+    pub key: String,
+    pub value: String,
+}
+
+const SNAPSHOT_VERSION: u32 = 1;
+const HASH_SIZE: usize = 32;
+
+impl Snapshot {
+    /// Create a snapshot from a NamespacedStore by iterating all namespaces and keys.
+    ///
+    /// This loads one namespace at a time to limit memory usage.
+    pub async fn create(
+        store: &dyn NamespacedStore,
+        device_id: &str,
+        last_seq: u64,
+    ) -> SyncResult<Self> {
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        let ns_names = store.list_namespaces().await?;
+        let mut namespaces = Vec::with_capacity(ns_names.len());
+
+        for ns_name in &ns_names {
+            // Skip internal sled namespace
+            if ns_name == "__sled__default" {
+                continue;
+            }
+
+            let kv = store.open_namespace(ns_name).await?;
+            let pairs = kv.scan_prefix(&[]).await?;
+
+            let entries: Vec<SnapshotEntry> = pairs
+                .into_iter()
+                .map(|(k, v)| SnapshotEntry {
+                    key: BASE64.encode(&k),
+                    value: BASE64.encode(&v),
+                })
+                .collect();
+
+            namespaces.push(NamespaceData {
+                name: ns_name.clone(),
+                entries,
+            });
+        }
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        Ok(Snapshot {
+            version: SNAPSHOT_VERSION,
+            created_at_ms: now,
+            device_id: device_id.to_string(),
+            last_seq,
+            namespaces,
+        })
+    }
+
+    /// Serialize the snapshot to a temp file to avoid holding everything in memory,
+    /// then encrypt the file contents.
+    ///
+    /// Returns the encrypted bytes (hash + ciphertext).
+    pub async fn seal(
+        &self,
+        crypto: &Arc<dyn CryptoProvider>,
+    ) -> SyncResult<Vec<u8>> {
+        // Serialize to a temp file for large snapshots
+        let json = tokio::task::spawn_blocking({
+            let snapshot = serde_json::to_vec(self)
+                .map_err(|e| SyncError::Serialization(e.to_string()));
+            move || snapshot
+        })
+        .await
+        .map_err(|e| SyncError::Serialization(e.to_string()))??;
+
+        // Hash the plaintext for integrity verification
+        let mut hasher = Sha256::new();
+        hasher.update(&json);
+        let hash: [u8; 32] = hasher.finalize().into();
+
+        let mut plaintext = Vec::with_capacity(HASH_SIZE + json.len());
+        plaintext.extend_from_slice(&hash);
+        plaintext.extend_from_slice(&json);
+
+        let ciphertext = crypto.encrypt(&plaintext).await?;
+        Ok(ciphertext)
+    }
+
+    /// Decrypt and deserialize a snapshot.
+    pub async fn unseal(
+        data: &[u8],
+        crypto: &Arc<dyn CryptoProvider>,
+    ) -> SyncResult<Self> {
+        let plaintext = crypto.decrypt(data).await.map_err(|_| SyncError::WrongKey)?;
+
+        if plaintext.len() < HASH_SIZE {
+            return Err(SyncError::Crypto("snapshot too short for hash".to_string()));
+        }
+
+        let (stored_hash, json_bytes) = plaintext.split_at(HASH_SIZE);
+
+        let mut hasher = Sha256::new();
+        hasher.update(json_bytes);
+        let computed_hash: [u8; 32] = hasher.finalize().into();
+
+        if stored_hash != computed_hash.as_slice() {
+            return Err(SyncError::Crypto("snapshot hash mismatch — data corrupted".to_string()));
+        }
+
+        let snapshot: Snapshot = serde_json::from_slice(json_bytes)?;
+
+        if snapshot.version != SNAPSHOT_VERSION {
+            return Err(SyncError::Crypto(format!(
+                "unsupported snapshot version: {} (expected {})",
+                snapshot.version, SNAPSHOT_VERSION
+            )));
+        }
+
+        Ok(snapshot)
+    }
+
+    /// Restore a snapshot into a NamespacedStore.
+    ///
+    /// This clears existing namespaces and writes the snapshot data.
+    pub async fn restore(
+        &self,
+        store: &dyn NamespacedStore,
+    ) -> SyncResult<()> {
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        for ns_data in &self.namespaces {
+            let kv = store.open_namespace(&ns_data.name).await?;
+
+            // Write entries in batches
+            const BATCH_SIZE: usize = 25;
+            for chunk in ns_data.entries.chunks(BATCH_SIZE) {
+                let items: Vec<(Vec<u8>, Vec<u8>)> = chunk
+                    .iter()
+                    .map(|entry| {
+                        let key = BASE64.decode(&entry.key).map_err(|e| {
+                            SyncError::Serialization(format!("invalid key base64: {e}"))
+                        });
+                        let value = BASE64.decode(&entry.value).map_err(|e| {
+                            SyncError::Serialization(format!("invalid value base64: {e}"))
+                        });
+                        Ok((key?, value?))
+                    })
+                    .collect::<SyncResult<Vec<_>>>()?;
+
+                kv.batch_put(items).await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::provider::LocalCryptoProvider;
+    use crate::storage::inmemory_backend::InMemoryNamespacedStore;
+    use crate::storage::traits::NamespacedStore;
+
+    fn test_crypto() -> Arc<dyn CryptoProvider> {
+        Arc::new(LocalCryptoProvider::from_key([0x42u8; 32]))
+    }
+
+    async fn populated_store() -> InMemoryNamespacedStore {
+        let store = InMemoryNamespacedStore::new();
+
+        let main = store.open_namespace("main").await.unwrap();
+        main.put(b"atom:1", b"value1".to_vec()).await.unwrap();
+        main.put(b"atom:2", b"value2".to_vec()).await.unwrap();
+
+        let meta = store.open_namespace("metadata").await.unwrap();
+        meta.put(b"schema:foo", b"schema_data".to_vec()).await.unwrap();
+
+        store
+    }
+
+    #[tokio::test]
+    async fn create_snapshot_from_store() {
+        let store = populated_store().await;
+        let snapshot = Snapshot::create(&store, "device-1", 10).await.unwrap();
+
+        assert_eq!(snapshot.version, SNAPSHOT_VERSION);
+        assert_eq!(snapshot.device_id, "device-1");
+        assert_eq!(snapshot.last_seq, 10);
+        assert_eq!(snapshot.namespaces.len(), 2);
+
+        let main_ns = snapshot.namespaces.iter().find(|n| n.name == "main").unwrap();
+        assert_eq!(main_ns.entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn seal_unseal_roundtrip() {
+        let store = populated_store().await;
+        let crypto = test_crypto();
+
+        let snapshot = Snapshot::create(&store, "device-1", 10).await.unwrap();
+        let sealed = snapshot.seal(&crypto).await.unwrap();
+        let unsealed = Snapshot::unseal(&sealed, &crypto).await.unwrap();
+
+        assert_eq!(unsealed.device_id, "device-1");
+        assert_eq!(unsealed.last_seq, 10);
+        assert_eq!(unsealed.namespaces.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn wrong_key_fails() {
+        let store = populated_store().await;
+        let crypto1 = test_crypto();
+        let crypto2: Arc<dyn CryptoProvider> =
+            Arc::new(LocalCryptoProvider::from_key([0x99u8; 32]));
+
+        let snapshot = Snapshot::create(&store, "device-1", 10).await.unwrap();
+        let sealed = snapshot.seal(&crypto1).await.unwrap();
+
+        let result = Snapshot::unseal(&sealed, &crypto2).await;
+        assert!(matches!(result, Err(SyncError::WrongKey)));
+    }
+
+    #[tokio::test]
+    async fn restore_snapshot_to_empty_store() {
+        let source = populated_store().await;
+        let crypto = test_crypto();
+
+        let snapshot = Snapshot::create(&source, "device-1", 10).await.unwrap();
+        let sealed = snapshot.seal(&crypto).await.unwrap();
+        let restored_snapshot = Snapshot::unseal(&sealed, &crypto).await.unwrap();
+
+        let target = InMemoryNamespacedStore::new();
+        restored_snapshot.restore(&target).await.unwrap();
+
+        // Verify data was restored
+        let main = target.open_namespace("main").await.unwrap();
+        let val = main.get(b"atom:1").await.unwrap();
+        assert_eq!(val, Some(b"value1".to_vec()));
+
+        let val2 = main.get(b"atom:2").await.unwrap();
+        assert_eq!(val2, Some(b"value2".to_vec()));
+
+        let meta = target.open_namespace("metadata").await.unwrap();
+        let schema = meta.get(b"schema:foo").await.unwrap();
+        assert_eq!(schema, Some(b"schema_data".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn empty_store_snapshot() {
+        let store = InMemoryNamespacedStore::new();
+        let crypto = test_crypto();
+
+        let snapshot = Snapshot::create(&store, "device-1", 0).await.unwrap();
+        assert!(snapshot.namespaces.is_empty());
+
+        let sealed = snapshot.seal(&crypto).await.unwrap();
+        let unsealed = Snapshot::unseal(&sealed, &crypto).await.unwrap();
+        assert!(unsealed.namespaces.is_empty());
+    }
+
+    #[tokio::test]
+    async fn tampered_snapshot_fails() {
+        let store = populated_store().await;
+        let crypto = test_crypto();
+
+        let snapshot = Snapshot::create(&store, "device-1", 10).await.unwrap();
+        let mut sealed = snapshot.seal(&crypto).await.unwrap();
+
+        // Tamper with the ciphertext
+        let last = sealed.len() - 1;
+        sealed[last] ^= 0x01;
+
+        let result = Snapshot::unseal(&sealed, &crypto).await;
+        assert!(result.is_err());
+    }
+}

--- a/tests/sync_integration_test.rs
+++ b/tests/sync_integration_test.rs
@@ -1,0 +1,242 @@
+//! Integration tests for the S3 sync system.
+//!
+//! These tests exercise the full local sync flow without a real S3 backend:
+//! - SyncingNamespacedStore recording writes to SyncEngine
+//! - Encrypted log entry seal/unseal roundtrips
+//! - Snapshot create → seal → unseal → restore
+//! - Full write-through-sync-restore cycle
+
+use fold_db::crypto::provider::LocalCryptoProvider;
+use fold_db::crypto::CryptoProvider;
+use fold_db::storage::encrypting_namespaced_store::EncryptingNamespacedStore;
+use fold_db::storage::inmemory_backend::InMemoryNamespacedStore;
+use fold_db::storage::syncing_namespaced_store::SyncingNamespacedStore;
+use fold_db::storage::traits::NamespacedStore;
+use fold_db::sync::auth::{AuthClient, SyncAuth};
+use fold_db::sync::s3::S3Client;
+use fold_db::sync::snapshot::Snapshot;
+use fold_db::sync::{SyncConfig, SyncEngine, SyncState};
+use std::sync::Arc;
+
+fn test_crypto() -> Arc<dyn CryptoProvider> {
+    Arc::new(LocalCryptoProvider::from_key([0x42u8; 32]))
+}
+
+/// Build the full storage stack: InMemory → Syncing → Encrypting
+async fn build_stack() -> (
+    Arc<dyn NamespacedStore>, // top-level store (encrypting)
+    Arc<SyncEngine>,
+    Arc<InMemoryNamespacedStore>, // raw base store (for snapshot verification)
+) {
+    let base = Arc::new(InMemoryNamespacedStore::new());
+    let crypto = test_crypto();
+
+    let http = Arc::new(reqwest::Client::new());
+    let s3 = S3Client::new(http.clone());
+    let auth = AuthClient::new(
+        http,
+        "http://localhost:0".to_string(), // not used in these tests
+        SyncAuth::ApiKey("test".to_string()),
+    );
+
+    let engine = Arc::new(SyncEngine::new(
+        "test-device".to_string(),
+        crypto.clone(),
+        s3,
+        auth,
+        base.clone() as Arc<dyn NamespacedStore>,
+        SyncConfig::default(),
+    ));
+
+    // Stack: base → syncing → encrypting
+    let syncing = SyncingNamespacedStore::new(
+        base.clone() as Arc<dyn NamespacedStore>,
+        engine.clone(),
+    );
+    let syncing_arc = Arc::new(syncing) as Arc<dyn NamespacedStore>;
+
+    let encrypting = EncryptingNamespacedStore::new(syncing_arc, crypto, false);
+    let top = Arc::new(encrypting) as Arc<dyn NamespacedStore>;
+
+    (top, engine, base)
+}
+
+#[tokio::test]
+async fn writes_flow_through_full_stack() {
+    let (store, engine, _base) = build_stack().await;
+
+    assert_eq!(engine.state().await, SyncState::Idle);
+    assert_eq!(engine.pending_count().await, 0);
+
+    // Write through the full stack (encrypting → syncing → inmemory)
+    let main = store.open_namespace("main").await.unwrap();
+    main.put(b"key1", b"value1".to_vec()).await.unwrap();
+
+    // SyncEngine should have recorded the write
+    assert_eq!(engine.state().await, SyncState::Dirty);
+    assert_eq!(engine.pending_count().await, 1);
+
+    // Data should be readable back through the encrypting layer
+    let val = main.get(b"key1").await.unwrap();
+    assert_eq!(val, Some(b"value1".to_vec()));
+}
+
+#[tokio::test]
+async fn multiple_namespaces_all_recorded() {
+    let (store, engine, _base) = build_stack().await;
+
+    let main = store.open_namespace("main").await.unwrap();
+    let meta = store.open_namespace("metadata").await.unwrap();
+
+    main.put(b"atom:1", b"data1".to_vec()).await.unwrap();
+    main.put(b"atom:2", b"data2".to_vec()).await.unwrap();
+    meta.put(b"schema:foo", b"schema".to_vec()).await.unwrap();
+
+    assert_eq!(engine.pending_count().await, 3);
+    assert_eq!(engine.state().await, SyncState::Dirty);
+}
+
+#[tokio::test]
+async fn reads_dont_trigger_sync() {
+    let (store, engine, _base) = build_stack().await;
+
+    let main = store.open_namespace("main").await.unwrap();
+    main.put(b"key1", b"val1".to_vec()).await.unwrap();
+    assert_eq!(engine.pending_count().await, 1);
+
+    // These reads should NOT add pending entries
+    main.get(b"key1").await.unwrap();
+    main.exists(b"key1").await.unwrap();
+    main.scan_prefix(b"key").await.unwrap();
+
+    assert_eq!(engine.pending_count().await, 1);
+}
+
+#[tokio::test]
+async fn delete_recorded() {
+    let (store, engine, _base) = build_stack().await;
+
+    let main = store.open_namespace("main").await.unwrap();
+    main.put(b"key1", b"val1".to_vec()).await.unwrap();
+    assert_eq!(engine.pending_count().await, 1);
+
+    main.delete(b"key1").await.unwrap();
+    assert_eq!(engine.pending_count().await, 2); // put + delete
+
+    let val = main.get(b"key1").await.unwrap();
+    assert_eq!(val, None);
+}
+
+#[tokio::test]
+async fn batch_operations_recorded() {
+    let (store, engine, _base) = build_stack().await;
+
+    let main = store.open_namespace("main").await.unwrap();
+    let items = vec![
+        (b"k1".to_vec(), b"v1".to_vec()),
+        (b"k2".to_vec(), b"v2".to_vec()),
+        (b"k3".to_vec(), b"v3".to_vec()),
+    ];
+    main.batch_put(items).await.unwrap();
+
+    assert_eq!(engine.pending_count().await, 1); // one batch op
+
+    // Verify all items readable
+    assert_eq!(main.get(b"k1").await.unwrap(), Some(b"v1".to_vec()));
+    assert_eq!(main.get(b"k2").await.unwrap(), Some(b"v2".to_vec()));
+    assert_eq!(main.get(b"k3").await.unwrap(), Some(b"v3".to_vec()));
+}
+
+#[tokio::test]
+async fn snapshot_captures_encrypted_data_and_restores() {
+    let (store, _engine, base) = build_stack().await;
+    let crypto = test_crypto();
+
+    // Write data through the encrypting stack
+    let main = store.open_namespace("main").await.unwrap();
+    main.put(b"atom:1", b"hello".to_vec()).await.unwrap();
+    main.put(b"atom:2", b"world".to_vec()).await.unwrap();
+
+    let meta = store.open_namespace("metadata").await.unwrap();
+    meta.put(b"schema:test", b"schema_data".to_vec())
+        .await
+        .unwrap();
+
+    // Create snapshot from the BASE store (contains encrypted data)
+    let snapshot = Snapshot::create(base.as_ref(), "test-device", 5)
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.device_id, "test-device");
+    assert_eq!(snapshot.last_seq, 5);
+    assert!(snapshot.namespaces.len() >= 2); // main + metadata
+
+    // Seal and unseal the snapshot
+    let sealed = snapshot.seal(&crypto).await.unwrap();
+    let restored_snapshot = Snapshot::unseal(&sealed, &crypto).await.unwrap();
+
+    assert_eq!(restored_snapshot.device_id, "test-device");
+    assert_eq!(restored_snapshot.last_seq, 5);
+
+    // Restore to a fresh store
+    let target = InMemoryNamespacedStore::new();
+    restored_snapshot.restore(&target).await.unwrap();
+
+    // The restored data is encrypted (it was stored encrypted in the base store).
+    // Wrap target with EncryptingNamespacedStore to decrypt and read back.
+    let target_enc = EncryptingNamespacedStore::new(
+        Arc::new(target) as Arc<dyn NamespacedStore>,
+        crypto,
+        false,
+    );
+
+    let restored_main = target_enc.open_namespace("main").await.unwrap();
+    assert_eq!(
+        restored_main.get(b"atom:1").await.unwrap(),
+        Some(b"hello".to_vec())
+    );
+    assert_eq!(
+        restored_main.get(b"atom:2").await.unwrap(),
+        Some(b"world".to_vec())
+    );
+
+    let restored_meta = target_enc.open_namespace("metadata").await.unwrap();
+    assert_eq!(
+        restored_meta.get(b"schema:test").await.unwrap(),
+        Some(b"schema_data".to_vec())
+    );
+}
+
+#[tokio::test]
+async fn snapshot_wrong_key_fails() {
+    let (store, _engine, base) = build_stack().await;
+    let crypto = test_crypto();
+    let wrong_crypto: Arc<dyn CryptoProvider> =
+        Arc::new(LocalCryptoProvider::from_key([0x99u8; 32]));
+
+    let main = store.open_namespace("main").await.unwrap();
+    main.put(b"secret", b"data".to_vec()).await.unwrap();
+
+    let snapshot = Snapshot::create(base.as_ref(), "dev-1", 1)
+        .await
+        .unwrap();
+    let sealed = snapshot.seal(&crypto).await.unwrap();
+
+    // Unseal with wrong key should fail
+    let result = Snapshot::unseal(&sealed, &wrong_crypto).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn list_namespaces_works_through_stack() {
+    let (store, _engine, _base) = build_stack().await;
+
+    store.open_namespace("main").await.unwrap();
+    store.open_namespace("metadata").await.unwrap();
+    store.open_namespace("schemas").await.unwrap();
+
+    let namespaces = store.list_namespaces().await.unwrap();
+    assert!(namespaces.contains(&"main".to_string()));
+    assert!(namespaces.contains(&"metadata".to_string()));
+    assert!(namespaces.contains(&"schemas".to_string()));
+}


### PR DESCRIPTION
## Summary
- Remove encryption-at-rest layer (replaced by E2E encryption exclusively)
- Add S3 sync module for encrypted cloud backup (auth, engine, snapshots, write logs)
- Add `SyncingKvStore` / `SyncingNamespacedStore` storage decorators for write-log recording
- Required by `fold_db_node` which imports `fold_db::sync::*`

## Test plan
- [ ] `cargo test --workspace --all-targets` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] fold_db_node CI passes after merge (depends on `fold_db::sync`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)