### PR TITLE
Add WASM transform execution tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ http = "1.4.0"
 
 tracing-subscriber = "0.3"
 tracing = "0.1"
+wat = "1"
 
 [lib]
 name = "fold_db"

--- a/tests/view_wasm_integration_test.rs
+++ b/tests/view_wasm_integration_test.rs
@@ -1,0 +1,238 @@
+//! Integration tests for WASM transform views through the full stack.
+//! Only run when the `transform-wasm` feature is enabled.
+#![cfg(feature = "transform-wasm")]
+
+use fold_db::fold_db_core::FoldDB;
+use fold_db::schema::types::field_value_type::FieldValueType;
+use fold_db::schema::types::operations::{MutationType, Query};
+use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
+use fold_db::schema::types::{KeyValue, Mutation};
+use fold_db::schema::SchemaState;
+use fold_db::view::types::TransformView;
+use serde_json::json;
+use std::collections::HashMap;
+
+fn wat_to_wasm(wat: &str) -> Vec<u8> {
+    wat::parse_str(wat).expect("valid WAT")
+}
+
+/// WASM module that returns a hardcoded output regardless of input.
+/// Output: {"fields": {"summary": {"k1": "hardcoded"}}}
+fn hardcoded_wasm() -> Vec<u8> {
+    let output = r#"{"fields":{"summary":{"k1":"hardcoded"}}}"#;
+    let output_bytes = output.as_bytes();
+    let len = output_bytes.len();
+    let escaped = output_bytes
+        .iter()
+        .map(|b| format!("\\{:02x}", b))
+        .collect::<String>();
+
+    let wat = format!(
+        r#"(module
+            (memory (export "memory") 1)
+            (data (i32.const 1024) "{escaped}")
+            (global $bump (mut i32) (i32.const 2048))
+            (func (export "alloc") (param $size i32) (result i32)
+                (local $ptr i32)
+                (local.set $ptr (global.get $bump))
+                (global.set $bump (i32.add (global.get $bump) (local.get $size)))
+                (local.get $ptr)
+            )
+            (func (export "transform") (param $ptr i32) (param $len i32) (result i64)
+                (i64.or
+                    (i64.shl (i64.extend_i32_u (i32.const 1024)) (i64.const 32))
+                    (i64.extend_i32_u (i32.const {len}))
+                )
+            )
+        )"#,
+    );
+    wat_to_wasm(&wat)
+}
+
+async fn setup_db() -> FoldDB {
+    let dir = tempfile::tempdir().unwrap();
+    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+}
+
+fn blogpost_schema_json() -> &'static str {
+    r#"{
+        "name": "BlogPost",
+        "key": { "range_field": "publish_date" },
+        "fields": {
+            "title": {},
+            "content": {},
+            "publish_date": {}
+        }
+    }"#
+}
+
+#[tokio::test]
+async fn wasm_view_query_returns_transformed_output() {
+    let mut db = setup_db().await;
+
+    // Setup schema with data
+    db.load_schema_from_json(blogpost_schema_json()).await.unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert("title".to_string(), json!("Hello World"));
+    fields.insert("content".to_string(), json!("Test content"));
+    fields.insert("publish_date".to_string(), json!("2026-01-01"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            fields,
+            KeyValue::new(None, Some("2026-01-01".to_string())),
+            "pk".to_string(),
+            MutationType::Create,
+        )])
+        .await
+        .unwrap();
+
+    // Register a WASM view with hardcoded output
+    let view = TransformView::new(
+        "SummaryView",
+        SchemaType::Single,
+        None,
+        vec![Query::new(
+            "BlogPost".to_string(),
+            vec!["title".to_string(), "content".to_string()],
+        )],
+        Some(hardcoded_wasm()),
+        HashMap::from([("summary".to_string(), FieldValueType::String)]),
+    );
+    db.schema_manager.register_view(view).await.unwrap();
+
+    // Query the view
+    let query = Query::new("SummaryView".to_string(), vec!["summary".to_string()]);
+    let results = db.query_executor.query(query).await.unwrap();
+
+    assert!(results.contains_key("summary"));
+    let summary_values = &results["summary"];
+    assert!(!summary_values.is_empty());
+    let value = summary_values.values().next().unwrap();
+    assert_eq!(value.value, json!("hardcoded"));
+}
+
+#[tokio::test]
+async fn wasm_view_output_type_validation_works() {
+    let mut db = setup_db().await;
+
+    db.load_schema_from_json(blogpost_schema_json()).await.unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert("title".to_string(), json!("Hello"));
+    fields.insert("publish_date".to_string(), json!("2026-01-01"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            fields,
+            KeyValue::new(None, Some("2026-01-01".to_string())),
+            "pk".to_string(),
+            MutationType::Create,
+        )])
+        .await
+        .unwrap();
+
+    // Register a WASM view that outputs a string, but declare it as Integer
+    let view = TransformView::new(
+        "BadTypeView",
+        SchemaType::Single,
+        None,
+        vec![Query::new(
+            "BlogPost".to_string(),
+            vec!["title".to_string()],
+        )],
+        Some(hardcoded_wasm()), // Returns {"summary": {"k1": "hardcoded"}} — a String
+        HashMap::from([("summary".to_string(), FieldValueType::Integer)]), // Declared as Integer
+    );
+    db.schema_manager.register_view(view).await.unwrap();
+
+    // Query should fail with type validation error
+    let query = Query::new("BadTypeView".to_string(), vec!["summary".to_string()]);
+    let result = db.query_executor.query(query).await;
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("type validation"),
+        "Should fail with type validation error"
+    );
+}
+
+#[tokio::test]
+async fn wasm_view_cache_invalidation_works() {
+    let mut db = setup_db().await;
+
+    db.load_schema_from_json(blogpost_schema_json()).await.unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert("title".to_string(), json!("Original"));
+    fields.insert("publish_date".to_string(), json!("2026-01-01"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            fields,
+            KeyValue::new(None, Some("2026-01-01".to_string())),
+            "pk".to_string(),
+            MutationType::Create,
+        )])
+        .await
+        .unwrap();
+
+    // Register WASM view
+    let view = TransformView::new(
+        "WasmCacheView",
+        SchemaType::Single,
+        None,
+        vec![Query::new(
+            "BlogPost".to_string(),
+            vec!["title".to_string()],
+        )],
+        Some(hardcoded_wasm()),
+        HashMap::from([("summary".to_string(), FieldValueType::String)]),
+    );
+    db.schema_manager.register_view(view).await.unwrap();
+
+    // First query: populates cache
+    let query = Query::new("WasmCacheView".to_string(), vec!["summary".to_string()]);
+    db.query_executor.query(query.clone()).await.unwrap();
+
+    // Verify cached
+    let state = db.db_ops.get_view_cache_state("WasmCacheView").await.unwrap();
+    assert!(
+        matches!(state, fold_db::view::ViewCacheState::Cached { .. }),
+        "View should be cached"
+    );
+
+    // Mutate source
+    let mut fields2 = HashMap::new();
+    fields2.insert("title".to_string(), json!("Updated"));
+    fields2.insert("publish_date".to_string(), json!("2026-01-02"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            fields2,
+            KeyValue::new(None, Some("2026-01-02".to_string())),
+            "pk".to_string(),
+            MutationType::Update,
+        )])
+        .await
+        .unwrap();
+
+    // Cache should be invalidated
+    let state2 = db.db_ops.get_view_cache_state("WasmCacheView").await.unwrap();
+    assert!(
+        matches!(state2, fold_db::view::ViewCacheState::Empty),
+        "View cache should be invalidated after source mutation"
+    );
+}

--- a/tests/wasm_transform_test.rs
+++ b/tests/wasm_transform_test.rs
@@ -1,0 +1,213 @@
+//! WASM transform execution tests.
+//! These tests verify the end-to-end WASM contract: alloc + transform + memory exports.
+//! Only run when the `transform-wasm` feature is enabled.
+#![cfg(feature = "transform-wasm")]
+
+use fold_db::view::WasmTransformEngine;
+use serde_json::json;
+
+/// Build a WASM module from WAT source text.
+fn wat_to_wasm(wat: &str) -> Vec<u8> {
+    wat::parse_str(wat).expect("valid WAT")
+}
+
+/// A minimal WASM module that returns a hardcoded JSON response.
+/// This verifies the alloc/transform/memory contract works end-to-end.
+///
+/// The module stores `{"fields":{"out":{"k1":"hello"}}}` in memory at offset 1024
+/// and returns a pointer to it from transform().
+fn hardcoded_output_module() -> Vec<u8> {
+    // The JSON output bytes: {"fields":{"out":{"k1":"hello"}}}
+    let output = r#"{"fields":{"out":{"k1":"hello"}}}"#;
+    let output_bytes = output.as_bytes();
+    let len = output_bytes.len();
+
+    // Build data section hex string for the output
+    let escaped = output_bytes
+        .iter()
+        .map(|b| format!("\\{:02x}", b))
+        .collect::<String>();
+
+    let wat = format!(
+        r#"(module
+            (memory (export "memory") 1)
+            ;; Store the output JSON at offset 1024
+            (data (i32.const 1024) "{escaped}")
+
+            ;; alloc: simple bump allocator starting at offset 2048
+            (global $bump (mut i32) (i32.const 2048))
+            (func (export "alloc") (param $size i32) (result i32)
+                (local $ptr i32)
+                (local.set $ptr (global.get $bump))
+                (global.set $bump (i32.add (global.get $bump) (local.get $size)))
+                (local.get $ptr)
+            )
+
+            ;; transform: ignore input, return hardcoded output at offset 1024
+            (func (export "transform") (param $ptr i32) (param $len i32) (result i64)
+                ;; Pack pointer (1024) and length ({len}) into i64: (ptr << 32) | len
+                (i64.or
+                    (i64.shl (i64.extend_i32_u (i32.const 1024)) (i64.const 32))
+                    (i64.extend_i32_u (i32.const {len}))
+                )
+            )
+        )"#,
+    );
+
+    wat_to_wasm(&wat)
+}
+
+/// A WASM module that echoes its input back as output.
+/// It reads the input JSON bytes and returns them unchanged.
+/// This verifies that input data is correctly passed through the alloc/memory protocol.
+fn echo_module() -> Vec<u8> {
+    let wat = r#"(module
+        (memory (export "memory") 1)
+
+        ;; alloc: bump allocator starting at offset 4096
+        (global $bump (mut i32) (i32.const 4096))
+        (func (export "alloc") (param $size i32) (result i32)
+            (local $ptr i32)
+            (local.set $ptr (global.get $bump))
+            (global.set $bump (i32.add (global.get $bump) (local.get $size)))
+            (local.get $ptr)
+        )
+
+        ;; transform: return the input pointer and length unchanged
+        (func (export "transform") (param $ptr i32) (param $len i32) (result i64)
+            (i64.or
+                (i64.shl (i64.extend_i32_u (local.get $ptr)) (i64.const 32))
+                (i64.extend_i32_u (local.get $len))
+            )
+        )
+    )"#;
+
+    wat_to_wasm(wat)
+}
+
+/// A WASM module that copies input to a new location and returns it.
+/// Verifies memory operations work correctly.
+fn copy_module() -> Vec<u8> {
+    let wat = r#"(module
+        (memory (export "memory") 2)
+
+        ;; alloc: bump allocator
+        (global $bump (mut i32) (i32.const 4096))
+        (func (export "alloc") (param $size i32) (result i32)
+            (local $ptr i32)
+            (local.set $ptr (global.get $bump))
+            (global.set $bump (i32.add (global.get $bump) (local.get $size)))
+            (local.get $ptr)
+        )
+
+        ;; transform: copy input to offset 32768 and return from there
+        (func (export "transform") (param $ptr i32) (param $len i32) (result i64)
+            ;; memory.copy dest=32768, src=$ptr, len=$len
+            (memory.copy
+                (i32.const 32768)
+                (local.get $ptr)
+                (local.get $len)
+            )
+            ;; Return packed (32768 << 32) | len
+            (i64.or
+                (i64.shl (i64.extend_i32_u (i32.const 32768)) (i64.const 32))
+                (i64.extend_i32_u (local.get $len))
+            )
+        )
+    )"#;
+
+    wat_to_wasm(wat)
+}
+
+#[test]
+fn wasm_engine_executes_hardcoded_output() {
+    let engine = WasmTransformEngine::new().unwrap();
+    let wasm = hardcoded_output_module();
+    let input = json!({"anything": "ignored"});
+
+    let result = engine.execute(&wasm, &input).unwrap();
+
+    assert_eq!(result, json!({"fields": {"out": {"k1": "hello"}}}));
+}
+
+#[test]
+fn wasm_engine_echo_returns_input() {
+    let engine = WasmTransformEngine::new().unwrap();
+    let wasm = echo_module();
+
+    let input = json!({"inputs": {"BlogPost": {"title": {"r1": "Hello"}}}});
+    let result = engine.execute(&wasm, &input).unwrap();
+
+    // Echo module returns input unchanged
+    assert_eq!(result, input);
+}
+
+#[test]
+fn wasm_engine_copy_returns_input() {
+    let engine = WasmTransformEngine::new().unwrap();
+    let wasm = copy_module();
+
+    let input = json!({"fields": {"word_count": {"r1": 42}}});
+    let result = engine.execute(&wasm, &input).unwrap();
+
+    assert_eq!(result, input);
+}
+
+#[test]
+fn wasm_engine_caches_compiled_modules() {
+    let engine = WasmTransformEngine::new().unwrap();
+    let wasm = hardcoded_output_module();
+
+    // Execute twice with same bytes — second should use cached module
+    let r1 = engine.execute(&wasm, &json!({})).unwrap();
+    let r2 = engine.execute(&wasm, &json!({})).unwrap();
+
+    assert_eq!(r1, r2);
+}
+
+#[test]
+fn wasm_engine_rejects_invalid_wasm() {
+    let engine = WasmTransformEngine::new().unwrap();
+    let invalid = vec![0, 1, 2, 3]; // Not valid WASM
+
+    let result = engine.execute(&invalid, &json!({}));
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("Failed to compile"));
+}
+
+#[test]
+fn wasm_engine_rejects_module_missing_exports() {
+    // Valid WASM module but missing required exports
+    let wat = r#"(module (memory (export "memory") 1))"#;
+    let wasm = wat_to_wasm(wat);
+
+    let engine = WasmTransformEngine::new().unwrap();
+    let result = engine.execute(&wasm, &json!({}));
+    assert!(result.is_err());
+    // Should mention missing alloc or transform
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("alloc") || err.contains("transform"),
+        "Error should mention missing export: {}",
+        err
+    );
+}
+
+#[test]
+fn wasm_engine_handles_large_input() {
+    let engine = WasmTransformEngine::new().unwrap();
+    let wasm = echo_module();
+
+    // Build a large input (~100KB of JSON)
+    let mut fields = serde_json::Map::new();
+    for i in 0..1000 {
+        fields.insert(
+            format!("field_{}", i),
+            json!({"key": format!("value_{}", i)}),
+        );
+    }
+    let input = json!({"inputs": {"LargeSchema": fields}});
+
+    let result = engine.execute(&wasm, &input).unwrap();
+    assert_eq!(result, input);
+}


### PR DESCRIPTION
## Summary

- 7 engine-level tests validating the alloc/transform/memory WASM contract
- 3 integration tests exercising WASM views through the full query stack
- Tests written in WAT (WebAssembly Text format), compiled at test time via `wat` crate
- All gated on `transform-wasm` feature flag

## Test plan
- [x] `cargo test --features transform-wasm wasm` — all 10 WASM tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo clippy --workspace --all-targets --features transform-wasm -- -D warnings` — zero warnings
- [x] `cargo test --workspace --all-targets` — 268 tests pass (default features)
- [x] `cargo test --workspace --all-targets --features transform-wasm` — 277 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)