### PR TITLE
Add source_pub_key to FieldValue and FieldMetadata

### DIFF
--- a/src/fold_db_core/query/formatter.rs
+++ b/src/fold_db_core/query/formatter.rs
@@ -48,6 +48,8 @@ pub struct FieldMetadata {
     pub molecule_uuid: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub molecule_version: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_pub_key: Option<String>,
 }
 
 /// Represents a single logical record keyed by `KeyValue`.
@@ -88,6 +90,7 @@ pub fn records_from_field_map(
                     metadata: field_val.metadata.clone(),
                     molecule_uuid: field_val.molecule_uuid.clone(),
                     molecule_version: field_val.molecule_version,
+                    source_pub_key: field_val.source_pub_key.clone(),
                 },
             );
         }
@@ -123,6 +126,7 @@ mod tests {
                 metadata: None,
                 molecule_uuid: None,
                 molecule_version: None,
+                source_pub_key: None,
             },
         );
         f1_map.insert(
@@ -134,6 +138,7 @@ mod tests {
                 metadata: None,
                 molecule_uuid: None,
                 molecule_version: None,
+                source_pub_key: None,
             },
         );
 
@@ -147,6 +152,7 @@ mod tests {
                 metadata: None,
                 molecule_uuid: None,
                 molecule_version: None,
+                source_pub_key: None,
             },
         );
 
@@ -180,6 +186,7 @@ mod tests {
                 metadata: None,
                 molecule_uuid: None,
                 molecule_version: None,
+                source_pub_key: None,
             },
         );
 
@@ -193,6 +200,7 @@ mod tests {
                 metadata: None,
                 molecule_uuid: None,
                 molecule_version: None,
+                source_pub_key: None,
             },
         );
 
@@ -241,6 +249,7 @@ mod tests {
                 metadata: None,
                 molecule_uuid: None,
                 molecule_version: None,
+                source_pub_key: None,
             },
         );
         field_map.insert(
@@ -252,6 +261,7 @@ mod tests {
                 metadata: None,
                 molecule_uuid: None,
                 molecule_version: None,
+                source_pub_key: None,
             },
         );
 
@@ -286,6 +296,7 @@ mod tests {
             metadata: None,
             molecule_uuid: None,
             molecule_version: None,
+            source_pub_key: None,
         };
 
         // Test serialization

--- a/src/schema/types/field/filter_utils.rs
+++ b/src/schema/types/field/filter_utils.rs
@@ -84,6 +84,7 @@ pub async fn fetch_atoms_with_key_metadata_async(
                         metadata,
                         molecule_uuid: None,
                         molecule_version: None,
+                        source_pub_key: Some(atom.source_pub_key().to_string()),
                     },
                 );
             }

--- a/src/schema/types/field/variant.rs
+++ b/src/schema/types/field/variant.rs
@@ -38,6 +38,8 @@ pub struct FieldValue {
     pub molecule_uuid: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub molecule_version: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_pub_key: Option<String>,
 }
 
 // Macro to reduce boilerplate for Field trait implementation

--- a/src/view/resolver.rs
+++ b/src/view/resolver.rs
@@ -222,6 +222,7 @@ impl ViewResolver {
                     metadata: None,
                     molecule_uuid: None,
                     molecule_version: None,
+                    source_pub_key: None,
                 };
                 field_entries.insert(key, fv);
             }
@@ -269,6 +270,7 @@ mod tests {
             metadata: None,
             molecule_uuid: None,
             molecule_version: None,
+            source_pub_key: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `source_pub_key: Option<String>` to `FieldValue` and `FieldMetadata` structs
- Populates `source_pub_key` from `Atom::source_pub_key()` during query resolution in `fetch_atoms_with_key_metadata_async`
- Enables downstream consumers (e.g. social feed endpoint in fold_db_node) to identify who authored each record in query results

## Test plan
- [x] All 437 existing fold_db library tests pass
- [x] New field is `Option<String>` with `serde(default)` — backwards compatible with existing serialized data

🤖 Generated with [Claude Code](https://claude.com/claude-code)