### PR TITLE
Expose NativeIndexManager store() and embed_text()

### DIFF
--- a/src/db_operations/native_index/mod.rs
+++ b/src/db_operations/native_index/mod.rs
@@ -66,6 +66,16 @@ impl NativeIndexManager {
             .await
     }
 
+    /// Get the underlying KV store (used by discovery publisher to scan embeddings).
+    pub fn store(&self) -> &Arc<dyn KvStore> {
+        &self.store
+    }
+
+    /// Embed a text query into a vector. Used by discovery to generate search embeddings.
+    pub fn embed_text(&self, text: &str) -> Result<Vec<f32>, SchemaError> {
+        self.embedding_model.embed_text(text)
+    }
+
     /// Semantic search: embed the query then return top-50 results by cosine similarity.
     pub async fn search_all_classifications(
         &self,


### PR DESCRIPTION
## Summary
- Add `store()` accessor to get the underlying KvStore (for scanning persisted embeddings)
- Add `embed_text()` wrapper to generate query vectors from text

## Why
The discovery module in `fold_db_node` needs to:
1. Scan stored embeddings by schema prefix to publish them to the discovery network
2. Generate embeddings from search queries to send to the discovery Lambda

## Test plan
- [x] No existing tests broken (methods are additive only)
- [x] Used by fold_db_node discovery module (shiba4life/fold_db_node#63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)