### PR TITLE
fix: break circular auto-correction for generic schema names

### DIFF
--- a/src/schema_service/state.rs
+++ b/src/schema_service/state.rs
@@ -640,19 +640,31 @@ impl SchemaServiceState {
         // Auto-correct bad descriptive names:
         // 1. AI captions ("A photo of a sunset") → use schema.name title-cased
         // 2. Generic structural names ("Document Collection") → use schema.name title-cased
-        // The ingestion layer already rejects these with retries, so this is a
-        // last-resort safety net that auto-corrects rather than failing.
+        // 3. If title-cased name is STILL generic (e.g. "content_articles" → "Content Articles"),
+        //    fall back to generate_collection_name() which infers from field patterns.
         if let Some(ref dn) = schema.descriptive_name.clone() {
             if Self::is_caption_name(dn) || super::name_validator::is_generic_name(dn) {
                 let title_cased = Self::snake_to_title_case(&schema.name);
+                let corrected = if super::name_validator::is_generic_name(&title_cased) {
+                    // schema.name is also generic (e.g. "content_articles") — infer from fields
+                    let inferred = self.generate_collection_name(&schema);
+                    if super::name_validator::is_generic_name(&inferred) {
+                        // Last resort: use schema.name as-is (better than a circular generic)
+                        title_cased
+                    } else {
+                        inferred
+                    }
+                } else {
+                    title_cased
+                };
                 log_feature!(
                     LogFeature::Schema,
                     warn,
                     "Auto-corrected descriptive_name from '{}' to '{}' (caption or generic)",
                     &dn[..dn.len().min(60)],
-                    title_cased
+                    corrected
                 );
-                schema.descriptive_name = Some(title_cased);
+                schema.descriptive_name = Some(corrected);
             }
         }
 


### PR DESCRIPTION
## Summary
- When the AI proposes `name="content_articles"` with `descriptive_name="Content Articles"`, the auto-corrector detects the descriptive_name as generic but falls back to `snake_to_title_case(name)` which produces "Content Articles" again — a no-op.
- Now checks if the title-cased fallback is **still** generic and falls back to `generate_collection_name()` which infers from field patterns (e.g., camera/GPS fields → "Photography").

## Test plan
- [ ] Existing 496 tests pass (verified locally)
- [ ] Ingest Apple Notes and verify schema name is topic-specific, not "Content Articles"

🤖 Generated with [Claude Code](https://claude.com/claude-code)