### PR TITLE
Add write-back through identity views

### DIFF
--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -84,8 +84,8 @@ impl MutationManager {
             return Ok(Vec::new());
         }
 
-        // Phase 0: Reject mutations targeting views
-        self.reject_view_mutations(&mutations).await?;
+        // Phase 0: Redirect identity view mutations to source schemas
+        let mutations = self.redirect_view_mutations(mutations).await?;
 
         log::info!(
             "🔄 write_mutations_batch_async: Starting batch of {} mutations",
@@ -717,28 +717,72 @@ impl MutationManager {
 
     // ========== View mutation rejection + invalidation ==========
 
-    /// Phase 0: Reject mutations targeting views.
-    /// Write-back through views is deferred — mutations must target source schemas directly.
-    async fn reject_view_mutations(
+    /// Phase 0: Redirect mutations targeting identity views to their source schemas.
+    /// WASM views are not writable (would require inverse transforms).
+    async fn redirect_view_mutations(
         &self,
-        mutations: &[Mutation],
-    ) -> Result<(), SchemaError> {
-        let registry = self
-            .schema_manager
-            .view_registry()
-            .lock()
-            .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+        mutations: Vec<Mutation>,
+    ) -> Result<Vec<Mutation>, SchemaError> {
+        let mut result = Vec::with_capacity(mutations.len());
 
         for mutation in mutations {
-            if registry.get_view(&mutation.schema_name).is_some() {
-                return Err(SchemaError::InvalidData(format!(
-                    "Cannot mutate view '{}' directly. Mutations must target source schemas.",
-                    mutation.schema_name
-                )));
+            let view_info = {
+                let registry = self
+                    .schema_manager
+                    .view_registry()
+                    .lock()
+                    .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+                registry.get_view(&mutation.schema_name).cloned()
+            };
+
+            let Some(view) = view_info else {
+                // Not a view — pass through to normal pipeline
+                result.push(mutation);
+                continue;
+            };
+
+            // Get source field map (only works for identity views)
+            let field_map = view.source_field_map().ok_or_else(|| {
+                SchemaError::InvalidData(format!(
+                    "Cannot write to WASM view '{}'. Write-back through WASM views is not yet supported.",
+                    view.name
+                ))
+            })?;
+
+            // Group mutation fields by target source schema
+            let mut redirected: HashMap<String, HashMap<String, serde_json::Value>> = HashMap::new();
+
+            for (field_name, value) in &mutation.fields_and_values {
+                let (source_schema, source_field) = field_map.get(field_name).ok_or_else(|| {
+                    SchemaError::InvalidField(format!(
+                        "Field '{}' not found in view '{}'",
+                        field_name, view.name
+                    ))
+                })?;
+
+                redirected
+                    .entry(source_schema.clone())
+                    .or_default()
+                    .insert(source_field.clone(), value.clone());
+            }
+
+            // Create one redirected mutation per source schema
+            for (target_schema, fields_and_values) in redirected {
+                result.push(Mutation {
+                    uuid: uuid::Uuid::new_v4().to_string(),
+                    schema_name: target_schema,
+                    fields_and_values,
+                    key_value: mutation.key_value.clone(),
+                    pub_key: mutation.pub_key.clone(),
+                    mutation_type: mutation.mutation_type.clone(),
+                    synchronous: mutation.synchronous,
+                    source_file_name: mutation.source_file_name.clone(),
+                    metadata: mutation.metadata.clone(),
+                });
             }
         }
 
-        Ok(())
+        Ok(result)
     }
 
     /// Phase 7.5: Invalidate view caches that depend on mutated source fields.

--- a/src/view/types.rs
+++ b/src/view/types.rs
@@ -96,6 +96,26 @@ impl TransformView {
     pub fn is_identity(&self) -> bool {
         self.wasm_transform.is_none()
     }
+
+    /// For identity views, returns output_field → (source_schema, source_field).
+    /// Returns None for WASM views (write-back requires inverse transform).
+    pub fn source_field_map(&self) -> Option<HashMap<String, (String, String)>> {
+        if !self.is_identity() {
+            return None;
+        }
+        let mut map = HashMap::new();
+        for query in &self.input_queries {
+            for field_name in &query.fields {
+                if self.output_fields.contains_key(field_name) {
+                    map.insert(
+                        field_name.clone(),
+                        (query.schema_name.clone(), field_name.clone()),
+                    );
+                }
+            }
+        }
+        Some(map)
+    }
 }
 
 #[cfg(test)]

--- a/tests/view_query_test.rs
+++ b/tests/view_query_test.rs
@@ -168,7 +168,7 @@ async fn query_view_with_empty_fields_returns_all() {
 }
 
 #[tokio::test]
-async fn mutation_targeting_view_is_rejected() {
+async fn identity_view_write_redirects_to_source() {
     let mut db = setup_db().await;
 
     db.load_schema_from_json(blogpost_schema_json())
@@ -182,11 +182,122 @@ async fn mutation_targeting_view_is_rejected() {
     let view = identity_view("MyView", "BlogPost", "content");
     db.schema_manager.register_view(view).await.unwrap();
 
-    // Try to mutate the view directly — should be rejected
+    // Write through the view — should redirect to BlogPost.content
     let mut mutation_fields = HashMap::new();
-    mutation_fields.insert("content".to_string(), json!("should fail"));
+    mutation_fields.insert("content".to_string(), json!("written via view"));
     let mutation = Mutation::new(
         "MyView".to_string(),
+        mutation_fields,
+        KeyValue::new(None, Some("2026-01-01".to_string())),
+        "pk".to_string(),
+        MutationType::Create,
+    );
+    db.mutation_manager
+        .write_mutations_batch_async(vec![mutation])
+        .await
+        .unwrap();
+
+    // Query the SOURCE schema to verify the write landed there
+    let query = Query::new("BlogPost".to_string(), vec!["content".to_string()]);
+    let results = db.query_executor.query(query).await.unwrap();
+    assert!(results.contains_key("content"));
+    let values: Vec<_> = results["content"].values().map(|fv| fv.value.clone()).collect();
+    assert!(
+        values.contains(&json!("written via view")),
+        "BlogPost.content should contain value written via view, got {:?}",
+        values
+    );
+}
+
+#[tokio::test]
+async fn identity_view_write_invalidates_view_cache() {
+    let mut db = setup_db().await;
+
+    db.load_schema_from_json(blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    // Write initial data
+    let mut fields = HashMap::new();
+    fields.insert("content".to_string(), json!("original"));
+    fields.insert("publish_date".to_string(), json!("2026-01-01"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            fields,
+            KeyValue::new(None, Some("2026-01-01".to_string())),
+            "pk".to_string(),
+            MutationType::Create,
+        )])
+        .await
+        .unwrap();
+
+    let view = identity_view("CacheView", "BlogPost", "content");
+    db.schema_manager.register_view(view).await.unwrap();
+
+    // Query view to populate cache
+    let query = Query::new("CacheView".to_string(), vec!["content".to_string()]);
+    db.query_executor.query(query.clone()).await.unwrap();
+
+    // Write through the view — should invalidate the cache
+    let mut mutation_fields = HashMap::new();
+    mutation_fields.insert("content".to_string(), json!("updated via view"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "CacheView".to_string(),
+            mutation_fields,
+            KeyValue::new(None, Some("2026-01-02".to_string())),
+            "pk".to_string(),
+            MutationType::Create,
+        )])
+        .await
+        .unwrap();
+
+    // Re-query view — should return fresh data including the new write
+    let results = db.query_executor.query(query).await.unwrap();
+    let values: Vec<_> = results["content"].values().map(|fv| fv.value.clone()).collect();
+    assert!(
+        values.contains(&json!("updated via view")),
+        "View should return fresh data after write-back, got {:?}",
+        values
+    );
+}
+
+#[tokio::test]
+async fn wasm_view_write_is_rejected() {
+    let mut db = setup_db().await;
+
+    db.load_schema_from_json(blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    // Register a WASM view (not identity)
+    let view = TransformView::new(
+        "WasmView",
+        SchemaType::Single,
+        None,
+        vec![Query::new(
+            "BlogPost".to_string(),
+            vec!["content".to_string()],
+        )],
+        Some(vec![0, 1, 2]), // Placeholder WASM — won't be executed
+        HashMap::from([("out".to_string(), FieldValueType::String)]),
+    );
+    db.schema_manager.register_view(view).await.unwrap();
+
+    // Try to mutate the WASM view — should be rejected
+    let mut mutation_fields = HashMap::new();
+    mutation_fields.insert("out".to_string(), json!("should fail"));
+    let mutation = Mutation::new(
+        "WasmView".to_string(),
         mutation_fields,
         KeyValue::new(None, Some("2026-01-01".to_string())),
         "pk".to_string(),
@@ -197,5 +308,8 @@ async fn mutation_targeting_view_is_rejected() {
         .write_mutations_batch_async(vec![mutation])
         .await;
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("Cannot mutate view"));
+    assert!(
+        result.unwrap_err().to_string().contains("WASM view"),
+        "Should mention WASM view write-back not supported"
+    );
 }


### PR DESCRIPTION
## Summary

- Identity views (no WASM) now support write-back: mutations targeting a view are transparently redirected to the source schema(s)
- `source_field_map()` on `TransformView` maps output fields → `(source_schema, source_field)` for identity views
- `redirect_view_mutations()` replaces `reject_view_mutations()` in the mutation pipeline
- WASM views still reject writes (requires inverse transforms — future work)
- Cache invalidation happens automatically via existing cascade

## Test plan
- [x] `identity_view_write_redirects_to_source` — write through view lands in source schema
- [x] `identity_view_write_invalidates_view_cache` — view cache refreshes after write-back
- [x] `wasm_view_write_is_rejected` — WASM views reject mutations with clear error
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo check --workspace --features aws-backend` — compiles
- [x] `cargo test --workspace --all-targets` — 270 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)