### PR TITLE
feat: expose embedder() accessor on NativeIndexManager

### DIFF
--- a/src/db_operations/native_index/mod.rs
+++ b/src/db_operations/native_index/mod.rs
@@ -87,6 +87,11 @@ impl NativeIndexManager {
         &self.store
     }
 
+    /// Get the embedding model (used by interest detection to embed seed phrases).
+    pub fn embedder(&self) -> &Arc<dyn Embedder> {
+        &self.embedding_model
+    }
+
     /// Embed a text query into a vector. Used by discovery to generate search embeddings.
     pub fn embed_text(&self, text: &str) -> Result<Vec<f32>, SchemaError> {
         self.embedding_model.embed_text(text)


### PR DESCRIPTION
## Summary
- Adds `pub fn embedder(&self) -> &Arc<dyn Embedder>` to `NativeIndexManager`
- Needed by fold_db_node's interest detection module to embed seed phrases using the same model

## Test plan
- [x] `cargo check` passes
- [x] No test changes needed — accessor only

🤖 Generated with [Claude Code](https://claude.com/claude-code)