### PR TITLE
Add data classification to schema_service canonical fields

### DIFF
--- a/src/schema_service/classify.rs
+++ b/src/schema_service/classify.rs
@@ -1,0 +1,189 @@
+//! Field sensitivity classification inference.
+//!
+//! Determines the (sensitivity_level, data_domain) for new canonical fields
+//! based on the field's description. The schema service is the sole authority
+//! on data classification.
+//!
+//! Strategy for new fields without an existing canonical match:
+//! 1. Caller-provided classification → use it
+//! 2. LLM call using field description (requires ANTHROPIC_API_KEY)
+//! 3. No fallback — returns error. Incorrect classification is worse than no schema.
+
+use crate::schema::types::data_classification::DataClassification;
+
+/// Prompt for LLM-based classification of a single field.
+fn build_classification_prompt(field_name: &str, description: &str) -> String {
+    format!(
+        r#"Classify this database field's data sensitivity. Return ONLY a JSON object with two fields, no explanation.
+
+Field name: "{field_name}"
+Description: "{description}"
+
+Sensitivity levels:
+0 = Public (freely distributable, no restrictions)
+1 = Internal (not sensitive but not for public release)
+2 = Confidential (business-sensitive, competitive value)
+3 = Restricted (personally identifiable or individually attributable)
+4 = Highly Restricted (regulated data: HIPAA, financial records, biometric)
+
+Data domains: "general", "financial", "medical", "identity", "behavioral", "location"
+
+Return format: {{"sensitivity_level": <0-4>, "data_domain": "<domain>"}}"#
+    )
+}
+
+/// Classify a field using LLM analysis of its description.
+/// Returns a descriptive error string on failure.
+pub async fn classify_with_llm(
+    field_name: &str,
+    description: &str,
+) -> Result<DataClassification, String> {
+    let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
+        "Schema service cannot classify new fields: ANTHROPIC_API_KEY not set. \
+         Set the environment variable to enable automatic sensitivity classification."
+            .to_string()
+    })?;
+    if api_key.trim().is_empty() {
+        return Err(
+            "Schema service cannot classify new fields: ANTHROPIC_API_KEY is empty".to_string(),
+        );
+    }
+
+    let prompt = build_classification_prompt(field_name, description);
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .no_proxy()
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client for classification: {}", e))?;
+
+    let request_body = serde_json::json!({
+        "model": "claude-haiku-4-5-20251001",
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 100,
+        "temperature": 0.0
+    });
+
+    let response = client
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", &api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("Content-Type", "application/json")
+        .json(&request_body)
+        .send()
+        .await
+        .map_err(|e| {
+            format!(
+                "Classification LLM call failed for field '{}': {}",
+                field_name, e
+            )
+        })?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "Classification LLM call returned status {} for field '{}'",
+            response.status(),
+            field_name
+        ));
+    }
+
+    let resp: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse LLM response for field '{}': {}", field_name, e))?;
+
+    let text = resp
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|a| a.first())
+        .and_then(|c| c.get("text"))
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| {
+            format!(
+                "LLM response missing content text for field '{}'",
+                field_name
+            )
+        })?;
+
+    // Parse the JSON response — try raw text first, then extract from markdown fence
+    let classification: DataClassification = serde_json::from_str(text)
+        .or_else(|_| {
+            let trimmed = text.trim();
+            let json_str = trimmed
+                .strip_prefix("```json")
+                .or_else(|| trimmed.strip_prefix("```"))
+                .and_then(|s| s.strip_suffix("```"))
+                .unwrap_or(trimmed)
+                .trim();
+            serde_json::from_str(json_str)
+        })
+        .map_err(|e| {
+            format!(
+                "Failed to parse LLM classification for field '{}': {} (raw: {})",
+                field_name, e, text
+            )
+        })?;
+
+    crate::log_feature!(
+        crate::logging::features::LogFeature::Schema,
+        info,
+        "LLM classified field '{}' as ({}, {})",
+        field_name,
+        classification.sensitivity_level,
+        classification.data_domain
+    );
+
+    Ok(classification)
+}
+
+/// Infer classification for a new canonical field.
+/// Returns an error if classification cannot be determined — no silent fallbacks.
+///
+/// ```text
+/// caller-provided? ──yes──▶ use it
+///       │ no
+///       ▼
+/// LLM call (ANTHROPIC_API_KEY) ──success──▶ use it
+///       │ no key / failure
+///       ▼
+/// ERROR: schema service cannot classify
+/// ```
+pub async fn infer_classification(
+    field_name: &str,
+    description: &str,
+    caller_provided: Option<&DataClassification>,
+) -> Result<DataClassification, String> {
+    if let Some(c) = caller_provided {
+        return Ok(c.clone());
+    }
+
+    classify_with_llm(field_name, description).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn infer_uses_caller_provided_first() {
+        let caller = DataClassification::new(4, "medical").unwrap();
+        let result = infer_classification("diagnosis", "patient diagnosis", Some(&caller)).await;
+        let c = result.unwrap();
+        assert_eq!(c.sensitivity_level, 4);
+        assert_eq!(c.data_domain, "medical");
+    }
+
+    #[tokio::test]
+    async fn infer_without_caller_uses_llm_or_errors() {
+        let result = infer_classification("salary", "employee annual salary", None).await;
+        match result {
+            Ok(c) => {
+                assert!(c.sensitivity_level <= 4);
+                assert!(!c.data_domain.is_empty());
+            }
+            Err(e) => {
+                assert!(e.contains("ANTHROPIC_API_KEY"), "got: {}", e);
+            }
+        }
+    }
+}

--- a/src/schema_service/mod.rs
+++ b/src/schema_service/mod.rs
@@ -3,6 +3,7 @@
 //! A standalone schema registry that provides schema discovery, deduplication,
 //! semantic similarity matching, field canonicalization, and view management.
 
+pub mod classify;
 mod state_expansion;
 mod state_fields;
 mod state_matching;

--- a/src/schema_service/state.rs
+++ b/src/schema_service/state.rs
@@ -578,11 +578,13 @@ impl SchemaServiceState {
             }
         }
 
-        // Register new fields as canonical for future schema proposals
-        self.register_canonical_fields(&schema);
+        // Register new fields as canonical for future schema proposals.
+        // Fails if classification cannot be determined (no ANTHROPIC_API_KEY for new fields).
+        self.register_canonical_fields(&schema).await?;
 
-        // Propagate canonical field types to the schema
+        // Propagate canonical field types and classifications to the schema
         self.apply_canonical_types(&mut schema);
+        self.apply_canonical_classifications(&mut schema);
 
         log_feature!(
             LogFeature::Schema,
@@ -861,6 +863,7 @@ impl SchemaServiceState {
         output_schema.descriptive_name = Some(request.descriptive_name.clone());
         output_schema.field_descriptions = request.field_descriptions.clone();
         output_schema.field_classifications = request.field_classifications.clone();
+        output_schema.field_data_classifications = request.field_data_classifications.clone();
         output_schema.schema_type = request.schema_type.clone();
 
         // Run through the full schema pipeline (similarity, canonicalization, dedup, expansion)

--- a/src/schema_service/state_expansion.rs
+++ b/src/schema_service/state_expansion.rs
@@ -191,13 +191,19 @@ impl SchemaServiceState {
             }
         }
 
-        // Rename in field_classifications
+        // Rename in field_classifications and field_data_classifications
         for (old_name, canonical) in rename_map {
             if let Some(classifications) = schema.field_classifications.remove(old_name) {
                 schema
                     .field_classifications
                     .entry(canonical.clone())
                     .or_insert(classifications);
+            }
+            if let Some(data_classification) = schema.field_data_classifications.remove(old_name) {
+                schema
+                    .field_data_classifications
+                    .entry(canonical.clone())
+                    .or_insert(data_classification);
             }
             // Add mutation_mapper: old_name → canonical so AI mutations still work
             mutation_mappers
@@ -281,6 +287,14 @@ impl SchemaServiceState {
                 .or_insert_with(|| classifications.clone());
         }
 
+        // Merge field_data_classifications (keep existing, add new)
+        for (field, classification) in &existing.field_data_classifications {
+            schema
+                .field_data_classifications
+                .entry(field.clone())
+                .or_insert_with(|| classification.clone());
+        }
+
         // Merge ref_fields (keep existing references)
         for (field, target) in &existing.ref_fields {
             schema
@@ -322,11 +336,13 @@ impl SchemaServiceState {
             index.insert(desc_name.to_string(), expanded_name);
         }
 
-        // Register new fields as canonical for future schema proposals
-        self.register_canonical_fields(schema);
+        // Register new fields as canonical for future schema proposals.
+        // Fails if classification cannot be determined (no ANTHROPIC_API_KEY for new fields).
+        self.register_canonical_fields(schema).await?;
 
-        // Propagate canonical field types to the expanded schema
+        // Propagate canonical field types and classifications to the expanded schema
         self.apply_canonical_types(schema);
+        self.apply_canonical_classifications(schema);
 
         log_feature!(
             LogFeature::Schema,

--- a/src/schema_service/state_fields.rs
+++ b/src/schema_service/state_fields.rs
@@ -73,35 +73,86 @@ impl SchemaServiceState {
 
     /// Register new fields from a schema as canonical.
     /// Only adds fields that don't already exist in the registry.
-    pub(super) fn register_canonical_fields(&self, schema: &Schema) {
+    ///
+    /// The schema service is the authority on classification. For each new field:
+    /// 1. Use caller-provided classification if present
+    /// 2. LLM call to analyze field description (requires ANTHROPIC_API_KEY)
+    /// 3. No fallback — returns error if classification cannot be determined
+    pub(super) async fn register_canonical_fields(
+        &self,
+        schema: &Schema,
+    ) -> FoldDbResult<()> {
         let field_names = schema.fields.as_deref().unwrap_or(&[]);
 
-        let mut fields = match self.canonical_fields.write() {
-            Ok(f) => f,
-            Err(_) => return,
-        };
-        let mut embeddings = match self.canonical_field_embeddings.write() {
-            Ok(e) => e,
-            Err(_) => return,
+        // Phase 1: Identify new fields (read lock only)
+        let new_fields: Vec<String> = {
+            let fields = self.canonical_fields.read().map_err(|_| {
+                FoldDbError::Config("Failed to acquire canonical_fields read lock".to_string())
+            })?;
+            field_names
+                .iter()
+                .filter(|f| !fields.contains_key(*f))
+                .cloned()
+                .collect()
         };
 
-        for field_name in field_names {
-            if fields.contains_key(field_name) {
-                continue;
-            }
+        if new_fields.is_empty() {
+            return Ok(());
+        }
+
+        // Phase 2: Build canonical entries with inferred classifications (no locks held)
+        let mut entries: Vec<(String, CanonicalField, Option<Vec<f32>>)> = Vec::new();
+
+        for field_name in &new_fields {
             let desc = Self::build_field_description(field_name, schema);
             let field_type = Self::infer_field_type(field_name, schema);
+            let caller_provided = schema.field_data_classifications.get(field_name);
+
+            let classification = super::classify::infer_classification(
+                field_name,
+                &desc,
+                caller_provided,
+            )
+            .await
+            .map_err(FoldDbError::Config)?;
+
             let embed_text = Self::build_embedding_text(field_name, &desc);
-            if let Ok(vec) = self.embedder.embed_text(&embed_text) {
+            let embedding = self.embedder.embed_text(&embed_text).ok();
+
+            entries.push((
+                field_name.clone(),
+                CanonicalField {
+                    description: desc,
+                    field_type,
+                    classification: Some(classification),
+                },
+                embedding,
+            ));
+        }
+
+        // Phase 3: Store under write locks
+        let mut fields = self.canonical_fields.write().map_err(|_| {
+            FoldDbError::Config("Failed to acquire canonical_fields write lock".to_string())
+        })?;
+        let mut embeddings = self.canonical_field_embeddings.write().map_err(|_| {
+            FoldDbError::Config(
+                "Failed to acquire canonical_field_embeddings write lock".to_string(),
+            )
+        })?;
+
+        for (field_name, canonical, embedding) in entries {
+            // Re-check in case another thread registered it between phase 1 and 3
+            if fields.contains_key(&field_name) {
+                continue;
+            }
+            if let Some(vec) = embedding {
                 embeddings.insert(field_name.clone(), vec);
             }
-            let canonical = CanonicalField {
-                description: desc,
-                field_type,
-            };
-            self.persist_canonical_field(field_name, &canonical);
-            fields.insert(field_name.clone(), canonical);
+            self.persist_canonical_field(&field_name, &canonical);
+            fields.insert(field_name, canonical);
         }
+
+        Ok(())
     }
 
     /// Canonicalize incoming field names against the global canonical field registry.
@@ -232,6 +283,7 @@ impl SchemaServiceState {
                     CanonicalField {
                         description: desc,
                         field_type: FieldValueType::Any,
+                        classification: None,
                     }
                 };
 
@@ -284,6 +336,7 @@ impl SchemaServiceState {
                         CanonicalField {
                             description: desc,
                             field_type,
+                            classification: None,
                         },
                     );
                 }
@@ -334,6 +387,30 @@ impl SchemaServiceState {
                     schema
                         .field_types
                         .insert(field_name.clone(), canonical.field_type.clone());
+                }
+            }
+        }
+    }
+
+    /// Populate a schema's `field_data_classifications` map from the canonical field registry.
+    /// Called after canonicalization to propagate classifications from the registry to the schema.
+    /// Only fills in fields that don't already have a classification declared.
+    pub(super) fn apply_canonical_classifications(&self, schema: &mut Schema) {
+        let fields = match self.canonical_fields.read() {
+            Ok(f) => f,
+            Err(_) => return,
+        };
+
+        for field_name in schema.fields.as_deref().unwrap_or(&[]) {
+            // Skip if the schema already has a classification for this field
+            if schema.field_data_classifications.contains_key(field_name) {
+                continue;
+            }
+            if let Some(canonical) = fields.get(field_name) {
+                if let Some(ref classification) = canonical.classification {
+                    schema
+                        .field_data_classifications
+                        .insert(field_name.clone(), classification.clone());
                 }
             }
         }

--- a/src/schema_service/types.rs
+++ b/src/schema_service/types.rs
@@ -1,3 +1,4 @@
+use crate::schema::types::data_classification::DataClassification;
 use crate::schema::types::field_value_type::FieldValueType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -7,11 +8,16 @@ use crate::schema::types::schema::DeclarativeSchemaType;
 use crate::schema::types::Schema;
 
 /// A canonical field entry in the global field registry.
-/// Carries description (for semantic matching) and type (for enforcement).
+/// Carries description (for semantic matching), type (for enforcement),
+/// and optional data classification (for sensitivity labeling).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CanonicalField {
     pub description: String,
     pub field_type: FieldValueType,
+    /// Data classification label for this field. `None` for legacy fields
+    /// that were registered before classification was required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub classification: Option<DataClassification>,
 }
 
 /// Response containing a list of available schema names
@@ -165,6 +171,9 @@ pub struct AddViewRequest {
     /// Classifications for each output field
     #[serde(default)]
     pub field_classifications: HashMap<String, Vec<String>>,
+    /// Data classifications for each output field (sensitivity + domain)
+    #[serde(default)]
+    pub field_data_classifications: HashMap<String, DataClassification>,
     /// Optional WASM transform bytes
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wasm_bytes: Option<Vec<u8>>,


### PR DESCRIPTION
## Summary
- Ports classification features from fold_db_node into fold_db so fold_db is the single source of truth for all schema_service logic
- Adds `classification: Option<DataClassification>` to `CanonicalField` and `field_data_classifications` to `AddViewRequest`
- Makes `register_canonical_fields` async with LLM-based classification inference (caller-provided → LLM → error, no fallback)
- Adds `apply_canonical_classifications` to propagate classifications from canonical registry to schemas
- Handles `field_data_classifications` in schema expansion and field renames

## Test plan
- [x] `cargo check` passes
- [x] `cargo check --features aws-backend` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` all pass
- [ ] Merge fold_db first, then merge companion PR in fold_db_node

**Companion PR:** fold_db_node will delete its duplicate copies and re-export from fold_db after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)