### PR TITLE
feat: add SyncStatus tracking to SyncEngine

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -138,6 +138,14 @@ impl FoldDB {
         }
     }
 
+    /// Get a full sync status snapshot, if sync is configured.
+    pub async fn sync_status(&self) -> Option<crate::sync::SyncStatus> {
+        match &self.sync_engine {
+            Some(engine) => Some(engine.status().await),
+            None => None,
+        }
+    }
+
     /// Creates a new FoldDB instance with the specified storage path.
     /// All initializations happen here. This is the main entry point for the FoldDB system.
     /// Do not initialize anywhere else.

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -5,11 +5,13 @@ use super::s3::S3Client;
 use super::snapshot::Snapshot;
 use crate::crypto::CryptoProvider;
 use crate::storage::traits::NamespacedStore;
+use serde::Serialize;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 /// Sync engine state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SyncState {
     /// No unsynced changes.
     Idle,
@@ -19,6 +21,19 @@ pub enum SyncState {
     Syncing,
     /// Network unavailable, will retry.
     Offline,
+}
+
+/// Snapshot of sync engine status for external consumers.
+#[derive(Debug, Clone, Serialize)]
+pub struct SyncStatus {
+    /// Current state of the sync engine.
+    pub state: SyncState,
+    /// Number of pending (unsynced) log entries.
+    pub pending_count: usize,
+    /// Unix timestamp (seconds) of last successful sync, if any.
+    pub last_sync_at: Option<u64>,
+    /// Last sync error message, if the most recent sync failed.
+    pub last_error: Option<String>,
 }
 
 /// Configuration for the sync engine.
@@ -86,6 +101,10 @@ pub struct SyncEngine {
     config: SyncConfig,
     /// Optional callback for status changes.
     status_callback: Option<StatusCallback>,
+    /// Unix timestamp (seconds) of last successful sync.
+    last_sync_at: Arc<Mutex<Option<u64>>>,
+    /// Last sync error message (cleared on success).
+    last_error: Arc<Mutex<Option<String>>>,
 }
 
 impl SyncEngine {
@@ -108,6 +127,8 @@ impl SyncEngine {
             store,
             config,
             status_callback: None,
+            last_sync_at: Arc::new(Mutex::new(None)),
+            last_error: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -129,6 +150,16 @@ impl SyncEngine {
     /// Get the number of pending (unsynced) log entries.
     pub async fn pending_count(&self) -> usize {
         self.pending.lock().await.len()
+    }
+
+    /// Get a full status snapshot of the sync engine.
+    pub async fn status(&self) -> SyncStatus {
+        SyncStatus {
+            state: *self.state.lock().await,
+            pending_count: self.pending.lock().await.len(),
+            last_sync_at: *self.last_sync_at.lock().await,
+            last_error: self.last_error.lock().await.clone(),
+        }
     }
 
     async fn set_state(&self, new_state: SyncState, message: Option<&str>) {
@@ -242,11 +273,20 @@ impl SyncEngine {
 
         match self.do_sync().await {
             Ok(synced) => {
+                if synced {
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    *self.last_sync_at.lock().await = Some(now);
+                    *self.last_error.lock().await = None;
+                }
                 self.set_state(SyncState::Idle, None).await;
                 Ok(synced)
             }
             Err(e) => {
                 let msg = e.to_string();
+                *self.last_error.lock().await = Some(msg.clone());
                 match &e {
                     SyncError::Network(_) => {
                         self.set_state(SyncState::Offline, Some(&msg)).await;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -55,7 +55,7 @@ pub mod log;
 pub mod s3;
 pub mod snapshot;
 
-pub use engine::{SyncConfig, SyncEngine, SyncState};
+pub use engine::{SyncConfig, SyncEngine, SyncState, SyncStatus};
 pub use error::{SyncError, SyncResult};
 
 /// Configuration needed to enable S3 sync.


### PR DESCRIPTION
## Summary
- Adds `SyncStatus` struct with `state`, `pending_count`, `last_sync_at`, and `last_error` fields
- Records timestamp on successful sync and error message on failure in `SyncEngine`
- Exposes `sync_status()` on `FoldDB` for external consumers (HTTP API in fold_db_node)

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` passes
- [ ] Verify sync status updates correctly during cloud sync cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)