### PR TITLE
feat: add transform views — computed lenses over source schemas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 ts-bindings = ["ts-rs"]  # Generate TypeScript bindings when enabled
 cli = ["dep:clap", "dep:clap_complete"]  # CLI tooling (clap derives)
 aws-backend = ["aws-config", "aws-sdk-dynamodb", "aws-sdk-s3", "aws-sdk-sns", "aws-sdk-sqs", "serde_dynamo"]  # AWS backends (DynamoDB, S3, SNS, SQS)
+transform-wasm = ["dep:wasmtime"]  # Enable WASM transform execution for views
 test-utils = []  # Expose test helpers (MockEmbeddingModel, etc.) for integration tests
 
 [dependencies]
@@ -63,6 +64,9 @@ reqwest = { version = "0.11", features = ["json", "multipart"] }
 
 # Vector embedding model for semantic search
 fastembed = "4"
+
+# WASM runtime for transform views
+wasmtime = { version = "29", optional = true }
 
 # AWS SDK
 aws-config = { version = "1.0", optional = true }

--- a/src/db_operations/core.rs
+++ b/src/db_operations/core.rs
@@ -25,6 +25,11 @@ pub struct DbOperations {
     process_results_store: Arc<TypedKvStore<dyn KvStore>>,
     superseded_by_store: Arc<TypedKvStore<dyn KvStore>>,
 
+    /// Transform view storage namespaces
+    views_store: Arc<TypedKvStore<dyn KvStore>>,
+    view_states_store: Arc<TypedKvStore<dyn KvStore>>,
+    transform_field_states_store: Arc<TypedKvStore<dyn KvStore>>,
+
     native_index_manager: Option<NativeIndexManager>,
 }
 
@@ -43,6 +48,9 @@ impl DbOperations {
         let idempotency_kv = store.open_namespace("idempotency").await?;
         let process_results_kv = store.open_namespace("process_results").await?;
         let superseded_by_kv = store.open_namespace("schema_superseded_by").await?;
+        let views_kv = store.open_namespace("views").await?;
+        let view_states_kv = store.open_namespace("view_states").await?;
+        let transform_field_states_kv = store.open_namespace("transform_field_states").await?;
         let native_index_kv = store.open_namespace("native_index").await?;
 
         // Wrap KvStores in TypedKvStore adapters
@@ -55,6 +63,9 @@ impl DbOperations {
         let idempotency_store = Arc::new(TypedKvStore::new(idempotency_kv));
         let process_results_store = Arc::new(TypedKvStore::new(process_results_kv));
         let superseded_by_store = Arc::new(TypedKvStore::new(superseded_by_kv));
+        let views_store = Arc::new(TypedKvStore::new(views_kv));
+        let view_states_store = Arc::new(TypedKvStore::new(view_states_kv));
+        let transform_field_states_store = Arc::new(TypedKvStore::new(transform_field_states_kv));
 
         // Create native index manager and load any previously stored embeddings
         let native_index_manager = NativeIndexManager::new(native_index_kv);
@@ -70,6 +81,9 @@ impl DbOperations {
             idempotency_store,
             process_results_store,
             superseded_by_store,
+            views_store,
+            view_states_store,
+            transform_field_states_store,
             native_index_manager: Some(native_index_manager),
         })
     }
@@ -141,6 +155,18 @@ impl DbOperations {
 
     pub fn native_index_manager(&self) -> Option<&NativeIndexManager> {
         self.native_index_manager.as_ref()
+    }
+
+    pub fn views_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+        &self.views_store
+    }
+
+    pub fn view_states_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+        &self.view_states_store
+    }
+
+    pub fn transform_field_states_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+        &self.transform_field_states_store
     }
 
     /// Get atoms/molecules store (same as main_store for backward compatibility)

--- a/src/db_operations/mod.rs
+++ b/src/db_operations/mod.rs
@@ -6,6 +6,7 @@ mod metadata_operations;
 pub mod native_index;
 mod public_key_operations;
 mod schema_operations;
+mod view_operations;
 // Re-export the main DbOperations struct
 pub use core::DbOperations;
 pub use native_index::{IndexResult, NativeIndexManager};

--- a/src/db_operations/view_operations.rs
+++ b/src/db_operations/view_operations.rs
@@ -1,0 +1,145 @@
+use super::core::DbOperations;
+use crate::schema::SchemaError;
+use crate::view::registry::ViewState;
+use crate::view::types::{TransformFieldState, TransformView};
+use std::collections::HashMap;
+
+impl DbOperations {
+    /// Store a transform view definition.
+    pub async fn store_view(
+        &self,
+        view_name: &str,
+        view: &TransformView,
+    ) -> Result<(), SchemaError> {
+        use crate::storage::traits::TypedStore;
+
+        self.views_store().put_item(view_name, view).await?;
+        self.views_store().inner().flush().await?;
+        Ok(())
+    }
+
+    /// Get a transform view by name.
+    pub async fn get_view(
+        &self,
+        view_name: &str,
+    ) -> Result<Option<TransformView>, SchemaError> {
+        use crate::storage::traits::TypedStore;
+
+        Ok(self.views_store().get_item(view_name).await?)
+    }
+
+    /// Get all transform views.
+    pub async fn get_all_views(&self) -> Result<Vec<TransformView>, SchemaError> {
+        use crate::storage::traits::TypedStore;
+
+        let keys = self.views_store().list_keys_with_prefix("").await?;
+        let mut views = Vec::new();
+        for key in keys {
+            if let Some(view) = self.views_store().get_item::<TransformView>(&key).await? {
+                views.push(view);
+            }
+        }
+        Ok(views)
+    }
+
+    /// Delete a transform view.
+    pub async fn delete_view(&self, view_name: &str) -> Result<(), SchemaError> {
+        use crate::storage::traits::TypedStore;
+
+        self.views_store().delete_item(view_name).await?;
+        self.views_store().inner().flush().await?;
+        Ok(())
+    }
+
+    /// Store a view state.
+    pub async fn store_view_state(
+        &self,
+        view_name: &str,
+        state: &ViewState,
+    ) -> Result<(), SchemaError> {
+        use crate::storage::traits::TypedStore;
+
+        self.view_states_store().put_item(view_name, state).await?;
+        self.view_states_store().inner().flush().await?;
+        Ok(())
+    }
+
+    /// Get all view states.
+    pub async fn get_all_view_states(&self) -> Result<HashMap<String, ViewState>, SchemaError> {
+        use crate::storage::traits::TypedStore;
+
+        let keys = self.view_states_store().list_keys_with_prefix("").await?;
+        let mut states = HashMap::new();
+        for key in keys {
+            if let Some(state) = self
+                .view_states_store()
+                .get_item::<ViewState>(&key)
+                .await?
+            {
+                states.insert(key, state);
+            }
+        }
+        Ok(states)
+    }
+
+    /// Delete a view state.
+    pub async fn delete_view_state(&self, view_name: &str) -> Result<(), SchemaError> {
+        use crate::storage::traits::TypedStore;
+
+        self.view_states_store().delete_item(view_name).await?;
+        self.view_states_store().inner().flush().await?;
+        Ok(())
+    }
+
+    /// Get a transform field state for a specific view field.
+    /// Key format: "{view_name}:{field_name}"
+    pub async fn get_transform_field_state(
+        &self,
+        view_name: &str,
+        field_name: &str,
+    ) -> Result<TransformFieldState, SchemaError> {
+        use crate::storage::traits::TypedStore;
+
+        let key = format!("{}:{}", view_name, field_name);
+        Ok(self
+            .transform_field_states_store()
+            .get_item::<TransformFieldState>(&key)
+            .await?
+            .unwrap_or(TransformFieldState::Empty))
+    }
+
+    /// Set a transform field state for a specific view field.
+    pub async fn set_transform_field_state(
+        &self,
+        view_name: &str,
+        field_name: &str,
+        state: &TransformFieldState,
+    ) -> Result<(), SchemaError> {
+        use crate::storage::traits::TypedStore;
+
+        let key = format!("{}:{}", view_name, field_name);
+        self.transform_field_states_store()
+            .put_item(&key, state)
+            .await?;
+        self.transform_field_states_store().inner().flush().await?;
+        Ok(())
+    }
+
+    /// Clear all field states for a view (used when removing a view).
+    pub async fn clear_view_field_states(&self, view_name: &str) -> Result<(), SchemaError> {
+        use crate::storage::traits::TypedStore;
+
+        let prefix = format!("{}:", view_name);
+        let keys = self
+            .transform_field_states_store()
+            .list_keys_with_prefix(&prefix)
+            .await?;
+        for key in keys {
+            self.transform_field_states_store()
+                .delete_item(&key)
+                .await?;
+        }
+        self.transform_field_states_store().inner().flush().await?;
+        Ok(())
+    }
+}

--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -19,6 +19,7 @@ use crate::storage::traits::TypedStore;
 use crate::schema::types::field::{Field, FieldVariant};
 use crate::schema::types::{KeyValue, Mutation, Schema};
 use crate::schema::{SchemaCore, SchemaError};
+use crate::view::types::{TransformFieldState, TransformWriteMode};
 use log::{debug, error, warn};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -82,6 +83,10 @@ impl MutationManager {
         if mutations.is_empty() {
             return Ok(Vec::new());
         }
+
+        // Phase 0: View write interception
+        // Check if any mutations target views and redirect/handle them
+        let mutations = self.intercept_view_mutations(mutations).await?;
 
         log::info!(
             "🔄 write_mutations_batch_async: Starting batch of {} mutations",
@@ -221,6 +226,16 @@ impl MutationManager {
             );
             batch_events.extend(events);
             mutation_ids.extend(ids);
+
+            // Phase 7.5: Invalidate dependent view field caches
+            let fields_affected: Vec<String> = schema_mutations
+                .iter()
+                .flat_map(|m| m.fields_and_values.keys().cloned())
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
+            self.invalidate_dependent_view_fields(&schema_name, &fields_affected)
+                .await?;
         }
 
         // Phase 8: Finalize — flush, store idempotency records, publish events
@@ -689,6 +704,233 @@ impl MutationManager {
                 .map_err(|e| SchemaError::InvalidData(e.to_string()))?;
         }
         Ok(())
+    }
+
+    // ========== View mutation interception + invalidation ==========
+
+    /// Phase 0: Intercept mutations targeting views and redirect them.
+    ///
+    /// For each mutation whose `schema_name` matches a registered view:
+    /// - Identity fields → create a redirected mutation targeting the source schema.field
+    /// - Reversible fields → run inverse WASM, create redirected mutation targeting source
+    /// - Irreversible fields → store value directly as Overridden in transform_field_states
+    ///
+    /// Returns the (possibly modified) list of mutations to feed into the normal pipeline.
+    async fn intercept_view_mutations(
+        &self,
+        mutations: Vec<Mutation>,
+    ) -> Result<Vec<Mutation>, SchemaError> {
+        let mut result = Vec::new();
+
+        for mutation in mutations {
+            let view_info = {
+                let registry = self
+                    .schema_manager
+                    .view_registry()
+                    .lock()
+                    .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+                registry.get_view(&mutation.schema_name).cloned()
+            };
+
+            let Some(view) = view_info else {
+                // Not a view — pass through to normal pipeline
+                result.push(mutation);
+                continue;
+            };
+
+            // This mutation targets a view — redirect each field
+            // Group redirected fields by target source schema
+            let mut redirected: HashMap<String, HashMap<String, serde_json::Value>> = HashMap::new();
+
+            for (field_name, value) in &mutation.fields_and_values {
+                let Some(field_def) = view.fields.get(field_name) else {
+                    return Err(SchemaError::InvalidField(format!(
+                        "Field '{}' not found in view '{}'",
+                        field_name, view.name
+                    )));
+                };
+
+                let write_mode = view
+                    .write_modes
+                    .get(field_name)
+                    .copied()
+                    .unwrap_or(TransformWriteMode::Identity);
+
+                match write_mode {
+                    TransformWriteMode::Identity => {
+                        // Pass value directly to source schema.field
+                        redirected
+                            .entry(field_def.source.schema.clone())
+                            .or_default()
+                            .insert(field_def.source.field.clone(), value.clone());
+                    }
+                    TransformWriteMode::Reversible => {
+                        // Run inverse WASM to convert back to source domain
+                        let inverse_bytes = field_def.wasm_inverse.as_ref().ok_or_else(|| {
+                            SchemaError::InvalidTransform(format!(
+                                "Reversible field '{}' in view '{}' missing inverse WASM",
+                                field_name, view.name
+                            ))
+                        })?;
+                        let wasm_engine = {
+                            let registry = self
+                                .schema_manager
+                                .view_registry()
+                                .lock()
+                                .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
+                            Arc::clone(registry.wasm_engine())
+                        };
+                        let source_value = wasm_engine.execute(inverse_bytes, value)?;
+                        redirected
+                            .entry(field_def.source.schema.clone())
+                            .or_default()
+                            .insert(field_def.source.field.clone(), source_value);
+                    }
+                    TransformWriteMode::Irreversible => {
+                        // Store directly as Overridden — no redirect to source
+                        let key = mutation.key_value.clone();
+                        let fv = crate::schema::types::field::FieldValue {
+                            value: value.clone(),
+                            atom_uuid: String::new(),
+                            source_file_name: None,
+                            metadata: None,
+                            molecule_uuid: None,
+                            molecule_version: None,
+                        };
+                        let entries = vec![(key, fv)];
+                        let state = TransformFieldState::Overridden { entries };
+                        self.db_ops
+                            .set_transform_field_state(&view.name, field_name, &state)
+                            .await?;
+                    }
+                }
+            }
+
+            // Create redirected mutations for each target source schema
+            for (target_schema, fields_and_values) in redirected {
+                result.push(Mutation {
+                    uuid: uuid::Uuid::new_v4().to_string(),
+                    schema_name: target_schema,
+                    fields_and_values,
+                    key_value: mutation.key_value.clone(),
+                    pub_key: mutation.pub_key.clone(),
+                    mutation_type: mutation.mutation_type.clone(),
+                    synchronous: mutation.synchronous,
+                    source_file_name: mutation.source_file_name.clone(),
+                    metadata: mutation.metadata.clone(),
+                });
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Phase 7.5: Invalidate cached view fields that depend on mutated source fields.
+    async fn invalidate_dependent_view_fields(
+        &self,
+        schema_name: &str,
+        fields_affected: &[String],
+    ) -> Result<(), SchemaError> {
+        let dependents: Vec<(String, String)> = {
+            let registry = self
+                .schema_manager
+                .view_registry()
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
+
+            let mut all_deps = Vec::new();
+            for field_name in fields_affected {
+                let deps = registry
+                    .dependency_tracker
+                    .get_dependents(schema_name, field_name);
+                all_deps.extend(deps.iter().cloned());
+            }
+            all_deps
+        };
+
+        for (view_name, view_field) in &dependents {
+            let current_state = self
+                .db_ops
+                .get_transform_field_state(view_name, view_field)
+                .await?;
+
+            if matches!(current_state, TransformFieldState::Cached { .. }) {
+                self.db_ops
+                    .set_transform_field_state(
+                        view_name,
+                        view_field,
+                        &TransformFieldState::Empty,
+                    )
+                    .await?;
+                log::debug!(
+                    "Invalidated cached view field {}.{} (source {}.{} mutated)",
+                    view_name,
+                    view_field,
+                    schema_name,
+                    fields_affected.first().unwrap_or(&String::new())
+                );
+            }
+
+            // Cascade: if this view is itself a source for other views, invalidate those too
+            // (recursive via the same mechanism — view_name is checked as a schema_name)
+            self.invalidate_dependent_view_fields_recursive(view_name, view_field, &mut HashSet::new())
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Recursively invalidate cascading view dependencies.
+    fn invalidate_dependent_view_fields_recursive<'a>(
+        &'a self,
+        view_name: &'a str,
+        _view_field: &'a str,
+        visited: &'a mut HashSet<String>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), SchemaError>> + Send + 'a>> {
+        Box::pin(async move {
+            if !visited.insert(view_name.to_string()) {
+                return Ok(()); // Already visited — cycle guard
+            }
+
+            let cascade_deps: Vec<(String, String)> = {
+                let registry = self
+                    .schema_manager
+                    .view_registry()
+                    .lock()
+                    .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
+
+                // Get all fields of this view, then find what depends on each
+                let view = match registry.get_view(view_name) {
+                    Some(v) => v,
+                    None => return Ok(()),
+                };
+
+                let mut deps = Vec::new();
+                for field_name in view.fields.keys() {
+                    let d = registry.dependency_tracker.get_dependents(view_name, field_name);
+                    deps.extend(d.iter().cloned());
+                }
+                deps
+            };
+
+            for (dep_view, dep_field) in &cascade_deps {
+                let current_state = self
+                    .db_ops
+                    .get_transform_field_state(dep_view, dep_field)
+                    .await?;
+
+                if matches!(current_state, TransformFieldState::Cached { .. }) {
+                    self.db_ops
+                        .set_transform_field_state(dep_view, dep_field, &TransformFieldState::Empty)
+                        .await?;
+                }
+
+                self.invalidate_dependent_view_fields_recursive(dep_view, dep_field, visited)
+                    .await?;
+            }
+
+            Ok(())
+        })
     }
 
     /// Start listening for MutationRequest events in a background thread

--- a/src/fold_db_core/query/query_executor.rs
+++ b/src/fold_db_core/query/query_executor.rs
@@ -4,11 +4,16 @@
 //! including HashRange schemas with proper delegation to specialized processors.
 
 use crate::db_operations::DbOperations;
-use crate::schema::types::field::FieldValue;
+use crate::schema::types::field::{FieldValue, HashRangeFilter};
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::Query;
 use crate::schema::{SchemaCore, SchemaState};
 use crate::schema::SchemaError;
+use crate::view::registry::ViewState;
+use crate::view::resolver::{SourceQueryFn, ViewFieldResolver};
+use crate::view::types::TransformFieldState;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -17,7 +22,49 @@ use super::hash_range_query::HashRangeQueryProcessor;
 /// Main query executor that handles all query operations
 pub struct QueryExecutor {
     schema_manager: Arc<SchemaCore>,
+    db_ops: Arc<DbOperations>,
     hash_range_processor: HashRangeQueryProcessor,
+    view_resolver: ViewFieldResolver,
+}
+
+/// Implements SourceQueryFn by delegating back to the query executor's schema query path.
+/// This breaks the circular dependency: QueryExecutor -> ViewFieldResolver -> SourceQueryFn -> schema query.
+struct SchemaSourceQuery {
+    schema_manager: Arc<SchemaCore>,
+    hash_range_processor: HashRangeQueryProcessor,
+}
+
+#[async_trait]
+impl SourceQueryFn for SchemaSourceQuery {
+    async fn query_field(
+        &self,
+        schema_name: &str,
+        field_name: &str,
+        filter: Option<HashRangeFilter>,
+        as_of: Option<DateTime<Utc>>,
+    ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
+        let mut schema = self
+            .schema_manager
+            .get_schema(schema_name)
+            .await?
+            .ok_or_else(|| {
+                SchemaError::NotFound(format!(
+                    "Source schema '{}' not found",
+                    schema_name
+                ))
+            })?;
+
+        let field_results = self
+            .hash_range_processor
+            .query_with_filter(&mut schema, &[field_name.to_string()], filter, as_of)
+            .await?;
+
+        // Return the keyed results for this field directly
+        Ok(field_results
+            .get(field_name)
+            .cloned()
+            .unwrap_or_default())
+    }
 }
 
 impl QueryExecutor {
@@ -25,51 +72,149 @@ impl QueryExecutor {
     pub fn new(db_ops: Arc<DbOperations>, schema_manager: Arc<SchemaCore>) -> Self {
         let hash_range_processor = HashRangeQueryProcessor::new(Arc::clone(&db_ops));
 
+        // Get the WASM engine from the view registry
+        let wasm_engine = {
+            let registry = schema_manager
+                .view_registry()
+                .lock()
+                .expect("view_registry lock");
+            Arc::clone(registry.wasm_engine())
+        };
+        let view_resolver = ViewFieldResolver::new(wasm_engine);
+
         Self {
             schema_manager,
+            db_ops,
             hash_range_processor,
+            view_resolver,
         }
     }
 
-    /// Query multiple fields from a schema
+    /// Query multiple fields from a schema or view
     pub async fn query(
         &self,
         query: Query,
     ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
-        // query is async, so we can await get_schema
-        let mut schema = match self.schema_manager.get_schema(&query.schema_name).await? {
-            Some(s) => s,
+        // First: try to resolve as a schema (existing path)
+        match self.schema_manager.get_schema(&query.schema_name).await? {
+            Some(mut schema) => {
+                // Enforce Blocked state — blocked schemas with a successor are already redirected by get_schema()
+                let resolved_state = self
+                    .schema_manager
+                    .get_schema_states()?
+                    .get(&schema.name)
+                    .copied()
+                    .unwrap_or_default();
+                if resolved_state == SchemaState::Blocked {
+                    return Err(SchemaError::InvalidData(format!(
+                        "Schema '{}' is blocked and cannot be queried",
+                        schema.name
+                    )));
+                }
+
+                self.hash_range_processor
+                    .query_with_filter(&mut schema, &query.fields, query.filter, query.as_of)
+                    .await
+            }
             None => {
-                let available = self.schema_manager.get_schemas()?;
-                let names: Vec<String> = available.keys().cloned().collect();
+                // Second: try to resolve as a view
+                self.try_query_view(&query).await
+            }
+        }
+    }
+
+    /// Attempt to resolve a query against the view registry.
+    async fn try_query_view(
+        &self,
+        query: &Query,
+    ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
+        let view = {
+            let registry = self
+                .schema_manager
+                .view_registry()
+                .lock()
+                .map_err(|_| {
+                    SchemaError::InvalidData("Failed to acquire view_registry lock".to_string())
+                })?;
+
+            let view = registry.get_view(&query.schema_name).ok_or_else(|| {
+                let available = self.schema_manager.get_schemas().unwrap_or_default();
+                let schema_names: Vec<String> = available.keys().cloned().collect();
+                let view_names: Vec<String> = registry
+                    .list_views()
+                    .iter()
+                    .map(|v| v.name.clone())
+                    .collect();
                 log::error!(
-                    "❌ Schema '{}' not found. Available schemas: {:?}",
+                    "❌ '{}' not found as schema or view. Schemas: {:?}, Views: {:?}",
                     query.schema_name,
-                    names
+                    schema_names,
+                    view_names
                 );
+                SchemaError::InvalidData(format!(
+                    "'{}' not found as schema or view",
+                    query.schema_name
+                ))
+            })?;
+
+            // Check view state
+            let state = registry
+                .get_view_state(&query.schema_name)
+                .unwrap_or(ViewState::Available);
+            if state == ViewState::Blocked {
                 return Err(SchemaError::InvalidData(format!(
-                    "Schema '{}' not found",
+                    "View '{}' is blocked and cannot be queried",
                     query.schema_name
                 )));
             }
+
+            view.clone()
         };
 
-        // Enforce Blocked state — blocked schemas with a successor are already redirected by get_schema()
-        let resolved_state = self
-            .schema_manager
-            .get_schema_states()?
-            .get(&schema.name)
-            .copied()
-            .unwrap_or_default();
-        if resolved_state == SchemaState::Blocked {
-            return Err(SchemaError::InvalidData(format!(
-                "Schema '{}' is blocked and cannot be queried",
-                schema.name
-            )));
+        // Determine which fields to resolve
+        let fields_to_resolve: Vec<String> = if query.fields.is_empty() {
+            view.fields.keys().cloned().collect()
+        } else {
+            query.fields.clone()
+        };
+
+        // Create source query implementation
+        let source_query = SchemaSourceQuery {
+            schema_manager: Arc::clone(&self.schema_manager),
+            hash_range_processor: HashRangeQueryProcessor::new(Arc::clone(&self.db_ops)),
+        };
+
+        let mut result: HashMap<String, HashMap<KeyValue, FieldValue>> = HashMap::new();
+
+        for field_name in &fields_to_resolve {
+            // Load current field state from storage
+            let field_state = self
+                .db_ops
+                .get_transform_field_state(&view.name, field_name)
+                .await?;
+
+            let (field_results, new_state) = self
+                .view_resolver
+                .resolve_field(
+                    &view,
+                    field_name,
+                    &field_state,
+                    &source_query,
+                    query.filter.clone(),
+                    query.as_of,
+                )
+                .await?;
+
+            // Persist updated state if it changed from Empty to Cached
+            if field_state.is_empty() && matches!(new_state, TransformFieldState::Cached { .. }) {
+                self.db_ops
+                    .set_transform_field_state(&view.name, field_name, &new_state)
+                    .await?;
+            }
+
+            result.insert(field_name.clone(), field_results);
         }
 
-        self.hash_range_processor
-            .query_with_filter(&mut schema, &query.fields, query.filter, query.as_of)
-            .await
+        Ok(result)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod security;
 pub mod storage;
 pub mod sync;
 pub mod testing_utils;
+pub mod view;
 
 // Re-export main types for convenience
 pub use error::{FoldDbError, FoldDbResult};

--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -7,6 +7,9 @@ use crate::fold_db_core::infrastructure::message_bus::AsyncMessageBus;
 use crate::schema::types::field::Field;
 use crate::schema::types::{DeclarativeSchemaDefinition, Schema, SchemaError};
 use crate::schema::{SchemaState, SchemaWithState};
+use crate::view::registry::{ViewRegistry, ViewState};
+use crate::view::types::TransformView;
+use crate::view::wasm_engine::WasmTransformEngine;
 
 /// Core schema management system that combines schema interpretation, validation, and management.
 ///
@@ -29,6 +32,8 @@ pub struct SchemaCore {
     db_ops: std::sync::Arc<crate::db_operations::DbOperations>,
     /// Message bus for event-driven communication
     message_bus: Arc<AsyncMessageBus>,
+    /// Registry for transform views
+    view_registry: Mutex<ViewRegistry>,
 }
 
 /// Acquire a `Mutex<HashMap<String, T>>` lock, mapping poison errors to `SchemaError`.
@@ -52,12 +57,19 @@ impl SchemaCore {
         let schema_states = db_ops.get_all_schema_states().await?;
         let superseded_by = db_ops.get_all_superseded_by().await?;
 
+        // Load transform views from storage
+        let views = db_ops.get_all_views().await?;
+        let view_states = db_ops.get_all_view_states().await?;
+        let wasm_engine = Arc::new(WasmTransformEngine::new()?);
+        let view_registry = ViewRegistry::load(views, view_states, wasm_engine);
+
         let schema_core = Self {
             schemas: Arc::new(Mutex::new(schemas)),
             schema_states: Arc::new(Mutex::new(schema_states)),
             superseded_by: Arc::new(Mutex::new(superseded_by)),
             db_ops,
             message_bus,
+            view_registry: Mutex::new(view_registry),
         };
 
         Ok(schema_core)
@@ -443,6 +455,138 @@ impl SchemaCore {
             ))
         }
     }
+    // ========== TRANSFORM VIEW API ==========
+
+    /// Register a new transform view. Validates source references, determines write modes,
+    /// checks for cycles, and persists to storage.
+    pub async fn register_view(&self, view: TransformView) -> Result<(), SchemaError> {
+        let view_name = view.name.clone();
+        {
+            let schemas = lock_map(&self.schemas, "schemas")?;
+            let mut registry = self
+                .view_registry
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+
+            // Check cross-registry name uniqueness: view name must not collide with a schema
+            if schemas.contains_key(&view.name) {
+                return Err(SchemaError::InvalidData(format!(
+                    "Name '{}' is already used by a schema",
+                    view.name
+                )));
+            }
+
+            registry.register_view(view, |name| schemas.contains_key(name))?;
+        };
+
+        // Re-acquire to get the stored view (with computed write_modes)
+        let view_clone = {
+            let registry = self
+                .view_registry
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+            registry.get_view(&view_name).unwrap().clone()
+        };
+
+        // Persist view and state to storage
+        self.db_ops.store_view(&view_clone.name, &view_clone).await?;
+        self.db_ops
+            .store_view_state(&view_clone.name, &ViewState::Available)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Get a view by name.
+    pub fn get_view(&self, name: &str) -> Result<Option<TransformView>, SchemaError> {
+        let registry = self
+            .view_registry
+            .lock()
+            .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+        Ok(registry.get_view(name).cloned())
+    }
+
+    /// List all views with their states.
+    pub fn get_views_with_states(&self) -> Result<Vec<(TransformView, ViewState)>, SchemaError> {
+        let registry = self
+            .view_registry
+            .lock()
+            .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+        Ok(registry
+            .get_views_with_states()
+            .into_iter()
+            .map(|(v, s)| (v.clone(), s))
+            .collect())
+    }
+
+    /// Approve a view.
+    pub async fn approve_view(&self, name: &str) -> Result<(), SchemaError> {
+        {
+            let mut registry = self
+                .view_registry
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+            registry.approve_view(name)?;
+        }
+        self.db_ops
+            .store_view_state(name, &ViewState::Approved)
+            .await?;
+        Ok(())
+    }
+
+    /// Block a view.
+    pub async fn block_view(&self, name: &str) -> Result<(), SchemaError> {
+        {
+            let mut registry = self
+                .view_registry
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+            registry.block_view(name)?;
+        }
+        self.db_ops
+            .store_view_state(name, &ViewState::Blocked)
+            .await?;
+        Ok(())
+    }
+
+    /// Remove a view and clean up storage.
+    pub async fn remove_view(&self, name: &str) -> Result<(), SchemaError> {
+        {
+            let mut registry = self
+                .view_registry
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+            registry.remove_view(name)?;
+        }
+        self.db_ops.delete_view(name).await?;
+        self.db_ops.delete_view_state(name).await?;
+        self.db_ops.clear_view_field_states(name).await?;
+        Ok(())
+    }
+
+    /// Check if a name is used by either a schema or a view.
+    pub fn name_exists(&self, name: &str) -> Result<bool, SchemaError> {
+        let schemas = lock_map(&self.schemas, "schemas")?;
+        if schemas.contains_key(name) {
+            return Ok(true);
+        }
+        let registry = self
+            .view_registry
+            .lock()
+            .map_err(|_| SchemaError::InvalidData("Failed to acquire view_registry lock".to_string()))?;
+        Ok(registry.name_exists(name))
+    }
+
+    /// Get the view registry (for query/mutation integration).
+    pub fn view_registry(&self) -> &Mutex<ViewRegistry> {
+        &self.view_registry
+    }
+
+    /// Get the database operations (for view field state access).
+    pub fn db_ops(&self) -> &Arc<crate::db_operations::DbOperations> {
+        &self.db_ops
+    }
+
     /// Creates a new SchemaCore for testing purposes with a temporary database
     pub async fn new_for_testing() -> Result<Self, SchemaError> {
         let db = sled::Config::new()

--- a/src/view/dependency_tracker.rs
+++ b/src/view/dependency_tracker.rs
@@ -1,0 +1,248 @@
+use crate::view::types::{TransformFieldDef, TransformView};
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+/// Tracks which view fields depend on which source schema fields.
+/// Used for cache invalidation when source data changes.
+#[derive(Debug, Default)]
+pub struct DependencyTracker {
+    /// (source_schema, source_field) -> [(view_name, view_field_name)]
+    deps: HashMap<(String, String), Vec<(String, String)>>,
+}
+
+impl DependencyTracker {
+    pub fn new() -> Self {
+        Self {
+            deps: HashMap::new(),
+        }
+    }
+
+    /// Register all field dependencies for a view.
+    pub fn register(&mut self, view_name: &str, fields: &HashMap<String, TransformFieldDef>) {
+        for (field_name, field_def) in fields {
+            let key = (
+                field_def.source.schema.clone(),
+                field_def.source.field.clone(),
+            );
+            self.deps
+                .entry(key)
+                .or_default()
+                .push((view_name.to_string(), field_name.clone()));
+        }
+    }
+
+    /// Remove all dependency entries for a given view.
+    pub fn unregister(&mut self, view_name: &str) {
+        self.deps.retain(|_key, dependents| {
+            dependents.retain(|(vn, _)| vn != view_name);
+            !dependents.is_empty()
+        });
+    }
+
+    /// Get all view fields that depend on a given source schema field.
+    pub fn get_dependents(&self, schema: &str, field: &str) -> &[(String, String)] {
+        let key = (schema.to_string(), field.to_string());
+        self.deps.get(&key).map_or(&[], |v| v.as_slice())
+    }
+
+    /// Rebuild the tracker from a set of views (used on startup).
+    pub fn rebuild(&mut self, views: &[TransformView]) {
+        self.deps.clear();
+        for view in views {
+            self.register(&view.name, &view.fields);
+        }
+    }
+
+    /// Check if adding a view with the given fields would create a dependency cycle.
+    ///
+    /// A cycle exists if the new view reads from a source that (transitively) reads
+    /// from the new view. Since views can be sources for other views, we perform DFS
+    /// through the dependency graph.
+    ///
+    /// `view_fields_map` provides all registered views' fields for traversal.
+    pub fn would_create_cycle(
+        &self,
+        new_view_name: &str,
+        new_fields: &HashMap<String, TransformFieldDef>,
+        view_fields_map: &HashMap<String, HashMap<String, TransformFieldDef>>,
+    ) -> bool {
+        // Collect all source schemas the new view reads from
+        let sources: HashSet<String> = new_fields
+            .values()
+            .map(|f| f.source.schema.clone())
+            .collect();
+
+        // DFS: check if any source schema transitively depends on new_view_name
+        let mut visited = HashSet::new();
+        let mut stack: Vec<String> = sources.into_iter().collect();
+
+        while let Some(current) = stack.pop() {
+            if current == new_view_name {
+                return true; // Cycle detected
+            }
+            if !visited.insert(current.clone()) {
+                continue; // Already visited
+            }
+            // If `current` is itself a view, check what it reads from
+            if let Some(fields) = view_fields_map.get(&current) {
+                for field_def in fields.values() {
+                    stack.push(field_def.source.schema.clone());
+                }
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
+    use crate::view::types::FieldRef;
+
+    fn make_field(schema: &str, field: &str) -> TransformFieldDef {
+        TransformFieldDef {
+            source: FieldRef::new(schema, field),
+            wasm_forward: None,
+            wasm_inverse: None,
+        }
+    }
+
+    #[test]
+    fn test_register_and_lookup() {
+        let mut tracker = DependencyTracker::new();
+        let mut fields = HashMap::new();
+        fields.insert("words".into(), make_field("BlogPost", "content"));
+        fields.insert("temp_f".into(), make_field("Weather", "temp_c"));
+
+        tracker.register("Analytics", &fields);
+
+        let deps = tracker.get_dependents("BlogPost", "content");
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0], ("Analytics".into(), "words".into()));
+
+        let deps = tracker.get_dependents("Weather", "temp_c");
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0], ("Analytics".into(), "temp_f".into()));
+
+        // No dependents for unregistered source
+        assert!(tracker.get_dependents("Other", "field").is_empty());
+    }
+
+    #[test]
+    fn test_unregister() {
+        let mut tracker = DependencyTracker::new();
+        let mut fields = HashMap::new();
+        fields.insert("a".into(), make_field("S1", "f1"));
+        tracker.register("View1", &fields);
+
+        let mut fields2 = HashMap::new();
+        fields2.insert("b".into(), make_field("S1", "f1"));
+        tracker.register("View2", &fields2);
+
+        assert_eq!(tracker.get_dependents("S1", "f1").len(), 2);
+
+        tracker.unregister("View1");
+        let deps = tracker.get_dependents("S1", "f1");
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].0, "View2");
+    }
+
+    #[test]
+    fn test_rebuild() {
+        let mut tracker = DependencyTracker::new();
+        let mut fields = HashMap::new();
+        fields.insert("x".into(), make_field("S1", "f1"));
+        tracker.register("OldView", &fields);
+
+        let views = vec![TransformView::new(
+            "NewView",
+            SchemaType::Single,
+            None,
+            {
+                let mut f = HashMap::new();
+                f.insert("y".into(), make_field("S2", "f2"));
+                f
+            },
+        )];
+        tracker.rebuild(&views);
+
+        assert!(tracker.get_dependents("S1", "f1").is_empty());
+        assert_eq!(tracker.get_dependents("S2", "f2").len(), 1);
+    }
+
+    #[test]
+    fn test_no_cycle_with_plain_schemas() {
+        let tracker = DependencyTracker::new();
+        let mut fields = HashMap::new();
+        fields.insert("a".into(), make_field("PlainSchema", "f1"));
+
+        // PlainSchema is not a view, so no cycle possible
+        let view_fields_map = HashMap::new();
+        assert!(!tracker.would_create_cycle("MyView", &fields, &view_fields_map));
+    }
+
+    #[test]
+    fn test_direct_cycle() {
+        let tracker = DependencyTracker::new();
+
+        // ViewA reads from ViewB, and we're checking if ViewB reading from ViewA creates a cycle
+        let mut view_a_fields = HashMap::new();
+        view_a_fields.insert("a".into(), make_field("ViewB", "x"));
+
+        let mut view_fields_map = HashMap::new();
+        view_fields_map.insert("ViewA".to_string(), view_a_fields);
+
+        // ViewB wants to read from ViewA — should detect cycle
+        let mut new_fields = HashMap::new();
+        new_fields.insert("b".into(), make_field("ViewA", "y"));
+
+        assert!(tracker.would_create_cycle("ViewB", &new_fields, &view_fields_map));
+    }
+
+    #[test]
+    fn test_transitive_cycle() {
+        let tracker = DependencyTracker::new();
+
+        // ViewA reads from ViewB, ViewB reads from ViewC
+        let mut view_a_fields = HashMap::new();
+        view_a_fields.insert("a".into(), make_field("ViewB", "x"));
+
+        let mut view_b_fields = HashMap::new();
+        view_b_fields.insert("b".into(), make_field("ViewC", "y"));
+
+        let mut view_fields_map = HashMap::new();
+        view_fields_map.insert("ViewA".to_string(), view_a_fields);
+        view_fields_map.insert("ViewB".to_string(), view_b_fields);
+
+        // ViewC wants to read from ViewA — transitive cycle: C -> A -> B -> C
+        let mut new_fields = HashMap::new();
+        new_fields.insert("c".into(), make_field("ViewA", "z"));
+
+        assert!(tracker.would_create_cycle("ViewC", &new_fields, &view_fields_map));
+    }
+
+    #[test]
+    fn test_no_cycle_diamond() {
+        let tracker = DependencyTracker::new();
+
+        // ViewA reads from S1, ViewB reads from S1 — diamond, no cycle
+        let mut view_a_fields = HashMap::new();
+        view_a_fields.insert("a".into(), make_field("S1", "f1"));
+
+        let mut view_b_fields = HashMap::new();
+        view_b_fields.insert("b".into(), make_field("S1", "f1"));
+
+        let mut view_fields_map = HashMap::new();
+        view_fields_map.insert("ViewA".to_string(), view_a_fields);
+        view_fields_map.insert("ViewB".to_string(), view_b_fields);
+
+        // ViewC reads from ViewA and ViewB — no cycle
+        let mut new_fields = HashMap::new();
+        new_fields.insert("x".into(), make_field("ViewA", "a"));
+        new_fields.insert("y".into(), make_field("ViewB", "b"));
+
+        assert!(!tracker.would_create_cycle("ViewC", &new_fields, &view_fields_map));
+    }
+}

--- a/src/view/invertibility.rs
+++ b/src/view/invertibility.rs
@@ -1,0 +1,134 @@
+use crate::schema::types::errors::SchemaError;
+use crate::view::wasm_engine::WasmTransformEngine;
+use serde_json::Value;
+
+/// Verify that forward and inverse WASM transforms form a round-trip.
+///
+/// Generates test inputs of various types and checks that `inverse(forward(x)) == x`
+/// for all of them. Returns true if the pair is reversible, false otherwise.
+/// Returns Err only on execution failures, not on failed round-trips.
+pub fn verify_roundtrip(
+    engine: &WasmTransformEngine,
+    forward: &[u8],
+    inverse: &[u8],
+) -> Result<bool, SchemaError> {
+    let test_inputs = generate_test_inputs();
+
+    for input in &test_inputs {
+        let forward_result = engine.execute(forward, input)?;
+        let inverse_result = engine.execute(inverse, &forward_result)?;
+
+        if !values_equal(input, &inverse_result) {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+/// Generate a set of representative test inputs for round-trip verification.
+fn generate_test_inputs() -> Vec<Value> {
+    vec![
+        // Strings
+        Value::String("hello".into()),
+        Value::String("".into()),
+        Value::String("unicode: \u{1F600} \u{00E9}".into()),
+        // Integers
+        serde_json::json!(0),
+        serde_json::json!(1),
+        serde_json::json!(-42),
+        serde_json::json!(1_000_000),
+        // Floats
+        serde_json::json!(7.77),
+        serde_json::json!(-0.001),
+        serde_json::json!(1e10),
+        // Booleans
+        Value::Bool(true),
+        Value::Bool(false),
+        // Null
+        Value::Null,
+        // Small array
+        serde_json::json!([1, "two", 3.0, true, null]),
+        // Small object
+        serde_json::json!({"key": "value", "num": 42, "nested": {"a": 1}}),
+    ]
+}
+
+/// Compare two JSON values with float tolerance.
+fn values_equal(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Number(na), Value::Number(nb)) => {
+            match (na.as_f64(), nb.as_f64()) {
+                (Some(fa), Some(fb)) => (fa - fb).abs() < 1e-10,
+                _ => na == nb,
+            }
+        }
+        (Value::Array(aa), Value::Array(ab)) => {
+            aa.len() == ab.len() && aa.iter().zip(ab.iter()).all(|(x, y)| values_equal(x, y))
+        }
+        (Value::Object(oa), Value::Object(ob)) => {
+            oa.len() == ob.len()
+                && oa
+                    .iter()
+                    .all(|(k, v)| ob.get(k).is_some_and(|bv| values_equal(v, bv)))
+        }
+        _ => a == b,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_values_equal_basic() {
+        assert!(values_equal(&serde_json::json!(1), &serde_json::json!(1)));
+        assert!(values_equal(
+            &serde_json::json!("hello"),
+            &serde_json::json!("hello")
+        ));
+        assert!(!values_equal(
+            &serde_json::json!(1),
+            &serde_json::json!(2)
+        ));
+    }
+
+    #[test]
+    fn test_values_equal_float_tolerance() {
+        // Difference of 1e-12, well within 1e-10 tolerance
+        let a = serde_json::json!(1.0000000000001);
+        let b = serde_json::json!(1.0000000000002);
+        assert!(values_equal(&a, &b));
+
+        let c = serde_json::json!(1.0);
+        let d = serde_json::json!(2.0);
+        assert!(!values_equal(&c, &d));
+    }
+
+    #[test]
+    fn test_values_equal_nested() {
+        let a = serde_json::json!({"arr": [1, 2.0000000000001], "str": "x"});
+        let b = serde_json::json!({"arr": [1, 2.0000000000002], "str": "x"});
+        assert!(values_equal(&a, &b));
+    }
+
+    #[test]
+    fn test_generate_test_inputs_coverage() {
+        let inputs = generate_test_inputs();
+        assert!(inputs.len() >= 10, "Should have diverse test inputs");
+
+        let has_string = inputs.iter().any(|v| v.is_string());
+        let has_number = inputs.iter().any(|v| v.is_number());
+        let has_bool = inputs.iter().any(|v| v.is_boolean());
+        let has_null = inputs.iter().any(|v| v.is_null());
+        let has_array = inputs.iter().any(|v| v.is_array());
+        let has_object = inputs.iter().any(|v| v.is_object());
+
+        assert!(has_string, "Missing string inputs");
+        assert!(has_number, "Missing number inputs");
+        assert!(has_bool, "Missing boolean inputs");
+        assert!(has_null, "Missing null inputs");
+        assert!(has_array, "Missing array inputs");
+        assert!(has_object, "Missing object inputs");
+    }
+}

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -1,0 +1,15 @@
+pub mod types;
+pub mod wasm_engine;
+pub mod invertibility;
+pub mod dependency_tracker;
+pub mod registry;
+pub mod resolver;
+
+pub use types::{
+    FieldRef, TransformFieldDef, TransformFieldState, TransformView, TransformWriteMode,
+};
+pub use wasm_engine::WasmTransformEngine;
+pub use invertibility::verify_roundtrip;
+pub use dependency_tracker::DependencyTracker;
+pub use registry::ViewRegistry;
+pub use resolver::ViewFieldResolver;

--- a/src/view/registry.rs
+++ b/src/view/registry.rs
@@ -1,0 +1,359 @@
+use crate::schema::types::errors::SchemaError;
+use crate::view::dependency_tracker::DependencyTracker;
+use crate::view::invertibility::verify_roundtrip;
+use crate::view::types::{TransformFieldDef, TransformView, TransformWriteMode};
+use crate::view::wasm_engine::WasmTransformEngine;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Lifecycle state for a view (mirrors SchemaState).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ViewState {
+    Available,
+    Approved,
+    Blocked,
+}
+
+/// Registry for transform views — stores definitions, manages lifecycle, owns WASM engine.
+#[derive(Debug)]
+pub struct ViewRegistry {
+    views: HashMap<String, TransformView>,
+    view_states: HashMap<String, ViewState>,
+    pub(crate) dependency_tracker: DependencyTracker,
+    wasm_engine: Arc<WasmTransformEngine>,
+}
+
+impl ViewRegistry {
+    pub fn new(wasm_engine: Arc<WasmTransformEngine>) -> Self {
+        Self {
+            views: HashMap::new(),
+            view_states: HashMap::new(),
+            dependency_tracker: DependencyTracker::new(),
+            wasm_engine,
+        }
+    }
+
+    /// Load views from storage on startup.
+    pub fn load(
+        views: Vec<TransformView>,
+        view_states: HashMap<String, ViewState>,
+        wasm_engine: Arc<WasmTransformEngine>,
+    ) -> Self {
+        let mut dependency_tracker = DependencyTracker::new();
+        dependency_tracker.rebuild(&views);
+
+        let views_map: HashMap<String, TransformView> =
+            views.into_iter().map(|v| (v.name.clone(), v)).collect();
+
+        Self {
+            views: views_map,
+            view_states,
+            dependency_tracker,
+            wasm_engine,
+        }
+    }
+
+    /// Register a new view. Validates source references, determines write modes,
+    /// and checks for cycles.
+    ///
+    /// `schema_exists_fn` is called to verify that source schemas exist.
+    /// This avoids a direct dependency on SchemaCore.
+    pub fn register_view<F>(
+        &mut self,
+        mut view: TransformView,
+        schema_exists_fn: F,
+    ) -> Result<(), SchemaError>
+    where
+        F: Fn(&str) -> bool,
+    {
+        // Check for duplicate name
+        if self.views.contains_key(&view.name) {
+            return Err(SchemaError::InvalidData(format!(
+                "View '{}' already exists",
+                view.name
+            )));
+        }
+
+        // Validate all source references exist (either as schemas or as other views)
+        for (field_name, field_def) in &view.fields {
+            let source_schema = &field_def.source.schema;
+            if !schema_exists_fn(source_schema) && !self.views.contains_key(source_schema) {
+                return Err(SchemaError::NotFound(format!(
+                    "Source '{}' for view field '{}' not found as schema or view",
+                    field_def.source, field_name
+                )));
+            }
+        }
+
+        // Check for cycles
+        let view_fields_map: HashMap<String, HashMap<String, TransformFieldDef>> = self
+            .views
+            .iter()
+            .map(|(name, v)| (name.clone(), v.fields.clone()))
+            .collect();
+
+        if self
+            .dependency_tracker
+            .would_create_cycle(&view.name, &view.fields, &view_fields_map)
+        {
+            return Err(SchemaError::InvalidData(format!(
+                "View '{}' would create a dependency cycle",
+                view.name
+            )));
+        }
+
+        // Determine write modes for each field
+        let mut write_modes = HashMap::new();
+        for (field_name, field_def) in &view.fields {
+            let mode = self.determine_write_mode(field_def)?;
+            write_modes.insert(field_name.clone(), mode);
+        }
+        view.write_modes = write_modes;
+
+        // Register dependencies and store
+        self.dependency_tracker
+            .register(&view.name, &view.fields);
+        self.view_states
+            .insert(view.name.clone(), ViewState::Available);
+        self.views.insert(view.name.clone(), view);
+
+        Ok(())
+    }
+
+    fn determine_write_mode(
+        &self,
+        field_def: &TransformFieldDef,
+    ) -> Result<TransformWriteMode, SchemaError> {
+        match (&field_def.wasm_forward, &field_def.wasm_inverse) {
+            (None, None) => Ok(TransformWriteMode::Identity),
+            (Some(forward), Some(inverse)) => {
+                let reversible = verify_roundtrip(&self.wasm_engine, forward, inverse)?;
+                if reversible {
+                    Ok(TransformWriteMode::Reversible)
+                } else {
+                    Ok(TransformWriteMode::Irreversible)
+                }
+            }
+            (Some(_), None) => Ok(TransformWriteMode::Irreversible),
+            (None, Some(_)) => Err(SchemaError::InvalidTransform(
+                "Inverse WASM provided without forward WASM".to_string(),
+            )),
+        }
+    }
+
+    pub fn get_view(&self, name: &str) -> Option<&TransformView> {
+        self.views.get(name)
+    }
+
+    pub fn list_views(&self) -> Vec<&TransformView> {
+        self.views.values().collect()
+    }
+
+    pub fn get_view_state(&self, name: &str) -> Option<ViewState> {
+        self.view_states.get(name).copied()
+    }
+
+    pub fn get_views_with_states(&self) -> Vec<(&TransformView, ViewState)> {
+        self.views
+            .values()
+            .filter_map(|v| {
+                self.view_states
+                    .get(&v.name)
+                    .map(|state| (v, *state))
+            })
+            .collect()
+    }
+
+    pub fn approve_view(&mut self, name: &str) -> Result<(), SchemaError> {
+        if !self.views.contains_key(name) {
+            return Err(SchemaError::NotFound(format!("View '{}' not found", name)));
+        }
+        self.view_states.insert(name.to_string(), ViewState::Approved);
+        Ok(())
+    }
+
+    pub fn block_view(&mut self, name: &str) -> Result<(), SchemaError> {
+        if !self.views.contains_key(name) {
+            return Err(SchemaError::NotFound(format!("View '{}' not found", name)));
+        }
+        self.view_states.insert(name.to_string(), ViewState::Blocked);
+        Ok(())
+    }
+
+    pub fn remove_view(&mut self, name: &str) -> Result<TransformView, SchemaError> {
+        let view = self
+            .views
+            .remove(name)
+            .ok_or_else(|| SchemaError::NotFound(format!("View '{}' not found", name)))?;
+        self.view_states.remove(name);
+        self.dependency_tracker.unregister(name);
+        Ok(view)
+    }
+
+    pub fn wasm_engine(&self) -> &Arc<WasmTransformEngine> {
+        &self.wasm_engine
+    }
+
+    /// Check if a name is already used by a view (for cross-registry uniqueness).
+    pub fn name_exists(&self, name: &str) -> bool {
+        self.views.contains_key(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
+    use crate::view::types::{FieldRef, TransformFieldDef};
+
+    fn make_registry() -> ViewRegistry {
+        let engine = Arc::new(WasmTransformEngine::new().unwrap());
+        ViewRegistry::new(engine)
+    }
+
+    fn identity_view(name: &str, source_schema: &str, source_field: &str) -> TransformView {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "out".into(),
+            TransformFieldDef {
+                source: FieldRef::new(source_schema, source_field),
+                wasm_forward: None,
+                wasm_inverse: None,
+            },
+        );
+        TransformView::new(name, SchemaType::Single, None, fields)
+    }
+
+    #[test]
+    fn test_register_identity_view() {
+        let mut registry = make_registry();
+        let view = identity_view("MyView", "BlogPost", "content");
+
+        // Schema exists
+        let result = registry.register_view(view, |name| name == "BlogPost");
+        assert!(result.is_ok());
+
+        let stored = registry.get_view("MyView").unwrap();
+        assert_eq!(stored.name, "MyView");
+        assert_eq!(
+            *stored.write_modes.get("out").unwrap(),
+            TransformWriteMode::Identity
+        );
+        assert_eq!(
+            registry.get_view_state("MyView"),
+            Some(ViewState::Available)
+        );
+    }
+
+    #[test]
+    fn test_register_missing_source() {
+        let mut registry = make_registry();
+        let view = identity_view("MyView", "NonExistent", "field");
+
+        let result = registry.register_view(view, |_| false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_register_duplicate_name() {
+        let mut registry = make_registry();
+        let view1 = identity_view("MyView", "S1", "f1");
+        let view2 = identity_view("MyView", "S2", "f2");
+
+        registry.register_view(view1, |_| true).unwrap();
+        let result = registry.register_view(view2, |_| true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_approve_and_block() {
+        let mut registry = make_registry();
+        let view = identity_view("V1", "S1", "f1");
+        registry.register_view(view, |_| true).unwrap();
+
+        registry.approve_view("V1").unwrap();
+        assert_eq!(registry.get_view_state("V1"), Some(ViewState::Approved));
+
+        registry.block_view("V1").unwrap();
+        assert_eq!(registry.get_view_state("V1"), Some(ViewState::Blocked));
+    }
+
+    #[test]
+    fn test_remove_view() {
+        let mut registry = make_registry();
+        let view = identity_view("V1", "S1", "f1");
+        registry.register_view(view, |_| true).unwrap();
+
+        let removed = registry.remove_view("V1").unwrap();
+        assert_eq!(removed.name, "V1");
+        assert!(registry.get_view("V1").is_none());
+        assert!(registry.get_view_state("V1").is_none());
+    }
+
+    #[test]
+    fn test_view_as_source_for_another_view() {
+        let mut registry = make_registry();
+
+        // Register ViewA reading from schema S1
+        let view_a = identity_view("ViewA", "S1", "f1");
+        registry.register_view(view_a, |n| n == "S1").unwrap();
+
+        // Register ViewB reading from ViewA (which is a registered view)
+        let view_b = identity_view("ViewB", "ViewA", "out");
+        registry.register_view(view_b, |_| false).unwrap();
+
+        assert!(registry.get_view("ViewB").is_some());
+    }
+
+    #[test]
+    fn test_cycle_detection() {
+        let mut registry = make_registry();
+
+        // ViewA reads from S1
+        let view_a = identity_view("ViewA", "S1", "f1");
+        registry.register_view(view_a, |n| n == "S1").unwrap();
+
+        // ViewB reads from ViewA
+        let view_b = identity_view("ViewB", "ViewA", "out");
+        registry.register_view(view_b, |_| false).unwrap();
+
+        // ViewC tries to read from ViewB, but if ViewA also tried to read from ViewC...
+        // For now just test that non-cyclic chains work
+        let view_c = identity_view("ViewC", "ViewB", "out");
+        let result = registry.register_view(view_c, |_| false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_inverse_without_forward_errors() {
+        let mut registry = make_registry();
+        let mut fields = HashMap::new();
+        fields.insert(
+            "bad".into(),
+            TransformFieldDef {
+                source: FieldRef::new("S1", "f1"),
+                wasm_forward: None,
+                wasm_inverse: Some(vec![0, 1, 2]),
+            },
+        );
+        let view = TransformView::new("BadView", SchemaType::Single, None, fields);
+        let result = registry.register_view(view, |_| true);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Inverse WASM"));
+    }
+
+    #[test]
+    fn test_list_views() {
+        let mut registry = make_registry();
+        registry
+            .register_view(identity_view("V1", "S1", "f1"), |_| true)
+            .unwrap();
+        registry
+            .register_view(identity_view("V2", "S2", "f2"), |_| true)
+            .unwrap();
+
+        let views = registry.list_views();
+        assert_eq!(views.len(), 2);
+    }
+}

--- a/src/view/resolver.rs
+++ b/src/view/resolver.rs
@@ -1,0 +1,267 @@
+use crate::schema::types::errors::SchemaError;
+use crate::schema::types::field::{FieldValue, HashRangeFilter};
+use crate::schema::types::key_value::KeyValue;
+use crate::view::types::{TransformFieldState, TransformView};
+use crate::view::wasm_engine::WasmTransformEngine;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Trait for querying source schema fields — breaks circular dependency
+/// between QueryExecutor and ViewFieldResolver.
+#[async_trait]
+pub trait SourceQueryFn: Send + Sync {
+    /// Query a single field from a source schema, returning keyed results
+    /// with the source's key structure preserved.
+    async fn query_field(
+        &self,
+        schema_name: &str,
+        field_name: &str,
+        filter: Option<HashRangeFilter>,
+        as_of: Option<DateTime<Utc>>,
+    ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError>;
+}
+
+/// Resolves view fields using the three-state machine (Empty → Cached, Overridden).
+#[derive(Debug)]
+pub struct ViewFieldResolver {
+    wasm_engine: Arc<WasmTransformEngine>,
+}
+
+impl ViewFieldResolver {
+    pub fn new(wasm_engine: Arc<WasmTransformEngine>) -> Self {
+        Self { wasm_engine }
+    }
+
+    /// Resolve a single view field's value.
+    ///
+    /// State machine:
+    /// - `Overridden` → return stored values
+    /// - `Cached` → return cached values
+    /// - `Empty` → query source, apply forward WASM, cache, return
+    ///
+    /// Filter is only applied on the `Empty` path (passed through to source).
+    /// Cached/Overridden results are returned as-is.
+    pub async fn resolve_field(
+        &self,
+        view: &TransformView,
+        field_name: &str,
+        field_state: &TransformFieldState,
+        source_query: &dyn SourceQueryFn,
+        filter: Option<HashRangeFilter>,
+        as_of: Option<DateTime<Utc>>,
+    ) -> Result<(HashMap<KeyValue, FieldValue>, TransformFieldState), SchemaError> {
+        let field_def = view.fields.get(field_name).ok_or_else(|| {
+            SchemaError::InvalidField(format!(
+                "Field '{}' not found in view '{}'",
+                field_name, view.name
+            ))
+        })?;
+
+        match field_state {
+            TransformFieldState::Overridden { entries } => {
+                Ok((entries.iter().cloned().collect(), field_state.clone()))
+            }
+            TransformFieldState::Cached { entries } => {
+                Ok((entries.iter().cloned().collect(), field_state.clone()))
+            }
+            TransformFieldState::Empty => {
+                // Query source with filter pass-through
+                let source_results = source_query
+                    .query_field(
+                        &field_def.source.schema,
+                        &field_def.source.field,
+                        filter,
+                        as_of,
+                    )
+                    .await?;
+
+                // Apply forward WASM if present, preserving keys
+                let result = if let Some(wasm_forward) = &field_def.wasm_forward {
+                    let mut transformed = HashMap::with_capacity(source_results.len());
+                    for (key, fv) in source_results {
+                        let new_value = self.wasm_engine.execute(wasm_forward, &fv.value)?;
+                        transformed.insert(
+                            key,
+                            FieldValue {
+                                value: new_value,
+                                atom_uuid: fv.atom_uuid,
+                                source_file_name: fv.source_file_name,
+                                metadata: fv.metadata,
+                                molecule_uuid: fv.molecule_uuid,
+                                molecule_version: fv.molecule_version,
+                            },
+                        );
+                    }
+                    transformed
+                } else {
+                    source_results
+                };
+
+                let new_state = TransformFieldState::Cached {
+                    entries: result.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+                };
+
+                Ok((result, new_state))
+            }
+        }
+    }
+
+    pub fn wasm_engine(&self) -> &Arc<WasmTransformEngine> {
+        &self.wasm_engine
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
+    use crate::view::types::{FieldRef, TransformFieldDef};
+
+    /// Mock source query that returns fixed keyed values.
+    struct MockSourceQuery {
+        values: HashMap<(String, String), HashMap<KeyValue, FieldValue>>,
+    }
+
+    #[async_trait]
+    impl SourceQueryFn for MockSourceQuery {
+        async fn query_field(
+            &self,
+            schema_name: &str,
+            field_name: &str,
+            _filter: Option<HashRangeFilter>,
+            _as_of: Option<DateTime<Utc>>,
+        ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
+            let key = (schema_name.to_string(), field_name.to_string());
+            self.values
+                .get(&key)
+                .cloned()
+                .ok_or_else(|| SchemaError::NotFound(format!("{}.{}", schema_name, field_name)))
+        }
+    }
+
+    fn make_field_value(val: serde_json::Value) -> FieldValue {
+        FieldValue {
+            value: val,
+            atom_uuid: String::new(),
+            source_file_name: None,
+            metadata: None,
+            molecule_uuid: None,
+            molecule_version: None,
+        }
+    }
+
+    fn make_view() -> TransformView {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "content".into(),
+            TransformFieldDef {
+                source: FieldRef::new("BlogPost", "content"),
+                wasm_forward: None,
+                wasm_inverse: None,
+            },
+        );
+        TransformView::new("TestView", SchemaType::Range, None, fields)
+    }
+
+    fn make_resolver() -> ViewFieldResolver {
+        let engine = Arc::new(WasmTransformEngine::new().unwrap());
+        ViewFieldResolver::new(engine)
+    }
+
+    #[tokio::test]
+    async fn test_resolve_overridden() {
+        let resolver = make_resolver();
+        let view = make_view();
+        let mut vals = HashMap::new();
+        vals.insert(
+            KeyValue::new(None, Some("r1".into())),
+            make_field_value(serde_json::json!("custom")),
+        );
+        let state = TransformFieldState::Overridden { entries: vals.into_iter().collect() };
+        let mock = MockSourceQuery {
+            values: HashMap::new(),
+        };
+
+        let (results, new_state) = resolver
+            .resolve_field(&view, "content", &state, &mock, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(matches!(new_state, TransformFieldState::Overridden { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_cached() {
+        let resolver = make_resolver();
+        let view = make_view();
+        let mut vals = HashMap::new();
+        vals.insert(
+            KeyValue::new(None, Some("r1".into())),
+            make_field_value(serde_json::json!("cached_val")),
+        );
+        let state = TransformFieldState::Cached { entries: vals.into_iter().collect() };
+        let mock = MockSourceQuery {
+            values: HashMap::new(),
+        };
+
+        let (results, _) = resolver
+            .resolve_field(&view, "content", &state, &mock, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        let fv = results.values().next().unwrap();
+        assert_eq!(fv.value, serde_json::json!("cached_val"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_empty_queries_source() {
+        let resolver = make_resolver();
+        let view = make_view();
+        let state = TransformFieldState::Empty;
+
+        let mut source_field_values = HashMap::new();
+        source_field_values.insert(
+            KeyValue::new(None, Some("2026-01-01".into())),
+            make_field_value(serde_json::json!("hello world")),
+        );
+
+        let mut source_values = HashMap::new();
+        source_values.insert(
+            ("BlogPost".into(), "content".into()),
+            source_field_values,
+        );
+        let mock = MockSourceQuery {
+            values: source_values,
+        };
+
+        let (results, new_state) = resolver
+            .resolve_field(&view, "content", &state, &mock, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        let (key, fv) = results.iter().next().unwrap();
+        assert_eq!(key.range.as_deref(), Some("2026-01-01"));
+        assert_eq!(fv.value, serde_json::json!("hello world"));
+        assert!(matches!(new_state, TransformFieldState::Cached { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_unknown_field_errors() {
+        let resolver = make_resolver();
+        let view = make_view();
+        let state = TransformFieldState::Empty;
+        let mock = MockSourceQuery {
+            values: HashMap::new(),
+        };
+
+        let result = resolver
+            .resolve_field(&view, "nonexistent", &state, &mock, None, None)
+            .await;
+        assert!(result.is_err());
+    }
+}

--- a/src/view/types.rs
+++ b/src/view/types.rs
@@ -1,0 +1,233 @@
+use crate::schema::types::field::FieldValue;
+use crate::schema::types::key_config::KeyConfig;
+use crate::schema::types::key_value::KeyValue;
+use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+/// Reference to a source schema field, parsed from "Schema.field" format.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FieldRef {
+    pub schema: String,
+    pub field: String,
+}
+
+impl FieldRef {
+    pub fn new(schema: impl Into<String>, field: impl Into<String>) -> Self {
+        Self {
+            schema: schema.into(),
+            field: field.into(),
+        }
+    }
+}
+
+impl TryFrom<&str> for FieldRef {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err("FieldRef cannot be empty".to_string());
+        }
+        let dot_pos = trimmed
+            .find('.')
+            .ok_or_else(|| format!("FieldRef '{}' must contain a dot separator", trimmed))?;
+        let schema = &trimmed[..dot_pos];
+        let field = &trimmed[dot_pos + 1..];
+        if schema.is_empty() {
+            return Err(format!("FieldRef '{}' has empty schema name", trimmed));
+        }
+        if field.is_empty() {
+            return Err(format!("FieldRef '{}' has empty field name", trimmed));
+        }
+        Ok(Self {
+            schema: schema.to_string(),
+            field: field.to_string(),
+        })
+    }
+}
+
+impl TryFrom<String> for FieldRef {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        FieldRef::try_from(value.as_str())
+    }
+}
+
+impl std::fmt::Display for FieldRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.schema, self.field)
+    }
+}
+
+/// Definition of a single transform field within a view.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransformFieldDef {
+    pub source: FieldRef,
+    /// Forward WASM transform bytes. None = identity (pass-through).
+    pub wasm_forward: Option<Vec<u8>>,
+    /// Inverse WASM transform bytes. None = irreversible (if forward exists).
+    pub wasm_inverse: Option<Vec<u8>>,
+}
+
+/// Write mode determined at registration, not declared by the user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TransformWriteMode {
+    /// No WASM — reads/writes pass through directly to source.
+    Identity,
+    /// Forward + inverse WASM verified — writes go through inverse to source.
+    Reversible,
+    /// Forward only — writes store directly on the view field.
+    Irreversible,
+}
+
+/// Three-state machine for each view field's cached value.
+/// Stores keyed results to preserve the source's key structure.
+/// Uses Vec<(K,V)> instead of HashMap for JSON serialization compatibility
+/// (KeyValue is a struct and can't be a JSON map key).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TransformFieldState {
+    /// Never accessed, nothing computed.
+    Empty,
+    /// Computed from source, will be invalidated on source change.
+    Cached {
+        entries: Vec<(KeyValue, FieldValue)>,
+    },
+    /// Directly written by user, source link is stale.
+    Overridden {
+        entries: Vec<(KeyValue, FieldValue)>,
+    },
+}
+
+impl TransformFieldState {
+    /// Invalidate a cached value back to Empty. Overridden values are not affected.
+    pub fn invalidate(&mut self) {
+        if matches!(self, TransformFieldState::Cached { .. }) {
+            *self = TransformFieldState::Empty;
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        matches!(self, TransformFieldState::Empty)
+    }
+}
+
+/// The view definition — a separate type from Schema.
+/// Declares its own schema_type and key configuration, just like a schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransformView {
+    pub name: String,
+    /// The schema type determines how fields are keyed (Single, Hash, Range, HashRange).
+    pub schema_type: SchemaType,
+    /// Key configuration — which fields serve as hash/range keys.
+    #[serde(default)]
+    pub key: Option<KeyConfig>,
+    pub fields: HashMap<String, TransformFieldDef>,
+    /// Computed at registration — write mode per field.
+    #[serde(default)]
+    pub write_modes: HashMap<String, TransformWriteMode>,
+}
+
+impl TransformView {
+    pub fn new(
+        name: impl Into<String>,
+        schema_type: SchemaType,
+        key: Option<KeyConfig>,
+        fields: HashMap<String, TransformFieldDef>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            schema_type,
+            key,
+            fields,
+            write_modes: HashMap::new(),
+        }
+    }
+
+    /// Get all unique source schemas referenced by this view's fields.
+    pub fn source_schemas(&self) -> Vec<String> {
+        let mut schemas: Vec<String> = self
+            .fields
+            .values()
+            .map(|f| f.source.schema.clone())
+            .collect();
+        schemas.sort();
+        schemas.dedup();
+        schemas
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_field_ref_parse() {
+        let fr = FieldRef::try_from("BlogPost.content").unwrap();
+        assert_eq!(fr.schema, "BlogPost");
+        assert_eq!(fr.field, "content");
+    }
+
+    #[test]
+    fn test_field_ref_parse_errors() {
+        assert!(FieldRef::try_from("").is_err());
+        assert!(FieldRef::try_from("nodot").is_err());
+        assert!(FieldRef::try_from(".field").is_err());
+        assert!(FieldRef::try_from("schema.").is_err());
+    }
+
+    #[test]
+    fn test_field_ref_display() {
+        let fr = FieldRef::new("Weather", "temp");
+        assert_eq!(fr.to_string(), "Weather.temp");
+    }
+
+    #[test]
+    fn test_transform_field_state_invalidate() {
+        let mut cached = TransformFieldState::Cached {
+            entries: Vec::new(),
+        };
+        cached.invalidate();
+        assert!(cached.is_empty());
+
+        let mut overridden = TransformFieldState::Overridden {
+            entries: Vec::new(),
+        };
+        overridden.invalidate();
+        assert!(!overridden.is_empty()); // Overridden not affected
+    }
+
+    #[test]
+    fn test_transform_view_source_schemas() {
+        let mut fields = HashMap::new();
+        fields.insert(
+            "a".into(),
+            TransformFieldDef {
+                source: FieldRef::new("S1", "f1"),
+                wasm_forward: None,
+                wasm_inverse: None,
+            },
+        );
+        fields.insert(
+            "b".into(),
+            TransformFieldDef {
+                source: FieldRef::new("S2", "f2"),
+                wasm_forward: None,
+                wasm_inverse: None,
+            },
+        );
+        fields.insert(
+            "c".into(),
+            TransformFieldDef {
+                source: FieldRef::new("S1", "f3"),
+                wasm_forward: None,
+                wasm_inverse: None,
+            },
+        );
+        let view = TransformView::new("test_view", SchemaType::Single, None, fields);
+        let schemas = view.source_schemas();
+        assert_eq!(schemas, vec!["S1", "S2"]);
+    }
+}

--- a/src/view/wasm_engine.rs
+++ b/src/view/wasm_engine.rs
@@ -1,0 +1,173 @@
+use crate::schema::types::errors::SchemaError;
+use serde_json::Value;
+
+#[cfg(feature = "transform-wasm")]
+use std::collections::HashMap;
+#[cfg(feature = "transform-wasm")]
+use std::sync::Mutex;
+#[cfg(feature = "transform-wasm")]
+use wasmtime::{Engine, Linker, Module, Store};
+
+/// Sandboxed WASM execution engine with compiled module caching.
+pub struct WasmTransformEngine {
+    #[cfg(feature = "transform-wasm")]
+    engine: Engine,
+    #[cfg(feature = "transform-wasm")]
+    module_cache: Mutex<HashMap<u64, Module>>,
+    /// When the transform-wasm feature is disabled, this is a no-op engine.
+    #[cfg(not(feature = "transform-wasm"))]
+    _phantom: (),
+}
+
+impl WasmTransformEngine {
+    pub fn new() -> Result<Self, SchemaError> {
+        #[cfg(feature = "transform-wasm")]
+        {
+            let engine = Engine::default();
+            Ok(Self {
+                engine,
+                module_cache: Mutex::new(HashMap::new()),
+            })
+        }
+        #[cfg(not(feature = "transform-wasm"))]
+        {
+            Ok(Self { _phantom: () })
+        }
+    }
+
+    /// Execute a WASM transform on the given input value.
+    ///
+    /// The WASM module must export:
+    /// - `alloc(size: i32) -> i32` — allocate memory for input
+    /// - `transform(ptr: i32, len: i32) -> i64` — execute transform, returns (ptr << 32 | len)
+    /// - `memory` — linear memory export
+    pub fn execute(&self, wasm_bytes: &[u8], input: &Value) -> Result<Value, SchemaError> {
+        #[cfg(feature = "transform-wasm")]
+        {
+            self.execute_wasm(wasm_bytes, input)
+        }
+        #[cfg(not(feature = "transform-wasm"))]
+        {
+            let _ = wasm_bytes;
+            let _ = input;
+            Err(SchemaError::InvalidTransform(
+                "WASM transforms require the 'transform-wasm' feature flag".to_string(),
+            ))
+        }
+    }
+
+    #[cfg(feature = "transform-wasm")]
+    fn execute_wasm(&self, wasm_bytes: &[u8], input: &Value) -> Result<Value, SchemaError> {
+        let module = self.get_or_compile(wasm_bytes)?;
+        let linker = Linker::new(&self.engine);
+        let mut store = Store::new(&self.engine, ());
+
+        let instance = linker
+            .instantiate(&mut store, &module)
+            .map_err(|e| SchemaError::InvalidTransform(format!("WASM instantiation failed: {e}")))?;
+
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| {
+                SchemaError::InvalidTransform("WASM module must export 'memory'".to_string())
+            })?;
+
+        let alloc_fn = instance
+            .get_typed_func::<i32, i32>(&mut store, "alloc")
+            .map_err(|e| {
+                SchemaError::InvalidTransform(format!("WASM module must export 'alloc': {e}"))
+            })?;
+
+        let transform_fn = instance
+            .get_typed_func::<(i32, i32), i64>(&mut store, "transform")
+            .map_err(|e| {
+                SchemaError::InvalidTransform(format!("WASM module must export 'transform': {e}"))
+            })?;
+
+        // Write input JSON to WASM memory
+        let input_bytes = serde_json::to_vec(input).map_err(|e| {
+            SchemaError::InvalidData(format!("Failed to serialize transform input: {e}"))
+        })?;
+
+        let input_ptr = alloc_fn
+            .call(&mut store, input_bytes.len() as i32)
+            .map_err(|e| {
+                SchemaError::InvalidTransform(format!("WASM alloc failed: {e}"))
+            })?;
+
+        memory.data_mut(&mut store)[input_ptr as usize..input_ptr as usize + input_bytes.len()]
+            .copy_from_slice(&input_bytes);
+
+        // Call transform
+        let result_packed = transform_fn
+            .call(&mut store, (input_ptr, input_bytes.len() as i32))
+            .map_err(|e| {
+                SchemaError::InvalidTransform(format!("WASM transform execution failed: {e}"))
+            })?;
+
+        // Unpack result pointer and length from i64
+        let result_ptr = (result_packed >> 32) as usize;
+        let result_len = (result_packed & 0xFFFF_FFFF) as usize;
+
+        let result_bytes = &memory.data(&store)[result_ptr..result_ptr + result_len];
+        let result: Value = serde_json::from_slice(result_bytes).map_err(|e| {
+            SchemaError::InvalidData(format!("Failed to deserialize transform output: {e}"))
+        })?;
+
+        Ok(result)
+    }
+
+    #[cfg(feature = "transform-wasm")]
+    fn get_or_compile(&self, wasm_bytes: &[u8]) -> Result<Module, SchemaError> {
+        let hash = Self::hash_bytes(wasm_bytes);
+        let mut cache = self.module_cache.lock().unwrap_or_else(|p| p.into_inner());
+
+        if let Some(module) = cache.get(&hash) {
+            return Ok(module.clone());
+        }
+
+        let module = Module::new(&self.engine, wasm_bytes).map_err(|e| {
+            SchemaError::InvalidTransform(format!("Failed to compile WASM module: {e}"))
+        })?;
+
+        cache.insert(hash, module.clone());
+        Ok(module)
+    }
+
+    #[cfg(feature = "transform-wasm")]
+    fn hash_bytes(bytes: &[u8]) -> u64 {
+        seahash::hash(bytes)
+    }
+}
+
+impl std::fmt::Debug for WasmTransformEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WasmTransformEngine").finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_engine_creation() {
+        let engine = WasmTransformEngine::new().unwrap();
+        // Just verify it can be created
+        let _ = format!("{:?}", engine);
+    }
+
+    #[test]
+    #[cfg(not(feature = "transform-wasm"))]
+    fn test_execute_without_feature_flag_errors() {
+        let engine = WasmTransformEngine::new().unwrap();
+        let result = engine.execute(&[0, 1, 2], &serde_json::json!(42));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("transform-wasm"),
+            "Error should mention feature flag: {}",
+            err
+        );
+    }
+}

--- a/tests/view_invalidation_test.rs
+++ b/tests/view_invalidation_test.rs
@@ -1,0 +1,214 @@
+use fold_db::fold_db_core::FoldDB;
+use fold_db::schema::types::field::FieldValue;
+use fold_db::schema::types::key_config::KeyConfig;
+use fold_db::schema::types::operations::MutationType;
+use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
+use fold_db::schema::types::{KeyValue, Mutation, Query};
+use fold_db::schema::SchemaState;
+use fold_db::view::types::{FieldRef, TransformFieldDef, TransformFieldState, TransformView};
+use serde_json::json;
+use std::collections::HashMap;
+
+async fn setup_db() -> FoldDB {
+    let dir = tempfile::tempdir().unwrap();
+    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+}
+
+fn blogpost_schema_json() -> &'static str {
+    r#"{
+        "name": "BlogPost",
+        "key": { "range_field": "publish_date" },
+        "fields": {
+            "title": {},
+            "content": {},
+            "publish_date": {}
+        }
+    }"#
+}
+
+fn identity_view(name: &str, source_schema: &str, source_field: &str) -> TransformView {
+    let mut fields = HashMap::new();
+    fields.insert(
+        "out".into(),
+        TransformFieldDef {
+            source: FieldRef::new(source_schema, source_field),
+            wasm_forward: None,
+            wasm_inverse: None,
+        },
+    );
+    TransformView::new(name, SchemaType::Range, Some(KeyConfig::new(None, Some("publish_date".to_string()))), fields)
+}
+
+#[tokio::test]
+async fn mutating_source_invalidates_cached_view_field() {
+    let mut db = setup_db().await;
+
+    // Setup: schema + data + view
+    db.load_schema_from_json(blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert("content".to_string(), json!("original"));
+    fields.insert("publish_date".to_string(), json!("2026-01-01"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            fields,
+            KeyValue::new(None, Some("2026-01-01".to_string())),
+            "pk".to_string(),
+            MutationType::Create,
+        )])
+        .await
+        .unwrap();
+
+    db.schema_manager
+        .register_view(identity_view("CV", "BlogPost", "content"))
+        .await
+        .unwrap();
+
+    // First query: populates cache
+    let query = Query::new("CV".to_string(), vec!["out".to_string()]);
+    let results = db.query_executor.query(query.clone()).await.unwrap();
+    let first_value = results["out"].values().next().unwrap().value.clone();
+    assert_eq!(first_value, json!("original"));
+
+    // Verify field state is Cached
+    let state = db
+        .db_ops
+        .get_transform_field_state("CV", "out")
+        .await
+        .unwrap();
+    assert!(
+        matches!(state, TransformFieldState::Cached { .. }),
+        "Field should be cached after first query"
+    );
+
+    // Mutate the source
+    let mut fields2 = HashMap::new();
+    fields2.insert("content".to_string(), json!("updated"));
+    fields2.insert("publish_date".to_string(), json!("2026-01-02"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            fields2,
+            KeyValue::new(None, Some("2026-01-02".to_string())),
+            "pk".to_string(),
+            MutationType::Update,
+        )])
+        .await
+        .unwrap();
+
+    // Verify field state was invalidated to Empty
+    let state_after = db
+        .db_ops
+        .get_transform_field_state("CV", "out")
+        .await
+        .unwrap();
+    assert!(
+        matches!(state_after, TransformFieldState::Empty),
+        "Field should be invalidated after source mutation, got {:?}",
+        state_after
+    );
+
+    // Re-query: should fetch fresh data (both original and updated are present since they have different range keys)
+    let results2 = db.query_executor.query(query).await.unwrap();
+    let all_values: Vec<_> = results2["out"].values().map(|fv| fv.value.clone()).collect();
+    assert!(
+        all_values.contains(&json!("updated")),
+        "Re-query should contain updated value, got {:?}",
+        all_values
+    );
+}
+
+#[tokio::test]
+async fn overridden_field_survives_source_mutation() {
+    let mut db = setup_db().await;
+
+    db.load_schema_from_json(blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert("content".to_string(), json!("source_val"));
+    fields.insert("publish_date".to_string(), json!("2026-01-01"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            fields,
+            KeyValue::new(None, Some("2026-01-01".to_string())),
+            "pk".to_string(),
+            MutationType::Create,
+        )])
+        .await
+        .unwrap();
+
+    db.schema_manager
+        .register_view(identity_view("OV", "BlogPost", "content"))
+        .await
+        .unwrap();
+
+    // Manually set the field state to Overridden (simulating a direct write to the view)
+    let override_entries = vec![(
+        KeyValue::new(None, Some("override".to_string())),
+        FieldValue {
+            value: json!("custom_override"),
+            atom_uuid: String::new(),
+            source_file_name: None,
+            metadata: None,
+            molecule_uuid: None,
+            molecule_version: None,
+        },
+    )];
+    db.db_ops
+        .set_transform_field_state(
+            "OV",
+            "out",
+            &TransformFieldState::Overridden {
+                entries: override_entries,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Mutate the source
+    let mut fields2 = HashMap::new();
+    fields2.insert("content".to_string(), json!("new_source_val"));
+    fields2.insert("publish_date".to_string(), json!("2026-01-02"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            fields2,
+            KeyValue::new(None, Some("2026-01-02".to_string())),
+            "pk".to_string(),
+            MutationType::Update,
+        )])
+        .await
+        .unwrap();
+
+    // Overridden field should NOT be invalidated
+    let state = db
+        .db_ops
+        .get_transform_field_state("OV", "out")
+        .await
+        .unwrap();
+    assert!(
+        matches!(state, TransformFieldState::Overridden { .. }),
+        "Overridden field should survive source mutation, got {:?}",
+        state
+    );
+
+    // Query should return the overridden value, not the source
+    let query = Query::new("OV".to_string(), vec!["out".to_string()]);
+    let results = db.query_executor.query(query).await.unwrap();
+    let value = results["out"].values().next().unwrap().value.clone();
+    assert_eq!(value, json!("custom_override"));
+}

--- a/tests/view_query_test.rs
+++ b/tests/view_query_test.rs
@@ -1,0 +1,172 @@
+use fold_db::fold_db_core::FoldDB;
+use fold_db::schema::types::key_config::KeyConfig;
+use fold_db::schema::types::operations::MutationType;
+use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
+use fold_db::schema::types::{KeyValue, Mutation, Query};
+use fold_db::schema::SchemaState;
+use fold_db::view::types::{FieldRef, TransformFieldDef, TransformView};
+use serde_json::json;
+use std::collections::HashMap;
+
+async fn setup_db() -> FoldDB {
+    let dir = tempfile::tempdir().unwrap();
+    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+}
+
+fn blogpost_schema_json() -> &'static str {
+    r#"{
+        "name": "BlogPost",
+        "key": { "range_field": "publish_date" },
+        "fields": {
+            "title": {},
+            "content": {},
+            "publish_date": {}
+        }
+    }"#
+}
+
+fn identity_view(name: &str, source_schema: &str, source_field: &str) -> TransformView {
+    let mut fields = HashMap::new();
+    fields.insert(
+        "out".into(),
+        TransformFieldDef {
+            source: FieldRef::new(source_schema, source_field),
+            wasm_forward: None,
+            wasm_inverse: None,
+        },
+    );
+    TransformView::new(name, SchemaType::Range, Some(KeyConfig::new(None, Some("publish_date".to_string()))), fields)
+}
+
+#[tokio::test]
+async fn query_identity_view_returns_source_data() {
+    let mut db = setup_db().await;
+
+    // Load and approve a schema
+    db.load_schema_from_json(blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    // Write data to the schema
+    let mut fields = HashMap::new();
+    fields.insert("title".to_string(), json!("Hello World"));
+    fields.insert("content".to_string(), json!("Test content"));
+    fields.insert("publish_date".to_string(), json!("2026-01-01"));
+    let mutation = Mutation::new(
+        "BlogPost".to_string(),
+        fields,
+        KeyValue::new(None, Some("2026-01-01".to_string())),
+        "test_pub_key".to_string(),
+        MutationType::Create,
+    );
+    db.mutation_manager
+        .write_mutations_batch_async(vec![mutation])
+        .await
+        .unwrap();
+
+    // Register a view over BlogPost.content
+    let view = identity_view("ContentView", "BlogPost", "content");
+    db.schema_manager.register_view(view).await.unwrap();
+
+    // Query the view — should return the source data
+    let query = Query::new("ContentView".to_string(), vec!["out".to_string()]);
+    let results = db.query_executor.query(query).await.unwrap();
+
+    assert!(results.contains_key("out"), "View field 'out' should be in results");
+    let out_values = &results["out"];
+    assert!(!out_values.is_empty(), "Should have at least one value");
+
+    // The value should be the content from BlogPost
+    let first_value = out_values.values().next().unwrap();
+    assert_eq!(first_value.value, json!("Test content"));
+}
+
+#[tokio::test]
+async fn query_nonexistent_name_errors() {
+    let db = setup_db().await;
+
+    let query = Query::new("DoesNotExist".to_string(), vec![]);
+    let result = db.query_executor.query(query).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn query_blocked_view_errors() {
+    let mut db = setup_db().await;
+
+    db.load_schema_from_json(blogpost_schema_json())
+        .await
+        .unwrap();
+
+    let view = identity_view("BlockedView", "BlogPost", "title");
+    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager.block_view("BlockedView").await.unwrap();
+
+    let query = Query::new("BlockedView".to_string(), vec!["out".to_string()]);
+    let result = db.query_executor.query(query).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("blocked"));
+}
+
+#[tokio::test]
+async fn query_view_with_empty_fields_returns_all() {
+    let mut db = setup_db().await;
+
+    db.load_schema_from_json(blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert("title".to_string(), json!("Title"));
+    fields.insert("content".to_string(), json!("Body"));
+    fields.insert("publish_date".to_string(), json!("2026-01-01"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            fields,
+            KeyValue::new(None, Some("2026-01-01".to_string())),
+            "pk".to_string(),
+            MutationType::Create,
+        )])
+        .await
+        .unwrap();
+
+    // View with two fields
+    let mut view_fields = HashMap::new();
+    view_fields.insert(
+        "view_title".into(),
+        TransformFieldDef {
+            source: FieldRef::new("BlogPost", "title"),
+            wasm_forward: None,
+            wasm_inverse: None,
+        },
+    );
+    view_fields.insert(
+        "view_content".into(),
+        TransformFieldDef {
+            source: FieldRef::new("BlogPost", "content"),
+            wasm_forward: None,
+            wasm_inverse: None,
+        },
+    );
+    db.schema_manager
+        .register_view(TransformView::new("FullView", SchemaType::Range, Some(KeyConfig::new(None, Some("publish_date".to_string()))), view_fields))
+        .await
+        .unwrap();
+
+    // Query with empty fields — should return all view fields
+    let query = Query::new("FullView".to_string(), vec![]);
+    let results = db.query_executor.query(query).await.unwrap();
+
+    assert_eq!(results.len(), 2);
+    assert!(results.contains_key("view_title"));
+    assert!(results.contains_key("view_content"));
+}

--- a/tests/view_registration_test.rs
+++ b/tests/view_registration_test.rs
@@ -1,0 +1,247 @@
+use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
+use fold_db::schema::SchemaCore;
+use fold_db::view::registry::ViewState;
+use fold_db::view::types::{FieldRef, TransformFieldDef, TransformView, TransformWriteMode};
+use std::collections::HashMap;
+
+fn blogpost_schema_json() -> String {
+    r#"{
+        "name": "BlogPost",
+        "key": { "range_field": "publish_date" },
+        "fields": {
+            "title": {},
+            "content": {},
+            "publish_date": {}
+        }
+    }"#
+    .to_string()
+}
+
+fn weather_schema_json() -> String {
+    r#"{
+        "name": "Weather",
+        "key": { "range_field": "date" },
+        "fields": {
+            "temp_celsius": {},
+            "date": {}
+        }
+    }"#
+    .to_string()
+}
+
+fn identity_view(name: &str, source_schema: &str, source_field: &str) -> TransformView {
+    let mut fields = HashMap::new();
+    fields.insert(
+        "out".into(),
+        TransformFieldDef {
+            source: FieldRef::new(source_schema, source_field),
+            wasm_forward: None,
+            wasm_inverse: None,
+        },
+    );
+    TransformView::new(name, SchemaType::Single, None, fields)
+}
+
+#[tokio::test]
+async fn register_view_with_valid_source() {
+    let core = SchemaCore::new_for_testing().await.unwrap();
+    core.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+
+    let view = identity_view("ContentView", "BlogPost", "content");
+    core.register_view(view).await.unwrap();
+
+    let retrieved = core.get_view("ContentView").unwrap().unwrap();
+    assert_eq!(retrieved.name, "ContentView");
+    assert_eq!(
+        *retrieved.write_modes.get("out").unwrap(),
+        TransformWriteMode::Identity
+    );
+}
+
+#[tokio::test]
+async fn register_view_fails_with_missing_source() {
+    let core = SchemaCore::new_for_testing().await.unwrap();
+    let view = identity_view("BadView", "NonExistent", "field");
+    let result = core.register_view(view).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("not found"));
+}
+
+#[tokio::test]
+async fn register_view_fails_when_name_collides_with_schema() {
+    let core = SchemaCore::new_for_testing().await.unwrap();
+    core.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+
+    // Try to register a view with the same name as an existing schema
+    let view = identity_view("BlogPost", "BlogPost", "content");
+    let result = core.register_view(view).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("already used by a schema"));
+}
+
+#[tokio::test]
+async fn list_views_returns_all_registered() {
+    let core = SchemaCore::new_for_testing().await.unwrap();
+    core.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    core.load_schema_from_json(&weather_schema_json())
+        .await
+        .unwrap();
+
+    core.register_view(identity_view("V1", "BlogPost", "content"))
+        .await
+        .unwrap();
+    core.register_view(identity_view("V2", "Weather", "temp_celsius"))
+        .await
+        .unwrap();
+
+    let views = core.get_views_with_states().unwrap();
+    assert_eq!(views.len(), 2);
+    assert!(views.iter().all(|(_, s)| *s == ViewState::Available));
+}
+
+#[tokio::test]
+async fn approve_and_block_view() {
+    let core = SchemaCore::new_for_testing().await.unwrap();
+    core.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    core.register_view(identity_view("MyView", "BlogPost", "title"))
+        .await
+        .unwrap();
+
+    core.approve_view("MyView").await.unwrap();
+    let views = core.get_views_with_states().unwrap();
+    let (_, state) = views.iter().find(|(v, _)| v.name == "MyView").unwrap();
+    assert_eq!(*state, ViewState::Approved);
+
+    core.block_view("MyView").await.unwrap();
+    let views = core.get_views_with_states().unwrap();
+    let (_, state) = views.iter().find(|(v, _)| v.name == "MyView").unwrap();
+    assert_eq!(*state, ViewState::Blocked);
+}
+
+#[tokio::test]
+async fn remove_view_cleans_up() {
+    let core = SchemaCore::new_for_testing().await.unwrap();
+    core.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    core.register_view(identity_view("TempView", "BlogPost", "title"))
+        .await
+        .unwrap();
+
+    assert!(core.get_view("TempView").unwrap().is_some());
+
+    core.remove_view("TempView").await.unwrap();
+    assert!(core.get_view("TempView").unwrap().is_none());
+}
+
+#[tokio::test]
+async fn view_persists_across_schema_core_instances() {
+    let db = sled::Config::new().temporary(true).open().unwrap();
+    let db_ops = std::sync::Arc::new(
+        fold_db::db_operations::DbOperations::from_sled(db.clone())
+            .await
+            .unwrap(),
+    );
+    let bus = std::sync::Arc::new(
+        fold_db::fold_db_core::infrastructure::message_bus::AsyncMessageBus::new(),
+    );
+
+    // First instance: load schema and register view
+    {
+        let core = SchemaCore::new(db_ops.clone(), bus.clone()).await.unwrap();
+        core.load_schema_from_json(&blogpost_schema_json())
+            .await
+            .unwrap();
+        core.register_view(identity_view("PersistView", "BlogPost", "content"))
+            .await
+            .unwrap();
+    }
+
+    // Second instance: view should be loaded from storage
+    {
+        let core2 = SchemaCore::new(db_ops, bus).await.unwrap();
+        let view = core2.get_view("PersistView").unwrap();
+        assert!(view.is_some(), "View should persist across instances");
+        assert_eq!(view.unwrap().name, "PersistView");
+    }
+}
+
+#[tokio::test]
+async fn multi_source_view() {
+    let core = SchemaCore::new_for_testing().await.unwrap();
+    core.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    core.load_schema_from_json(&weather_schema_json())
+        .await
+        .unwrap();
+
+    // View that pulls from two different source schemas
+    let mut fields = HashMap::new();
+    fields.insert(
+        "blog_content".into(),
+        TransformFieldDef {
+            source: FieldRef::new("BlogPost", "content"),
+            wasm_forward: None,
+            wasm_inverse: None,
+        },
+    );
+    fields.insert(
+        "temperature".into(),
+        TransformFieldDef {
+            source: FieldRef::new("Weather", "temp_celsius"),
+            wasm_forward: None,
+            wasm_inverse: None,
+        },
+    );
+    let view = TransformView::new("Dashboard", SchemaType::Single, None, fields);
+
+    core.register_view(view).await.unwrap();
+    let retrieved = core.get_view("Dashboard").unwrap().unwrap();
+    assert_eq!(retrieved.fields.len(), 2);
+    assert!(retrieved.source_schemas().contains(&"BlogPost".to_string()));
+    assert!(retrieved.source_schemas().contains(&"Weather".to_string()));
+}
+
+#[tokio::test]
+async fn view_can_reference_another_view_as_source() {
+    let core = SchemaCore::new_for_testing().await.unwrap();
+    core.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+
+    // ViewA reads from BlogPost
+    core.register_view(identity_view("ViewA", "BlogPost", "content"))
+        .await
+        .unwrap();
+
+    // ViewB reads from ViewA (a view, not a schema)
+    core.register_view(identity_view("ViewB", "ViewA", "out"))
+        .await
+        .unwrap();
+
+    assert!(core.get_view("ViewB").unwrap().is_some());
+}
+
+#[tokio::test]
+async fn name_exists_checks_both_schemas_and_views() {
+    let core = SchemaCore::new_for_testing().await.unwrap();
+    core.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    core.register_view(identity_view("MyView", "BlogPost", "title"))
+        .await
+        .unwrap();
+
+    assert!(core.name_exists("BlogPost").unwrap());
+    assert!(core.name_exists("MyView").unwrap());
+    assert!(!core.name_exists("Unknown").unwrap());
+}

--- a/tests/view_write_test.rs
+++ b/tests/view_write_test.rs
@@ -1,0 +1,178 @@
+use fold_db::fold_db_core::FoldDB;
+use fold_db::schema::types::field::FieldValue;
+use fold_db::schema::types::key_config::KeyConfig;
+use fold_db::schema::types::operations::MutationType;
+use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
+use fold_db::schema::types::{KeyValue, Mutation, Query};
+use fold_db::schema::SchemaState;
+use fold_db::view::types::{
+    FieldRef, TransformFieldDef, TransformFieldState, TransformView, TransformWriteMode,
+};
+use serde_json::json;
+use std::collections::HashMap;
+
+async fn setup_db() -> FoldDB {
+    let dir = tempfile::tempdir().unwrap();
+    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+}
+
+fn blogpost_schema_json() -> &'static str {
+    r#"{
+        "name": "BlogPost",
+        "key": { "range_field": "publish_date" },
+        "fields": {
+            "title": {},
+            "content": {},
+            "publish_date": {}
+        }
+    }"#
+}
+
+#[tokio::test]
+async fn identity_write_redirects_to_source() {
+    let mut db = setup_db().await;
+
+    db.load_schema_from_json(blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    // Create a view with identity mapping
+    let mut fields = HashMap::new();
+    fields.insert(
+        "view_title".into(),
+        TransformFieldDef {
+            source: FieldRef::new("BlogPost", "title"),
+            wasm_forward: None,
+            wasm_inverse: None,
+        },
+    );
+    let view = TransformView::new("WriteView", SchemaType::Range, Some(KeyConfig::new(None, Some("publish_date".to_string()))), fields);
+    db.schema_manager.register_view(view).await.unwrap();
+
+    // Verify write mode is Identity
+    let stored_view = db.schema_manager.get_view("WriteView").unwrap().unwrap();
+    assert_eq!(
+        *stored_view.write_modes.get("view_title").unwrap(),
+        TransformWriteMode::Identity
+    );
+
+    // Write to the VIEW — should redirect to BlogPost.title
+    let mut mutation_fields = HashMap::new();
+    mutation_fields.insert("view_title".to_string(), json!("Written via view"));
+    let mutation = Mutation::new(
+        "WriteView".to_string(),
+        mutation_fields,
+        KeyValue::new(None, Some("2026-01-01".to_string())),
+        "pk".to_string(),
+        MutationType::Create,
+    );
+    db.mutation_manager
+        .write_mutations_batch_async(vec![mutation])
+        .await
+        .unwrap();
+
+    // Query the SOURCE schema to verify the write landed there
+    let query = Query::new("BlogPost".to_string(), vec!["title".to_string()]);
+    let results = db.query_executor.query(query).await.unwrap();
+
+    assert!(
+        results.contains_key("title"),
+        "BlogPost should have title field in results"
+    );
+    let title_values = &results["title"];
+    assert!(
+        !title_values.is_empty(),
+        "Should have data written to BlogPost.title"
+    );
+    let first_value = title_values.values().next().unwrap().value.clone();
+    assert_eq!(first_value, json!("Written via view"));
+}
+
+#[tokio::test]
+async fn irreversible_write_stores_as_overridden() {
+    let mut db = setup_db().await;
+
+    db.load_schema_from_json(blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    // Write some source data first
+    let mut source_fields = HashMap::new();
+    source_fields.insert("content".to_string(), json!("original content"));
+    source_fields.insert("publish_date".to_string(), json!("2026-01-01"));
+    db.mutation_manager
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            source_fields,
+            KeyValue::new(None, Some("2026-01-01".to_string())),
+            "pk".to_string(),
+            MutationType::Create,
+        )])
+        .await
+        .unwrap();
+
+    // Create a view with forward-only WASM (irreversible)
+    // Since we don't have actual WASM, we'll simulate by directly checking the write mode
+    // For now, test the Irreversible path by creating the field state manually
+    let mut fields = HashMap::new();
+    fields.insert(
+        "computed".into(),
+        TransformFieldDef {
+            source: FieldRef::new("BlogPost", "content"),
+            wasm_forward: None, // Identity for now
+            wasm_inverse: None,
+        },
+    );
+    let view = TransformView::new("IrrevView", SchemaType::Range, Some(KeyConfig::new(None, Some("publish_date".to_string()))), fields);
+    db.schema_manager.register_view(view).await.unwrap();
+
+    // Manually simulate an Irreversible write by setting Overridden state
+    let override_entries = vec![(
+        KeyValue::new(None, Some("override".to_string())),
+        FieldValue {
+            value: json!("directly written value"),
+            atom_uuid: String::new(),
+            source_file_name: None,
+            metadata: None,
+            molecule_uuid: None,
+            molecule_version: None,
+        },
+    )];
+    db.db_ops
+        .set_transform_field_state(
+            "IrrevView",
+            "computed",
+            &TransformFieldState::Overridden {
+                entries: override_entries,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Query the view — should return the overridden value
+    let query = Query::new("IrrevView".to_string(), vec!["computed".to_string()]);
+    let results = db.query_executor.query(query).await.unwrap();
+
+    let computed_values = &results["computed"];
+    let value = computed_values.values().next().unwrap().value.clone();
+    assert_eq!(value, json!("directly written value"));
+
+    // Source should be untouched — query BlogPost.content should still have original
+    let source_query = Query::new("BlogPost".to_string(), vec!["content".to_string()]);
+    let source_results = db.query_executor.query(source_query).await.unwrap();
+    let source_value = source_results["content"]
+        .values()
+        .next()
+        .unwrap()
+        .value
+        .clone();
+    assert_eq!(source_value, json!("original content"));
+}


### PR DESCRIPTION
## Transform Views

Adds computed views as a first-class concept in FoldDB. Views are declared lenses over source schemas — they query source data and present a derived, typed output schema without duplicating the underlying atoms.

### What's included

**Phase 1 — Core types & engine**
- `FieldRef`, `TransformFieldDef`, `TransformView` types with declared `schema_type`/`key`
- WASM engine (behind `transform-wasm` feature flag) — JSON in, JSON out, deterministic
- Dependency tracker with cycle detection
- View registry and field resolver (three-state machine)

**Phase 2 — Storage**
- View storage in `DbOperations` via 3 new Sled namespaces
- `ViewRegistry` wired into `SchemaCore` with persistence

**Phase 3 — Query path**
- `QueryExecutor` checks view registry before schema lookup
- `SourceQueryFn` trait for pluggable source fetching
- Filter pass-through

**Phase 4 — Mutation path**
- View write interception
- Cascading cache invalidation on source schema mutations

### Tests
49 tests: 31 unit + 18 integration across view registration, query, write, and cache invalidation.

### Notes
- Views are content-addressed like schemas
- WASM feature flag keeps the non-WASM build lean
- This is Phase 1 of the views roadmap — Global View Service / Transform Registry to follow