### PR TITLE
Add Hash schema type and enforce key validation

### DIFF
--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -1,5 +1,6 @@
 mod atom_def;
 mod molecule;
+mod molecule_hash;
 mod molecule_hash_range;
 mod molecule_range;
 mod molecule_tests;
@@ -7,6 +8,7 @@ pub mod mutation_event;
 
 pub use atom_def::Atom;
 pub use molecule::Molecule;
+pub use molecule_hash::MoleculeHash;
 pub use molecule_hash_range::MoleculeHashRange;
 pub use molecule_range::MoleculeRange;
 pub use mutation_event::{FieldKey, MutationEvent};

--- a/src/atom/molecule_hash.rs
+++ b/src/atom/molecule_hash.rs
@@ -1,0 +1,121 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// A hash-based collection of atom references stored in a HashMap.
+/// Used for collections keyed by a single hash key (no ordering needed).
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct MoleculeHash {
+    uuid: String,
+    pub(crate) atom_uuids: HashMap<String, String>,
+    #[schema(value_type = String, format = "date-time")]
+    updated_at: DateTime<Utc>,
+    #[serde(default)]
+    version: u64,
+}
+
+impl MoleculeHash {
+    /// Creates a new empty MoleculeHash.
+    #[must_use]
+    pub fn new(_source_pub_key: String) -> Self {
+        Self {
+            uuid: Uuid::new_v4().to_string(),
+            atom_uuids: HashMap::new(),
+            updated_at: Utc::now(),
+            version: 0,
+        }
+    }
+
+    /// Returns the unique identifier of this molecule.
+    #[must_use]
+    pub fn uuid(&self) -> &str {
+        &self.uuid
+    }
+
+    /// Returns the timestamp of the last update.
+    #[must_use]
+    pub fn updated_at(&self) -> DateTime<Utc> {
+        self.updated_at
+    }
+
+    /// Updates or adds a reference at the specified key.
+    /// Bumps the version counter only when the atom actually changes.
+    pub fn set_atom_uuid(&mut self, key: String, atom_uuid: String) {
+        if self.atom_uuids.get(&key) != Some(&atom_uuid) {
+            self.version += 1;
+        }
+        self.atom_uuids.insert(key, atom_uuid);
+        self.updated_at = Utc::now();
+    }
+
+    /// Returns the UUID of the Atom referenced by the specified key.
+    #[must_use]
+    pub fn get_atom_uuid(&self, key: &str) -> Option<&String> {
+        self.atom_uuids.get(key)
+    }
+
+    /// Removes the reference at the specified key.
+    /// Bumps the version counter if an entry was actually removed.
+    #[allow(clippy::manual_inspect)]
+    pub fn remove_atom_uuid(&mut self, key: &str) -> Option<String> {
+        self.atom_uuids.remove(key).map(|uuid| {
+            self.version += 1;
+            self.updated_at = Utc::now();
+            uuid
+        })
+    }
+
+    /// Returns the version counter for this molecule.
+    #[must_use]
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// Returns all hash keys.
+    pub fn keys(&self) -> impl Iterator<Item = &String> {
+        self.atom_uuids.keys()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_starts_at_zero() {
+        let mol = MoleculeHash::new("key".to_string());
+        assert_eq!(mol.version(), 0);
+    }
+
+    #[test]
+    fn test_version_bumps_on_insert() {
+        let mut mol = MoleculeHash::new("key".to_string());
+        mol.set_atom_uuid("k1".to_string(), "atom-1".to_string());
+        assert_eq!(mol.version(), 1);
+    }
+
+    #[test]
+    fn test_version_no_bump_on_same_value() {
+        let mut mol = MoleculeHash::new("key".to_string());
+        mol.set_atom_uuid("k1".to_string(), "atom-1".to_string());
+        mol.set_atom_uuid("k1".to_string(), "atom-1".to_string());
+        assert_eq!(mol.version(), 1);
+    }
+
+    #[test]
+    fn test_version_bumps_on_remove() {
+        let mut mol = MoleculeHash::new("key".to_string());
+        mol.set_atom_uuid("k1".to_string(), "atom-1".to_string());
+        assert_eq!(mol.version(), 1);
+        mol.remove_atom_uuid("k1");
+        assert_eq!(mol.version(), 2);
+    }
+
+    #[test]
+    fn test_version_no_bump_on_remove_missing() {
+        let mut mol = MoleculeHash::new("key".to_string());
+        mol.remove_atom_uuid("nonexistent");
+        assert_eq!(mol.version(), 0);
+    }
+}

--- a/src/atom/mutation_event.rs
+++ b/src/atom/mutation_event.rs
@@ -19,6 +19,7 @@ pub struct MutationEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum FieldKey {
     Single,
+    Hash { hash: String },
     Range { range: String },
     HashRange { hash: String, range: String },
 }

--- a/src/db_operations/atom_operations.rs
+++ b/src/db_operations/atom_operations.rs
@@ -1,5 +1,5 @@
 use super::core::DbOperations;
-use crate::atom::{Atom, Molecule, MoleculeHashRange, MoleculeRange, MutationEvent};
+use crate::atom::{Atom, Molecule, MoleculeHash, MoleculeHashRange, MoleculeRange, MutationEvent};
 use crate::schema::SchemaError;
 use crate::storage::traits::TypedStore;
 use serde_json::Value;
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 #[derive(Clone)]
 pub enum MoleculeData {
     Single(Molecule),
+    Hash(MoleculeHash),
     Range(MoleculeRange),
     HashRange(MoleculeHashRange),
 }
@@ -91,6 +92,8 @@ impl DbOperations {
                     let value = match mol_data {
                         MoleculeData::Single(mol) => serde_json::to_value(mol)
                             .expect("Molecule is always serializable"),
+                        MoleculeData::Hash(mol) => serde_json::to_value(mol)
+                            .expect("MoleculeHash is always serializable"),
                         MoleculeData::Range(mol) => serde_json::to_value(mol)
                             .expect("MoleculeRange is always serializable"),
                         MoleculeData::HashRange(mol) => serde_json::to_value(mol)

--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -354,6 +354,35 @@ impl MutationManager {
                 key_value.hash = Some(short.to_string());
             }
 
+            // Validate that the key matches the schema type.
+            // A mismatch means a bug upstream — fail loudly.
+            {
+                use crate::schema::types::schema::DeclarativeSchemaType;
+                match &schema.schema_type {
+                    DeclarativeSchemaType::Hash if key_value.hash.is_none() => {
+                        return Err(SchemaError::InvalidData(format!(
+                            "Hash schema '{}' mutation {} has no hash key",
+                            schema_name, mutation.uuid
+                        )));
+                    }
+                    DeclarativeSchemaType::Range if key_value.range.is_none() => {
+                        return Err(SchemaError::InvalidData(format!(
+                            "Range schema '{}' mutation {} has no range key",
+                            schema_name, mutation.uuid
+                        )));
+                    }
+                    DeclarativeSchemaType::HashRange => {
+                        if key_value.hash.is_none() || key_value.range.is_none() {
+                            return Err(SchemaError::InvalidData(format!(
+                                "HashRange schema '{}' mutation {} requires both hash and range keys, got hash={:?} range={:?}",
+                                schema_name, mutation.uuid, key_value.hash, key_value.range
+                            )));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
             mutation_key_values.push(key_value);
 
             // Create atoms in memory (no storage yet)
@@ -424,6 +453,11 @@ impl MutationManager {
                 FieldVariant::Single(f) => {
                     f.base.molecule.as_ref().map(|m| m.get_atom_uuid().to_string())
                 }
+                FieldVariant::Hash(f) => {
+                    key_value.hash.as_ref().and_then(|h| {
+                        f.base.molecule.as_ref().and_then(|m| m.get_atom_uuid(h).cloned())
+                    })
+                }
                 FieldVariant::Range(f) => {
                     key_value.range.as_ref().and_then(|r| {
                         f.base.molecule.as_ref().and_then(|m| m.get_atom_uuid(r).cloned())
@@ -443,6 +477,9 @@ impl MutationManager {
             if old_atom_uuid.as_deref() != Some(atom.uuid()) {
                 let field_key = match schema_field {
                     FieldVariant::Single(_) => FieldKey::Single,
+                    FieldVariant::Hash(_) => FieldKey::Hash {
+                        hash: key_value.hash.clone().unwrap_or_default(),
+                    },
                     FieldVariant::Range(_) => FieldKey::Range {
                         range: key_value.range.clone().unwrap_or_default(),
                     },

--- a/src/schema/types/declarative_schemas.rs
+++ b/src/schema/types/declarative_schemas.rs
@@ -170,8 +170,9 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
                 let has_range = k.range_field.is_some();
                 if has_hash && has_range {
                     SchemaType::HashRange
-                } else if has_range || has_hash {
-                    // If either key exists (but not both), treat as Range
+                } else if has_hash {
+                    SchemaType::Hash
+                } else if has_range {
                     SchemaType::Range
                 } else {
                     SchemaType::Single
@@ -225,9 +226,9 @@ pub struct DeclarativeSchemaDefinition {
     /// Human-readable descriptive name for the schema (used in AI-generated proposals)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub descriptive_name: Option<String>,
-    /// Schema type ("Single" | "Range" | "HashRange")
+    /// Schema type ("Single" | "Hash" | "Range" | "HashRange")
     pub schema_type: SchemaType,
-    /// Key configuration (required when schema_type == "HashRange" or "Range")
+    /// Key configuration (required when schema_type == "Hash", "Range", or "HashRange")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<KeyConfig>,
     /// Field names - plain data fields without transformations
@@ -313,7 +314,9 @@ impl DeclarativeSchemaDefinition {
     /// This is called after deserializing from database to ensure runtime state is initialized
     /// Also regenerates transform metadata (hash mappings, inputs, source schemas) which are not persisted
     pub fn populate_runtime_fields(&mut self) -> Result<(), crate::schema::SchemaError> {
-        use crate::schema::types::field::{FieldVariant, HashRangeField, RangeField, SingleField};
+        use crate::schema::types::field::{
+            FieldVariant, HashField, HashRangeField, RangeField, SingleField,
+        };
         use std::collections::HashMap;
 
         let default_field_mappers = HashMap::new();
@@ -325,6 +328,10 @@ impl DeclarativeSchemaDefinition {
                 SchemaType::HashRange => {
                     let hashrange_field = HashRangeField::new(default_field_mappers.clone(), None);
                     runtime_fields.insert(field_name, FieldVariant::HashRange(hashrange_field));
+                }
+                SchemaType::Hash => {
+                    let hash_field = HashField::new(default_field_mappers.clone(), None);
+                    runtime_fields.insert(field_name, FieldVariant::Hash(hash_field));
                 }
                 SchemaType::Range => {
                     let range_field = RangeField::new(default_field_mappers.clone(), None);

--- a/src/schema/types/field/filter_utils.rs
+++ b/src/schema/types/field/filter_utils.rs
@@ -3,7 +3,7 @@
 //! This module provides common filter logic that can be reused by RangeField,
 //! HashRangeField, and other field types to eliminate code duplication.
 
-use crate::atom::{MoleculeHashRange, MoleculeRange};
+use crate::atom::{MoleculeHash, MoleculeHashRange, MoleculeRange};
 use crate::db_operations::DbOperations;
 use crate::schema::types::field::FieldValue;
 use crate::schema::types::field::{HashRangeFilter, HashRangeFilterResult};
@@ -121,6 +121,16 @@ pub trait RangeOperations {
     fn get_atoms_with_prefix(&self, prefix: &str) -> Vec<(String, String)>;
 }
 
+/// Helper trait for hash-based operations (single hash key, no range)
+/// Used by fields that work with hash keys (like HashField)
+pub trait HashOperations {
+    /// Get a single atom UUID by hash key
+    fn get_atom_uuid(&self, key: &str) -> Option<String>;
+
+    /// Get all atom UUIDs as key-value pairs
+    fn get_all_atoms(&self) -> Vec<(String, String)>;
+}
+
 /// Helper trait for hash-range operations
 /// Used by fields that work with hash-range combinations (like HashRangeField)
 pub trait HashRangeOperations {
@@ -152,6 +162,42 @@ pub trait HashRangeOperations {
 
     /// Get atoms in hash range
     fn get_atoms_in_hash_range(&self, start: &str, end: &str) -> Vec<(String, String, String)>;
+}
+
+fn insert_hash(m: &mut HashMap<KeyValue, String>, key: String, uuid: String) {
+    m.insert(KeyValue::new(Some(key), None), uuid);
+}
+
+fn extend_hash<I: IntoIterator<Item = (String, String)>>(m: &mut HashMap<KeyValue, String>, iter: I) {
+    for (k, v) in iter {
+        insert_hash(m, k, v);
+    }
+}
+
+/// Generic filter application for HashField (single hash key, no range)
+pub fn apply_hash_filter<T: HashOperations>(
+    operations: &T,
+    optional_filter: Option<HashRangeFilter>,
+) -> HashRangeFilterResult {
+    let filter = optional_filter.unwrap_or(HashRangeFilter::SampleN(100));
+    let mut matches = HashMap::new();
+
+    match filter {
+        HashRangeFilter::SampleN(n) => {
+            extend_hash(&mut matches, operations.get_all_atoms().into_iter().take(n));
+        }
+        HashRangeFilter::HashKey(key) => {
+            if let Some(uuid) = operations.get_atom_uuid(&key) {
+                insert_hash(&mut matches, key, uuid);
+            }
+        }
+        // For Hash fields, range filters don't apply — return all matches
+        _ => {
+            extend_hash(&mut matches, operations.get_all_atoms());
+        }
+    }
+
+    HashRangeFilterResult::new(matches)
 }
 
 fn insert_range(m: &mut HashMap<KeyValue, String>, key: String, uuid: String) {
@@ -334,6 +380,20 @@ pub fn apply_hash_range_filter<T: HashRangeOperations>(
     }
 
     HashRangeFilterResult::new(matches)
+}
+
+/// Implementation of HashOperations for MoleculeHash
+impl HashOperations for MoleculeHash {
+    fn get_atom_uuid(&self, key: &str) -> Option<String> {
+        self.get_atom_uuid(key).cloned()
+    }
+
+    fn get_all_atoms(&self) -> Vec<(String, String)> {
+        self.atom_uuids
+            .iter()
+            .map(|(key, uuid)| (key.clone(), uuid.clone()))
+            .collect()
+    }
 }
 
 /// Implementation of RangeOperations for MoleculeRange

--- a/src/schema/types/field/hash_field.rs
+++ b/src/schema/types/field/hash_field.rs
@@ -1,0 +1,107 @@
+//! Hash field type for schema indexing
+//!
+//! Provides a field type keyed by a single hash key (unordered collection).
+
+use crate::db_operations::DbOperations;
+use crate::schema::types::declarative_schemas::FieldMapper;
+use crate::schema::types::field::base::FieldBase;
+use crate::schema::types::field::hash_range_filter::{HashRangeFilter, HashRangeFilterResult};
+use crate::schema::types::field::FieldValue;
+use crate::schema::types::field::{apply_hash_filter, FilterApplicator};
+use crate::schema::types::key_value::KeyValue;
+use crate::schema::types::SchemaError;
+use serde::{Deserialize, Serialize};
+
+use crate::atom::MoleculeHash;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Field keyed by a single hash key (unordered collection).
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct HashField {
+    #[serde(flatten)]
+    pub base: FieldBase<MoleculeHash>,
+}
+
+impl HashField {
+    /// Creates a new Hash field
+    #[must_use]
+    pub fn new(
+        field_mappers: HashMap<String, FieldMapper>,
+        molecule: Option<MoleculeHash>,
+    ) -> Self {
+        Self {
+            base: FieldBase::new(field_mappers, molecule),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::schema::types::field::Field for HashField {
+    fn common(&self) -> &crate::schema::types::field::FieldCommon {
+        &self.base.inner
+    }
+
+    fn common_mut(&mut self) -> &mut crate::schema::types::field::FieldCommon {
+        &mut self.base.inner
+    }
+
+    async fn refresh_from_db(&mut self, db_ops: &crate::db_operations::DbOperations) {
+        self.base.refresh_from_db(db_ops).await;
+    }
+
+    fn write_mutation(
+        &mut self,
+        key_value: &crate::schema::types::key_value::KeyValue,
+        atom: crate::atom::Atom,
+        pub_key: String,
+    ) {
+        // Initialize molecule if needed and set molecule_uuid in FieldCommon
+        if self.base.molecule.is_none() {
+            let new_molecule = crate::atom::MoleculeHash::new(pub_key.clone());
+            self.base
+                .inner
+                .set_molecule_uuid(new_molecule.uuid().to_string());
+            self.base.molecule = Some(new_molecule);
+        }
+
+        // For HashField, we use the hash key to store the atom
+        if let Some(hash_key) = &key_value.hash {
+            if let Some(molecule) = &mut self.base.molecule {
+                molecule.set_atom_uuid(hash_key.clone(), atom.uuid().to_string());
+            }
+        }
+    }
+
+    async fn resolve_value(
+        &mut self,
+        db_ops: &Arc<DbOperations>,
+        filter: Option<HashRangeFilter>,
+        _as_of: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
+        self.refresh_from_db(db_ops).await;
+        let result = self.apply_filter(filter);
+        super::fetch_atoms_for_matches_async(db_ops, result.matches).await
+    }
+}
+
+impl HashField {
+    /// Gets all keys in the hash (useful for pagination or listing)
+    pub fn get_all_keys(&self) -> Vec<String> {
+        self.base
+            .molecule
+            .as_ref()
+            .map(|molecule| molecule.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+impl FilterApplicator for HashField {
+    fn apply_filter(&self, filter: Option<HashRangeFilter>) -> HashRangeFilterResult {
+        let Some(molecule) = &self.base.molecule else {
+            return HashRangeFilterResult::empty();
+        };
+
+        apply_hash_filter(molecule, filter)
+    }
+}

--- a/src/schema/types/field/mod.rs
+++ b/src/schema/types/field/mod.rs
@@ -1,5 +1,6 @@
 pub mod common;
 pub mod filter_utils;
+pub mod hash_field;
 pub mod hash_range_field;
 pub mod hash_range_filter;
 pub mod range_field;
@@ -8,9 +9,10 @@ pub mod variant;
 
 pub use common::{Field, FieldCommon, FieldType};
 pub use filter_utils::{
-    apply_hash_range_filter, apply_range_filter, fetch_atoms_for_matches_async, FilterApplicator,
-    FilterUtils, HashRangeOperations, RangeOperations,
+    apply_hash_filter, apply_hash_range_filter, apply_range_filter, fetch_atoms_for_matches_async,
+    FilterApplicator, FilterUtils, HashOperations, HashRangeOperations, RangeOperations,
 };
+pub use hash_field::HashField;
 pub use hash_range_field::HashRangeField;
 pub use hash_range_filter::{HashRangeFilter, HashRangeFilterResult};
 pub use range_field::RangeField;

--- a/src/schema/types/field/variant.rs
+++ b/src/schema/types/field/variant.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use crate::atom::{FieldKey, MutationEvent};
 use crate::db_operations::DbOperations;
 use crate::schema::types::field::{
-    fetch_atoms_for_matches_async, Field, FieldCommon, FilterApplicator, HashRangeField,
-    HashRangeFilter, RangeField, SingleField,
+    fetch_atoms_for_matches_async, Field, FieldCommon, FilterApplicator, HashField,
+    HashRangeField, HashRangeFilter, RangeField, SingleField,
 };
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::SchemaError;
@@ -19,6 +19,8 @@ use serde_json::Value as JsonValue;
 pub enum FieldVariant {
     /// Single value field
     Single(SingleField),
+    /// Hash-keyed collection (unordered)
+    Hash(HashField),
     /// Range of values
     Range(RangeField),
     /// Hash-range field for complex indexing
@@ -43,6 +45,7 @@ macro_rules! delegate_field_method {
     ($self:ident, $method:ident) => {
         match $self {
             Self::Single(f) => f.$method(),
+            Self::Hash(f) => f.$method(),
             Self::Range(f) => f.$method(),
             Self::HashRange(f) => f.$method(),
         }
@@ -50,6 +53,7 @@ macro_rules! delegate_field_method {
     ($self:ident, $method:ident, $($args:expr),+) => {
         match $self {
             Self::Single(f) => f.$method($($args),+),
+            Self::Hash(f) => f.$method($($args),+),
             Self::Range(f) => f.$method($($args),+),
             Self::HashRange(f) => f.$method($($args),+),
         }
@@ -69,6 +73,7 @@ impl Field for FieldVariant {
     async fn refresh_from_db(&mut self, db_ops: &DbOperations) {
         match self {
             Self::Single(f) => f.refresh_from_db(db_ops).await,
+            Self::Hash(f) => f.refresh_from_db(db_ops).await,
             Self::Range(f) => f.refresh_from_db(db_ops).await,
             Self::HashRange(f) => f.refresh_from_db(db_ops).await,
         }
@@ -100,6 +105,7 @@ impl Field for FieldVariant {
         // Fetch actual atom content from database using shared helper
         let results = match self {
             FieldVariant::Single(f) => f.apply_filter(filter),
+            FieldVariant::Hash(f) => f.apply_filter(filter),
             FieldVariant::Range(f) => f.apply_filter(filter),
             FieldVariant::HashRange(f) => f.apply_filter(filter),
         };
@@ -123,6 +129,7 @@ impl FieldVariant {
     pub fn has_molecule(&self) -> bool {
         match self {
             Self::Single(f) => f.base.molecule.is_some(),
+            Self::Hash(f) => f.base.molecule.is_some(),
             Self::Range(f) => f.base.molecule.is_some(),
             Self::HashRange(f) => f.base.molecule.is_some(),
         }
@@ -134,6 +141,7 @@ impl FieldVariant {
         use crate::db_operations::MoleculeData;
         match self {
             Self::Single(f) => f.base.molecule.clone().map(MoleculeData::Single),
+            Self::Hash(f) => f.base.molecule.clone().map(MoleculeData::Hash),
             Self::Range(f) => f.base.molecule.clone().map(MoleculeData::Range),
             Self::HashRange(f) => f.base.molecule.clone().map(MoleculeData::HashRange),
         }
@@ -143,6 +151,11 @@ impl FieldVariant {
     pub fn get_all_keys(&self) -> Vec<KeyValue> {
         match self {
             Self::Single(_) => vec![KeyValue::new(None, None)],
+            Self::Hash(f) => f
+                .get_all_keys()
+                .into_iter()
+                .map(|hash| KeyValue::new(Some(hash), None))
+                .collect(),
             Self::Range(f) => f
                 .get_all_keys()
                 .into_iter()
@@ -157,6 +170,7 @@ impl FieldVariant {
     pub fn molecule_version(&self) -> Option<u64> {
         match self {
             Self::Single(f) => f.base.molecule.as_ref().map(|m| m.version()),
+            Self::Hash(f) => f.base.molecule.as_ref().map(|m| m.version()),
             Self::Range(f) => f.base.molecule.as_ref().map(|m| m.version()),
             Self::HashRange(f) => f.base.molecule.as_ref().map(|m| m.version()),
         }
@@ -197,6 +211,18 @@ impl FieldVariant {
                         None => {
                             // Field didn't exist before this mutation — clear molecule
                             f.base.molecule = None;
+                        }
+                    }
+                }
+                (FieldKey::Hash { hash }, FieldVariant::Hash(f)) => {
+                    if let Some(mol) = &mut f.base.molecule {
+                        match &event.old_atom_uuid {
+                            Some(old) => {
+                                mol.set_atom_uuid(hash.clone(), old.clone());
+                            }
+                            None => {
+                                mol.remove_atom_uuid(hash);
+                            }
                         }
                     }
                 }

--- a/src/schema/types/schema.rs
+++ b/src/schema/types/schema.rs
@@ -17,6 +17,8 @@ use ts_rs::TS;
 pub enum DeclarativeSchemaType {
     /// Single schema without range semantics
     Single,
+    /// Schema keyed by a single hash key (unordered collection)
+    Hash,
     /// Schema that stores data in a key range
     Range,
     /// Schema that uses hashed and ranged keys for partitioning


### PR DESCRIPTION
## Summary
- Adds `Hash` as a fourth schema type (`Single`, `Hash`, `Range`, `HashRange`) for unordered collections keyed by a single hash key
- Fixes silent data loss bug: `HashRangeField::write_mutation` silently dropped atoms when either hash or range key was `None`
- Mutation manager now returns an explicit error on key/schema-type mismatch instead of silently dropping data

## Changes
- **New**: `MoleculeHash` (`src/atom/molecule_hash.rs`) — HashMap-based molecule for unordered collections
- **New**: `HashField` (`src/schema/types/field/hash_field.rs`) — field type for Hash schemas
- **New**: `HashOperations` trait + `apply_hash_filter` in filter_utils
- `Hash` variant added to `DeclarativeSchemaType`, `FieldKey`, `FieldVariant`, `MoleculeData`
- Schema type inference fixed: `hash_field` only now correctly infers `Hash` (was incorrectly `Range`)
- `populate_runtime_fields` handles `Hash` schema type
- Mutation manager validates key completeness per schema type — errors loudly on mismatch

## Test plan
- [ ] `cargo test --lib` — all 175 unit tests pass
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo check --features aws-backend` — compiles
- [ ] Integration tests in fold_db_node (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)