### PR TITLE
feat: add session_token and user_hash to DatabaseConfig::Exemem

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -28,7 +28,7 @@ pub async fn create_fold_db(
 ) -> FoldDbResult<Arc<Mutex<FoldDB>>> {
     match config {
         DatabaseConfig::Local { path } => create_local_fold_db(path, e2e_keys, None).await,
-        DatabaseConfig::Exemem { api_url, api_key } => {
+        DatabaseConfig::Exemem { api_url, api_key, .. } => {
             // Exemem mode: local Sled + S3 sync via the Exemem platform.
             // The sync auth Lambda shares the same API URL and API key.
             let path = std::path::PathBuf::from(

--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -28,7 +28,9 @@ pub async fn create_fold_db(
 ) -> FoldDbResult<Arc<Mutex<FoldDB>>> {
     match config {
         DatabaseConfig::Local { path } => create_local_fold_db(path, e2e_keys, None).await,
-        DatabaseConfig::Exemem { api_url, api_key, .. } => {
+        DatabaseConfig::Exemem {
+            api_url, api_key, ..
+        } => {
             // Exemem mode: local Sled + S3 sync via the Exemem platform.
             // The sync auth Lambda shares the same API URL and API key.
             let path = std::path::PathBuf::from(

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -146,6 +146,12 @@ pub enum DatabaseConfig {
         api_url: String,
         /// API key for authentication
         api_key: String,
+        /// Session token for authenticated API access
+        #[serde(default)]
+        session_token: Option<String>,
+        /// User hash derived from email or credentials
+        #[serde(default)]
+        user_hash: Option<String>,
     },
 }
 
@@ -223,7 +229,12 @@ impl DatabaseConfig {
                     .map_err(|_| ConfigError::MissingVariable("EXEMEM_API_URL".to_string()))?;
                 let api_key = env::var("EXEMEM_API_KEY")
                     .map_err(|_| ConfigError::MissingVariable("EXEMEM_API_KEY".to_string()))?;
-                Ok(DatabaseConfig::Exemem { api_url, api_key })
+                Ok(DatabaseConfig::Exemem {
+                    api_url,
+                    api_key,
+                    session_token: std::env::var("EXEMEM_SESSION_TOKEN").ok(),
+                    user_hash: std::env::var("EXEMEM_USER_HASH").ok(),
+                })
             }
             _ => Err(ConfigError::InvalidValue(format!(
                 "Invalid FOLD_STORAGE_MODE: '{}'. Must be 'local', 'exemem'{}",


### PR DESCRIPTION
## Summary
- Adds optional `session_token` and `user_hash` fields to `DatabaseConfig::Exemem` variant
- Both fields use `#[serde(default)]` for backward compatibility with existing configs
- Supports the B3 account creation flow where fold_db_node stores credentials from email magic link auth

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo check --features aws-backend` passes
- [x] `cargo test --lib` — 437 tests pass
- [x] Existing serialization unaffected (fields default to `None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)