### PR TITLE
Inject embedder via Arc<dyn Embedder> for configurable backends

### DIFF
--- a/src/db_operations/core.rs
+++ b/src/db_operations/core.rs
@@ -1,3 +1,4 @@
+use super::native_index::Embedder;
 use super::NativeIndexManager;
 use crate::schema::SchemaError;
 use crate::storage::traits::*;
@@ -37,6 +38,7 @@ impl DbOperations {
     /// Create from a NamespacedStore (works with any backend)
     pub async fn from_namespaced_store(
         store: Arc<dyn NamespacedStore>,
+        embedder: Arc<dyn Embedder>,
     ) -> Result<Self, crate::storage::StorageError> {
         // Open all required namespaces
         let main_kv = store.open_namespace("main").await?;
@@ -68,7 +70,7 @@ impl DbOperations {
         let transform_field_states_store = Arc::new(TypedKvStore::new(transform_field_states_kv));
 
         // Create native index manager and load any previously stored embeddings
-        let native_index_manager = NativeIndexManager::new(native_index_kv);
+        let native_index_manager = NativeIndexManager::new(native_index_kv, embedder);
         native_index_manager.restore_from_store().await;
 
         Ok(Self {
@@ -88,10 +90,10 @@ impl DbOperations {
         })
     }
 
-    /// Convenience constructor for Sled backend (backward compatible, no E2E)
-    pub async fn from_sled(db: sled::Db) -> Result<Self, crate::storage::StorageError> {
+    /// Convenience constructor for Sled backend
+    pub async fn from_sled(db: sled::Db, embedder: Arc<dyn Embedder>) -> Result<Self, crate::storage::StorageError> {
         let store = Arc::new(SledNamespacedStore::new(db)) as Arc<dyn NamespacedStore>;
-        Self::from_namespaced_store(store).await
+        Self::from_namespaced_store(store, embedder).await
     }
 
     /// Convenience constructor for Cloud backend with simplified config
@@ -100,10 +102,11 @@ impl DbOperations {
         client: aws_sdk_dynamodb::Client,
         table_name: String,
         user_id: String,
+        embedder: Arc<dyn Embedder>,
     ) -> Result<Self, crate::storage::StorageError> {
         let _ = user_id; // Suppress unused warning - user_id will be obtained from request context
         let store = DynamoDbNamespacedStore::new_with_prefix(client, table_name);
-        Self::from_namespaced_store(Arc::new(store)).await
+        Self::from_namespaced_store(Arc::new(store), embedder).await
     }
 
     /// Constructor for Cloud backend with detailed configuration
@@ -113,10 +116,11 @@ impl DbOperations {
         resolver: crate::storage::TableNameResolver,
         auto_create: bool,
         user_id: String,
+        embedder: Arc<dyn Embedder>,
     ) -> Result<Self, crate::storage::StorageError> {
         let _ = user_id; // Suppress unused warning - user_id will be obtained from request context
         let store = DynamoDbNamespacedStore::new(client, resolver, auto_create);
-        Self::from_namespaced_store(Arc::new(store)).await
+        Self::from_namespaced_store(Arc::new(store), embedder).await
     }
 
     // ===== Namespace-specific store getters =====

--- a/src/db_operations/native_index/mod.rs
+++ b/src/db_operations/native_index/mod.rs
@@ -26,10 +26,10 @@ pub struct NativeIndexManager {
 }
 
 impl NativeIndexManager {
-    pub fn new(store: Arc<dyn KvStore>) -> Self {
+    pub fn new(store: Arc<dyn KvStore>, model: Arc<dyn Embedder>) -> Self {
         Self {
             store,
-            embedding_model: Arc::new(FastEmbedModel::new()),
+            embedding_model: model,
             embedding_index: Arc::new(EmbeddingIndex::new(Vec::new())),
         }
     }
@@ -38,15 +38,6 @@ impl NativeIndexManager {
     pub async fn restore_from_store(&self) {
         let entries = EmbeddingIndex::load_from_store(&*self.store).await;
         *self.embedding_index.entries.write().unwrap() = entries;
-    }
-
-    #[cfg(any(test, feature = "test-utils"))]
-    pub(crate) fn with_model(store: Arc<dyn KvStore>, model: Arc<dyn Embedder>) -> Self {
-        Self {
-            store,
-            embedding_model: model,
-            embedding_index: Arc::new(EmbeddingIndex::new(Vec::new())),
-        }
     }
 
     /// Index all fields of a record as a single document embedding.

--- a/src/db_operations/native_index/tests.rs
+++ b/src/db_operations/native_index/tests.rs
@@ -8,7 +8,7 @@ async fn make_manager() -> NativeIndexManager {
     let db = sled::Config::new().temporary(true).open().unwrap();
     let store = Arc::new(SledNamespacedStore::new(db));
     let kv = store.open_namespace("native_index").await.unwrap();
-    NativeIndexManager::with_model(kv, Arc::new(MockEmbeddingModel))
+    NativeIndexManager::new(kv, Arc::new(MockEmbeddingModel))
 }
 
 #[tokio::test]
@@ -115,7 +115,7 @@ async fn test_restore_from_store_loads_existing_embeddings() {
     let kv = store.open_namespace("native_index").await.unwrap();
 
     // Index a record with manager 1
-    let mgr1 = NativeIndexManager::with_model(kv.clone(), Arc::new(MockEmbeddingModel));
+    let mgr1 = NativeIndexManager::new(kv.clone(), Arc::new(MockEmbeddingModel));
     let key = KeyValue::new(Some("rec1".to_string()), None);
     let fields = std::collections::HashMap::from([
         ("field".to_string(), serde_json::json!("value")),
@@ -123,7 +123,7 @@ async fn test_restore_from_store_loads_existing_embeddings() {
     mgr1.index_record("S", &key, &fields).await.unwrap();
 
     // Create manager 2 with same store, restore from store
-    let mgr2 = NativeIndexManager::with_model(kv, Arc::new(MockEmbeddingModel));
+    let mgr2 = NativeIndexManager::new(kv, Arc::new(MockEmbeddingModel));
     mgr2.restore_from_store().await;
 
     let entries = mgr2.embedding_index.entries.read().unwrap();

--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -1,4 +1,5 @@
 use crate::crypto::E2eKeys;
+use crate::db_operations::native_index::Embedder;
 use crate::db_operations::DbOperations;
 use crate::error::{FoldDbError, FoldDbResult};
 use crate::fold_db_core::FoldDB;
@@ -25,10 +26,11 @@ use crate::log_feature;
 pub async fn create_fold_db(
     config: &DatabaseConfig,
     e2e_keys: &E2eKeys,
+    embedder: Arc<dyn Embedder>,
 ) -> FoldDbResult<Arc<Mutex<FoldDB>>> {
     match config {
         DatabaseConfig::Local { path } => {
-            create_local_fold_db(path, e2e_keys, None).await
+            create_local_fold_db(path, e2e_keys, None, embedder).await
         }
         DatabaseConfig::Exemem { api_url, api_key } => {
             // Exemem mode: local Sled + S3 sync via the Exemem platform.
@@ -39,11 +41,11 @@ pub async fn create_fold_db(
             let data_dir = path.to_str()
                 .ok_or_else(|| FoldDbError::Config("Invalid storage path".to_string()))?;
             let sync_setup = SyncSetup::from_exemem(api_url, api_key, data_dir);
-            create_local_fold_db(&path, e2e_keys, Some(sync_setup)).await
+            create_local_fold_db(&path, e2e_keys, Some(sync_setup), embedder).await
         }
         #[cfg(feature = "aws-backend")]
         DatabaseConfig::Cloud(cloud_config) => {
-            create_cloud_fold_db(cloud_config, e2e_keys).await
+            create_cloud_fold_db(cloud_config, e2e_keys, embedder).await
         }
     }
 }
@@ -62,6 +64,7 @@ async fn create_local_fold_db(
     path: &std::path::Path,
     e2e_keys: &E2eKeys,
     sync_setup: Option<SyncSetup>,
+    embedder: Arc<dyn Embedder>,
 ) -> FoldDbResult<Arc<Mutex<FoldDB>>> {
     let path_str = path
         .to_str()
@@ -136,7 +139,7 @@ async fn create_local_fold_db(
         (Arc::new(enc_store), None, 0)
     };
 
-    let db_ops = DbOperations::from_namespaced_store(store)
+    let db_ops = DbOperations::from_namespaced_store(store, embedder)
         .await
         .map_err(|e| FoldDbError::Config(e.to_string()))?;
 
@@ -163,6 +166,7 @@ async fn create_local_fold_db(
 async fn create_cloud_fold_db(
     cloud_config: &crate::storage::config::CloudConfig,
     e2e_keys: &E2eKeys,
+    embedder: Arc<dyn Embedder>,
 ) -> FoldDbResult<Arc<Mutex<FoldDB>>> {
     log_feature!(
         LogFeature::Database,
@@ -232,7 +236,7 @@ async fn create_cloud_fold_db(
         Arc::new(e2e_store) as Arc<dyn crate::storage::traits::NamespacedStore>;
 
     let db_ops = Arc::new(
-        DbOperations::from_namespaced_store(final_store)
+        DbOperations::from_namespaced_store(final_store, embedder)
             .await
             .map_err(|e| {
                 FoldDbError::Config(format!("Failed to initialize DynamoDB backend: {}", e))

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use log::{debug, info};
 
 // Internal crate imports
+use crate::db_operations::native_index::Embedder;
 use crate::db_operations::{DbOperations, IndexResult};
 use crate::logging::features::{log_feature, LogFeature};
 use crate::schema::{SchemaCore, SchemaError};
@@ -140,11 +141,11 @@ impl FoldDB {
     /// Creates a new FoldDB instance with the specified storage path.
     /// All initializations happen here. This is the main entry point for the FoldDB system.
     /// Do not initialize anywhere else.
-    pub async fn new(path: &str) -> Result<Self, StorageError> {
+    pub async fn new(path: &str, embedder: Arc<dyn Embedder>) -> Result<Self, StorageError> {
         let db = sled::open(path)
             .map_err(|e| StorageError::IoError(std::io::Error::other(e.to_string())))?;
 
-        Self::initialize_from_db(db, path).await
+        Self::initialize_from_db(db, path, embedder).await
     }
 
     /// Creates a new FoldDB instance with fully initialized components.
@@ -163,14 +164,14 @@ impl FoldDB {
 
     /// Common initialization logic shared by both new() and new_with_s3()
     /// This method initializes all FoldDB components from an already-opened sled database
-    async fn initialize_from_db(db: sled::Db, db_path: &str) -> Result<Self, StorageError> {
+    async fn initialize_from_db(db: sled::Db, db_path: &str, embedder: Arc<dyn Embedder>) -> Result<Self, StorageError> {
         log_feature!(
             LogFeature::Database,
             info,
             "🔄 Using DbOperations with storage abstraction layer (Sled backend)"
         );
 
-        let db_ops = Arc::new(DbOperations::from_sled(db.clone()).await?);
+        let db_ops = Arc::new(DbOperations::from_sled(db.clone(), embedder).await?);
 
         log_feature!(
             LogFeature::Database,

--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -594,9 +594,12 @@ impl SchemaCore {
             .open()
             .map_err(|e| SchemaError::InvalidData(e.to_string()))?;
         let db_ops = std::sync::Arc::new(
-            crate::db_operations::DbOperations::from_sled(db)
-                .await
-                .map_err(|e| SchemaError::InvalidData(e.to_string()))?,
+            crate::db_operations::DbOperations::from_sled(
+                db,
+                Arc::new(crate::db_operations::native_index::FastEmbedModel::new()),
+            )
+            .await
+            .map_err(|e| SchemaError::InvalidData(e.to_string()))?,
         );
         let message_bus = Arc::new(AsyncMessageBus::new());
         Self::new(db_ops, message_bus).await

--- a/src/schema/types/field/variant.rs
+++ b/src/schema/types/field/variant.rs
@@ -347,7 +347,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db = sled::open(tmp.path()).unwrap();
         let db_ops =
-            Arc::new(crate::db_operations::DbOperations::from_sled(db).await.unwrap());
+            Arc::new(crate::db_operations::DbOperations::from_sled(db, std::sync::Arc::new(crate::db_operations::native_index::FastEmbedModel::new())).await.unwrap());
 
         let mol_uuid = "mol-single-1";
         let t0 = Utc::now() - Duration::seconds(10);
@@ -396,7 +396,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db = sled::open(tmp.path()).unwrap();
         let db_ops =
-            Arc::new(crate::db_operations::DbOperations::from_sled(db).await.unwrap());
+            Arc::new(crate::db_operations::DbOperations::from_sled(db, std::sync::Arc::new(crate::db_operations::native_index::FastEmbedModel::new())).await.unwrap());
 
         let mol_uuid = "mol-single-2";
         let t0 = Utc::now() - Duration::seconds(10);
@@ -430,7 +430,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db = sled::open(tmp.path()).unwrap();
         let db_ops =
-            Arc::new(crate::db_operations::DbOperations::from_sled(db).await.unwrap());
+            Arc::new(crate::db_operations::DbOperations::from_sled(db, std::sync::Arc::new(crate::db_operations::native_index::FastEmbedModel::new())).await.unwrap());
 
         let mol_uuid = "mol-range-1";
         let t0 = Utc::now() - Duration::seconds(10);
@@ -483,7 +483,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db = sled::open(tmp.path()).unwrap();
         let db_ops =
-            Arc::new(crate::db_operations::DbOperations::from_sled(db).await.unwrap());
+            Arc::new(crate::db_operations::DbOperations::from_sled(db, std::sync::Arc::new(crate::db_operations::native_index::FastEmbedModel::new())).await.unwrap());
 
         let mol_uuid = "mol-hr-1";
         let t0 = Utc::now() - Duration::seconds(10);
@@ -544,7 +544,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db = sled::open(tmp.path()).unwrap();
         let db_ops =
-            Arc::new(crate::db_operations::DbOperations::from_sled(db).await.unwrap());
+            Arc::new(crate::db_operations::DbOperations::from_sled(db, std::sync::Arc::new(crate::db_operations::native_index::FastEmbedModel::new())).await.unwrap());
 
         let mol_uuid = "mol-aba";
         let t0 = Utc::now() - Duration::seconds(10);
@@ -604,7 +604,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db = sled::open(tmp.path()).unwrap();
         let db_ops =
-            Arc::new(crate::db_operations::DbOperations::from_sled(db).await.unwrap());
+            Arc::new(crate::db_operations::DbOperations::from_sled(db, std::sync::Arc::new(crate::db_operations::native_index::FastEmbedModel::new())).await.unwrap());
 
         let mol_uuid = "mol-empty";
         let mut field = make_single_field("atom-current", mol_uuid);

--- a/src/testing_utils.rs
+++ b/src/testing_utils.rs
@@ -2,6 +2,7 @@
 //!
 //! This module eliminates duplicate database setup code found across 11+ files
 
+use crate::db_operations::native_index::FastEmbedModel;
 use crate::db_operations::DbOperations;
 use crate::fold_db_core::infrastructure::message_bus::AsyncMessageBus;
 use sled::{Db, Tree};
@@ -19,7 +20,7 @@ impl TestDatabaseFactory {
     /// Create temporary DbOperations for testing - consolidates pattern from multiple files
     pub async fn create_temp_db_ops() -> Result<DbOperations, Box<dyn std::error::Error>> {
         let db = Self::create_temp_sled_db()?;
-        Ok(DbOperations::from_sled(db).await?)
+        Ok(DbOperations::from_sled(db, Arc::new(FastEmbedModel::new())).await?)
     }
 
     /// Create complete test environment with db_ops and message bus

--- a/tests/access_control_test.rs
+++ b/tests/access_control_test.rs
@@ -2,6 +2,7 @@ use fold_db::access::{
     AccessContext, FieldAccessPolicy, PaymentGate,
     SecurityLabel, TrustDistancePolicy, TrustGraph,
 };
+use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::fold_db_core::FoldDB;
 use fold_db::schema::types::field::Field;
 use fold_db::schema::types::operations::{MutationType, Query};
@@ -9,10 +10,13 @@ use fold_db::schema::SchemaState;
 use fold_db::schema::types::{KeyValue, Mutation};
 use serde_json::json;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 async fn setup_db() -> FoldDB {
     let dir = tempfile::tempdir().unwrap();
-    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+    FoldDB::new(dir.path().to_str().unwrap(), Arc::new(FastEmbedModel::new()))
+        .await
+        .unwrap()
 }
 
 fn notes_schema_json() -> &'static str {

--- a/tests/field_type_validation_test.rs
+++ b/tests/field_type_validation_test.rs
@@ -1,4 +1,6 @@
+use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::fold_db_core::FoldDB;
+use std::sync::Arc;
 use fold_db::schema::types::operations::MutationType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
@@ -7,7 +9,7 @@ use std::collections::HashMap;
 
 async fn setup_db() -> FoldDB {
     let dir = tempfile::tempdir().unwrap();
-    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+    FoldDB::new(dir.path().to_str().unwrap(), Arc::new(FastEmbedModel::new())).await.unwrap()
 }
 
 fn typed_schema_json() -> &'static str {

--- a/tests/repro_schema_error.rs
+++ b/tests/repro_schema_error.rs
@@ -1,4 +1,6 @@
+use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::fold_db_core::fold_db::FoldDB;
+use std::sync::Arc;
 
 #[tokio::test]
 async fn test_reproduce_schema_mismatch() {
@@ -8,7 +10,7 @@ async fn test_reproduce_schema_mismatch() {
     // 1. Setup FoldDB with a temp dir
     let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
     let db_path = temp_dir.path().to_str().expect("failed to get path");
-    let mut db = FoldDB::new(db_path).await.expect("Failed to create DB");
+    let mut db = FoldDB::new(db_path, Arc::new(FastEmbedModel::new())).await.expect("Failed to create DB");
 
     let schema_json = r#"{
         "name": "lowercase_hash",

--- a/tests/schema_superseded_by_test.rs
+++ b/tests/schema_superseded_by_test.rs
@@ -1,6 +1,5 @@
 use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::schema::{SchemaCore, SchemaState};
-use std::sync::Arc;
 
 fn schema_a_json() -> String {
     r#"{

--- a/tests/schema_superseded_by_test.rs
+++ b/tests/schema_superseded_by_test.rs
@@ -1,4 +1,6 @@
+use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::schema::{SchemaCore, SchemaState};
+use std::sync::Arc;
 
 fn schema_a_json() -> String {
     r#"{
@@ -133,7 +135,7 @@ async fn superseded_by_persists_across_schema_core_instances() {
     let dir = tempfile::tempdir().expect("tempdir");
     let db = sled::open(dir.path()).expect("open sled");
     let db_ops = Arc::new(
-        fold_db::db_operations::DbOperations::from_sled(db)
+        fold_db::db_operations::DbOperations::from_sled(db, Arc::new(FastEmbedModel::new()))
             .await
             .expect("db_ops"),
     );

--- a/tests/view_invalidation_test.rs
+++ b/tests/view_invalidation_test.rs
@@ -1,4 +1,6 @@
+use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::fold_db_core::FoldDB;
+use std::sync::Arc;
 use fold_db::schema::types::field_value_type::FieldValueType;
 use fold_db::schema::types::key_config::KeyConfig;
 use fold_db::schema::types::operations::{MutationType, Query};
@@ -11,7 +13,7 @@ use std::collections::HashMap;
 
 async fn setup_db() -> FoldDB {
     let dir = tempfile::tempdir().unwrap();
-    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+    FoldDB::new(dir.path().to_str().unwrap(), Arc::new(FastEmbedModel::new())).await.unwrap()
 }
 
 fn blogpost_schema_json() -> &'static str {

--- a/tests/view_precomputation_test.rs
+++ b/tests/view_precomputation_test.rs
@@ -4,7 +4,9 @@
 //! transition through Computing state during background precomputation,
 //! and that queries against Computing views return a clear error.
 
+use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::fold_db_core::FoldDB;
+use std::sync::Arc;
 use fold_db::schema::types::field_value_type::FieldValueType;
 use fold_db::schema::types::key_config::KeyConfig;
 use fold_db::schema::types::operations::{MutationType, Query};
@@ -17,7 +19,7 @@ use std::collections::HashMap;
 
 async fn setup_db() -> FoldDB {
     let dir = tempfile::tempdir().unwrap();
-    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+    FoldDB::new(dir.path().to_str().unwrap(), Arc::new(FastEmbedModel::new())).await.unwrap()
 }
 
 fn blogpost_schema_json() -> &'static str {

--- a/tests/view_query_test.rs
+++ b/tests/view_query_test.rs
@@ -1,4 +1,6 @@
+use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::fold_db_core::FoldDB;
+use std::sync::Arc;
 use fold_db::schema::types::field_value_type::FieldValueType;
 use fold_db::schema::types::key_config::KeyConfig;
 use fold_db::schema::types::operations::{MutationType, Query};
@@ -11,7 +13,7 @@ use std::collections::HashMap;
 
 async fn setup_db() -> FoldDB {
     let dir = tempfile::tempdir().unwrap();
-    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+    FoldDB::new(dir.path().to_str().unwrap(), Arc::new(FastEmbedModel::new())).await.unwrap()
 }
 
 fn blogpost_schema_json() -> &'static str {

--- a/tests/view_registration_test.rs
+++ b/tests/view_registration_test.rs
@@ -1,3 +1,4 @@
+use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::schema::types::field_value_type::FieldValueType;
 use fold_db::schema::types::operations::Query;
 use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
@@ -5,6 +6,7 @@ use fold_db::schema::SchemaCore;
 use fold_db::view::registry::ViewState;
 use fold_db::view::types::TransformView;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 fn blogpost_schema_json() -> String {
     r#"{
@@ -145,7 +147,7 @@ async fn remove_view_cleans_up() {
 async fn view_persists_across_schema_core_instances() {
     let db = sled::Config::new().temporary(true).open().unwrap();
     let db_ops = std::sync::Arc::new(
-        fold_db::db_operations::DbOperations::from_sled(db.clone())
+        fold_db::db_operations::DbOperations::from_sled(db.clone(), Arc::new(FastEmbedModel::new()))
             .await
             .unwrap(),
     );

--- a/tests/view_wasm_integration_test.rs
+++ b/tests/view_wasm_integration_test.rs
@@ -2,7 +2,9 @@
 //! Only run when the `transform-wasm` feature is enabled.
 #![cfg(feature = "transform-wasm")]
 
+use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::fold_db_core::FoldDB;
+use std::sync::Arc;
 use fold_db::schema::types::field_value_type::FieldValueType;
 use fold_db::schema::types::operations::{MutationType, Query};
 use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
@@ -51,7 +53,7 @@ fn hardcoded_wasm() -> Vec<u8> {
 
 async fn setup_db() -> FoldDB {
     let dir = tempfile::tempdir().unwrap();
-    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+    FoldDB::new(dir.path().to_str().unwrap(), Arc::new(FastEmbedModel::new())).await.unwrap()
 }
 
 fn blogpost_schema_json() -> &'static str {

--- a/tests/view_write_test.rs
+++ b/tests/view_write_test.rs
@@ -1,3 +1,4 @@
+use fold_db::db_operations::native_index::FastEmbedModel;
 use fold_db::fold_db_core::FoldDB;
 use fold_db::schema::types::field_value_type::FieldValueType;
 use fold_db::schema::types::key_config::KeyConfig;
@@ -8,10 +9,13 @@ use fold_db::schema::SchemaState;
 use fold_db::view::types::{TransformView, ViewCacheState};
 use serde_json::json;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 async fn setup_db() -> FoldDB {
     let dir = tempfile::tempdir().unwrap();
-    FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
+    FoldDB::new(dir.path().to_str().unwrap(), Arc::new(FastEmbedModel::new()))
+        .await
+        .unwrap()
 }
 
 fn blogpost_schema_json() -> &'static str {


### PR DESCRIPTION
## Summary
- Replace hardcoded `FastEmbedModel` with injected `Arc<dyn Embedder>` across `FoldDB::new`, `DbOperations::from_sled`/`from_namespaced_store`, `factory::create_fold_db`, and `NativeIndexManager`
- Enables switching between FastEmbed (ONNX) and Ollama embedding models at the node layer
- Update all integration tests to pass the embedder argument

## Test plan
- [x] `cargo test` passes (all 16 test suites)
- [ ] Verify fold_db_node builds against this branch with the embedding provider wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)