### PR TITLE
feat: add schema_display_name to IndexResult

### DIFF
--- a/src/db_operations/native_index/embedding_index.rs
+++ b/src/db_operations/native_index/embedding_index.rs
@@ -238,6 +238,7 @@ impl EmbeddingIndex {
                         .iter()
                         .map(|field| IndexResult {
                             schema_name: e.schema.clone(),
+                            schema_display_name: None,
                             field: field.clone(),
                             key_value: e.key.clone(),
                             value: Value::Null,
@@ -251,6 +252,7 @@ impl EmbeddingIndex {
                     // Per-fragment: one result for the matched field+fragment
                     vec![IndexResult {
                         schema_name: e.schema.clone(),
+                        schema_display_name: None,
                         field: e.field_name.clone(),
                         key_value: e.key.clone(),
                         value: Value::Null,

--- a/src/db_operations/native_index/types.rs
+++ b/src/db_operations/native_index/types.rs
@@ -6,6 +6,8 @@ use std::collections::HashSet;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
 pub struct IndexResult {
     pub schema_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_display_name: Option<String>,
     pub field: String,
     pub key_value: KeyValue,
     pub value: Value,


### PR DESCRIPTION
## Summary
- Adds `schema_display_name: Option<String>` field to `IndexResult` struct
- Allows consumers (fold_db_node) to enrich search results with human-readable schema names instead of opaque hash identifiers
- Field is `None` by default and `skip_serializing_if = "Option::is_none"` for backward compatibility

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo check --workspace --features aws-backend` compiles
- [x] `cargo test --workspace --all-targets` all pass
- [x] New field is optional with serde skip — no breaking changes to existing serialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)