### PR TITLE
Preserve classifications when rebuilding canonical fields

### DIFF
--- a/src/schema_service/state_fields.rs
+++ b/src/schema_service/state_fields.rs
@@ -331,12 +331,14 @@ impl SchemaServiceState {
                     if let Ok(vec) = self.embedder.embed_text(&embed_text) {
                         embeddings.insert(field_name.clone(), vec);
                     }
+                    let classification =
+                        schema.field_data_classifications.get(field_name).cloned();
                     fields.insert(
                         field_name.clone(),
                         CanonicalField {
                             description: desc,
                             field_type,
-                            classification: None,
+                            classification,
                         },
                     );
                 }


### PR DESCRIPTION
## Summary
- Fixes cloud rebuild path that was creating canonical fields with `classification: None`
- Now reads from `schema.field_data_classifications` so classifications survive Lambda cold starts

## Test plan
- [x] `cargo check --features aws-backend` passes
- [x] `cargo test --lib --features aws-backend` — 241 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)