### PR TITLE
feat: centralized LLM registry for models and prompts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod crypto;
 pub mod db_operations;
 pub mod error;
 pub mod fold_db_core;
+pub mod llm_registry;
 pub mod logging;
 pub mod progress;
 pub mod schema;

--- a/src/llm_registry/mod.rs
+++ b/src/llm_registry/mod.rs
@@ -1,0 +1,23 @@
+//! Centralized LLM registry for model definitions, provider configs, and prompt templates.
+//!
+//! All LLM model IDs, API configurations, and prompt templates live here so that
+//! every project in the workspace (`fold_db_node`, `file_to_json`, `file_to_markdown`,
+//! `exemem-infra`) can reference a single source of truth.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use fold_db::llm_registry::models;
+//! use fold_db::llm_registry::prompts;
+//!
+//! // Model constants
+//! let model = models::ANTHROPIC_SONNET;
+//! let api_url = models::ANTHROPIC_API_URL;
+//!
+//! // Prompt templates
+//! let header = prompts::ingestion::PROMPT_HEADER;
+//! let prompt = prompts::classification::build_classification_prompt("email", "user email address");
+//! ```
+
+pub mod models;
+pub mod prompts;

--- a/src/llm_registry/models.rs
+++ b/src/llm_registry/models.rs
@@ -1,0 +1,139 @@
+//! Model constants, provider defaults, and generation parameters.
+//!
+//! Every hardcoded model ID across the workspace should reference these constants
+//! so that model upgrades happen in one place.
+
+// ---- Anthropic Models ----
+
+/// Fast, cheap model for structured classification tasks.
+/// Used by: schema service field classification (`fold_db`).
+pub const ANTHROPIC_HAIKU: &str = "claude-haiku-4-5-20251001";
+
+/// Default model for complex reasoning tasks (ingestion, query analysis, agents).
+/// Used by: `fold_db_node` ingestion + LLM query service.
+pub const ANTHROPIC_SONNET: &str = "claude-sonnet-4-20250514";
+
+/// OpenRouter-style model path for Sonnet (used by `file_to_json`).
+pub const ANTHROPIC_SONNET_OPENROUTER: &str = "anthropic/claude-sonnet-4-20250514";
+
+// ---- Ollama Models ----
+
+/// Default Ollama model for general text tasks (ingestion, queries).
+/// Used by: `fold_db_node` Ollama backend.
+pub const OLLAMA_DEFAULT: &str = "llama3.3";
+
+/// Vision model for image captioning and classification.
+/// Used by: `file_to_markdown` image extraction.
+pub const OLLAMA_VISION: &str = "qwen3-vl:2b";
+
+/// OCR model for text extraction from scanned documents and image-based PDFs.
+/// Used by: `file_to_markdown` PDF/document extraction.
+pub const OLLAMA_OCR: &str = "glm-ocr:latest";
+
+// ---- Embedding Models ----
+
+/// Sentence embedding model for semantic search indexing.
+/// Used by: `fold_db` native index (`fastembed` crate, ONNX runtime).
+/// Dimension: 384.
+pub const EMBEDDING_MODEL: &str = "all-MiniLM-L6-v2";
+
+/// Vector dimension produced by [`EMBEDDING_MODEL`].
+pub const EMBEDDING_DIMENSION: usize = 384;
+
+// ---- API Configuration ----
+
+/// Anthropic Messages API base URL.
+pub const ANTHROPIC_API_URL: &str = "https://api.anthropic.com";
+
+/// Anthropic API version header value.
+pub const ANTHROPIC_API_VERSION: &str = "2023-06-01";
+
+/// Default Ollama server URL.
+pub const OLLAMA_DEFAULT_URL: &str = "http://localhost:11434";
+
+// ---- Temperature Presets ----
+
+/// Deterministic output — classification, structured extraction.
+pub const TEMPERATURE_DETERMINISTIC: f32 = 0.0;
+
+/// Low creativity — ingestion schema analysis, query planning.
+pub const TEMPERATURE_FOCUSED: f32 = 0.1;
+
+/// Higher creativity — Ollama default, open-ended generation.
+pub const TEMPERATURE_CREATIVE: f32 = 0.8;
+
+// ---- Token Limits ----
+
+/// Max output tokens for classification tasks (small JSON responses).
+pub const MAX_TOKENS_CLASSIFICATION: u32 = 100;
+
+/// Max output tokens for ingestion / query analysis (large JSON + reasoning).
+pub const MAX_TOKENS_ANALYSIS: u32 = 16_000;
+
+// ---- Timeout Presets (seconds) ----
+
+/// Quick LLM calls (classification, small structured output).
+pub const TIMEOUT_CLASSIFICATION: u64 = 15;
+
+/// Standard LLM calls (ingestion, query planning).
+pub const TIMEOUT_STANDARD: u64 = 300;
+
+// ---- Ollama Generation Parameter Defaults ----
+
+/// Default context window for Ollama models (tokens).
+pub const OLLAMA_NUM_CTX: u32 = 16_384;
+
+/// Default max prediction tokens for Ollama.
+pub const OLLAMA_NUM_PREDICT: u32 = 16_384;
+
+/// Default top-p sampling for Ollama.
+pub const OLLAMA_TOP_P: f32 = 0.95;
+
+/// Default top-k sampling for Ollama (0 = disabled).
+pub const OLLAMA_TOP_K: u32 = 0;
+
+/// Default repeat penalty for Ollama.
+pub const OLLAMA_REPEAT_PENALTY: f32 = 1.0;
+
+/// Default presence penalty for Ollama.
+pub const OLLAMA_PRESENCE_PENALTY: f32 = 0.0;
+
+/// Default min-p threshold for Ollama.
+pub const OLLAMA_MIN_P: f32 = 0.0;
+
+// ---- Ingestion Limits ----
+
+/// Maximum characters before a field value is truncated in prompts.
+pub const PROMPT_FIELD_TRUNCATION_LIMIT: usize = 300;
+
+/// Maximum bytes for LLM input in `file_to_json` before chunking kicks in.
+pub const MAX_LLM_INPUT_BYTES: usize = 128 * 1024;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_ids_are_non_empty() {
+        assert!(!ANTHROPIC_HAIKU.is_empty());
+        assert!(!ANTHROPIC_SONNET.is_empty());
+        assert!(!ANTHROPIC_SONNET_OPENROUTER.is_empty());
+        assert!(!OLLAMA_DEFAULT.is_empty());
+        assert!(!OLLAMA_VISION.is_empty());
+        assert!(!OLLAMA_OCR.is_empty());
+        assert!(!EMBEDDING_MODEL.is_empty());
+    }
+
+    #[test]
+    fn api_urls_are_valid() {
+        assert!(ANTHROPIC_API_URL.starts_with("https://"));
+        assert!(OLLAMA_DEFAULT_URL.starts_with("http://"));
+    }
+
+    #[test]
+    fn temperatures_in_valid_range() {
+        assert!((0.0..=2.0).contains(&TEMPERATURE_DETERMINISTIC));
+        assert!((0.0..=2.0).contains(&TEMPERATURE_FOCUSED));
+        assert!((0.0..=2.0).contains(&TEMPERATURE_CREATIVE));
+    }
+}

--- a/src/llm_registry/prompts/classification.rs
+++ b/src/llm_registry/prompts/classification.rs
@@ -1,0 +1,56 @@
+//! Prompt templates for field sensitivity and domain classification.
+//!
+//! Used by the schema service to classify new canonical fields.
+
+/// Build the classification prompt for a single field.
+///
+/// The LLM should return a JSON object with `sensitivity_level` (0–4) and `data_domain`.
+pub fn build_classification_prompt(field_name: &str, description: &str) -> String {
+    format!(
+        r#"Classify this database field's data sensitivity. Return ONLY a JSON object with two fields, no explanation.
+
+Field name: "{field_name}"
+Description: "{description}"
+
+Sensitivity levels:
+0 = Public (freely distributable, no restrictions)
+1 = Internal (not sensitive but not for public release)
+2 = Confidential (business-sensitive, competitive value)
+3 = Restricted (personally identifiable or individually attributable)
+4 = Highly Restricted (regulated data: HIPAA, financial records, biometric)
+
+Data domains: "general", "financial", "medical", "identity", "behavioral", "location"
+
+Return format: {{"sensitivity_level": <0-4>, "data_domain": "<domain>"}}"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_contains_field_name_and_description() {
+        let prompt = build_classification_prompt("salary", "employee annual salary");
+        assert!(prompt.contains("salary"));
+        assert!(prompt.contains("employee annual salary"));
+        assert!(prompt.contains("sensitivity_level"));
+        assert!(prompt.contains("data_domain"));
+    }
+
+    #[test]
+    fn prompt_lists_all_sensitivity_levels() {
+        let prompt = build_classification_prompt("x", "y");
+        for level in 0..=4 {
+            assert!(prompt.contains(&format!("{} =", level)));
+        }
+    }
+
+    #[test]
+    fn prompt_lists_all_domains() {
+        let prompt = build_classification_prompt("x", "y");
+        for domain in &["general", "financial", "medical", "identity", "behavioral", "location"] {
+            assert!(prompt.contains(domain));
+        }
+    }
+}

--- a/src/llm_registry/prompts/ingestion.rs
+++ b/src/llm_registry/prompts/ingestion.rs
@@ -1,0 +1,264 @@
+//! Prompt templates for AI-powered schema analysis during data ingestion.
+//!
+//! These prompts instruct the LLM to analyze sample JSON data and propose
+//! schema definitions with field descriptions and classifications.
+
+/// Prompt header describing the response format, schema structure, and classification rules.
+///
+/// Appended before the sample data in every ingestion prompt.
+pub const PROMPT_HEADER: &str = r#"Create a schema for this sample json data. Return the value in this format:
+{
+  "new_schemas": <single_schema_definition>,
+  "mutation_mappers": {json_field_name: schema_field_name}
+}
+
+Where:
+- new_schemas is a single schema definition for the input data
+- mutation_mappers maps ONLY TOP-LEVEL JSON field names to schema field names (e.g., {"id": "id", "user": "user"})
+
+CRITICAL - Mutation Mappers:
+- ONLY use top-level field names in mutation_mappers (e.g., "user", "comments", "id")
+- DO NOT use nested paths (e.g., "user.name", "comments[*].content") - they will not work
+- Nested objects and arrays will be stored as-is in their top-level field
+- Example: if JSON has {"user": {"id": 1, "name": "Tom"}}, mapper should be {"user": "user"}, NOT {"user.id": "id"}
+
+IMPORTANT - Schema Types (4 types: Single, Hash, Range, HashRange):
+- ALWAYS assume the data belongs to a COLLECTION/SET of similar items, even if only one item is provided now.
+- STRONGLY PREFER HashRange schemas. Most data benefits from both a hash key (for grouping) and a range key (for ordering).
+- Choose a meaningful hash_field that groups related records (e.g., "author", "category", "user_id", "type", "source").
+  If the data has a natural grouping dimension, use it. If not, pick the most useful field for filtering.
+- Choose a range_field based on a date/timestamp if one exists (e.g., "created_at", "date", "timestamp", "posted_at").
+  If no date field exists, use a unique identifier or sequential field (e.g., "id", "name").
+- hash_field and range_field can use dot-notation to reference nested values (e.g., "departure.date", "departure.airport").
+  The parent field (e.g., "departure") MUST still be included in "fields" and "mutation_mappers" as a top-level entry.
+- NEVER use "file_type" as a hash_field or range_field — it is metadata, not a semantic grouping dimension.
+  For text/document data, use "source_file" or "category" as hash_field if available, and derive the schema name from the content's topic (e.g., "recipes", "meeting_notes", "journal_entries"), not the file extension.
+- Use Hash (hash_field only, no range_field) when items are uniquely keyed but have no meaningful ordering dimension.
+  Good for: images (keyed by filename), user profiles (keyed by user_id), config entries (keyed by name).
+- Use Range (range_field only, no hash_field) ONLY when there is genuinely no meaningful grouping dimension.
+- Use Single (no "key" field) ONLY for truly singleton global config/settings with no possibility of multiple records.
+- If the user provides an ARRAY of objects, you MUST use HashRange, Hash, or Range with a "key".
+
+IMPORTANT - Schema Name and Descriptive Name:
+- "name" MUST be a short, semantic, snake_case name describing the CONTENT TOPIC (e.g., "recipes", "journal_entries", "medical_records", "meeting_notes", "blog_posts").
+  Think of it as a database table name — concise, plural, descriptive of the data set.
+- READ THE ACTUAL CONTENT to determine the topic. A file containing a cookie recipe should produce "recipes", not "document_content".
+  A file containing a journal entry should produce "journal_entries". A file about doctor visits should produce "medical_records".
+- NEVER use generic names like "document_content", "text_content", "file_content", or "text_records". These are useless.
+  If the data has a "content" field with text, read that text to determine the domain/topic.
+- If a "category" field is present (e.g., "recipes", "journal", "health"), use it as a strong hint for the schema name.
+- ALWAYS include "descriptive_name": a clear, human-readable description of what this schema stores
+- Example: "name": "recipes", "descriptive_name": "Recipe Collection"
+
+IMPORTANT - Field Descriptions:
+- EVERY field MUST have a "field_descriptions" entry
+- Each entry is a short natural language description of what the field represents
+- Descriptions should be specific enough to distinguish semantically similar fields across different domains
+- Example: "field_descriptions": {"artist": "the person who created the artwork", "title": "the name of the artwork"}
+
+IMPORTANT - Field Classifications:
+- EVERY field MUST have a "field_classifications" entry
+- Analyze field semantic meaning and assign appropriate classification types
+- Multiple classifications per field are encouraged (e.g., ["name:person", "word"])
+- ALWAYS include "word" classification for any string field that contains searchable text
+- Available classification types:
+  * "word" - general text, split into words for search (MANDATORY for searchable text)
+  * "name:person" - person names (kept whole: "Jennifer Liu")
+  * "name:company" - company/organization names
+  * "name:place" - location names (cities, countries, places)
+  * "email" - email addresses
+  * "phone" - phone numbers
+  * "url" - URLs or domains
+  * "date" - dates and timestamps
+  * "hashtag" - hashtags (from social media)
+  * "username" - usernames/handles
+  * "number" - numeric values (amounts, counts, scores, percentages, quantities)
+- "field_classifications" is a flat map from field name to list of classification strings
+
+Example HashRange schema (PREFERRED — grouping + time ordering):
+{
+  "name": "social_media_posts",
+  "descriptive_name": "Social Media Posts",
+  "key": {"hash_field": "author", "range_field": "created_at"},
+  "fields": ["created_at", "author", "content"],
+  "field_descriptions": {
+    "created_at": "when the post was published",
+    "author": "the person who wrote the post",
+    "content": "the text body of the post"
+  },
+  "field_classifications": {
+    "created_at": ["date"],
+    "author": ["name:person", "word"],
+    "content": ["word"]
+  }
+}
+
+Example HashRange schema with non-date range (when no timestamp exists):
+{
+  "name": "user_profiles",
+  "descriptive_name": "User Profile Information",
+  "key": {"hash_field": "department", "range_field": "id"},
+  "fields": ["id", "department", "name", "age"],
+  "field_descriptions": {
+    "id": "unique identifier for the user",
+    "department": "the department the user belongs to",
+    "name": "the user's full name",
+    "age": "the user's age in years"
+  },
+  "field_classifications": {
+    "id": ["word"],
+    "department": ["word"],
+    "name": ["name:person", "word"],
+    "age": ["number"]
+  }
+}
+
+Example Hash schema (unique key, no ordering needed):
+{
+  "name": "image_collection",
+  "descriptive_name": "Image Collection",
+  "key": {"hash_field": "source_file_name"},
+  "fields": ["source_file_name", "image_type", "subjects", "description"],
+  "field_descriptions": {
+    "source_file_name": "the filename of the image",
+    "image_type": "the type or category of the image",
+    "subjects": "the subjects depicted in the image",
+    "description": "a description of what the image shows"
+  },
+  "field_classifications": {
+    "source_file_name": ["word"],
+    "image_type": ["word"],
+    "subjects": ["word"],
+    "description": ["word"]
+  }
+}
+
+Example Range schema (only when NO meaningful grouping dimension exists):
+{
+  "name": "global_metrics",
+  "descriptive_name": "Global System Metrics",
+  "key": {"range_field": "recorded_at"},
+  "fields": ["recorded_at", "cpu_usage", "memory_usage"],
+  "field_descriptions": {
+    "recorded_at": "when the metric was recorded",
+    "cpu_usage": "CPU utilization percentage",
+    "memory_usage": "memory utilization percentage"
+  },
+  "field_classifications": {
+    "recorded_at": ["date"],
+    "cpu_usage": ["number"],
+    "memory_usage": ["number"]
+  }
+}
+
+Example with Arrays and Objects (HashRange with date range):
+{
+  "name": "blog_posts",
+  "descriptive_name": "Blog Posts with Media",
+  "key": {"hash_field": "author", "range_field": "posted_at"},
+  "fields": ["posted_at", "author", "content", "hashtags", "media"],
+  "field_descriptions": {
+    "posted_at": "when the post was published",
+    "author": "the person who wrote the post",
+    "content": "the text body of the post",
+    "hashtags": "tags or topics associated with the post",
+    "media": "URLs to attached images or videos"
+  },
+  "field_classifications": {
+    "posted_at": ["date"],
+    "author": ["name:person", "word"],
+    "content": ["word"],
+    "hashtags": ["hashtag", "word"],
+    "media": ["url", "word"]
+  }
+}
+
+IMPORTANT - Transform Fields (DSL):
+- You can add a "transform_fields" map to the schema to derive new fields from existing ones.
+- SYNTAX: "SourceField.function().function()"
+- IMPLICIT CARDINALITY:
+  * The system automatically iterates over every record in the schema (1:N). You do NOT need a .map() token.
+  * Iterator Functions (like split_by_word, split_array) INCREASE depth/cardinality (one row -> many rows).
+  * Reducer Functions (like count, join, sum) DECREASE depth/cardinality (many rows -> one row).
+- DEPRECATION: The ".map()" token is DEPRECATED. Do not use it.
+- Examples:
+  * Word Count: "content.split_by_word().count()" (Iterates content -> splits into words -> counts words per row)
+  * Character Count: "content.slugify().len()"
+  * Array Join: "hashtags.join(', ')" (Joins array elements into a string)
+"#;
+
+/// Instructions appended to every ingestion prompt after the sample data.
+pub const PROMPT_ACTIONS: &str = r#"Please analyze the sample data and create a new schema definition in new_schemas with mutation_mappers.
+
+CRITICAL RULES:
+- ALWAYS assume data belongs to a collection. Use HashRange with a meaningful hash_field for grouping and range_field for ordering.
+- PREFER a date/timestamp field as range_field (e.g., "created_at", "date", "timestamp") — this enables time-based queries. Only use an ID field if no date/timestamp exists.
+- Pick a hash_field that provides a useful grouping dimension (e.g., author, category, type, source, department).
+- hash_field and range_field can use dot-notation for nested values (e.g., "departure.date"). The parent must be in mutation_mappers.
+- Only fall back to Range (no hash_field) if there is genuinely no meaningful grouping. Never use Single for array inputs.
+- The schema "name" MUST describe the content topic, NOT the format. Read the actual text/data to determine the topic.
+  Good: "recipes", "journal_entries", "medical_records", "meeting_notes". Bad: "document_content", "text_records", "file_data".
+- If there is a "category" field, use it as a strong signal for the schema name.
+- ALWAYS provide field_descriptions and field_classifications for every field
+- For document/note/journal schemas where "title" is not guaranteed unique (e.g., dated entries, journal notes),
+  use "content_hash" as the range_field if it is present in the data. This guarantees uniqueness.
+  Use "title" or a category field as hash_field for grouping.
+  Example for notes: {"hash_field": "title", "range_field": "content_hash"}
+  This prevents collision when multiple notes share the same title.
+
+The response must be valid JSON."#;
+
+/// Prompt for a second AI pass that generates field_descriptions when the
+/// initial schema proposal omitted them.
+pub const FIELD_DESCRIPTIONS_PROMPT: &str = r#"Given the following JSON data structure and a list of field names, provide a short natural language description for each field.
+
+Return ONLY a JSON object mapping field names to descriptions. Example:
+{
+  "artist": "the person who created the artwork",
+  "title": "the name of the artwork",
+  "year": "the year the artwork was created"
+}
+
+Descriptions should be:
+- Specific enough to distinguish semantically similar fields across different domains
+- Short (one sentence max)
+- Focused on what the field represents, not its data type
+
+JSON data sample:
+{sample}
+
+Fields that need descriptions:
+{fields}
+
+Return ONLY the JSON object with field descriptions. No other text."#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_header_mentions_all_schema_types() {
+        assert!(PROMPT_HEADER.contains("Single"));
+        assert!(PROMPT_HEADER.contains("Hash"));
+        assert!(PROMPT_HEADER.contains("Range"));
+        assert!(PROMPT_HEADER.contains("HashRange"));
+    }
+
+    #[test]
+    fn prompt_header_mentions_all_classification_types() {
+        for cls in &["word", "name:person", "name:company", "name:place", "email", "phone", "url", "date", "hashtag", "username", "number"] {
+            assert!(PROMPT_HEADER.contains(cls), "Missing classification type: {}", cls);
+        }
+    }
+
+    #[test]
+    fn prompt_actions_requires_json() {
+        assert!(PROMPT_ACTIONS.contains("valid JSON"));
+    }
+
+    #[test]
+    fn field_descriptions_prompt_has_placeholders() {
+        assert!(FIELD_DESCRIPTIONS_PROMPT.contains("{sample}"));
+        assert!(FIELD_DESCRIPTIONS_PROMPT.contains("{fields}"));
+    }
+}

--- a/src/llm_registry/prompts/mod.rs
+++ b/src/llm_registry/prompts/mod.rs
@@ -1,0 +1,12 @@
+//! Centralized prompt templates for all LLM interactions across the workspace.
+//!
+//! Organized by domain:
+//! - [`classification`] — Field sensitivity/domain classification
+//! - [`ingestion`] — Schema analysis from raw data
+//! - [`query`] — Natural language query planning and result interpretation
+//! - [`smart_folder`] — File classification for ingestion scanning
+
+pub mod classification;
+pub mod ingestion;
+pub mod query;
+pub mod smart_folder;

--- a/src/llm_registry/prompts/query.rs
+++ b/src/llm_registry/prompts/query.rs
@@ -1,0 +1,160 @@
+//! Prompt templates and instruction blocks for LLM-powered query analysis.
+//!
+//! The dynamic prompt builders live in `fold_db_node` (they depend on runtime schema
+//! data), but the static instruction text is centralized here.
+
+/// Filter type documentation shared across query analysis and followup prompts.
+pub const FILTER_TYPES_INSTRUCTION: &str = r#"FILTER TYPES AVAILABLE:
+
+Filters for HashRange schemas (have both Hash Key and Range Key):
+- HashRangeKey: {"HashRangeKey": {"hash": "value", "range": "value"}} - exact match on BOTH hash key field AND range key field
+- HashKey: {"HashKey": "value"} - filter on hash key field only, returns all records with this hash
+- HashRangePrefix: {"HashRangePrefix": {"hash": "value", "prefix": "prefix"}} - filter on hash key field + range key field prefix
+- HashPattern: {"HashPattern": "*pattern*"} - glob pattern matching on hash key field
+
+Filters for Hash schemas (have Hash Key only, no Range Key):
+- HashKey: {"HashKey": "value"} - exact match on hash key field
+- HashPattern: {"HashPattern": "*pattern*"} - glob pattern matching on hash key field
+
+Filters for Range schemas (have Range Key only):
+- RangePrefix: {"RangePrefix": "prefix"} - filter on range key field, returns records with range starting with prefix
+- RangePattern: {"RangePattern": "*pattern*"} - glob pattern matching on range key field
+- RangeRange: {"RangeRange": {"start": "2025-01-01", "end": "2025-12-31"}} - filter on range key field for values within range
+
+Universal filters (work on any schema type):
+- SampleN: {"SampleN": 100} - return N RANDOM records (NOT sorted)
+- null - no filter (return all records)"#;
+
+/// Critical rules for selecting the right filter type.
+pub const FILTER_SELECTION_RULES: &str = r#"IMPORTANT JSON FORMATTING:
+- All string values in filters MUST be properly JSON-escaped
+- Special characters like @ # $ etc. do NOT need escaping in JSON strings
+- Example: {"HashKey": "user@domain.com"} is valid JSON
+
+CRITICAL FILTER SELECTION RULES:
+1. ALWAYS check the schema's Hash Key and Range Key fields to determine the correct filter
+2. If the search term matches a Hash Key field value, use HashKey or HashPattern filter
+3. If the search term matches a Range Key field value, use RangePrefix, RangePattern, or RangeRange filter
+4. Examples of when to use each:
+   - Searching for author "Jennifer Liu" on a schema with hash_field=author → use {"HashKey": "Jennifer Liu"}
+   - Searching for date "2025-09" on a schema with range_field=publish_date → use {"RangePrefix": "2025-09"}
+
+IMPORTANT NOTES:
+- For HashRange schemas, HashKey filters operate on the hash_field, Range filters operate on the range_field
+- For Hash schemas, HashKey and HashPattern filters operate on the hash_field (no range filters available)
+- For Range schemas, Range filters operate on the range_field
+- SampleN returns RANDOM records, NOT sorted or ordered
+- For "most recent" or "latest" queries, use null filter with sort_order "desc" to get results sorted newest-first by range key
+- Range keys are stored as strings and compared lexicographically"#;
+
+/// JSON response format expected from query analysis.
+pub const QUERY_RESPONSE_FORMAT: &str = r#"Respond in JSON format with:
+{
+  "query": {
+    "schema_name": "string",
+    "fields": ["field1", "field2"],
+    "filter": null or one of the filter types above,
+    "sort_order": "asc" or "desc" or null
+  },
+  "reasoning": "your analysis"
+}
+
+IMPORTANT:
+- Return ONLY the JSON object, no additional text
+- Use the EXACT filter format shown above
+- For "most recent", "latest", or "newest" queries, use null filter with sort_order "desc" (NOT SampleN)
+- Prefer existing approved schemas for queries"#;
+
+/// JSON response format for followup analysis.
+pub const FOLLOWUP_RESPONSE_FORMAT: &str = r#"Respond in JSON format:
+{
+  "needs_query": true/false,
+  "query": null or {"schema_name": "...", "fields": [...], "filter": ..., "sort_order": "asc" or "desc" or null},
+  "reasoning": "explanation"
+}
+
+IMPORTANT: Return ONLY the JSON object, no additional text."#;
+
+/// System preamble for query analysis prompts.
+pub const QUERY_ANALYSIS_PREAMBLE: &str =
+    "You are a database query optimizer. Analyze the following natural language query \
+    and available schemas to create an execution plan.\n\n";
+
+/// System preamble for result summarization.
+pub const SUMMARIZATION_PREAMBLE: &str =
+    "Summarize the following query results for the user.\n\n";
+
+/// System preamble for chat follow-up answers.
+pub const CHAT_PREAMBLE: &str =
+    "You are helping a user explore query results. Answer their question based on \
+    the context provided.\n\n";
+
+/// System preamble for followup analysis.
+pub const FOLLOWUP_ANALYSIS_PREAMBLE: &str =
+    "You are analyzing whether a follow-up question can be answered from existing query results or needs a new query.\n\n";
+
+/// System preamble for native index search term generation.
+pub const NATIVE_INDEX_QUERY_TERMS_PREAMBLE: &str =
+    "You are generating search terms for a native word index. Based on the user's natural language query, \
+    generate relevant search terms that would help find matching records.\n\n";
+
+/// System preamble for native index result interpretation.
+pub const NATIVE_INDEX_INTERPRETATION_PREAMBLE: &str =
+    "You are interpreting native index search results for a user. Analyze the search results and provide a helpful response.\n\n";
+
+/// Guidelines for generating native index search terms.
+pub const NATIVE_INDEX_SEARCH_GUIDELINES: &str = r#"Guidelines:
+- Extract the most important keywords from the query
+- Include specific names, places, or entities mentioned
+- Generate terms that would be found in indexed text fields
+- Avoid very common words (stopwords)
+- Keep terms concise but meaningful
+- Focus on terms that are likely to appear in the data
+
+Examples:
+- Query: "Find posts about artificial intelligence"
+  Terms: ["artificial", "intelligence", "AI", "machine learning"]
+- Query: "Show me articles by Jennifer Liu"
+  Terms: ["Jennifer", "Liu", "Jennifer Liu"]
+- Query: "Products with electronics tag"
+  Terms: ["electronics", "electronic", "tech"]
+
+Respond with a JSON array of strings:
+["term1", "term2", "term3", ...]
+
+IMPORTANT: Return ONLY the JSON array, no additional text."#;
+
+/// System preamble for alternative query suggestion.
+pub const ALTERNATIVE_QUERY_PREAMBLE: &str =
+    "A query returned no results. Suggest an alternative approach to find the data the user wants.\n\n";
+
+/// Agent system prompt preamble (the tool definitions are built dynamically).
+pub const AGENT_SYSTEM_PREAMBLE: &str =
+    "You are a helpful database assistant with access to tools. Use the tools to query and manipulate data to answer the user's question.\n\n";
+
+/// Agent response format instruction.
+pub const AGENT_RESPONSE_FORMAT: &str =
+    "IMPORTANT: Always respond with valid JSON. Either:\n\
+    - {\"tool\": \"tool_name\", \"params\": {...}} to call a tool\n\
+    - {\"answer\": \"your response\"} to provide the final answer\n";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_types_lists_all_filters() {
+        for filter in &["HashRangeKey", "HashKey", "HashRangePrefix", "HashPattern",
+                        "RangePrefix", "RangePattern", "RangeRange", "SampleN"] {
+            assert!(FILTER_TYPES_INSTRUCTION.contains(filter), "Missing filter: {}", filter);
+        }
+    }
+
+    #[test]
+    fn query_response_format_has_required_fields() {
+        assert!(QUERY_RESPONSE_FORMAT.contains("schema_name"));
+        assert!(QUERY_RESPONSE_FORMAT.contains("fields"));
+        assert!(QUERY_RESPONSE_FORMAT.contains("filter"));
+        assert!(QUERY_RESPONSE_FORMAT.contains("sort_order"));
+    }
+}

--- a/src/llm_registry/prompts/smart_folder.rs
+++ b/src/llm_registry/prompts/smart_folder.rs
@@ -1,0 +1,191 @@
+//! Prompt templates for smart folder scanning and file classification.
+//!
+//! Used by the ingestion pipeline to classify files for database ingestion.
+
+/// Build the LLM prompt for classifying files in a user's folder.
+///
+/// Takes a directory tree display and list of file paths to classify.
+pub fn build_smart_folder_prompt(tree_display: &str, file_paths: &[String]) -> String {
+    let files_list = file_paths.join("\n");
+
+    format!(
+        r#"You are classifying files in a user's personal folder for ingestion into their personal database.
+
+DIRECTORY TREE (for context — understand what each folder represents):
+{tree_display}
+
+FILES TO CLASSIFY:
+{files_list}
+
+For each file path listed in FILES TO CLASSIFY, determine:
+1. Should it be ingested into the user's personal database?
+2. What category does it belong to?
+
+IMPORTANT: Use the directory tree to understand context. For example:
+- A .gif inside a "Bank of America" saved HTML page is website scaffolding, NOT personal media
+- A .js file inside a Twitter data export IS personal data
+- A .css or .html file inside a saved webpage folder is scaffolding
+- A .pdf in a "Statements" folder IS personal financial data
+- Source code files (.py, .rs, .js) in a code project folder are NOT personal data
+- But a .py notebook in a "Research" folder might be personal work
+
+{CATEGORIES}
+
+{SKIP_CRITERIA}
+
+{INGEST_CRITERIA}
+
+When in doubt, set should_ingest to false.
+
+Respond with a JSON array of objects:
+```json
+[
+  {{"path": "file/path.ext", "should_ingest": true, "category": "personal_data", "reason": "Brief reason"}},
+  ...
+]
+```
+
+Only return the JSON array, no other text."#,
+        CATEGORIES = FILE_CATEGORIES,
+        SKIP_CRITERIA = SKIP_CRITERIA,
+        INGEST_CRITERIA = INGEST_CRITERIA,
+    )
+}
+
+/// Build an LLM prompt to classify image directories as personal or asset.
+pub fn build_image_directory_prompt(dir_lines: &[String]) -> String {
+    format!(
+        r#"You are classifying IMAGE DIRECTORIES to determine if they contain personal images or non-personal asset images.
+
+IMAGE DIRECTORIES (with file counts and sample filenames):
+{}
+
+For each directory, classify it as either:
+- "personal" — user photos, screenshots, personal artwork, scanned documents, camera images
+- "asset" — UI assets, emoji/icon collections, website graphics, app resources, stock images, thumbnails
+
+GUIDELINES:
+- Directories named like "tweets_media", "profile_media", "photos", "camera", "screenshots" → personal
+- Directories named like "twemoji", "emoji", "icons", "assets/images", "thumbnails", "sprites" → asset
+- Directories with few large files (photos) → likely personal
+- Directories with many small files (icons, emoji) → likely asset
+- When in doubt, classify as "personal" (better to include than exclude)
+
+Respond with a JSON object mapping each directory path to "personal" or "asset":
+```json
+{{
+  "directory/path": "personal",
+  "assets/images/twemoji": "asset"
+}}
+```
+
+Only return the JSON object, no other text."#,
+        dir_lines.join("\n")
+    )
+}
+
+/// Build a prompt for adjusting scan results based on a user instruction.
+pub fn build_adjust_prompt(
+    instruction: &str,
+    rec_lines: &[String],
+    skip_lines: &[String],
+) -> String {
+    format!(
+        r#"You are adjusting file ingestion recommendations based on the user's instruction.
+
+USER INSTRUCTION: "{instruction}"
+
+CURRENT FILES TO INGEST:
+[
+{rec_list}
+]
+
+CURRENT SKIPPED FILES:
+[
+{skip_list}
+]
+
+Apply the user's instruction to reclassify files. For example:
+- "include all work files" → move work-category files from skipped to should_ingest=true
+- "skip all images" → move image files from recommended to should_ingest=false
+- "include everything" → set all files to should_ingest=true
+
+{CATEGORIES}
+
+Respond with a JSON array of ALL files (both recommended and skipped) with updated classifications:
+```json
+[
+  {{"path": "file/path.ext", "should_ingest": true, "category": "personal_data", "reason": "Brief reason"}},
+  ...
+]
+```
+
+Only return the JSON array, no other text."#,
+        rec_list = rec_lines.join(",\n"),
+        skip_list = skip_lines.join(",\n"),
+        CATEGORIES = FILE_CATEGORIES,
+    )
+}
+
+/// File category definitions shared across smart folder prompts.
+pub const FILE_CATEGORIES: &str = r#"CATEGORIES:
+- personal_data: Personal documents, notes, journals, financial records, health data, creative work, personal projects
+- media: Images, videos, audio that are user-created content (NOT UI assets or website graphics)
+- config: Application configs, settings files, dotfiles
+- website_scaffolding: HTML templates, CSS, JS bundles, emoji assets, fonts, saved webpage resources
+- work: Work/corporate files, professional documents
+- unknown: Cannot determine"#;
+
+/// Criteria for skipping files (should_ingest = false).
+const SKIP_CRITERIA: &str = r#"SKIP CRITERIA (should_ingest = false):
+- Website scaffolding (CSS, JS bundles, images that are part of saved web pages)
+- Application config files
+- Source code (unless it's personal creative work)
+- Cache and temporary files
+- Downloaded installers/archives"#;
+
+/// Criteria for ingesting files (should_ingest = true).
+const INGEST_CRITERIA: &str = r#"INGEST CRITERIA (should_ingest = true):
+- Personal documents (letters, notes, journals)
+- Photos and videos (user-created, not UI assets)
+- Messages and chat logs
+- Financial records (statements, budgets, tax documents)
+- Health data
+- Creative work (writing, art, music)
+- Data exports from services (Twitter, Facebook, Google Takeout, etc.)
+- Personal work output (reports, presentations, research notes)"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smart_folder_prompt_contains_tree_and_files() {
+        let prompt = build_smart_folder_prompt("docs/\n  notes.txt", &["docs/notes.txt".to_string()]);
+        assert!(prompt.contains("docs/\n  notes.txt"));
+        assert!(prompt.contains("docs/notes.txt"));
+        assert!(prompt.contains("personal_data"));
+        assert!(prompt.contains("should_ingest"));
+    }
+
+    #[test]
+    fn image_directory_prompt_contains_dirs() {
+        let lines = vec!["photos/vacation: 5 files [img1.jpg, img2.jpg]".to_string()];
+        let prompt = build_image_directory_prompt(&lines);
+        assert!(prompt.contains("photos/vacation"));
+        assert!(prompt.contains("personal"));
+        assert!(prompt.contains("asset"));
+    }
+
+    #[test]
+    fn adjust_prompt_contains_instruction() {
+        let prompt = build_adjust_prompt(
+            "include all work files",
+            &[r#"{"path": "a.txt", "should_ingest": true}"#.to_string()],
+            &[r#"{"path": "b.txt", "should_ingest": false}"#.to_string()],
+        );
+        assert!(prompt.contains("include all work files"));
+        assert!(prompt.contains("a.txt"));
+        assert!(prompt.contains("b.txt"));
+    }
+}

--- a/src/schema_service/classify.rs
+++ b/src/schema_service/classify.rs
@@ -9,28 +9,9 @@
 //! 2. LLM call using field description (requires ANTHROPIC_API_KEY)
 //! 3. No fallback — returns error. Incorrect classification is worse than no schema.
 
+use crate::llm_registry::models;
+use crate::llm_registry::prompts::classification::build_classification_prompt;
 use crate::schema::types::data_classification::DataClassification;
-
-/// Prompt for LLM-based classification of a single field.
-fn build_classification_prompt(field_name: &str, description: &str) -> String {
-    format!(
-        r#"Classify this database field's data sensitivity. Return ONLY a JSON object with two fields, no explanation.
-
-Field name: "{field_name}"
-Description: "{description}"
-
-Sensitivity levels:
-0 = Public (freely distributable, no restrictions)
-1 = Internal (not sensitive but not for public release)
-2 = Confidential (business-sensitive, competitive value)
-3 = Restricted (personally identifiable or individually attributable)
-4 = Highly Restricted (regulated data: HIPAA, financial records, biometric)
-
-Data domains: "general", "financial", "medical", "identity", "behavioral", "location"
-
-Return format: {{"sensitivity_level": <0-4>, "data_domain": "<domain>"}}"#
-    )
-}
 
 /// Classify a field using LLM analysis of its description.
 /// Returns a descriptive error string on failure.
@@ -52,22 +33,22 @@ pub async fn classify_with_llm(
     let prompt = build_classification_prompt(field_name, description);
 
     let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(15))
+        .timeout(std::time::Duration::from_secs(models::TIMEOUT_CLASSIFICATION))
         .no_proxy()
         .build()
         .map_err(|e| format!("Failed to create HTTP client for classification: {}", e))?;
 
     let request_body = serde_json::json!({
-        "model": "claude-haiku-4-5-20251001",
+        "model": models::ANTHROPIC_HAIKU,
         "messages": [{"role": "user", "content": prompt}],
-        "max_tokens": 100,
-        "temperature": 0.0
+        "max_tokens": models::MAX_TOKENS_CLASSIFICATION,
+        "temperature": models::TEMPERATURE_DETERMINISTIC
     });
 
     let response = client
-        .post("https://api.anthropic.com/v1/messages")
+        .post(format!("{}/v1/messages", models::ANTHROPIC_API_URL))
         .header("x-api-key", &api_key)
-        .header("anthropic-version", "2023-06-01")
+        .header("anthropic-version", models::ANTHROPIC_API_VERSION)
         .header("Content-Type", "application/json")
         .json(&request_body)
         .send()

--- a/src/schema_service/state.rs
+++ b/src/schema_service/state.rs
@@ -1124,9 +1124,12 @@ impl SchemaServiceState {
             }
         }
 
-        // Build an output schema from the view's fields and run it through add_schema
+        // Build an output schema from the view's fields and run it through add_schema.
+        // Use descriptive_name as the initial schema name — add_schema replaces it with
+        // the identity hash, but having a meaningful name prevents infer_name_from_fields
+        // from falling back to the view name (which is not a collection name).
         let mut output_schema = Schema::new(
-            request.name.clone(),
+            request.descriptive_name.clone(),
             crate::schema::types::schema::DeclarativeSchemaType::Single,
             None,
             Some(request.output_fields.clone()),


### PR DESCRIPTION
## Summary
- Add `llm_registry` module with centralized model IDs, API configs, temperature presets, token limits, and all prompt templates across the workspace
- Migrate `classify.rs` to use registry constants instead of hardcoded model IDs and API URLs
- Fix `add_view` bug where output schema's `descriptive_name` was overwritten by the view name during `infer_name_from_fields` fallback

## Details

**New module: `src/llm_registry/`**
- `models.rs` — Constants for Anthropic (Haiku, Sonnet), Ollama (llama3.3, qwen3-vl, glm-ocr), embedding model, API URLs, temperatures, token limits, timeouts, Ollama generation params
- `prompts/classification.rs` — Field sensitivity classification prompt
- `prompts/ingestion.rs` — `PROMPT_HEADER`, `PROMPT_ACTIONS`, `FIELD_DESCRIPTIONS_PROMPT` (schema analysis)
- `prompts/query.rs` — Filter type docs, response formats, preambles for query/chat/followup/agent
- `prompts/smart_folder.rs` — File classification, image directory, and scan adjustment prompts

**Bug fix: `state.rs` add_view**
`add_view` created the output schema with the view name ("TestView") as `schema.name`. When `is_valid_collection_name` rejected the descriptive name and `generate_collection_name` fell back to `infer_name_from_fields`, it used `schema.name` ("TestView") to overwrite `descriptive_name`. Fix: use `descriptive_name` as the initial schema name (it gets replaced by the identity hash anyway).

## Test plan
- [x] `cargo test --lib` — 345 passed in fold_db, 247 passed in fold_db_node (0 failures)
- [x] `cargo clippy -- -D warnings` — clean
- [x] Pre-existing `add_view_registers_output_schema` and `add_view_deduplicates_output_schema` test failures now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)