### PR TITLE
feat: store per-key write metadata on molecules instead of atoms

### DIFF
--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -12,3 +12,14 @@ pub use molecule_hash::MoleculeHash;
 pub use molecule_hash_range::MoleculeHashRange;
 pub use molecule_range::MoleculeRange;
 pub use mutation_event::{FieldKey, MutationEvent};
+
+/// Write-time metadata stored per-key on the molecule.
+/// Survives atom deduplication because it lives on the key-to-atom
+/// association, not on the content-addressed atom itself.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq)]
+pub struct KeyMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_file_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<std::collections::HashMap<String, String>>,
+}

--- a/src/atom/molecule.rs
+++ b/src/atom/molecule.rs
@@ -11,6 +11,8 @@ pub struct Molecule {
     updated_at: DateTime<Utc>,
     #[serde(default)]
     version: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    key_metadata: Option<super::KeyMetadata>,
 }
 
 impl Molecule {
@@ -22,6 +24,7 @@ impl Molecule {
             atom_uuid,
             updated_at: Utc::now(),
             version: 0,
+            key_metadata: None,
         }
     }
 
@@ -57,6 +60,17 @@ impl Molecule {
     #[must_use]
     pub fn get_atom_uuid(&self) -> &String {
         &self.atom_uuid
+    }
+
+    /// Sets per-key metadata on the molecule.
+    pub fn set_key_metadata(&mut self, meta: super::KeyMetadata) {
+        self.key_metadata = Some(meta);
+    }
+
+    /// Returns the per-key metadata, if any.
+    #[must_use]
+    pub fn get_key_metadata(&self) -> Option<&super::KeyMetadata> {
+        self.key_metadata.as_ref()
     }
 }
 

--- a/src/atom/molecule_hash.rs
+++ b/src/atom/molecule_hash.rs
@@ -13,6 +13,8 @@ pub struct MoleculeHash {
     updated_at: DateTime<Utc>,
     #[serde(default)]
     version: u64,
+    #[serde(default)]
+    key_metadata: HashMap<String, super::KeyMetadata>,
 }
 
 impl MoleculeHash {
@@ -24,6 +26,7 @@ impl MoleculeHash {
             atom_uuids: HashMap::new(),
             updated_at: Utc::now(),
             version: 0,
+            key_metadata: HashMap::new(),
         }
     }
 
@@ -76,6 +79,17 @@ impl MoleculeHash {
     pub fn keys(&self) -> impl Iterator<Item = &String> {
         self.atom_uuids.keys()
     }
+
+    /// Sets per-key metadata for a given hash key.
+    pub fn set_key_metadata(&mut self, key: String, meta: super::KeyMetadata) {
+        self.key_metadata.insert(key, meta);
+    }
+
+    /// Returns the per-key metadata for a given hash key, if any.
+    #[must_use]
+    pub fn get_key_metadata(&self, key: &str) -> Option<&super::KeyMetadata> {
+        self.key_metadata.get(key)
+    }
 }
 
 #[cfg(test)]
@@ -117,5 +131,76 @@ mod tests {
         let mut mol = MoleculeHash::new("key".to_string());
         mol.remove_atom_uuid("nonexistent");
         assert_eq!(mol.version(), 0);
+    }
+
+    #[test]
+    fn test_key_metadata_per_key_isolation() {
+        let mut mol = MoleculeHash::new("pub".to_string());
+        // Two keys sharing the same atom UUID (content-addressed dedup)
+        mol.set_atom_uuid("photo_a".to_string(), "atom-shared".to_string());
+        mol.set_atom_uuid("photo_b".to_string(), "atom-shared".to_string());
+        // Different metadata per key
+        mol.set_key_metadata(
+            "photo_a".to_string(),
+            super::super::KeyMetadata {
+                source_file_name: Some("beach.jpg".to_string()),
+                metadata: None,
+            },
+        );
+        mol.set_key_metadata(
+            "photo_b".to_string(),
+            super::super::KeyMetadata {
+                source_file_name: Some("sunset.jpg".to_string()),
+                metadata: None,
+            },
+        );
+        assert_eq!(
+            mol.get_key_metadata("photo_a").unwrap().source_file_name.as_deref(),
+            Some("beach.jpg")
+        );
+        assert_eq!(
+            mol.get_key_metadata("photo_b").unwrap().source_file_name.as_deref(),
+            Some("sunset.jpg")
+        );
+        // But both point to the same atom
+        assert_eq!(mol.get_atom_uuid("photo_a"), mol.get_atom_uuid("photo_b"));
+    }
+
+    #[test]
+    fn test_key_metadata_serde_roundtrip() {
+        let mut mol = MoleculeHash::new("pub".to_string());
+        mol.set_atom_uuid("k1".to_string(), "atom-1".to_string());
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("file_hash".to_string(), "abc123".to_string());
+        mol.set_key_metadata(
+            "k1".to_string(),
+            super::super::KeyMetadata {
+                source_file_name: Some("test.txt".to_string()),
+                metadata: Some(extra),
+            },
+        );
+        let json = serde_json::to_string(&mol).unwrap();
+        let deser: MoleculeHash = serde_json::from_str(&json).unwrap();
+        let meta = deser.get_key_metadata("k1").unwrap();
+        assert_eq!(meta.source_file_name.as_deref(), Some("test.txt"));
+        assert_eq!(
+            meta.metadata.as_ref().unwrap().get("file_hash").map(|s| s.as_str()),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn test_key_metadata_backward_compat() {
+        // Old serialized JSON without key_metadata should deserialize fine
+        let json = r#"{
+            "uuid": "test-uuid",
+            "atom_uuids": {"k1": "atom-1"},
+            "updated_at": "2024-01-01T00:00:00Z",
+            "version": 1
+        }"#;
+        let mol: MoleculeHash = serde_json::from_str(json).unwrap();
+        assert_eq!(mol.get_atom_uuid("k1"), Some(&"atom-1".to_string()));
+        assert!(mol.get_key_metadata("k1").is_none());
+        assert!(mol.key_metadata.is_empty());
     }
 }

--- a/src/atom/molecule_hash_range.rs
+++ b/src/atom/molecule_hash_range.rs
@@ -33,6 +33,10 @@ pub struct MoleculeHashRange {
     /// Monotonic version counter, bumped on each actual change
     #[serde(default)]
     version: u64,
+    /// Per-key metadata organized by hash and range values
+    /// Structure: HashMap<hash_value, BTreeMap<range_value, KeyMetadata>>
+    #[serde(default)]
+    key_metadata: HashMap<String, BTreeMap<String, crate::atom::KeyMetadata>>,
 }
 
 impl MoleculeHashRange {
@@ -45,6 +49,7 @@ impl MoleculeHashRange {
             updated_at: Utc::now(),
             update_order: vec![],
             version: 0,
+            key_metadata: HashMap::new(),
         }
     }
 
@@ -69,6 +74,7 @@ impl MoleculeHashRange {
             updated_at: Utc::now(),
             update_order,
             version: 0,
+            key_metadata: HashMap::new(),
         }
     }
 
@@ -210,6 +216,27 @@ impl MoleculeHashRange {
     #[must_use]
     pub fn sample(&self, n: usize) -> Vec<KeyValue> {
         self.update_order.iter().take(n).cloned().collect()
+    }
+
+    /// Sets per-key metadata for a given hash + range key combination.
+    pub fn set_key_metadata(
+        &mut self,
+        hash: String,
+        range: String,
+        meta: crate::atom::KeyMetadata,
+    ) {
+        self.key_metadata
+            .entry(hash)
+            .or_default()
+            .insert(range, meta);
+    }
+
+    /// Returns the per-key metadata for a given hash + range key, if any.
+    #[must_use]
+    pub fn get_key_metadata(&self, hash: &str, range: &str) -> Option<&crate::atom::KeyMetadata> {
+        self.key_metadata
+            .get(hash)
+            .and_then(|range_map| range_map.get(range))
     }
 }
 

--- a/src/atom/molecule_range.rs
+++ b/src/atom/molecule_range.rs
@@ -12,6 +12,8 @@ pub struct MoleculeRange {
     updated_at: DateTime<Utc>,
     #[serde(default)]
     version: u64,
+    #[serde(default)]
+    key_metadata: BTreeMap<String, super::KeyMetadata>,
 }
 
 impl MoleculeRange {
@@ -23,6 +25,7 @@ impl MoleculeRange {
             atom_uuids: BTreeMap::new(),
             updated_at: Utc::now(),
             version: 0,
+            key_metadata: BTreeMap::new(),
         }
     }
 
@@ -70,6 +73,17 @@ impl MoleculeRange {
     #[must_use]
     pub fn version(&self) -> u64 {
         self.version
+    }
+
+    /// Sets per-key metadata for a given range key.
+    pub fn set_key_metadata(&mut self, key: String, meta: super::KeyMetadata) {
+        self.key_metadata.insert(key, meta);
+    }
+
+    /// Returns the per-key metadata for a given range key, if any.
+    #[must_use]
+    pub fn get_key_metadata(&self, key: &str) -> Option<&super::KeyMetadata> {
+        self.key_metadata.get(key)
     }
 }
 

--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -630,7 +630,12 @@ impl MutationManager {
             };
 
             // Write mutation to memory
-            schema_field.write_mutation(key_value, atom.clone(), mutation.pub_key.clone());
+            schema_field.write_mutation(key_value, crate::schema::types::field::WriteContext {
+                atom: atom.clone(),
+                pub_key: mutation.pub_key.clone(),
+                source_file_name: mutation.source_file_name.clone(),
+                metadata: mutation.metadata.clone(),
+            });
 
             // Build mutation event if something actually changed
             if old_atom_uuid.as_deref() != Some(atom.uuid()) {

--- a/src/schema/types/field/common.rs
+++ b/src/schema/types/field/common.rs
@@ -12,6 +12,17 @@ use crate::schema::types::field::HashRangeFilter;
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::SchemaError;
 use crate::schema::types::Transform;
+
+/// Bundles all write-time provenance through the Field trait.
+/// Contains the atom plus optional metadata that should be stored
+/// per-key on the molecule (surviving atom dedup).
+pub struct WriteContext {
+    pub atom: crate::atom::Atom,
+    pub pub_key: String,
+    pub source_file_name: Option<String>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
+}
+
 /// Common interface for all schema fields.
 ///
 /// The `Field` trait exposes accessors for properties shared by all field
@@ -29,7 +40,7 @@ pub trait Field: Send + Sync {
     async fn refresh_from_db(&mut self, db_ops: &crate::db_operations::DbOperations);
 
     /// Writes a mutation to the field
-    fn write_mutation(&mut self, key_value: &KeyValue, atom: crate::atom::Atom, pub_key: String);
+    fn write_mutation(&mut self, key_value: &KeyValue, ctx: WriteContext);
 
     /// Resolves field values by refreshing the field, applying filters, and fetching atom content.
     /// If `as_of` is provided, rewinds the molecule to that point in time before resolving.
@@ -121,9 +132,9 @@ macro_rules! impl_field {
             fn write_mutation(
                 &mut self,
                 key_value: &$crate::schema::types::key_value::KeyValue,
-                atom: $crate::atom::Atom,
-                pub_key: String,
+                ctx: $crate::schema::types::field::WriteContext,
             ) {
+                let _ = (key_value, ctx);
                 log::error!("write_mutation not implemented for {}", stringify!($t));
             }
 

--- a/src/schema/types/field/filter_utils.rs
+++ b/src/schema/types/field/filter_utils.rs
@@ -41,23 +41,49 @@ pub async fn fetch_atoms_for_matches_async(
     db_ops: &Arc<DbOperations>,
     matches: impl IntoIterator<Item = (KeyValue, String)>,
 ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
+    // Delegate to the metadata-aware version with None metadata
+    fetch_atoms_with_key_metadata_async(
+        db_ops,
+        matches.into_iter().map(|(kv, uuid)| (kv, uuid, None)),
+    )
+    .await
+}
+
+/// Resolve atom UUID matches into concrete FieldValue map, preferring molecule
+/// per-key metadata over atom metadata for source_file_name and metadata fields.
+/// Falls back to atom metadata for backward compatibility with pre-existing data.
+pub async fn fetch_atoms_with_key_metadata_async(
+    db_ops: &Arc<DbOperations>,
+    matches: impl IntoIterator<Item = (KeyValue, String, Option<crate::atom::KeyMetadata>)>,
+) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
     let mut resolved_values: HashMap<KeyValue, FieldValue> = HashMap::new();
 
     use crate::storage::traits::TypedStore;
-    for (key, atom_uuid) in matches.into_iter() {
+    for (key, atom_uuid, key_meta) in matches.into_iter() {
         match db_ops
             .atoms_store()
             .get_item::<crate::atom::Atom>(&format!("atom:{}", atom_uuid))
             .await
         {
             Ok(Some(atom)) => {
+                // Prefer molecule per-key metadata, fall back to atom metadata
+                let (source_file_name, metadata) = match key_meta {
+                    Some(km) => (
+                        km.source_file_name.or_else(|| atom.source_file_name().cloned()),
+                        km.metadata.or_else(|| atom.metadata().cloned()),
+                    ),
+                    None => (
+                        atom.source_file_name().cloned(),
+                        atom.metadata().cloned(),
+                    ),
+                };
                 resolved_values.insert(
                     key,
                     FieldValue {
                         value: atom.content().clone(),
                         atom_uuid: atom_uuid.clone(),
-                        source_file_name: atom.source_file_name().cloned(),
-                        metadata: atom.metadata().cloned(),
+                        source_file_name,
+                        metadata,
                         molecule_uuid: None,
                         molecule_version: None,
                     },

--- a/src/schema/types/field/hash_field.rs
+++ b/src/schema/types/field/hash_field.rs
@@ -8,6 +8,7 @@ use crate::schema::types::field::base::FieldBase;
 use crate::schema::types::field::hash_range_filter::{HashRangeFilter, HashRangeFilterResult};
 use crate::schema::types::field::FieldValue;
 use crate::schema::types::field::{apply_hash_filter, FilterApplicator};
+use crate::schema::types::field::WriteContext;
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::SchemaError;
 use serde::{Deserialize, Serialize};
@@ -53,12 +54,11 @@ impl crate::schema::types::field::Field for HashField {
     fn write_mutation(
         &mut self,
         key_value: &crate::schema::types::key_value::KeyValue,
-        atom: crate::atom::Atom,
-        pub_key: String,
+        ctx: WriteContext,
     ) {
         // Initialize molecule if needed and set molecule_uuid in FieldCommon
         if self.base.molecule.is_none() {
-            let new_molecule = crate::atom::MoleculeHash::new(pub_key.clone());
+            let new_molecule = crate::atom::MoleculeHash::new(ctx.pub_key.clone());
             self.base
                 .inner
                 .set_molecule_uuid(new_molecule.uuid().to_string());
@@ -68,7 +68,12 @@ impl crate::schema::types::field::Field for HashField {
         // For HashField, we use the hash key to store the atom
         if let Some(hash_key) = &key_value.hash {
             if let Some(molecule) = &mut self.base.molecule {
-                molecule.set_atom_uuid(hash_key.clone(), atom.uuid().to_string());
+                molecule.set_atom_uuid(hash_key.clone(), ctx.atom.uuid().to_string());
+                // Store per-key metadata on the molecule
+                molecule.set_key_metadata(hash_key.clone(), crate::atom::KeyMetadata {
+                    source_file_name: ctx.source_file_name,
+                    metadata: ctx.metadata,
+                });
             }
         }
     }
@@ -81,7 +86,18 @@ impl crate::schema::types::field::Field for HashField {
     ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
         self.refresh_from_db(db_ops).await;
         let result = self.apply_filter(filter);
-        super::fetch_atoms_for_matches_async(db_ops, result.matches).await
+        // Attach per-key metadata from molecule to each match
+        let matches_with_meta: Vec<(KeyValue, String, Option<crate::atom::KeyMetadata>)> = result
+            .matches
+            .into_iter()
+            .map(|(kv, atom_uuid)| {
+                let key_meta = kv.hash.as_ref().and_then(|h| {
+                    self.base.molecule.as_ref().and_then(|m| m.get_key_metadata(h).cloned())
+                });
+                (kv, atom_uuid, key_meta)
+            })
+            .collect();
+        super::fetch_atoms_with_key_metadata_async(db_ops, matches_with_meta.into_iter()).await
     }
 }
 

--- a/src/schema/types/field/hash_range_field.rs
+++ b/src/schema/types/field/hash_range_field.rs
@@ -9,6 +9,7 @@ use crate::schema::types::declarative_schemas::FieldMapper;
 use crate::schema::types::field::hash_range_filter::{HashRangeFilter, HashRangeFilterResult};
 use crate::schema::types::field::FieldValue;
 use crate::schema::types::field::{apply_hash_range_filter, FilterApplicator};
+use crate::schema::types::field::WriteContext;
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::SchemaError;
 use serde::{Deserialize, Serialize};
@@ -56,12 +57,11 @@ impl crate::schema::types::field::Field for HashRangeField {
     fn write_mutation(
         &mut self,
         key_value: &crate::schema::types::key_value::KeyValue,
-        atom: crate::atom::Atom,
-        pub_key: String,
+        ctx: WriteContext,
     ) {
         // Initialize molecule if needed and set molecule_uuid in FieldCommon
         if self.base.molecule.is_none() {
-            let new_molecule = crate::atom::MoleculeHashRange::new(pub_key.clone());
+            let new_molecule = crate::atom::MoleculeHashRange::new(ctx.pub_key.clone());
             // Get the molecule's UUID and set it in FieldCommon for persistence lookup
             self.base
                 .inner
@@ -76,7 +76,16 @@ impl crate::schema::types::field::Field for HashRangeField {
                     molecule.set_atom_uuid_from_values(
                         hash_key.clone(),
                         range_key.clone(),
-                        atom.uuid().to_string(),
+                        ctx.atom.uuid().to_string(),
+                    );
+                    // Store per-key metadata on the molecule
+                    molecule.set_key_metadata(
+                        hash_key.clone(),
+                        range_key.clone(),
+                        crate::atom::KeyMetadata {
+                            source_file_name: ctx.source_file_name,
+                            metadata: ctx.metadata,
+                        },
                     );
                 }
             }
@@ -84,7 +93,7 @@ impl crate::schema::types::field::Field for HashRangeField {
                 log::warn!(
                     "HashRangeField::write_mutation: atom {} not indexed — hash={:?}, range={:?}. \
                      Both hash and range keys are required for HashRange fields.",
-                    atom.uuid(), key_value.hash, key_value.range
+                    ctx.atom.uuid(), key_value.hash, key_value.range
                 );
             }
         }
@@ -97,16 +106,25 @@ impl crate::schema::types::field::Field for HashRangeField {
         _as_of: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
         self.refresh_from_db(db_ops).await;
-        // let filter_debug = filter.clone();
         let result = self.apply_filter(filter);
-        // log::debug!("🔍 HashRangeField::resolve_value: filter={:?}, matches={}", filter_debug, result.matches.len());
         if result.matches.is_empty() {
-            // log::warn!("⚠️ HashRangeField::resolve_value: No matches found. molecule={:?}, molecule_uuid={:?}",
-            //    self.base.molecule.is_some(),
-            //    self.base.inner.molecule_uuid()
-            // );
+            // No matches found
         }
-        super::fetch_atoms_for_matches_async(db_ops, result.matches).await
+        // Attach per-key metadata from molecule to each match
+        let matches_with_meta: Vec<(KeyValue, String, Option<crate::atom::KeyMetadata>)> = result
+            .matches
+            .into_iter()
+            .map(|(kv, atom_uuid)| {
+                let key_meta = match (&kv.hash, &kv.range) {
+                    (Some(h), Some(r)) => {
+                        self.base.molecule.as_ref().and_then(|m| m.get_key_metadata(h, r).cloned())
+                    }
+                    _ => None,
+                };
+                (kv, atom_uuid, key_meta)
+            })
+            .collect();
+        super::fetch_atoms_with_key_metadata_async(db_ops, matches_with_meta.into_iter()).await
     }
 }
 

--- a/src/schema/types/field/mod.rs
+++ b/src/schema/types/field/mod.rs
@@ -7,9 +7,10 @@ pub mod range_field;
 pub mod single_field;
 pub mod variant;
 
-pub use common::{Field, FieldCommon, FieldType};
+pub use common::{Field, FieldCommon, FieldType, WriteContext};
 pub use filter_utils::{
-    apply_hash_filter, apply_hash_range_filter, apply_range_filter, fetch_atoms_for_matches_async,
+    apply_hash_filter, apply_hash_range_filter, apply_range_filter,
+    fetch_atoms_for_matches_async, fetch_atoms_with_key_metadata_async,
     FilterApplicator, FilterUtils, HashOperations, HashRangeOperations, RangeOperations,
 };
 pub use hash_field::HashField;

--- a/src/schema/types/field/range_field.rs
+++ b/src/schema/types/field/range_field.rs
@@ -11,6 +11,7 @@ use crate::schema::types::field::FieldValue;
 use crate::schema::types::field::{
     apply_range_filter, FilterApplicator, HashRangeFilter, HashRangeFilterResult,
 };
+use crate::schema::types::field::WriteContext;
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::SchemaError;
 
@@ -79,12 +80,11 @@ impl crate::schema::types::field::Field for RangeField {
     fn write_mutation(
         &mut self,
         key_value: &crate::schema::types::key_value::KeyValue,
-        atom: crate::atom::Atom,
-        pub_key: String,
+        ctx: WriteContext,
     ) {
         // Initialize molecule if needed and set molecule_uuid in FieldCommon
         if self.base.molecule.is_none() {
-            self.ensure_molecule(pub_key.clone());
+            self.ensure_molecule(ctx.pub_key.clone());
             // After creating the molecule, get its UUID and set it in FieldCommon
             if let Some(mol) = &self.base.molecule {
                 self.base.inner.set_molecule_uuid(mol.uuid().to_string());
@@ -94,7 +94,12 @@ impl crate::schema::types::field::Field for RangeField {
         // For RangeField, we use the range key to store the atom
         if let Some(range_key) = &key_value.range {
             if let Some(molecule) = &mut self.base.molecule {
-                molecule.set_atom_uuid(range_key.clone(), atom.uuid().to_string());
+                molecule.set_atom_uuid(range_key.clone(), ctx.atom.uuid().to_string());
+                // Store per-key metadata on the molecule
+                molecule.set_key_metadata(range_key.clone(), crate::atom::KeyMetadata {
+                    source_file_name: ctx.source_file_name,
+                    metadata: ctx.metadata,
+                });
             }
         }
     }
@@ -109,6 +114,17 @@ impl crate::schema::types::field::Field for RangeField {
 
         // Fetch actual atom content from database using shared helper
         let result = self.apply_filter(filter);
-        super::fetch_atoms_for_matches_async(db_ops, result.matches).await
+        // Attach per-key metadata from molecule to each match
+        let matches_with_meta: Vec<(KeyValue, String, Option<crate::atom::KeyMetadata>)> = result
+            .matches
+            .into_iter()
+            .map(|(kv, atom_uuid)| {
+                let key_meta = kv.range.as_ref().and_then(|r| {
+                    self.base.molecule.as_ref().and_then(|m| m.get_key_metadata(r).cloned())
+                });
+                (kv, atom_uuid, key_meta)
+            })
+            .collect();
+        super::fetch_atoms_with_key_metadata_async(db_ops, matches_with_meta.into_iter()).await
     }
 }

--- a/src/schema/types/field/single_field.rs
+++ b/src/schema/types/field/single_field.rs
@@ -9,6 +9,7 @@ use crate::schema::types::declarative_schemas::FieldMapper;
 use crate::schema::types::field::base::FieldBase;
 use crate::schema::types::field::FieldValue;
 use crate::schema::types::field::{FilterApplicator, HashRangeFilter, HashRangeFilterResult};
+use crate::schema::types::field::WriteContext;
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::SchemaError;
 // Removed unused JsonValue import
@@ -46,12 +47,11 @@ impl crate::schema::types::field::Field for SingleField {
     fn write_mutation(
         &mut self,
         _key_value: &crate::schema::types::key_value::KeyValue,
-        atom: crate::atom::Atom,
-        pub_key: String,
+        ctx: WriteContext,
     ) {
         // Initialize molecule if needed and set molecule_uuid in FieldCommon
         if self.base.molecule.is_none() {
-            let new_molecule = crate::atom::Molecule::new(atom.uuid().to_string(), pub_key.clone());
+            let new_molecule = crate::atom::Molecule::new(ctx.atom.uuid().to_string(), ctx.pub_key.clone());
             // Get the molecule's UUID and set it in FieldCommon for persistence lookup
             self.base
                 .inner
@@ -61,7 +61,12 @@ impl crate::schema::types::field::Field for SingleField {
 
         // For SingleField, we store the atom using the pub_key
         if let Some(molecule) = &mut self.base.molecule {
-            molecule.set_atom_uuid(atom.uuid().to_string());
+            molecule.set_atom_uuid(ctx.atom.uuid().to_string());
+            // Store per-key metadata on the molecule
+            molecule.set_key_metadata(crate::atom::KeyMetadata {
+                source_file_name: ctx.source_file_name,
+                metadata: ctx.metadata,
+            });
         }
     }
 
@@ -74,9 +79,10 @@ impl crate::schema::types::field::Field for SingleField {
         self.refresh_from_db(db_ops).await;
         if let Some(molecule) = &self.base.molecule {
             let uuid = molecule.get_atom_uuid().clone();
-            let result = super::fetch_atoms_for_matches_async(
+            let key_meta = molecule.get_key_metadata().cloned();
+            let result = super::fetch_atoms_with_key_metadata_async(
                 db_ops,
-                vec![(KeyValue::new(None, None), uuid)].into_iter(),
+                vec![(KeyValue::new(None, None), uuid, key_meta)].into_iter(),
             )
             .await?;
             Ok(result)

--- a/src/schema/types/field/variant.rs
+++ b/src/schema/types/field/variant.rs
@@ -8,7 +8,7 @@ use crate::atom::{FieldKey, MutationEvent};
 use crate::db_operations::DbOperations;
 use crate::schema::types::field::{
     fetch_atoms_for_matches_async, Field, FieldCommon, FilterApplicator, HashField,
-    HashRangeField, HashRangeFilter, RangeField, SingleField,
+    HashRangeField, HashRangeFilter, RangeField, SingleField, WriteContext,
 };
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::SchemaError;
@@ -82,10 +82,9 @@ impl Field for FieldVariant {
     fn write_mutation(
         &mut self,
         key_value: &crate::schema::types::key_value::KeyValue,
-        atom: crate::atom::Atom,
-        pub_key: String,
+        ctx: WriteContext,
     ) {
-        delegate_field_method!(self, write_mutation, key_value, atom, pub_key)
+        delegate_field_method!(self, write_mutation, key_value, ctx)
     }
 
     async fn resolve_value(


### PR DESCRIPTION
## Summary
- Atoms are content-addressed and deduplicated, so `source_file_name` and `metadata` stored on atoms get overwritten when two records share the same value (e.g. `camera_model="iPhone 5s"` across all photos). This caused the data browser to show the wrong image for photo records.
- Now each molecule type stores a parallel `key_metadata` map alongside `atom_uuids`, giving every key its own write-time provenance that survives atom dedup
- The read path prefers molecule metadata, falling back to atom metadata for backward compatibility with pre-existing data

## Changes
- **`KeyMetadata` struct** in `atom/mod.rs` — `source_file_name` + `metadata`
- **4 molecule types** — parallel `key_metadata` maps with getter/setter per type
- **`WriteContext` struct** — bundles atom + pub_key + provenance through the `Field` trait
- **`fetch_atoms_with_key_metadata_async`** — read path prefers molecule metadata, falls back to atom
- **3 new tests** — per-key isolation (dedup correctness), serde roundtrip, backward compat

## Data flow
```
WRITE: Mutation.source_file_name → WriteContext → molecule.set_key_metadata(key, meta)
READ:  molecule.get_key_metadata(key) → FieldValue.source_file_name (fallback: atom)
```

## Backward compatibility
- `#[serde(default)]` on all `key_metadata` fields — old molecules deserialize cleanly
- Read path falls back to `atom.source_file_name()` when molecule metadata is absent
- `source_file_name` still written to atoms for old code that reads from there

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --features aws-backend`
- [x] `cargo test --workspace --all-targets` — 486 tests pass (3 new)
- [ ] Dogfood: ingest photos, verify data browser shows correct image per record

🤖 Generated with [Claude Code](https://claude.com/claude-code)