### PR TITLE
Auto-bootstrap from B2 on new device setup

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -100,6 +100,18 @@ async fn create_local_fold_db(
             sync_config,
         ));
 
+        // Bootstrap from B2 if the local database is empty (new device connecting
+        // to an existing user database — like a password manager on a new device).
+        let namespaces = base_store.list_namespaces().await.unwrap_or_default();
+        let has_user_data = namespaces.iter().any(|ns| ns != "__sled__default");
+        if !has_user_data {
+            log::info!("empty local database with sync enabled — bootstrapping from cloud");
+            match engine.bootstrap().await {
+                Ok(seq) => log::info!("bootstrap complete: restored to seq {seq}"),
+                Err(e) => log::warn!("bootstrap failed (starting fresh): {e}"),
+            }
+        }
+
         // Sled → SyncingNamespacedStore → EncryptingNamespacedStore
         let syncing_store = crate::storage::SyncingNamespacedStore::new(base_store, engine.clone());
         let mid_store: Arc<dyn crate::storage::traits::NamespacedStore> = Arc::new(syncing_store);

--- a/tests/sync_integration_test.rs
+++ b/tests/sync_integration_test.rs
@@ -233,3 +233,22 @@ async fn list_namespaces_works_through_stack() {
     assert!(namespaces.contains(&"metadata".to_string()));
     assert!(namespaces.contains(&"schemas".to_string()));
 }
+
+#[tokio::test]
+async fn empty_store_has_no_user_data() {
+    let base = Arc::new(InMemoryNamespacedStore::new());
+    let namespaces = base.list_namespaces().await.unwrap();
+    let has_user_data = namespaces.iter().any(|ns| ns != "__sled__default");
+    assert!(!has_user_data, "fresh store should have no user data");
+}
+
+#[tokio::test]
+async fn store_with_data_detected_as_non_empty() {
+    let base = Arc::new(InMemoryNamespacedStore::new());
+    let main = base.open_namespace("main").await.unwrap();
+    main.put(b"key", b"val".to_vec()).await.unwrap();
+
+    let namespaces = base.list_namespaces().await.unwrap();
+    let has_user_data = namespaces.iter().any(|ns| ns != "__sled__default");
+    assert!(has_user_data, "store with data should be detected as non-empty");
+}

--- a/tests/sync_integration_test.rs
+++ b/tests/sync_integration_test.rs
@@ -250,5 +250,8 @@ async fn store_with_data_detected_as_non_empty() {
 
     let namespaces = base.list_namespaces().await.unwrap();
     let has_user_data = namespaces.iter().any(|ns| ns != "__sled__default");
-    assert!(has_user_data, "store with data should be detected as non-empty");
+    assert!(
+        has_user_data,
+        "store with data should be detected as non-empty"
+    );
 }


### PR DESCRIPTION
## Summary
- When a new device connects with Exemem credentials and the local Sled database is empty, automatically call `bootstrap()` to pull down the existing database from B2
- Enables the password-manager model: one database per user, many devices — new device just connects and gets the data
- No UI changes needed — bootstrap happens automatically during initialization

## Changes
- `src/fold_db_core/factory.rs`: Check if local store has user data; if empty and sync is enabled, call `engine.bootstrap()` before starting the sync timer
- `tests/sync_integration_test.rs`: Tests for empty-database detection logic

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo check --workspace --features aws-backend` passes
- [x] `cargo test --workspace --all-targets` passes (all 10 sync integration tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)