### PR TITLE
feat: expose sync status methods on FoldDB

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -138,6 +138,20 @@ impl FoldDB {
         }
     }
 
+    /// Get the number of pending (unsynced) log entries.
+    /// Returns None if sync is not configured.
+    pub async fn sync_pending_count(&self) -> Option<usize> {
+        match &self.sync_engine {
+            Some(engine) => Some(engine.pending_count().await),
+            None => None,
+        }
+    }
+
+    /// Returns true if the sync engine is configured.
+    pub fn is_sync_enabled(&self) -> bool {
+        self.sync_engine.is_some()
+    }
+
     /// Creates a new FoldDB instance with the specified storage path.
     /// All initializations happen here. This is the main entry point for the FoldDB system.
     /// Do not initialize anywhere else.


### PR DESCRIPTION
## Summary
- Add `sync_pending_count()` method to query unsynced log entry count
- Add `is_sync_enabled()` method to check if sync engine is configured
- These methods are needed by the backup settings panel UI in fold_db_node

## Test plan
- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test --workspace --all-targets` passes
- [ ] Verify methods return correct values when sync engine is configured (Exemem mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)