### PR TITLE
feat: org CRUD + schema tagging (Phase 1)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod error;
 pub mod fold_db_core;
 pub mod llm_registry;
 pub mod logging;
+pub mod org;
 pub mod progress;
 pub mod schema;
 pub mod schema_service;

--- a/src/org/mod.rs
+++ b/src/org/mod.rs
@@ -1,0 +1,7 @@
+pub mod operations;
+pub mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use types::{OrgInviteBundle, OrgMemberInfo, OrgMembership, OrgRole};

--- a/src/org/operations.rs
+++ b/src/org/operations.rs
@@ -33,8 +33,9 @@ pub fn create_org(
     creator_public_key: &str,
     creator_display_name: &str,
 ) -> Result<OrgMembership, FoldDbError> {
-    let keypair = Ed25519KeyPair::generate()
-        .map_err(|e| FoldDbError::SecurityError(format!("Failed to generate org keypair: {}", e)))?;
+    let keypair = Ed25519KeyPair::generate().map_err(|e| {
+        FoldDbError::SecurityError(format!("Failed to generate org keypair: {}", e))
+    })?;
 
     // Generate random 32-byte E2E secret
     let mut e2e_bytes = [0u8; 32];
@@ -85,9 +86,9 @@ pub fn join_org(
     my_display_name: &str,
 ) -> Result<OrgMembership, FoldDbError> {
     // Derive org_hash from the invite's public key
-    let pub_bytes = STANDARD.decode(&invite.org_public_key).map_err(|e| {
-        FoldDbError::SecurityError(format!("Invalid org public key base64: {}", e))
-    })?;
+    let pub_bytes = STANDARD
+        .decode(&invite.org_public_key)
+        .map_err(|e| FoldDbError::SecurityError(format!("Invalid org public key base64: {}", e)))?;
     let mut hasher = Sha256::new();
     hasher.update(&pub_bytes);
     let org_hash = format!("{:x}", hasher.finalize());
@@ -171,11 +172,7 @@ pub fn get_org(db: &sled::Db, org_hash: &str) -> Result<Option<OrgMembership>, F
 }
 
 /// Add a member to an existing organization. Only admins should call this.
-pub fn add_member(
-    db: &sled::Db,
-    org_hash: &str,
-    member: OrgMemberInfo,
-) -> Result<(), FoldDbError> {
+pub fn add_member(db: &sled::Db, org_hash: &str, member: OrgMemberInfo) -> Result<(), FoldDbError> {
     let tree = org_tree(db)?;
     let key = org_key(org_hash);
 
@@ -247,10 +244,7 @@ pub fn remove_member(
 }
 
 /// Generate an invite bundle for an organization. Requires admin access (has org_secret_key).
-pub fn generate_invite(
-    db: &sled::Db,
-    org_hash: &str,
-) -> Result<OrgInviteBundle, FoldDbError> {
+pub fn generate_invite(db: &sled::Db, org_hash: &str) -> Result<OrgInviteBundle, FoldDbError> {
     let membership = get_org(db, org_hash)?.ok_or_else(|| {
         FoldDbError::Database(format!("Organization with hash '{}' not found", org_hash))
     })?;

--- a/src/org/operations.rs
+++ b/src/org/operations.rs
@@ -1,0 +1,289 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use sha2::{Digest, Sha256};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::error::FoldDbError;
+use crate::security::Ed25519KeyPair;
+
+use super::types::{OrgInviteBundle, OrgMemberInfo, OrgMembership, OrgRole};
+
+const ORG_TREE_NAME: &str = "org_memberships";
+
+fn org_key(org_hash: &str) -> String {
+    format!("org:{}", org_hash)
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs()
+}
+
+fn org_tree(db: &sled::Db) -> Result<sled::Tree, FoldDbError> {
+    db.open_tree(ORG_TREE_NAME)
+        .map_err(|e| FoldDbError::Database(format!("Failed to open org_memberships tree: {}", e)))
+}
+
+/// Create a new organization. Generates an Ed25519 keypair and random E2E secret.
+/// The calling node becomes the admin.
+pub fn create_org(
+    db: &sled::Db,
+    org_name: &str,
+    creator_public_key: &str,
+    creator_display_name: &str,
+) -> Result<OrgMembership, FoldDbError> {
+    let keypair = Ed25519KeyPair::generate()
+        .map_err(|e| FoldDbError::SecurityError(format!("Failed to generate org keypair: {}", e)))?;
+
+    // Generate random 32-byte E2E secret
+    let mut e2e_bytes = [0u8; 32];
+    rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut e2e_bytes);
+    let org_e2e_secret = STANDARD.encode(e2e_bytes);
+
+    // Derive org_hash = hex(SHA256(public_key_bytes))
+    let pub_bytes = keypair.public_key_bytes();
+    let mut hasher = Sha256::new();
+    hasher.update(pub_bytes);
+    let org_hash = format!("{:x}", hasher.finalize());
+
+    let ts = now_secs();
+
+    let founder = OrgMemberInfo {
+        node_public_key: creator_public_key.to_string(),
+        display_name: creator_display_name.to_string(),
+        added_at: ts,
+        added_by: creator_public_key.to_string(),
+    };
+
+    let membership = OrgMembership {
+        org_name: org_name.to_string(),
+        org_hash: org_hash.clone(),
+        org_public_key: keypair.public_key_base64(),
+        org_secret_key: Some(keypair.secret_key_base64()),
+        org_e2e_secret,
+        role: OrgRole::Admin,
+        members: vec![founder],
+        created_at: ts,
+        joined_at: ts,
+    };
+
+    let tree = org_tree(db)?;
+    let key = org_key(&org_hash);
+    let value = serde_json::to_vec(&membership)?;
+    tree.insert(key.as_bytes(), value)
+        .map_err(|e| FoldDbError::Database(format!("Failed to store org membership: {}", e)))?;
+
+    Ok(membership)
+}
+
+/// Join an existing organization using an invite bundle.
+pub fn join_org(
+    db: &sled::Db,
+    invite: &OrgInviteBundle,
+    my_public_key: &str,
+    my_display_name: &str,
+) -> Result<OrgMembership, FoldDbError> {
+    // Derive org_hash from the invite's public key
+    let pub_bytes = STANDARD.decode(&invite.org_public_key).map_err(|e| {
+        FoldDbError::SecurityError(format!("Invalid org public key base64: {}", e))
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(&pub_bytes);
+    let org_hash = format!("{:x}", hasher.finalize());
+
+    let tree = org_tree(db)?;
+    let key = org_key(&org_hash);
+
+    // Check if already a member
+    if tree
+        .get(key.as_bytes())
+        .map_err(|e| FoldDbError::Database(format!("Failed to read org tree: {}", e)))?
+        .is_some()
+    {
+        return Err(FoldDbError::Database(format!(
+            "Already a member of org '{}'",
+            invite.org_name
+        )));
+    }
+
+    let ts = now_secs();
+
+    // Start with the invite's member list and add ourselves
+    let mut members = invite.members.clone();
+    let me = OrgMemberInfo {
+        node_public_key: my_public_key.to_string(),
+        display_name: my_display_name.to_string(),
+        added_at: ts,
+        added_by: my_public_key.to_string(),
+    };
+    members.push(me);
+
+    let membership = OrgMembership {
+        org_name: invite.org_name.clone(),
+        org_hash: org_hash.clone(),
+        org_public_key: invite.org_public_key.clone(),
+        org_secret_key: None, // Joiners don't get the secret key
+        org_e2e_secret: invite.org_e2e_secret.clone(),
+        role: OrgRole::Member,
+        members,
+        created_at: ts,
+        joined_at: ts,
+    };
+
+    let value = serde_json::to_vec(&membership)?;
+    tree.insert(key.as_bytes(), value)
+        .map_err(|e| FoldDbError::Database(format!("Failed to store org membership: {}", e)))?;
+
+    Ok(membership)
+}
+
+/// List all organizations this node belongs to.
+pub fn list_orgs(db: &sled::Db) -> Result<Vec<OrgMembership>, FoldDbError> {
+    let tree = org_tree(db)?;
+    let mut orgs = Vec::new();
+
+    for entry in tree.iter() {
+        let (_, value) = entry
+            .map_err(|e| FoldDbError::Database(format!("Failed to iterate org tree: {}", e)))?;
+        let membership: OrgMembership = serde_json::from_slice(&value)?;
+        orgs.push(membership);
+    }
+
+    Ok(orgs)
+}
+
+/// Get a single organization by its hash.
+pub fn get_org(db: &sled::Db, org_hash: &str) -> Result<Option<OrgMembership>, FoldDbError> {
+    let tree = org_tree(db)?;
+    let key = org_key(org_hash);
+
+    match tree
+        .get(key.as_bytes())
+        .map_err(|e| FoldDbError::Database(format!("Failed to read org tree: {}", e)))?
+    {
+        Some(value) => {
+            let membership: OrgMembership = serde_json::from_slice(&value)?;
+            Ok(Some(membership))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Add a member to an existing organization. Only admins should call this.
+pub fn add_member(
+    db: &sled::Db,
+    org_hash: &str,
+    member: OrgMemberInfo,
+) -> Result<(), FoldDbError> {
+    let tree = org_tree(db)?;
+    let key = org_key(org_hash);
+
+    let value = tree
+        .get(key.as_bytes())
+        .map_err(|e| FoldDbError::Database(format!("Failed to read org tree: {}", e)))?
+        .ok_or_else(|| {
+            FoldDbError::Database(format!("Organization with hash '{}' not found", org_hash))
+        })?;
+
+    let mut membership: OrgMembership = serde_json::from_slice(&value)?;
+
+    // Check for duplicate
+    if membership
+        .members
+        .iter()
+        .any(|m| m.node_public_key == member.node_public_key)
+    {
+        return Err(FoldDbError::Database(format!(
+            "Member with public key '{}' already exists in org",
+            member.node_public_key
+        )));
+    }
+
+    membership.members.push(member);
+
+    let updated = serde_json::to_vec(&membership)?;
+    tree.insert(key.as_bytes(), updated)
+        .map_err(|e| FoldDbError::Database(format!("Failed to update org membership: {}", e)))?;
+
+    Ok(())
+}
+
+/// Remove a member from an organization by their node public key.
+pub fn remove_member(
+    db: &sled::Db,
+    org_hash: &str,
+    node_public_key: &str,
+) -> Result<(), FoldDbError> {
+    let tree = org_tree(db)?;
+    let key = org_key(org_hash);
+
+    let value = tree
+        .get(key.as_bytes())
+        .map_err(|e| FoldDbError::Database(format!("Failed to read org tree: {}", e)))?
+        .ok_or_else(|| {
+            FoldDbError::Database(format!("Organization with hash '{}' not found", org_hash))
+        })?;
+
+    let mut membership: OrgMembership = serde_json::from_slice(&value)?;
+
+    let original_len = membership.members.len();
+    membership
+        .members
+        .retain(|m| m.node_public_key != node_public_key);
+
+    if membership.members.len() == original_len {
+        return Err(FoldDbError::Database(format!(
+            "Member with public key '{}' not found in org",
+            node_public_key
+        )));
+    }
+
+    let updated = serde_json::to_vec(&membership)?;
+    tree.insert(key.as_bytes(), updated)
+        .map_err(|e| FoldDbError::Database(format!("Failed to update org membership: {}", e)))?;
+
+    Ok(())
+}
+
+/// Generate an invite bundle for an organization. Requires admin access (has org_secret_key).
+pub fn generate_invite(
+    db: &sled::Db,
+    org_hash: &str,
+) -> Result<OrgInviteBundle, FoldDbError> {
+    let membership = get_org(db, org_hash)?.ok_or_else(|| {
+        FoldDbError::Database(format!("Organization with hash '{}' not found", org_hash))
+    })?;
+
+    if membership.role != OrgRole::Admin {
+        return Err(FoldDbError::Permission(
+            "Only admins can generate invites".to_string(),
+        ));
+    }
+
+    Ok(OrgInviteBundle {
+        org_name: membership.org_name,
+        org_public_key: membership.org_public_key,
+        org_e2e_secret: membership.org_e2e_secret,
+        members: membership.members,
+    })
+}
+
+/// Delete an organization from local storage.
+pub fn delete_org(db: &sled::Db, org_hash: &str) -> Result<(), FoldDbError> {
+    let tree = org_tree(db)?;
+    let key = org_key(org_hash);
+
+    let existed = tree
+        .remove(key.as_bytes())
+        .map_err(|e| FoldDbError::Database(format!("Failed to delete org: {}", e)))?;
+
+    if existed.is_none() {
+        return Err(FoldDbError::Database(format!(
+            "Organization with hash '{}' not found",
+            org_hash
+        )));
+    }
+
+    Ok(())
+}

--- a/src/org/tests.rs
+++ b/src/org/tests.rs
@@ -1,0 +1,159 @@
+use crate::org::operations;
+use crate::org::types::{OrgMemberInfo, OrgRole};
+
+fn temp_db() -> sled::Db {
+    sled::Config::new().temporary(true).open().unwrap()
+}
+
+#[test]
+fn test_create_org() {
+    let db = temp_db();
+    let membership =
+        operations::create_org(&db, "Edge Vector Foundation", "pubkey_alice", "Alice").unwrap();
+
+    assert_eq!(membership.org_name, "Edge Vector Foundation");
+    assert_eq!(membership.role, OrgRole::Admin);
+    assert!(membership.org_secret_key.is_some());
+    assert!(!membership.org_hash.is_empty());
+    assert!(!membership.org_public_key.is_empty());
+    assert!(!membership.org_e2e_secret.is_empty());
+    assert_eq!(membership.members.len(), 1);
+    assert_eq!(membership.members[0].display_name, "Alice");
+    assert_eq!(membership.members[0].node_public_key, "pubkey_alice");
+
+    // Verify it was persisted
+    let retrieved = operations::get_org(&db, &membership.org_hash)
+        .unwrap()
+        .unwrap();
+    assert_eq!(retrieved.org_name, "Edge Vector Foundation");
+    assert_eq!(retrieved.org_hash, membership.org_hash);
+}
+
+#[test]
+fn test_join_org() {
+    let db = temp_db();
+
+    // Alice creates the org
+    let created =
+        operations::create_org(&db, "Edge Vector Foundation", "pubkey_alice", "Alice").unwrap();
+
+    // Generate invite
+    let invite = operations::generate_invite(&db, &created.org_hash).unwrap();
+
+    // Bob joins using a separate db (simulating a different node)
+    let db_bob = temp_db();
+    let bob_membership =
+        operations::join_org(&db_bob, &invite, "pubkey_bob", "Bob").unwrap();
+
+    assert_eq!(bob_membership.org_name, "Edge Vector Foundation");
+    assert_eq!(bob_membership.role, OrgRole::Member);
+    assert!(bob_membership.org_secret_key.is_none());
+    assert_eq!(bob_membership.org_hash, created.org_hash);
+    // Should have Alice (from invite) + Bob (self-added)
+    assert_eq!(bob_membership.members.len(), 2);
+    assert!(bob_membership
+        .members
+        .iter()
+        .any(|m| m.display_name == "Bob"));
+    assert!(bob_membership
+        .members
+        .iter()
+        .any(|m| m.display_name == "Alice"));
+
+    // Verify Bob can't join again
+    let err = operations::join_org(&db_bob, &invite, "pubkey_bob", "Bob");
+    assert!(err.is_err());
+}
+
+#[test]
+fn test_list_orgs() {
+    let db = temp_db();
+
+    // Create two orgs
+    operations::create_org(&db, "Org Alpha", "pubkey_alice", "Alice").unwrap();
+    operations::create_org(&db, "Org Beta", "pubkey_alice", "Alice").unwrap();
+
+    let orgs = operations::list_orgs(&db).unwrap();
+    assert_eq!(orgs.len(), 2);
+
+    let names: Vec<&str> = orgs.iter().map(|o| o.org_name.as_str()).collect();
+    assert!(names.contains(&"Org Alpha"));
+    assert!(names.contains(&"Org Beta"));
+}
+
+#[test]
+fn test_add_remove_member() {
+    let db = temp_db();
+    let created =
+        operations::create_org(&db, "Edge Vector Foundation", "pubkey_alice", "Alice").unwrap();
+    let org_hash = &created.org_hash;
+
+    // Add Bob
+    let bob = OrgMemberInfo {
+        node_public_key: "pubkey_bob".to_string(),
+        display_name: "Bob".to_string(),
+        added_at: 1000,
+        added_by: "pubkey_alice".to_string(),
+    };
+    operations::add_member(&db, org_hash, bob).unwrap();
+
+    let org = operations::get_org(&db, org_hash).unwrap().unwrap();
+    assert_eq!(org.members.len(), 2);
+
+    // Adding duplicate should fail
+    let bob_dup = OrgMemberInfo {
+        node_public_key: "pubkey_bob".to_string(),
+        display_name: "Bob Again".to_string(),
+        added_at: 2000,
+        added_by: "pubkey_alice".to_string(),
+    };
+    assert!(operations::add_member(&db, org_hash, bob_dup).is_err());
+
+    // Remove Bob
+    operations::remove_member(&db, org_hash, "pubkey_bob").unwrap();
+
+    let org = operations::get_org(&db, org_hash).unwrap().unwrap();
+    assert_eq!(org.members.len(), 1);
+    assert_eq!(org.members[0].display_name, "Alice");
+
+    // Removing non-existent member should fail
+    assert!(operations::remove_member(&db, org_hash, "pubkey_nobody").is_err());
+}
+
+#[test]
+fn test_generate_invite() {
+    let db = temp_db();
+    let created =
+        operations::create_org(&db, "Edge Vector Foundation", "pubkey_alice", "Alice").unwrap();
+
+    let invite = operations::generate_invite(&db, &created.org_hash).unwrap();
+    assert_eq!(invite.org_name, "Edge Vector Foundation");
+    assert_eq!(invite.org_public_key, created.org_public_key);
+    assert_eq!(invite.org_e2e_secret, created.org_e2e_secret);
+    assert_eq!(invite.members.len(), 1);
+
+    // Non-existent org should fail
+    assert!(operations::generate_invite(&db, "nonexistent_hash").is_err());
+
+    // Member (non-admin) should not be able to generate invite
+    let db_bob = temp_db();
+    operations::join_org(&db_bob, &invite, "pubkey_bob", "Bob").unwrap();
+    assert!(operations::generate_invite(&db_bob, &created.org_hash).is_err());
+}
+
+#[test]
+fn test_delete_org() {
+    let db = temp_db();
+    let created =
+        operations::create_org(&db, "Edge Vector Foundation", "pubkey_alice", "Alice").unwrap();
+
+    // Delete
+    operations::delete_org(&db, &created.org_hash).unwrap();
+
+    // Should be gone
+    let result = operations::get_org(&db, &created.org_hash).unwrap();
+    assert!(result.is_none());
+
+    // Deleting again should fail
+    assert!(operations::delete_org(&db, &created.org_hash).is_err());
+}

--- a/src/org/tests.rs
+++ b/src/org/tests.rs
@@ -42,8 +42,7 @@ fn test_join_org() {
 
     // Bob joins using a separate db (simulating a different node)
     let db_bob = temp_db();
-    let bob_membership =
-        operations::join_org(&db_bob, &invite, "pubkey_bob", "Bob").unwrap();
+    let bob_membership = operations::join_org(&db_bob, &invite, "pubkey_bob", "Bob").unwrap();
 
     assert_eq!(bob_membership.org_name, "Edge Vector Foundation");
     assert_eq!(bob_membership.role, OrgRole::Member);

--- a/src/org/types.rs
+++ b/src/org/types.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+
+/// Represents a node's membership in an organization.
+/// Stored locally in Sled under the "org_memberships" tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrgMembership {
+    /// Human-readable organization name
+    pub org_name: String,
+    /// Hex-encoded SHA256 hash of the org public key bytes — used as the S3 prefix
+    pub org_hash: String,
+    /// Base64-encoded Ed25519 public key for the organization
+    pub org_public_key: String,
+    /// Base64-encoded Ed25519 secret key (only present for the admin who created the org)
+    pub org_secret_key: Option<String>,
+    /// Base64-encoded AES-256-GCM shared secret for E2E encryption of org data
+    pub org_e2e_secret: String,
+    /// Role of this node in the organization
+    pub role: OrgRole,
+    /// Known members of the organization
+    pub members: Vec<OrgMemberInfo>,
+    /// Unix timestamp (seconds) when the org was created
+    pub created_at: u64,
+    /// Unix timestamp (seconds) when this node joined the org
+    pub joined_at: u64,
+}
+
+/// Information about a single member of an organization.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrgMemberInfo {
+    /// Base64-encoded Ed25519 public key of the member's node
+    pub node_public_key: String,
+    /// Human-readable display name for this member
+    pub display_name: String,
+    /// Unix timestamp (seconds) when this member was added
+    pub added_at: u64,
+    /// Base64-encoded public key of the admin who added this member
+    pub added_by: String,
+}
+
+/// Role within an organization.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum OrgRole {
+    /// Can add/remove members, generate invites, delete the org
+    Admin,
+    /// Can read/write org-tagged schemas but cannot manage membership
+    Member,
+}
+
+/// Bundle sent to a new member to join an organization.
+/// Contains everything needed to participate in org sync.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrgInviteBundle {
+    /// Human-readable organization name
+    pub org_name: String,
+    /// Base64-encoded Ed25519 public key for the organization
+    pub org_public_key: String,
+    /// Base64-encoded AES-256-GCM shared secret for E2E encryption
+    pub org_e2e_secret: String,
+    /// Current member list at time of invite generation
+    pub members: Vec<OrgMemberInfo>,
+}

--- a/src/schema/types/declarative_schemas.rs
+++ b/src/schema/types/declarative_schemas.rs
@@ -134,6 +134,8 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
             field_types: HashMap<String, crate::schema::types::field_value_type::FieldValueType>,
             #[serde(skip_serializing_if = "Option::is_none")]
             identity_hash: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none", default)]
+            org_hash: Option<String>,
         }
 
         // Deserialize into the helper struct
@@ -216,6 +218,7 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
         schema.ref_fields = helper.ref_fields;
         schema.field_types = helper.field_types;
         schema.identity_hash = helper.identity_hash;
+        schema.org_hash = helper.org_hash;
 
         Ok(schema)
     }
@@ -290,6 +293,10 @@ pub struct DeclarativeSchemaDefinition {
     /// Superseded schemas are excluded from active indexes and matching.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub superseded_by: Option<String>,
+    /// If set, this schema belongs to an organization and its molecules sync to all org members.
+    /// Value is the hex-encoded SHA256 hash of the org's Ed25519 public key.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub org_hash: Option<String>,
 
     // Runtime state fields (not serialized)
     /// Runtime field storage with molecules (for database operations)
@@ -337,6 +344,7 @@ impl PartialEq for DeclarativeSchemaDefinition {
             && self.field_types == other.field_types
             && self.identity_hash == other.identity_hash
             && self.superseded_by == other.superseded_by
+            && self.org_hash == other.org_hash
         // Exclude runtime_fields, inputs_schema_fields, source_schemas, and hash mappings
         // These are derived/runtime state and don't affect schema identity
     }
@@ -477,6 +485,7 @@ impl DeclarativeSchemaDefinition {
             field_types: HashMap::new(),
             identity_hash: None,
             superseded_by: None,
+            org_hash: None,
             runtime_fields: HashMap::new(),
             inputs_schema_fields: Vec::new(),
             source_schemas: Vec::new(),


### PR DESCRIPTION
## Summary

- Add `src/org/` module with types (`OrgMembership`, `OrgMemberInfo`, `OrgRole`, `OrgInviteBundle`) and CRUD operations stored in Sled (`org_memberships` tree)
- Operations: `create_org`, `join_org`, `list_orgs`, `get_org`, `add_member`, `remove_member`, `generate_invite`, `delete_org`
- Add `org_hash: Option<String>` field to `DeclarativeSchemaDefinition` for tagging schemas to organizations (backward-compatible, serde skip_serializing_if + default)
- 6 tests covering create, join, list, add/remove member, invite generation, and delete

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo check --workspace --features aws-backend` compiles
- [x] `cargo test --workspace --all-targets` — all tests pass (including 6 new org tests)
- [ ] Manual: verify org_hash field serializes/deserializes correctly in schema JSON

## Follow-up tasks

- **Phase 2**: Org sync engine — `OrgSyncEngine`, `OrgRouter`, sync_auth Lambda changes for org prefix
- **Phase 3**: Conflict resolution — LWW resolver, conflict log, polling loop
- **Phase 4**: UI + company schemas — OrgTab in React dashboard, seed company schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)