### PR TITLE
Per-field indexing and anonymity gate for network discovery

### DIFF
--- a/src/db_operations/native_index/anonymity.rs
+++ b/src/db_operations/native_index/anonymity.rs
@@ -1,0 +1,360 @@
+// Pre-publication anonymity gate for discovery fragments.
+//
+// Every fragment must pass local checks before it can be submitted to the
+// network discovery index. This prevents PII leakage and ensures fragments
+// meet a minimum anonymity threshold.
+
+/// Privacy classification for a schema field.
+/// Determines whether field values can be published to the discovery index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldPrivacyClass {
+    /// PII fields — never published under any circumstances.
+    /// Examples: name, email, phone, address, ssn, date_of_birth
+    NeverPublish,
+
+    /// Content fields — published only if they pass anonymity checks.
+    /// Examples: description, notes, instructions, content, body
+    PublishIfAnonymous,
+
+    /// Category fields — always safe to publish (low-cardinality, non-identifying).
+    /// Examples: genre, category, content_type, cuisine_type, tags
+    AlwaysPublish,
+}
+
+/// Result of the local anonymity check on a fragment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FragmentDecision {
+    /// Fragment passed all checks and can be submitted for network k-anonymity check.
+    SubmitForNetworkCheck,
+    /// Fragment was rejected locally. Reason is included.
+    Reject(&'static str),
+}
+
+/// Minimum number of whitespace-separated tokens for a fragment to be publishable.
+const MIN_TOKEN_COUNT: usize = 3;
+
+/// Minimum Shannon entropy (bits) for a fragment's token distribution.
+const MIN_ENTROPY_BITS: f64 = 1.5;
+
+/// Infer the default privacy class for a field based on its name.
+///
+/// This is a heuristic — users can override per-field when opting into discovery.
+pub fn default_privacy_class(field_name: &str) -> FieldPrivacyClass {
+    let name = field_name.to_lowercase();
+
+    const NEVER: &[&str] = &[
+        "name", "first_name", "last_name", "full_name",
+        "email", "phone", "address", "street", "city", "zip", "postal",
+        "ssn", "social_security", "tax_id",
+        "date_of_birth", "dob", "birthday",
+        "ip_address", "ip", "mac_address",
+        "passport", "license", "credit_card", "account_number",
+        "username", "user_id", "user_name", "author",
+        "url", "link", "website", "source_url",
+        "sender", "recipient", "from", "to",
+    ];
+
+    const ALWAYS: &[&str] = &[
+        "category", "genre", "type", "content_type", "kind",
+        "cuisine", "language", "country", "tags", "label",
+        "format", "status", "priority", "level", "rating",
+    ];
+
+    if NEVER.iter().any(|&p| name == p || name.ends_with(&format!("_{}", p)) || name.starts_with(&format!("{}_", p))) {
+        FieldPrivacyClass::NeverPublish
+    } else if ALWAYS.iter().any(|&p| name == p || name.ends_with(&format!("_{}", p)) || name.starts_with(&format!("{}_", p))) {
+        FieldPrivacyClass::AlwaysPublish
+    } else {
+        FieldPrivacyClass::PublishIfAnonymous
+    }
+}
+
+/// Run the local anonymity gate on a fragment.
+///
+/// This is Stage 1 of the two-stage anonymity check. Fragments that pass
+/// this check are submitted to the network for Stage 2 (k-anonymity).
+pub fn check_fragment_anonymity(
+    fragment_text: &str,
+    privacy_class: FieldPrivacyClass,
+) -> FragmentDecision {
+    match privacy_class {
+        FieldPrivacyClass::NeverPublish => {
+            FragmentDecision::Reject("PII field class")
+        }
+        FieldPrivacyClass::AlwaysPublish => {
+            FragmentDecision::SubmitForNetworkCheck
+        }
+        FieldPrivacyClass::PublishIfAnonymous => {
+            if contains_named_entities(fragment_text) {
+                return FragmentDecision::Reject("contains named entities");
+            }
+            let token_count = fragment_text.split_whitespace().count();
+            if token_count < MIN_TOKEN_COUNT {
+                return FragmentDecision::Reject("too short for anonymity");
+            }
+            if token_entropy(fragment_text) < MIN_ENTROPY_BITS {
+                return FragmentDecision::Reject("insufficient entropy");
+            }
+            FragmentDecision::SubmitForNetworkCheck
+        }
+    }
+}
+
+/// Rule-based named entity detection.
+///
+/// Conservative: prefers false positives (rejecting safe text) over false
+/// negatives (publishing PII). No ML model needed.
+pub fn contains_named_entities(text: &str) -> bool {
+    has_email(text) || has_phone(text) || has_url(text)
+        || has_address_pattern(text) || has_id_pattern(text)
+}
+
+/// Detect email addresses: word@word.tld
+fn has_email(text: &str) -> bool {
+    text.contains('@') && {
+        text.split_whitespace().any(|token| {
+            let parts: Vec<&str> = token.split('@').collect();
+            parts.len() == 2
+                && !parts[0].is_empty()
+                && parts[1].contains('.')
+                && parts[1].len() > 2
+        })
+    }
+}
+
+/// Detect phone numbers: sequences of 7+ digits with optional separators (hyphens, spaces, parens)
+fn has_phone(text: &str) -> bool {
+    // Look for phone-like patterns: groups of digits separated by hyphens/spaces/parens
+    // that total 7+ digits within a compact span
+    for token in text.split_whitespace() {
+        // Strip non-digit, non-separator chars
+        let digits_only: String = token.chars().filter(|c| c.is_ascii_digit()).collect();
+        if digits_only.len() >= 7 {
+            // Check that the token looks phone-like (digits with separators, not prose)
+            let non_phone_chars = token.chars().filter(|c| {
+                !c.is_ascii_digit() && *c != '-' && *c != '(' && *c != ')' && *c != '+' && *c != '.'
+            }).count();
+            if non_phone_chars == 0 {
+                return true;
+            }
+        }
+    }
+    // Also check for spaced phone numbers like "555 123 4567"
+    // by scanning for runs of digit-groups separated by single spaces/hyphens
+    let chars: Vec<char> = text.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i].is_ascii_digit() {
+            let mut digit_count = 0;
+            let start = i;
+            while i < chars.len() && (chars[i].is_ascii_digit() || chars[i] == '-' || chars[i] == ' ' || chars[i] == '(' || chars[i] == ')' || chars[i] == '+' || chars[i] == '.') {
+                if chars[i].is_ascii_digit() {
+                    digit_count += 1;
+                }
+                i += 1;
+            }
+            if digit_count >= 7 {
+                // Check the span isn't too wide (phone numbers are compact)
+                let span_len = i - start;
+                if span_len <= digit_count * 2 + 5 {
+                    return true;
+                }
+            }
+        } else {
+            i += 1;
+        }
+    }
+    false
+}
+
+/// Detect URLs: http(s)://... or www....
+fn has_url(text: &str) -> bool {
+    text.contains("http://") || text.contains("https://") || text.contains("www.")
+}
+
+/// Detect street address patterns: number + street name + (St|Ave|Blvd|Dr|Rd|Ln)
+fn has_address_pattern(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    let words: Vec<&str> = lower.split_whitespace().collect();
+    for window in words.windows(3) {
+        if window[0].chars().all(|c| c.is_ascii_digit()) {
+            let suffix = window[2].trim_end_matches(['.', ',']);
+            if matches!(suffix, "st" | "ave" | "avenue" | "blvd" | "boulevard" | "dr" | "drive"
+                | "rd" | "road" | "ln" | "lane" | "ct" | "court" | "way" | "pl" | "place"
+                | "street" | "circle" | "terrace" | "pkwy" | "parkway") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Detect ID-like patterns: SSN (XXX-XX-XXXX), credit card (4 groups of 4 digits)
+fn has_id_pattern(text: &str) -> bool {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    for word in &words {
+        let cleaned = word.trim_matches(|c: char| !c.is_ascii_digit() && c != '-');
+        // SSN pattern: 3-2-4 digits
+        if cleaned.len() == 11 {
+            let parts: Vec<&str> = cleaned.split('-').collect();
+            if parts.len() == 3
+                && parts[0].len() == 3 && parts[0].chars().all(|c| c.is_ascii_digit())
+                && parts[1].len() == 2 && parts[1].chars().all(|c| c.is_ascii_digit())
+                && parts[2].len() == 4 && parts[2].chars().all(|c| c.is_ascii_digit())
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Shannon entropy of a fragment's whitespace-separated tokens.
+///
+/// Higher entropy = more diverse token distribution = less identifying.
+/// A fragment of all identical tokens has entropy 0.
+pub fn token_entropy(text: &str) -> f64 {
+    let tokens: Vec<&str> = text.split_whitespace().collect();
+    if tokens.is_empty() {
+        return 0.0;
+    }
+
+    let mut freq: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for token in &tokens {
+        *freq.entry(token).or_default() += 1;
+    }
+
+    let n = tokens.len() as f64;
+    freq.values()
+        .map(|&count| {
+            let p = count as f64 / n;
+            -p * p.log2()
+        })
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- FieldPrivacyClass defaults ---
+
+    #[test]
+    fn test_pii_fields_are_never_publish() {
+        assert_eq!(default_privacy_class("email"), FieldPrivacyClass::NeverPublish);
+        assert_eq!(default_privacy_class("phone"), FieldPrivacyClass::NeverPublish);
+        assert_eq!(default_privacy_class("first_name"), FieldPrivacyClass::NeverPublish);
+        assert_eq!(default_privacy_class("address"), FieldPrivacyClass::NeverPublish);
+        assert_eq!(default_privacy_class("ssn"), FieldPrivacyClass::NeverPublish);
+        assert_eq!(default_privacy_class("date_of_birth"), FieldPrivacyClass::NeverPublish);
+        assert_eq!(default_privacy_class("user_name"), FieldPrivacyClass::NeverPublish);
+    }
+
+    #[test]
+    fn test_category_fields_are_always_publish() {
+        assert_eq!(default_privacy_class("category"), FieldPrivacyClass::AlwaysPublish);
+        assert_eq!(default_privacy_class("genre"), FieldPrivacyClass::AlwaysPublish);
+        assert_eq!(default_privacy_class("content_type"), FieldPrivacyClass::AlwaysPublish);
+        assert_eq!(default_privacy_class("cuisine"), FieldPrivacyClass::AlwaysPublish);
+        assert_eq!(default_privacy_class("tags"), FieldPrivacyClass::AlwaysPublish);
+    }
+
+    #[test]
+    fn test_content_fields_are_publish_if_anonymous() {
+        assert_eq!(default_privacy_class("description"), FieldPrivacyClass::PublishIfAnonymous);
+        assert_eq!(default_privacy_class("notes"), FieldPrivacyClass::PublishIfAnonymous);
+        assert_eq!(default_privacy_class("ingredients"), FieldPrivacyClass::PublishIfAnonymous);
+        assert_eq!(default_privacy_class("content"), FieldPrivacyClass::PublishIfAnonymous);
+    }
+
+    // --- NER detection ---
+
+    #[test]
+    fn test_detects_email() {
+        assert!(contains_named_entities("Contact me at john@example.com"));
+        assert!(!contains_named_entities("A recipe for chocolate cake"));
+    }
+
+    #[test]
+    fn test_detects_phone() {
+        assert!(contains_named_entities("Call 555-123-4567 for info"));
+        assert!(contains_named_entities("Phone: 5551234567"));
+        assert!(!contains_named_entities("Mix 2 cups flour with 3 eggs"));
+    }
+
+    #[test]
+    fn test_detects_url() {
+        assert!(contains_named_entities("Visit https://example.com"));
+        assert!(contains_named_entities("Go to www.example.com"));
+        assert!(!contains_named_entities("A delicious curry recipe"));
+    }
+
+    #[test]
+    fn test_detects_address() {
+        assert!(contains_named_entities("Located at 123 Main St"));
+        assert!(contains_named_entities("Visit us at 456 Oak Avenue"));
+        assert!(!contains_named_entities("Bake at 350 degrees for 30 minutes"));
+    }
+
+    #[test]
+    fn test_detects_ssn() {
+        assert!(contains_named_entities("SSN is 123-45-6789"));
+        assert!(!contains_named_entities("The ratio is 3-to-1"));
+    }
+
+    // --- Entropy ---
+
+    #[test]
+    fn test_entropy_single_token() {
+        assert_eq!(token_entropy("hello"), 0.0);
+    }
+
+    #[test]
+    fn test_entropy_all_unique() {
+        let entropy = token_entropy("the quick brown fox jumps");
+        assert!(entropy > 2.0, "Expected high entropy for all-unique tokens, got {}", entropy);
+    }
+
+    #[test]
+    fn test_entropy_all_same() {
+        assert_eq!(token_entropy("the the the the"), 0.0);
+    }
+
+    // --- Fragment decisions ---
+
+    #[test]
+    fn test_never_publish_always_rejects() {
+        let result = check_fragment_anonymity("perfectly fine text here", FieldPrivacyClass::NeverPublish);
+        assert_eq!(result, FragmentDecision::Reject("PII field class"));
+    }
+
+    #[test]
+    fn test_always_publish_always_accepts() {
+        let result = check_fragment_anonymity("x", FieldPrivacyClass::AlwaysPublish);
+        assert_eq!(result, FragmentDecision::SubmitForNetworkCheck);
+    }
+
+    #[test]
+    fn test_rejects_short_fragments() {
+        let result = check_fragment_anonymity("hi", FieldPrivacyClass::PublishIfAnonymous);
+        assert_eq!(result, FragmentDecision::Reject("too short for anonymity"));
+    }
+
+    #[test]
+    fn test_rejects_fragments_with_email() {
+        let result = check_fragment_anonymity(
+            "Send your recipes to chef@kitchen.com for review",
+            FieldPrivacyClass::PublishIfAnonymous,
+        );
+        assert_eq!(result, FragmentDecision::Reject("contains named entities"));
+    }
+
+    #[test]
+    fn test_accepts_anonymous_content() {
+        let result = check_fragment_anonymity(
+            "A rich Japanese curry with potatoes and carrots simmered in coconut milk",
+            FieldPrivacyClass::PublishIfAnonymous,
+        );
+        assert_eq!(result, FragmentDecision::SubmitForNetworkCheck);
+    }
+}

--- a/src/db_operations/native_index/embedding_index.rs
+++ b/src/db_operations/native_index/embedding_index.rs
@@ -9,32 +9,53 @@ use super::types::IndexResult;
 
 pub(super) const EMB_PREFIX: &str = "emb:";
 
-/// Entry stored in Sled for each indexed record.
+/// Entry stored in Sled for each indexed fragment.
 #[derive(Serialize, Deserialize)]
 pub(super) struct StoredEmbedding {
     pub schema: String,
     pub key: KeyValue,
-    pub field_names: Vec<String>,
+    pub field_name: String,
+    pub fragment_index: usize,
     pub embedding: Vec<f32>,
+    // Legacy: populated only for old-format entries (pre per-field split)
+    #[serde(default)]
+    pub field_names: Option<Vec<String>>,
 }
 
 /// Entry held in the in-memory index.
 pub(super) struct EmbeddingEntry {
     pub schema: String,
     pub key: KeyValue,
-    pub field_names: Vec<String>,
+    pub field_name: String,
+    pub fragment_index: usize,
     pub embedding: Vec<f32>,
 }
 
 impl EmbeddingEntry {
-    pub(super) fn storage_key(schema: &str, key: &KeyValue) -> String {
-        let key_hash = match (&key.hash, &key.range) {
-            (Some(h), Some(r)) => format!("{}_{}", h, r),
-            (Some(h), None) => h.clone(),
-            (None, Some(r)) => format!("_{}", r),
-            (None, None) => "empty".to_string(),
-        };
-        format!("{}{}:{}", EMB_PREFIX, schema, key_hash)
+    /// Storage key for a per-field fragment.
+    pub(super) fn fragment_storage_key(
+        schema: &str,
+        key: &KeyValue,
+        field_name: &str,
+        fragment_index: usize,
+    ) -> String {
+        let key_hash = key_hash_string(key);
+        format!("{}{}:{}:{}:{}", EMB_PREFIX, schema, key_hash, field_name, fragment_index)
+    }
+
+    /// Unique record identifier for dedup (schema + key hash).
+    fn record_id(&self) -> String {
+        let key_hash = key_hash_string(&self.key);
+        format!("{}:{}", self.schema, key_hash)
+    }
+}
+
+fn key_hash_string(key: &KeyValue) -> String {
+    match (&key.hash, &key.range) {
+        (Some(h), Some(r)) => format!("{}_{}", h, r),
+        (Some(h), None) => h.clone(),
+        (None, Some(r)) => format!("_{}", r),
+        (None, None) => "empty".to_string(),
     }
 }
 
@@ -45,10 +66,13 @@ pub(super) struct EmbeddingIndex {
 
 impl EmbeddingIndex {
     pub(super) fn new(entries: Vec<EmbeddingEntry>) -> Self {
-        Self { entries: std::sync::RwLock::new(entries) }
+        Self {
+            entries: std::sync::RwLock::new(entries),
+        }
     }
 
     /// Load all persisted embeddings from the KV store into memory.
+    /// Handles both legacy (whole-record) and new (per-field) formats.
     pub(super) async fn load_from_store(store: &dyn KvStore) -> Vec<EmbeddingEntry> {
         let raw = match store.scan_prefix(EMB_PREFIX.as_bytes()).await {
             Ok(r) => r,
@@ -61,12 +85,27 @@ impl EmbeddingIndex {
         let mut entries = Vec::with_capacity(raw.len());
         for (_key, value) in raw {
             match serde_json::from_slice::<StoredEmbedding>(&value) {
-                Ok(stored) => entries.push(EmbeddingEntry {
-                    schema: stored.schema,
-                    key: stored.key,
-                    field_names: stored.field_names,
-                    embedding: stored.embedding,
-                }),
+                Ok(stored) => {
+                    if stored.field_names.is_some() && stored.field_name.is_empty() {
+                        // Legacy format: whole-record embedding with field_names list.
+                        // Convert to a single entry with field_name="*" for backward compat.
+                        entries.push(EmbeddingEntry {
+                            schema: stored.schema,
+                            key: stored.key,
+                            field_name: "*".to_string(),
+                            fragment_index: 0,
+                            embedding: stored.embedding,
+                        });
+                    } else {
+                        entries.push(EmbeddingEntry {
+                            schema: stored.schema,
+                            key: stored.key,
+                            field_name: stored.field_name,
+                            fragment_index: stored.fragment_index,
+                            embedding: stored.embedding,
+                        });
+                    }
+                }
                 Err(e) => log::warn!("Failed to deserialize StoredEmbedding: {}", e),
             }
         }
@@ -75,23 +114,27 @@ impl EmbeddingIndex {
         entries
     }
 
-    /// Persist and upsert a record embedding.
-    pub(super) async fn insert(
+    /// Persist and upsert a single field fragment embedding.
+    pub(super) async fn insert_fragment(
         &self,
         store: &dyn KvStore,
         schema: &str,
         key: &KeyValue,
-        field_names: Vec<String>,
+        field_name: &str,
+        fragment_index: usize,
         embedding: Vec<f32>,
     ) -> Result<(), SchemaError> {
         let stored = StoredEmbedding {
             schema: schema.to_string(),
             key: key.clone(),
-            field_names: field_names.clone(),
+            field_name: field_name.to_string(),
+            fragment_index,
             embedding: embedding.clone(),
+            field_names: None,
         };
 
-        let storage_key = EmbeddingEntry::storage_key(schema, key);
+        let storage_key =
+            EmbeddingEntry::fragment_storage_key(schema, key, field_name, fragment_index);
         let bytes = serde_json::to_vec(&stored)
             .map_err(|e| SchemaError::InvalidData(format!("Serialization failed: {}", e)))?;
 
@@ -103,15 +146,16 @@ impl EmbeddingIndex {
         let new_entry = EmbeddingEntry {
             schema: schema.to_string(),
             key: key.clone(),
-            field_names,
+            field_name: field_name.to_string(),
+            fragment_index,
             embedding,
         };
 
         let mut entries = self.entries.write().unwrap();
-        if let Some(existing) = entries
-            .iter_mut()
-            .find(|e| EmbeddingEntry::storage_key(&e.schema, &e.key) == storage_key)
-        {
+        if let Some(existing) = entries.iter_mut().find(|e| {
+            EmbeddingEntry::fragment_storage_key(&e.schema, &e.key, &e.field_name, e.fragment_index)
+                == storage_key
+        }) {
             *existing = new_entry;
         } else {
             entries.push(new_entry);
@@ -120,10 +164,14 @@ impl EmbeddingIndex {
         Ok(())
     }
 
-    /// Brute-force cosine similarity search. Returns up to `k` results sorted by score.
+    /// Cosine similarity search with per-record deduplication.
+    ///
+    /// Multiple fragments of the same record may match. We keep only the
+    /// highest-scoring fragment per record and return it as the representative.
     pub(super) fn search(&self, query_vec: &[f32], k: usize) -> Vec<IndexResult> {
         let entries = self.entries.read().unwrap();
 
+        // Score all entries
         let mut scored: Vec<(f32, usize)> = entries
             .iter()
             .enumerate()
@@ -134,21 +182,36 @@ impl EmbeddingIndex {
             b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
         });
 
-        scored
-            .into_iter()
-            .take(k)
-            .flat_map(|(score, i)| {
-                let e = &entries[i];
-                e.field_names.iter().map(move |field| IndexResult {
-                    schema_name: e.schema.clone(),
-                    field: field.clone(),
-                    key_value: e.key.clone(),
-                    value: Value::Null,
-                    metadata: Some(serde_json::json!({"score": score, "match_type": "semantic"})),
-                    molecule_versions: None,
-                })
-            })
-            .collect()
+        // Dedup by record key, keeping highest score per record
+        let mut seen: HashMap<String, f32> = HashMap::new();
+        let mut results: Vec<IndexResult> = Vec::new();
+
+        for (score, i) in scored {
+            if results.len() >= k {
+                break;
+            }
+            let e = &entries[i];
+            let record_id = e.record_id();
+
+            // Skip if we already have a higher-scoring fragment for this record
+            if let Some(&existing_score) = seen.get(&record_id) {
+                if existing_score >= score {
+                    continue;
+                }
+            }
+            seen.insert(record_id, score);
+
+            results.push(IndexResult {
+                schema_name: e.schema.clone(),
+                field: e.field_name.clone(),
+                key_value: e.key.clone(),
+                value: Value::Null,
+                metadata: Some(serde_json::json!({"score": score, "match_type": "semantic"})),
+                molecule_versions: None,
+            });
+        }
+
+        results
     }
 }
 
@@ -156,21 +219,9 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
     let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
     let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if norm_a == 0.0 || norm_b == 0.0 { 0.0 } else { dot / (norm_a * norm_b) }
-}
-
-/// Convert a map of field values to a single text string for embedding.
-pub(super) fn fields_to_text(fields: &HashMap<String, Value>) -> String {
-    fields.values().map(value_to_text).collect::<Vec<_>>().join(" ")
-}
-
-fn value_to_text(v: &Value) -> String {
-    match v {
-        Value::String(s) => s.clone(),
-        Value::Number(n) => n.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Array(arr) => arr.iter().map(value_to_text).collect::<Vec<_>>().join(" "),
-        Value::Object(obj) => obj.values().map(value_to_text).collect::<Vec<_>>().join(" "),
-        Value::Null => String::new(),
+    if norm_a == 0.0 || norm_b == 0.0 {
+        0.0
+    } else {
+        dot / (norm_a * norm_b)
     }
 }

--- a/src/db_operations/native_index/fragmentation.rs
+++ b/src/db_operations/native_index/fragmentation.rs
@@ -1,0 +1,184 @@
+// Content-aware fragmentation for discovery index.
+//
+// Splits field values into semantically meaningful fragments.
+// Short values remain as single fragments; long text is split at sentence boundaries.
+
+/// A single fragment produced from a field value.
+#[derive(Debug, Clone)]
+pub struct Fragment {
+    /// The text content of this fragment
+    pub text: String,
+    /// Index within the field (0 for single-fragment fields)
+    pub index: usize,
+}
+
+/// Minimum character length before sentence splitting is attempted.
+const SENTENCE_SPLIT_THRESHOLD: usize = 100;
+
+/// Minimum fragment length in characters. Fragments shorter than this are merged
+/// with the next fragment to avoid semantically empty embeddings.
+const MIN_FRAGMENT_LENGTH: usize = 20;
+
+/// Split a field value into fragments suitable for independent embedding.
+///
+/// - Short text (<100 chars): returned as a single fragment
+/// - Long text: split at sentence boundaries (period/question/exclamation)
+/// - Each fragment is a coherent semantic unit
+pub fn split_into_fragments(text: &str) -> Vec<Fragment> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+
+    if trimmed.len() < SENTENCE_SPLIT_THRESHOLD {
+        return vec![Fragment { text: trimmed.to_string(), index: 0 }];
+    }
+
+    let sentences = split_sentences(trimmed);
+    if sentences.len() <= 1 {
+        return vec![Fragment { text: trimmed.to_string(), index: 0 }];
+    }
+
+    // Merge short sentences with the next one
+    let mut merged: Vec<String> = Vec::new();
+    let mut buffer = String::new();
+
+    for sentence in sentences {
+        if buffer.is_empty() {
+            buffer = sentence;
+        } else {
+            buffer.push(' ');
+            buffer.push_str(&sentence);
+        }
+
+        if buffer.len() >= MIN_FRAGMENT_LENGTH {
+            merged.push(buffer.clone());
+            buffer.clear();
+        }
+    }
+
+    // Append remaining buffer to the last fragment
+    if !buffer.is_empty() {
+        if let Some(last) = merged.last_mut() {
+            last.push(' ');
+            last.push_str(&buffer);
+        } else {
+            merged.push(buffer);
+        }
+    }
+
+    merged
+        .into_iter()
+        .enumerate()
+        .map(|(i, text)| Fragment { text, index: i })
+        .collect()
+}
+
+/// Split text at sentence boundaries.
+/// Handles: periods, question marks, exclamation marks followed by whitespace or end of string.
+fn split_sentences(text: &str) -> Vec<String> {
+    let mut sentences = Vec::new();
+    let mut start = 0;
+    let chars: Vec<char> = text.chars().collect();
+    let len = chars.len();
+
+    let mut i = 0;
+    while i < len {
+        let ch = chars[i];
+        // Check for sentence-ending punctuation
+        if (ch == '.' || ch == '?' || ch == '!') && i + 1 < len {
+            // Look ahead: must be followed by whitespace (sentence boundary)
+            // Skip consecutive punctuation (e.g., "..." or "?!")
+            let mut end = i + 1;
+            while end < len && (chars[end] == '.' || chars[end] == '?' || chars[end] == '!') {
+                end += 1;
+            }
+            if end < len && chars[end].is_whitespace() {
+                let sentence: String = chars[start..end].iter().collect();
+                let trimmed = sentence.trim().to_string();
+                if !trimmed.is_empty() {
+                    sentences.push(trimmed);
+                }
+                // Skip whitespace after punctuation
+                while end < len && chars[end].is_whitespace() {
+                    end += 1;
+                }
+                start = end;
+                i = end;
+                continue;
+            }
+        }
+        i += 1;
+    }
+
+    // Remaining text
+    if start < len {
+        let sentence: String = chars[start..].iter().collect();
+        let trimmed = sentence.trim().to_string();
+        if !trimmed.is_empty() {
+            sentences.push(trimmed);
+        }
+    }
+
+    sentences
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_input() {
+        assert!(split_into_fragments("").is_empty());
+        assert!(split_into_fragments("   ").is_empty());
+    }
+
+    #[test]
+    fn test_short_text_single_fragment() {
+        let frags = split_into_fragments("A simple recipe for chocolate cake");
+        assert_eq!(frags.len(), 1);
+        assert_eq!(frags[0].index, 0);
+        assert_eq!(frags[0].text, "A simple recipe for chocolate cake");
+    }
+
+    #[test]
+    fn test_long_text_splits_at_sentences() {
+        let text = "This is the first sentence about cooking. \
+                    The second sentence describes ingredients in great detail. \
+                    A third sentence explains the preparation method step by step.";
+        let frags = split_into_fragments(text);
+        assert!(frags.len() > 1, "Expected multiple fragments, got {}", frags.len());
+        // Each fragment should be coherent text
+        for frag in &frags {
+            assert!(!frag.text.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_fragments_have_sequential_indices() {
+        let text = "First sentence here. Second sentence there. Third one too. \
+                    Fourth sentence is longer to pass the threshold for splitting.";
+        let frags = split_into_fragments(text);
+        for (i, frag) in frags.iter().enumerate() {
+            assert_eq!(frag.index, i);
+        }
+    }
+
+    #[test]
+    fn test_sentence_splitting_handles_abbreviations() {
+        // "Dr." followed by capital letter shouldn't split ideally, but our simple
+        // splitter may split here. That's acceptable — fragments just need to be
+        // coherent enough for embedding.
+        let text = "Dr. Smith went to the store. He bought some apples. \
+                    Then he went home and made a pie that was delicious.";
+        let frags = split_into_fragments(text);
+        assert!(!frags.is_empty());
+    }
+
+    #[test]
+    fn test_no_split_under_threshold() {
+        let text = "Short text that is under one hundred characters total.";
+        let frags = split_into_fragments(text);
+        assert_eq!(frags.len(), 1);
+    }
+}

--- a/src/db_operations/native_index/mod.rs
+++ b/src/db_operations/native_index/mod.rs
@@ -1,12 +1,18 @@
+pub mod anonymity;
 mod embedding_index;
 mod embedding_model;
+pub mod fragmentation;
 mod types;
 
 #[cfg(test)]
 mod tests;
 
+pub use anonymity::{
+    check_fragment_anonymity, default_privacy_class, FieldPrivacyClass, FragmentDecision,
+};
 pub use embedding_index::cosine_similarity;
 pub use embedding_model::{Embedder, FastEmbedModel};
+pub use fragmentation::{split_into_fragments, Fragment};
 #[cfg(any(test, feature = "test-utils"))]
 pub use embedding_model::{MockEmbeddingModel, ScriptedEmbeddingModel};
 pub use types::IndexResult;
@@ -14,7 +20,7 @@ pub use types::IndexResult;
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::SchemaError;
 use crate::storage::traits::KvStore;
-use embedding_index::{fields_to_text, EmbeddingIndex};
+use embedding_index::EmbeddingIndex;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -49,27 +55,45 @@ impl NativeIndexManager {
         }
     }
 
-    /// Index all fields of a record as a single document embedding.
+    /// Index each field of a record as an independent embedding.
+    ///
+    /// Each field value is embedded separately (and long text fields are further
+    /// split into sentence-level fragments). This produces one embedding per
+    /// fragment, enabling per-fragment discovery and anonymity checks.
     pub async fn index_record(
         &self,
         schema: &str,
         key: &KeyValue,
         fields_and_values: &HashMap<String, serde_json::Value>,
     ) -> Result<(), SchemaError> {
-        let text = fields_to_text(fields_and_values);
-        if text.trim().is_empty() {
-            return Ok(());
+        for (field_name, value) in fields_and_values {
+            let text = value_to_text(value);
+            if text.trim().is_empty() {
+                continue;
+            }
+
+            let fragments = split_into_fragments(&text);
+            for fragment in &fragments {
+                let embedding = self.embedding_model.embed_text(&fragment.text)?;
+                self.embedding_index
+                    .insert_fragment(
+                        &*self.store,
+                        schema,
+                        key,
+                        field_name,
+                        fragment.index,
+                        embedding,
+                    )
+                    .await?;
+            }
         }
-
-        let embedding = self.embedding_model.embed_text(&text)?;
-        let field_names: Vec<String> = fields_and_values.keys().cloned().collect();
-
-        self.embedding_index
-            .insert(&*self.store, schema, key, field_names, embedding)
-            .await
+        Ok(())
     }
 
-    /// Semantic search: embed the query then return top-50 results by cosine similarity.
+    /// Semantic search: embed the query then return top results by cosine similarity.
+    ///
+    /// Results are deduplicated by record key — if multiple fragments of the same
+    /// record match, only the highest-scoring match is returned.
     pub async fn search_all_classifications(
         &self,
         query: &str,
@@ -80,5 +104,18 @@ impl NativeIndexManager {
 
         let query_vec = self.embedding_model.embed_text(query)?;
         Ok(self.embedding_index.search(&query_vec, 50))
+    }
+}
+
+fn value_to_text(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Array(arr) => arr.iter().map(value_to_text).collect::<Vec<_>>().join(" "),
+        serde_json::Value::Object(obj) => {
+            obj.values().map(value_to_text).collect::<Vec<_>>().join(" ")
+        }
+        serde_json::Value::Null => String::new(),
     }
 }

--- a/src/db_operations/native_index/tests.rs
+++ b/src/db_operations/native_index/tests.rs
@@ -48,7 +48,7 @@ async fn test_index_record_then_search() {
 }
 
 #[tokio::test]
-async fn test_index_record_produces_one_result_per_field() {
+async fn test_per_field_indexing_creates_separate_embeddings() {
     let mgr = make_manager().await;
 
     let key = KeyValue::new(Some("doc1".to_string()), None);
@@ -60,13 +60,34 @@ async fn test_index_record_produces_one_result_per_field() {
 
     mgr.index_record("Post", &key, &fields).await.unwrap();
 
-    let results = mgr.search_all_classifications("blog").await.unwrap();
-    // One IndexResult per field in the matched document
-    assert_eq!(results.len(), 3);
-    let field_names: std::collections::HashSet<_> = results.iter().map(|r| r.field.as_str()).collect();
+    // Per-field indexing produces one embedding entry per field
+    let entries = mgr.embedding_index.entries.read().unwrap();
+    assert_eq!(entries.len(), 3, "Expected 3 entries (one per field)");
+
+    let field_names: std::collections::HashSet<_> =
+        entries.iter().map(|e| e.field_name.as_str()).collect();
     assert!(field_names.contains("title"));
     assert!(field_names.contains("body"));
     assert!(field_names.contains("author"));
+}
+
+#[tokio::test]
+async fn test_search_deduplicates_by_record() {
+    let mgr = make_manager().await;
+
+    let key = KeyValue::new(Some("doc1".to_string()), None);
+    let fields = std::collections::HashMap::from([
+        ("title".to_string(), serde_json::json!("hello world")),
+        ("body".to_string(), serde_json::json!("hello there")),
+        ("tags".to_string(), serde_json::json!("hello greetings")),
+    ]);
+
+    mgr.index_record("Post", &key, &fields).await.unwrap();
+
+    // Search should return at most 1 result for this record (deduped by record key)
+    let results = mgr.search_all_classifications("hello").await.unwrap();
+    assert_eq!(results.len(), 1, "Expected deduplication to 1 result per record");
+    assert_eq!(results[0].schema_name, "Post");
 }
 
 #[tokio::test]
@@ -85,10 +106,10 @@ async fn test_upsert_replaces_existing_entry() {
     mgr.index_record("User", &key, &v1).await.unwrap();
     mgr.index_record("User", &key, &v2).await.unwrap();
 
-    // Only one document in the index (upserted, not appended)
     let entries = mgr.embedding_index.entries.read().unwrap();
-    assert_eq!(entries.len(), 1);
-    assert_eq!(entries[0].field_names.len(), 2);
+    // v1 had 1 field (name), v2 has 2 fields (name, role).
+    // "name" is upserted (same key), "role" is new → total 2
+    assert_eq!(entries.len(), 2);
 }
 
 #[tokio::test]
@@ -129,4 +150,27 @@ async fn test_restore_from_store_loads_existing_embeddings() {
     let entries = mgr2.embedding_index.entries.read().unwrap();
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].schema, "S");
+    assert_eq!(entries[0].field_name, "field");
+}
+
+#[tokio::test]
+async fn test_multiple_records_return_separate_results() {
+    let mgr = make_manager().await;
+
+    let key1 = KeyValue::new(Some("rec1".to_string()), None);
+    let key2 = KeyValue::new(Some("rec2".to_string()), None);
+
+    let fields1 = std::collections::HashMap::from([
+        ("content".to_string(), serde_json::json!("chocolate cake recipe")),
+    ]);
+    let fields2 = std::collections::HashMap::from([
+        ("content".to_string(), serde_json::json!("vanilla cake recipe")),
+    ]);
+
+    mgr.index_record("Recipe", &key1, &fields1).await.unwrap();
+    mgr.index_record("Recipe", &key2, &fields2).await.unwrap();
+
+    let results = mgr.search_all_classifications("cake recipe").await.unwrap();
+    // Should return 2 results (one per record, deduped)
+    assert_eq!(results.len(), 2);
 }


### PR DESCRIPTION
## Summary
- **Per-field indexing**: Each field value is now embedded independently (not concatenated). Long text is split at sentence boundaries. Search deduplicates by record key.
- **Anonymity gate**: Pre-publication check classifies fields as NeverPublish/PublishIfAnonymous/AlwaysPublish. Rule-based NER, token count, and Shannon entropy checks reject identifying fragments.
- **Fragmentation module**: Sentence-level splitting for long text fields with minimum fragment length merging.

Phase 1-2 of network vector discovery. See `docs/design/network_vector_discovery.md` in the workspace repo for full design.

## Test plan
- [x] 31 unit tests pass (per-field indexing, dedup, fragmentation, anonymity gate, NER, entropy)
- [x] 6 integration tests pass in fold_db_node (vector_embedding_index_test)
- [x] clippy -D warnings clean
- [x] cargo check --features aws-backend passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)