### PR TITLE
chore: update GitHub org references from shiba4life to EdgeVector

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # These are supported funding model platforms
 
-github: [shiba4life]
+github: [EdgeVector]
 patreon: https://patreon.com/EuclidCodes?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink

--- a/HomebrewFormula/folddb.rb
+++ b/HomebrewFormula/folddb.rb
@@ -1,6 +1,6 @@
 class Folddb < Formula
   desc "Personal data sovereignty platform — CLI and server for FoldDB"
-  homepage "https://github.com/shiba4life/fold_db"
+  homepage "https://github.com/EdgeVector/fold_db"
   version "0.3.0"
   license "MIT"
 
@@ -8,20 +8,20 @@ class Folddb < Formula
 
   on_macos do
     on_arm do
-      url "https://github.com/shiba4life/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb-macos-aarch64-#{FOLDDB_VERSION}.tar.gz"
+      url "https://github.com/EdgeVector/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb-macos-aarch64-#{FOLDDB_VERSION}.tar.gz"
       sha256 "2b69979017b05d0602a762069e5a05e82fc1edc6a88eadc1348fe8bc76191f11"
 
       resource "folddb_server" do
-        url "https://github.com/shiba4life/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb_server-macos-aarch64-#{FOLDDB_VERSION}.tar.gz"
+        url "https://github.com/EdgeVector/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb_server-macos-aarch64-#{FOLDDB_VERSION}.tar.gz"
         sha256 "75b20a7dfa4cff2fd01b54eaf4c191c1051975f439453fb5b5f652dc8c47c281"
       end
     end
     on_intel do
-      url "https://github.com/shiba4life/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb-macos-x86_64-#{FOLDDB_VERSION}.tar.gz"
+      url "https://github.com/EdgeVector/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb-macos-x86_64-#{FOLDDB_VERSION}.tar.gz"
       sha256 "fa336444d5399d7b915c7ab25a05c2b20b5d7445209d66d36d489f58239ff397"
 
       resource "folddb_server" do
-        url "https://github.com/shiba4life/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb_server-macos-x86_64-#{FOLDDB_VERSION}.tar.gz"
+        url "https://github.com/EdgeVector/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb_server-macos-x86_64-#{FOLDDB_VERSION}.tar.gz"
         sha256 "ce9dee5b348e0efe9b1dcc76547944f693aac28e1a53b48169121d8d9cef4059"
       end
     end
@@ -29,11 +29,11 @@ class Folddb < Formula
 
   on_linux do
     on_intel do
-      url "https://github.com/shiba4life/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb-linux-x86_64-#{FOLDDB_VERSION}.tar.gz"
+      url "https://github.com/EdgeVector/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb-linux-x86_64-#{FOLDDB_VERSION}.tar.gz"
       sha256 "4ecad09f4b31477c9263d6c7382a279969c9c3816c0929bcb5164bcf67f39d15"
 
       resource "folddb_server" do
-        url "https://github.com/shiba4life/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb_server-linux-x86_64-#{FOLDDB_VERSION}.tar.gz"
+        url "https://github.com/EdgeVector/fold_db/releases/download/v#{FOLDDB_VERSION}/folddb_server-linux-x86_64-#{FOLDDB_VERSION}.tar.gz"
         sha256 "bcdc21390cf2ddb3d45e9ba816bcdf9a99104611535175bb187b046bd5894dd8"
       end
     end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FoldDB
 
-[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/shiba4life/fold_db)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/EdgeVector/fold_db)
 
 **Your personal database with AI that organizes everything for you.**
 
@@ -9,7 +9,7 @@ Drop in files, JSON, or social media exports — FoldDB detects schemas, extract
 **Try it now** — install with one command and have a working database in under a minute:
 
 ```bash
-brew tap shiba4life/fold_db && brew install folddb
+brew tap EdgeVector/fold_db && brew install folddb
 folddb_server --port 9001
 # Open http://localhost:9001 — drag in a JSON file, ask a question
 ```
@@ -18,21 +18,21 @@ folddb_server --port 9001
 
 ### Option A: Desktop App (macOS)
 
-Download the latest `.dmg` from [GitHub Releases](https://github.com/shiba4life/fold_db/releases), open it, and drag **FoldDB.app** to Applications. Double-click to launch — no terminal needed.
+Download the latest `.dmg` from [GitHub Releases](https://github.com/EdgeVector/fold_db/releases), open it, and drag **FoldDB.app** to Applications. Double-click to launch — no terminal needed.
 
 > **First launch:** macOS will block the unsigned app. Right-click the app → **Open** → click **Open** in the dialog, or go to **System Settings → Privacy & Security → Open Anyway**.
 
 ### Option B: Install via Homebrew
 
 ```bash
-brew tap shiba4life/fold_db
+brew tap EdgeVector/fold_db
 brew install folddb
 ```
 
 ### Option C: Install from Source
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/shiba4life/fold_db/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/EdgeVector/fold_db/master/install.sh | sh
 ```
 
 ### Run
@@ -169,7 +169,7 @@ Run `folddb --help` for the full command reference.
 ### Building from Source
 
 ```bash
-git clone https://github.com/shiba4life/fold_db.git
+git clone https://github.com/EdgeVector/fold_db.git
 cd fold_db
 cargo build --release --workspace
 cargo test --workspace
@@ -187,7 +187,7 @@ cargo test --workspace
 ### Install from Source (alternative)
 
 ```bash
-cargo install --git https://github.com/shiba4life/fold_db.git --bin folddb
+cargo install --git https://github.com/EdgeVector/fold_db.git --bin folddb
 ```
 
 ## Configuration
@@ -349,5 +349,5 @@ Dual-licensed under [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-APACHE), at your 
 
 ## Community
 
-- **[GitHub Issues](https://github.com/shiba4life/fold_db/issues)** — Report bugs and request features
-- **[GitHub Discussions](https://github.com/shiba4life/fold_db/discussions)** — Questions and community discussion
+- **[GitHub Issues](https://github.com/EdgeVector/fold_db/issues)** — Report bugs and request features
+- **[GitHub Discussions](https://github.com/EdgeVector/fold_db/discussions)** — Questions and community discussion


### PR DESCRIPTION
## Summary
- Replaces all `shiba4life` GitHub org references with `EdgeVector` across README.md, HomebrewFormula/folddb.rb, and .github/FUNDING.yml
- Reflects the repo transfer from github.com/shiba4life/fold_db to github.com/EdgeVector/fold_db

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` passes
- [x] Verified no remaining `shiba4life` references in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)