### PR TITLE
feat: org sync Phase 2 — key-prefix partitioning

### DIFF
--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -312,4 +312,95 @@ impl AuthClient {
 
         Ok(())
     }
+
+    // =========================================================================
+    // Org sync operations
+    // =========================================================================
+
+    /// Request presigned URLs for uploading org log entries.
+    ///
+    /// The Lambda scopes URLs to `/{org_hash}/log/{member_id}/{seq}.enc`.
+    pub async fn presign_org_log_upload(
+        &self,
+        org_hash: &str,
+        member_id: &str,
+        seq_numbers: &[u64],
+    ) -> SyncResult<Vec<PresignedUrl>> {
+        let body = serde_json::json!({
+            "action": "presign_org_log_upload",
+            "org_hash": org_hash,
+            "member_id": member_id,
+            "seq_numbers": seq_numbers,
+        });
+
+        let resp = self.post("/api/sync/presign", body).await?;
+        let parsed: PresignedResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed
+                    .error
+                    .unwrap_or_else(|| "org presign upload failed".to_string()),
+            ));
+        }
+
+        Ok(parsed.urls)
+    }
+
+    /// Request presigned URLs for downloading org log entries from a specific member.
+    pub async fn presign_org_log_download(
+        &self,
+        org_hash: &str,
+        member_id: &str,
+        seq_numbers: &[u64],
+    ) -> SyncResult<Vec<PresignedUrl>> {
+        let body = serde_json::json!({
+            "action": "presign_org_log_download",
+            "org_hash": org_hash,
+            "member_id": member_id,
+            "seq_numbers": seq_numbers,
+        });
+
+        let resp = self.post("/api/sync/presign", body).await?;
+        let parsed: PresignedResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed
+                    .error
+                    .unwrap_or_else(|| "org presign download failed".to_string()),
+            ));
+        }
+
+        Ok(parsed.urls)
+    }
+
+    /// List objects in an org's S3 prefix.
+    ///
+    /// The prefix is relative to `/{org_hash}/`, so `"log/"` lists all log entries
+    /// across all members.
+    pub async fn list_org_objects(
+        &self,
+        org_hash: &str,
+        prefix: &str,
+    ) -> SyncResult<Vec<S3ObjectInfo>> {
+        let body = serde_json::json!({
+            "action": "list_objects",
+            "org_hash": org_hash,
+            "prefix": prefix,
+        });
+
+        let resp = self.post("/api/sync/list", body).await?;
+        let parsed: ListObjectsResponse = serde_json::from_value(resp)?;
+
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed
+                    .error
+                    .unwrap_or_else(|| "org list failed".to_string()),
+            ));
+        }
+
+        Ok(parsed.objects)
+    }
 }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -659,10 +659,7 @@ impl SyncEngine {
                     personal_entries.push(entry.clone());
                 }
                 SyncDestination::Org { org_hash, .. } => {
-                    org_entries
-                        .entry(org_hash)
-                        .or_default()
-                        .push(entry.clone());
+                    org_entries.entry(org_hash).or_default().push(entry.clone());
                 }
             }
         }
@@ -748,10 +745,9 @@ impl SyncEngine {
     /// Classify a single log entry by examining its key.
     fn classify_entry(partitioner: &SyncPartitioner, entry: &LogEntry) -> SyncDestination {
         match &entry.op {
-            LogOp::Put {
-                namespace, key, ..
+            LogOp::Put { namespace, key, .. } | LogOp::Delete { namespace, key } => {
+                partitioner.partition_log_key(namespace, key)
             }
-            | LogOp::Delete { namespace, key } => partitioner.partition_log_key(namespace, key),
             LogOp::BatchPut {
                 namespace, items, ..
             } => {
@@ -799,9 +795,7 @@ impl SyncEngine {
         let mut total_replayed: u64 = 0;
 
         for org_hash in &org_hashes {
-            let replayed = self
-                .download_org_entries(org_hash, &member_id)
-                .await?;
+            let replayed = self.download_org_entries(org_hash, &member_id).await?;
             total_replayed += replayed;
         }
 
@@ -809,11 +803,7 @@ impl SyncEngine {
     }
 
     /// Download and replay entries for a single org from all other members.
-    async fn download_org_entries(
-        &self,
-        org_hash: &str,
-        my_member_id: &str,
-    ) -> SyncResult<u64> {
+    async fn download_org_entries(&self, org_hash: &str, my_member_id: &str) -> SyncResult<u64> {
         // List all objects under the org's log prefix
         let all_objects = self.auth.list_org_objects(org_hash, "log/").await?;
 
@@ -839,7 +829,10 @@ impl SyncEngine {
         let crypto = match org_crypto.get(org_hash) {
             Some(c) => c.clone(),
             None => {
-                log::warn!("no CryptoProvider for org_hash={}, skipping download", org_hash);
+                log::warn!(
+                    "no CryptoProvider for org_hash={}, skipping download",
+                    org_hash
+                );
                 return Ok(0);
             }
         };

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1,6 +1,7 @@
 use super::auth::AuthClient;
 use super::error::{SyncError, SyncResult};
 use super::log::{LogEntry, LogOp};
+use super::org_sync::{SyncDestination, SyncPartitioner};
 use super::s3::S3Client;
 use super::snapshot::Snapshot;
 use crate::crypto::CryptoProvider;
@@ -105,6 +106,20 @@ pub struct SyncEngine {
     last_sync_at: Arc<Mutex<Option<u64>>>,
     /// Last sync error message (cleared on success).
     last_error: Arc<Mutex<Option<String>>>,
+    /// Optional partitioner for routing org-prefixed keys to org S3 prefixes.
+    /// When set, pending entries are partitioned at upload time:
+    /// - Personal keys -> personal sync path (as today)
+    /// - Org-prefixed keys -> `/{org_hash}/log/{member_id}/{seq}.enc`
+    partitioner: Arc<Mutex<Option<SyncPartitioner>>>,
+    /// Short member ID for org sync (first 8 hex chars of SHA256 of node public key).
+    /// Only needed when partitioner is set.
+    member_id: Arc<Mutex<Option<String>>>,
+    /// Org-specific crypto providers keyed by org_hash.
+    /// Each org has its own E2E key for encrypting org data.
+    org_crypto: Arc<Mutex<std::collections::HashMap<String, Arc<dyn CryptoProvider>>>>,
+    /// Tracks the last downloaded sequence per org member for incremental download.
+    /// Maps `{org_hash}:{member_id}` -> last_seq downloaded from that member.
+    org_member_cursors: Arc<Mutex<std::collections::HashMap<String, u64>>>,
 }
 
 impl SyncEngine {
@@ -129,6 +144,10 @@ impl SyncEngine {
             status_callback: None,
             last_sync_at: Arc::new(Mutex::new(None)),
             last_error: Arc::new(Mutex::new(None)),
+            partitioner: Arc::new(Mutex::new(None)),
+            member_id: Arc::new(Mutex::new(None)),
+            org_crypto: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            org_member_cursors: Arc::new(Mutex::new(std::collections::HashMap::new())),
         }
     }
 
@@ -304,11 +323,34 @@ impl SyncEngine {
     }
 
     async fn do_sync(&self) -> SyncResult<bool> {
+        let has_pending = !self.pending.lock().await.is_empty();
+        if !has_pending {
+            // Even with no pending entries, we may need to download org entries
+            let org_downloaded = self.sync_org_download().await.unwrap_or(0);
+            return Ok(org_downloaded > 0);
+        }
+
+        // If org sync is configured, use partitioned upload
+        let has_partitioner = self.partitioner.lock().await.is_some();
+        if has_partitioner {
+            let uploaded = self.sync_org_entries().await?;
+            // Also download from org members
+            let downloaded = self.sync_org_download().await.unwrap_or(0);
+
+            // Check if compaction is needed (personal entries only)
+            let current_seq = *self.seq.lock().await;
+            if current_seq > 0 && current_seq % self.config.compaction_threshold == 0 {
+                if let Err(e) = self.compact(current_seq).await {
+                    log::warn!("compaction failed (non-fatal): {e}");
+                }
+            }
+
+            return Ok(uploaded > 0 || downloaded > 0);
+        }
+
+        // Standard personal-only sync path (no partitioner)
         let entries = {
             let pending = self.pending.lock().await;
-            if pending.is_empty() {
-                return Ok(false);
-            }
             pending.clone()
         };
 
@@ -545,6 +587,350 @@ impl SyncEngine {
             .renew_lock(&self.device_id, self.config.lock_ttl_secs)
             .await
     }
+
+    // =========================================================================
+    // Org sync configuration
+    // =========================================================================
+
+    /// Configure org sync partitioning.
+    ///
+    /// Once set, the sync engine will partition pending entries at upload time:
+    /// personal-keyed entries sync as today, org-prefixed entries encrypt with the
+    /// org's E2E key and upload to `/{org_hash}/log/{member_id}/{seq}.enc`.
+    ///
+    /// # Arguments
+    /// - `partitioner`: routes keys to personal or org destinations
+    /// - `member_id`: this node's short ID (first 8 hex chars of SHA256 of public key)
+    /// - `org_crypto`: map of org_hash -> CryptoProvider initialized with that org's E2E key
+    pub async fn configure_org_sync(
+        &self,
+        partitioner: SyncPartitioner,
+        member_id: String,
+        org_crypto: std::collections::HashMap<String, Arc<dyn CryptoProvider>>,
+    ) {
+        *self.partitioner.lock().await = Some(partitioner);
+        *self.member_id.lock().await = Some(member_id);
+        *self.org_crypto.lock().await = org_crypto;
+    }
+
+    /// Check if org sync is configured.
+    pub async fn has_org_sync(&self) -> bool {
+        self.partitioner.lock().await.is_some()
+    }
+
+    // =========================================================================
+    // Org sync: upload org-partitioned entries
+    // =========================================================================
+
+    /// Upload org-partitioned pending entries.
+    ///
+    /// Called as part of `do_sync` when a partitioner is configured.
+    /// Partitions pending entries into personal and org buckets, then:
+    /// - Personal entries: uploaded as normal (existing path)
+    /// - Org entries: sealed with org E2E key, uploaded to org S3 prefix
+    ///
+    /// Returns the number of entries uploaded (personal + org).
+    async fn sync_org_entries(&self) -> SyncResult<usize> {
+        let entries = {
+            let pending = self.pending.lock().await;
+            if pending.is_empty() {
+                return Ok(0);
+            }
+            pending.clone()
+        };
+
+        let partitioner = self.partitioner.lock().await;
+        let partitioner = match partitioner.as_ref() {
+            Some(p) => p,
+            None => return Ok(0), // No partitioner, nothing to do here
+        };
+
+        let member_id = self.member_id.lock().await.clone().unwrap_or_default();
+
+        // Partition entries by destination
+        let mut personal_entries: Vec<LogEntry> = Vec::new();
+        let mut org_entries: std::collections::HashMap<String, Vec<LogEntry>> =
+            std::collections::HashMap::new();
+
+        for entry in &entries {
+            let dest = Self::classify_entry(partitioner, entry);
+            match dest {
+                SyncDestination::Personal => {
+                    personal_entries.push(entry.clone());
+                }
+                SyncDestination::Org { org_hash, .. } => {
+                    org_entries
+                        .entry(org_hash)
+                        .or_default()
+                        .push(entry.clone());
+                }
+            }
+        }
+
+        let mut uploaded = 0;
+
+        // Upload personal entries via existing path
+        if !personal_entries.is_empty() {
+            let mut sealed = Vec::with_capacity(personal_entries.len());
+            for entry in &personal_entries {
+                let s = entry.seal(&self.crypto).await?;
+                sealed.push((entry.seq, s));
+            }
+
+            let seq_numbers: Vec<u64> = sealed.iter().map(|(seq, _)| *seq).collect();
+            let urls = self.auth.presign_log_upload(&seq_numbers).await?;
+
+            if urls.len() != sealed.len() {
+                return Err(SyncError::Auth(format!(
+                    "expected {} presigned URLs, got {}",
+                    sealed.len(),
+                    urls.len()
+                )));
+            }
+
+            for ((_seq, s), url) in sealed.into_iter().zip(urls.iter()) {
+                self.s3.upload(url, s.bytes).await?;
+            }
+            uploaded += personal_entries.len();
+        }
+
+        // Upload org entries
+        let org_crypto = self.org_crypto.lock().await;
+        for (org_hash, entries) in &org_entries {
+            let crypto = match org_crypto.get(org_hash) {
+                Some(c) => c,
+                None => {
+                    log::warn!(
+                        "no CryptoProvider for org_hash={}, skipping {} entries",
+                        org_hash,
+                        entries.len()
+                    );
+                    continue;
+                }
+            };
+
+            let mut sealed = Vec::with_capacity(entries.len());
+            for entry in entries {
+                let s = entry.seal(crypto).await?;
+                sealed.push((entry.seq, s));
+            }
+
+            let seq_numbers: Vec<u64> = sealed.iter().map(|(seq, _)| *seq).collect();
+            let urls = self
+                .auth
+                .presign_org_log_upload(org_hash, &member_id, &seq_numbers)
+                .await?;
+
+            if urls.len() != sealed.len() {
+                return Err(SyncError::Auth(format!(
+                    "expected {} org presigned URLs, got {}",
+                    sealed.len(),
+                    urls.len()
+                )));
+            }
+
+            for ((_seq, s), url) in sealed.into_iter().zip(urls.iter()) {
+                self.s3.upload(url, s.bytes).await?;
+            }
+            uploaded += entries.len();
+        }
+
+        // Clear all uploaded entries from pending
+        {
+            let mut pending = self.pending.lock().await;
+            let count = entries.len().min(pending.len());
+            pending.drain(..count);
+        }
+
+        Ok(uploaded)
+    }
+
+    /// Classify a single log entry by examining its key.
+    fn classify_entry(partitioner: &SyncPartitioner, entry: &LogEntry) -> SyncDestination {
+        match &entry.op {
+            LogOp::Put {
+                namespace, key, ..
+            }
+            | LogOp::Delete { namespace, key } => partitioner.partition_log_key(namespace, key),
+            LogOp::BatchPut {
+                namespace, items, ..
+            } => {
+                // Use the first item's key to classify the batch
+                // (batches within a single schema always share the same org prefix)
+                if let Some((key, _)) = items.first() {
+                    partitioner.partition_log_key(namespace, key)
+                } else {
+                    SyncDestination::Personal
+                }
+            }
+            LogOp::BatchDelete {
+                namespace, keys, ..
+            } => {
+                if let Some(key) = keys.first() {
+                    partitioner.partition_log_key(namespace, key)
+                } else {
+                    SyncDestination::Personal
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Org sync: download from other members
+    // =========================================================================
+
+    /// Download and replay org log entries from all members of all orgs.
+    ///
+    /// For each org the node belongs to, lists `/{org_hash}/log/*/` to discover
+    /// member sub-prefixes, then downloads new entries from each member.
+    ///
+    /// Returns the total number of entries replayed.
+    pub async fn sync_org_download(&self) -> SyncResult<u64> {
+        let org_hashes = {
+            let partitioner = self.partitioner.lock().await;
+            match partitioner.as_ref() {
+                Some(p) => p.org_hashes(),
+                None => return Ok(0),
+            }
+        };
+
+        let member_id = self.member_id.lock().await.clone().unwrap_or_default();
+
+        let mut total_replayed: u64 = 0;
+
+        for org_hash in &org_hashes {
+            let replayed = self
+                .download_org_entries(org_hash, &member_id)
+                .await?;
+            total_replayed += replayed;
+        }
+
+        Ok(total_replayed)
+    }
+
+    /// Download and replay entries for a single org from all other members.
+    async fn download_org_entries(
+        &self,
+        org_hash: &str,
+        my_member_id: &str,
+    ) -> SyncResult<u64> {
+        // List all objects under the org's log prefix
+        let all_objects = self.auth.list_org_objects(org_hash, "log/").await?;
+
+        // Group objects by member_id.
+        // Keys look like: log/{member_id}/{seq}.enc
+        let mut member_entries: std::collections::HashMap<String, Vec<u64>> =
+            std::collections::HashMap::new();
+
+        for obj in &all_objects {
+            if let Some(parsed) = parse_org_log_key(&obj.key) {
+                // Skip our own entries
+                if parsed.member_id == my_member_id {
+                    continue;
+                }
+                member_entries
+                    .entry(parsed.member_id)
+                    .or_default()
+                    .push(parsed.seq);
+            }
+        }
+
+        let org_crypto = self.org_crypto.lock().await;
+        let crypto = match org_crypto.get(org_hash) {
+            Some(c) => c.clone(),
+            None => {
+                log::warn!("no CryptoProvider for org_hash={}, skipping download", org_hash);
+                return Ok(0);
+            }
+        };
+        drop(org_crypto);
+
+        let mut total_replayed: u64 = 0;
+        let mut cursors = self.org_member_cursors.lock().await;
+
+        for (remote_member_id, mut seqs) in member_entries {
+            seqs.sort();
+
+            // Filter to only new entries
+            let cursor_key = format!("{org_hash}:{remote_member_id}");
+            let cursor = cursors.get(&cursor_key).copied().unwrap_or(0);
+            let new_seqs: Vec<u64> = seqs.into_iter().filter(|s| *s > cursor).collect();
+
+            if new_seqs.is_empty() {
+                continue;
+            }
+
+            let urls = self
+                .auth
+                .presign_org_log_download(org_hash, &remote_member_id, &new_seqs)
+                .await?;
+
+            for (seq, url) in new_seqs.iter().zip(urls.iter()) {
+                let data = self.s3.download(url).await?;
+                match data {
+                    Some(bytes) => match LogEntry::unseal(&bytes, &crypto).await {
+                        Ok(entry) => {
+                            self.replay_entry(&entry).await?;
+                            total_replayed += 1;
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "skipping corrupt org log entry org={} member={} seq={}: {}",
+                                org_hash,
+                                remote_member_id,
+                                seq,
+                                e
+                            );
+                        }
+                    },
+                    None => {
+                        log::warn!(
+                            "org log entry not found: org={} member={} seq={}",
+                            org_hash,
+                            remote_member_id,
+                            seq
+                        );
+                    }
+                }
+            }
+
+            // Update cursor
+            if let Some(max_seq) = new_seqs.last() {
+                cursors.insert(cursor_key, *max_seq);
+            }
+        }
+
+        Ok(total_replayed)
+    }
+}
+
+/// Parsed components of an org log S3 key.
+struct ParsedOrgLogKey {
+    member_id: String,
+    seq: u64,
+}
+
+/// Parse an S3 object key like `log/{member_id}/{seq}.enc` into its components.
+fn parse_org_log_key(key: &str) -> Option<ParsedOrgLogKey> {
+    // Key format: log/{member_id}/{seq}.enc
+    // The key may or may not have the org_hash prefix stripped by the auth Lambda
+    let parts: Vec<&str> = key.split('/').collect();
+
+    // Try matching from the end: .../{member_id}/{seq}.enc
+    if parts.len() < 2 {
+        return None;
+    }
+
+    let filename = parts[parts.len() - 1];
+    let member_id = parts[parts.len() - 2];
+
+    let seq_str = filename.strip_suffix(".enc")?;
+    let seq = seq_str.parse::<u64>().ok()?;
+
+    Some(ParsedOrgLogKey {
+        member_id: member_id.to_string(),
+        seq,
+    })
 }
 
 #[cfg(test)]
@@ -558,5 +944,92 @@ mod tests {
         assert_eq!(config.compaction_threshold, 100);
         assert_eq!(config.lock_ttl_secs, 300);
         assert_eq!(config.max_retries, 2);
+    }
+
+    #[test]
+    fn test_parse_org_log_key() {
+        let parsed = parse_org_log_key("log/a1b2c3d4/42.enc").unwrap();
+        assert_eq!(parsed.member_id, "a1b2c3d4");
+        assert_eq!(parsed.seq, 42);
+
+        // With org_hash prefix (as it might appear in full S3 key)
+        let parsed2 = parse_org_log_key("org_abc/log/e5f6a7b8/1.enc").unwrap();
+        assert_eq!(parsed2.member_id, "e5f6a7b8");
+        assert_eq!(parsed2.seq, 1);
+
+        // Invalid
+        assert!(parse_org_log_key("log/a1b2c3d4/not_a_number.enc").is_none());
+        assert!(parse_org_log_key("single").is_none());
+    }
+
+    #[test]
+    fn test_classify_entry_personal() {
+        use crate::org::OrgMembership;
+
+        let memberships = vec![OrgMembership {
+            org_name: "Test".to_string(),
+            org_hash: "org_abc".to_string(),
+            org_public_key: "pk".to_string(),
+            org_secret_key: None,
+            org_e2e_secret: "secret".to_string(),
+            role: crate::org::OrgRole::Member,
+            members: vec![],
+            created_at: 0,
+            joined_at: 0,
+        }];
+        let partitioner = SyncPartitioner::new(&memberships);
+
+        let entry = LogEntry {
+            seq: 1,
+            timestamp_ms: 1000,
+            device_id: "dev".to_string(),
+            op: LogOp::Put {
+                namespace: "main".to_string(),
+                key: LogOp::encode_bytes(b"atom:uuid-1"),
+                value: LogOp::encode_bytes(b"data"),
+            },
+        };
+
+        assert_eq!(
+            SyncEngine::classify_entry(&partitioner, &entry),
+            SyncDestination::Personal
+        );
+    }
+
+    #[test]
+    fn test_classify_entry_org() {
+        use crate::org::OrgMembership;
+
+        let memberships = vec![OrgMembership {
+            org_name: "Test".to_string(),
+            org_hash: "org_abc".to_string(),
+            org_public_key: "pk".to_string(),
+            org_secret_key: None,
+            org_e2e_secret: "secret".to_string(),
+            role: crate::org::OrgRole::Member,
+            members: vec![],
+            created_at: 0,
+            joined_at: 0,
+        }];
+        let partitioner = SyncPartitioner::new(&memberships);
+
+        let entry = LogEntry {
+            seq: 1,
+            timestamp_ms: 1000,
+            device_id: "dev".to_string(),
+            op: LogOp::Put {
+                namespace: "main".to_string(),
+                key: LogOp::encode_bytes(b"org_abc:atom:uuid-1"),
+                value: LogOp::encode_bytes(b"data"),
+            },
+        };
+
+        assert_eq!(
+            SyncEngine::classify_entry(&partitioner, &entry),
+            SyncDestination::Org {
+                org_hash: "org_abc".to_string(),
+                org_e2e_secret: "secret".to_string(),
+            }
+        );
     }
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -52,11 +52,13 @@ pub mod auth;
 pub mod engine;
 pub mod error;
 pub mod log;
+pub mod org_sync;
 pub mod s3;
 pub mod snapshot;
 
 pub use engine::{SyncConfig, SyncEngine, SyncState, SyncStatus};
 pub use error::{SyncError, SyncResult};
+pub use org_sync::{SyncDestination, SyncPartitioner};
 
 /// Configuration needed to enable S3 sync.
 ///

--- a/src/sync/org_sync.rs
+++ b/src/sync/org_sync.rs
@@ -1,0 +1,328 @@
+//! Key-prefix-based sync partitioning for org-scoped data.
+//!
+//! Org schemas use key prefixes (`{org_hash}:`) to namespace their data in Sled.
+//! The `SyncPartitioner` inspects each log entry's key to determine whether it
+//! should be synced to the personal S3 prefix or an org's shared S3 prefix.
+//!
+//! This is much simpler than a mapping table — the key itself tells you where
+//! the data belongs. No registration of atoms/molecules required.
+//!
+//! ## Key format
+//!
+//! - Personal: `atom:{uuid}`, `ref:{uuid}`, `history:{mol}:{ts}`
+//! - Org: `{org_hash}:atom:{uuid}`, `{org_hash}:ref:{uuid}`, etc.
+//!
+//! The org_hash prefix is added at write time when a schema has `org_hash = Some(hash)`.
+//! The sync layer just reads it back.
+
+use crate::org::OrgMembership;
+use sha2::{Digest, Sha256};
+
+/// Where a log entry should be synced to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncDestination {
+    /// Personal data — sync to `/{user_hash}/log/{seq}.enc`
+    Personal,
+    /// Org data — sync to `/{org_hash}/log/{member_id}/{seq}.enc`
+    /// with the org's E2E key for encryption.
+    Org {
+        org_hash: String,
+        org_e2e_secret: String,
+    },
+}
+
+/// Partitions log entries by destination based on key prefix.
+///
+/// Given a Sled key (from a LogEntry's namespace+key), determines whether it
+/// belongs to an org (key starts with `{org_hash}:`) or is personal data.
+///
+/// The partitioner is initialized from the node's org memberships and updated
+/// when memberships change (join/leave org).
+pub struct SyncPartitioner {
+    /// Known org memberships with their E2E secrets.
+    org_memberships: Vec<OrgMembershipEntry>,
+}
+
+/// Minimal info needed for partitioning decisions.
+#[derive(Debug, Clone)]
+struct OrgMembershipEntry {
+    org_hash: String,
+    org_e2e_secret: String,
+}
+
+impl SyncPartitioner {
+    /// Create a new partitioner from org memberships.
+    pub fn new(memberships: &[OrgMembership]) -> Self {
+        let org_memberships = memberships
+            .iter()
+            .map(|m| OrgMembershipEntry {
+                org_hash: m.org_hash.clone(),
+                org_e2e_secret: m.org_e2e_secret.clone(),
+            })
+            .collect();
+
+        Self { org_memberships }
+    }
+
+    /// Create an empty partitioner (no org memberships — everything is personal).
+    pub fn empty() -> Self {
+        Self {
+            org_memberships: Vec::new(),
+        }
+    }
+
+    /// Determine where a key should be synced based on its prefix.
+    ///
+    /// Checks if the key (decoded from base64 in the LogEntry) starts with
+    /// any known org_hash followed by `:`. If so, routes to that org.
+    /// Otherwise, routes to personal sync.
+    pub fn partition(&self, key: &str) -> SyncDestination {
+        for entry in &self.org_memberships {
+            let prefix = format!("{}:", entry.org_hash);
+            if key.starts_with(&prefix) {
+                return SyncDestination::Org {
+                    org_hash: entry.org_hash.clone(),
+                    org_e2e_secret: entry.org_e2e_secret.clone(),
+                };
+            }
+        }
+        SyncDestination::Personal
+    }
+
+    /// Partition a LogOp's key string (already decoded from the LogEntry).
+    ///
+    /// For namespace-level keys (like schema names in the "schemas" namespace),
+    /// also checks the namespace+key combination.
+    pub fn partition_log_key(&self, namespace: &str, key_b64: &str) -> SyncDestination {
+        // Decode the base64 key to get the raw key string
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+        let key_bytes = match BASE64.decode(key_b64) {
+            Ok(bytes) => bytes,
+            Err(_) => return SyncDestination::Personal,
+        };
+        let key_str = match std::str::from_utf8(&key_bytes) {
+            Ok(s) => s,
+            Err(_) => return SyncDestination::Personal,
+        };
+
+        // For any namespace, check if the key itself has an org prefix
+        let dest = self.partition(key_str);
+        if dest != SyncDestination::Personal {
+            return dest;
+        }
+
+        // For schema-level namespaces, the key might be a schema name
+        // that was stored under an org-prefixed schema name
+        // (e.g., key = "{org_hash}:board_meeting" in the "schemas" namespace)
+        let _ = namespace; // namespace used for potential future routing logic
+
+        SyncDestination::Personal
+    }
+
+    /// Get the list of org hashes this partitioner knows about.
+    pub fn org_hashes(&self) -> Vec<String> {
+        self.org_memberships
+            .iter()
+            .map(|m| m.org_hash.clone())
+            .collect()
+    }
+
+    /// Check if this partitioner has any org memberships.
+    pub fn has_orgs(&self) -> bool {
+        !self.org_memberships.is_empty()
+    }
+}
+
+/// Derive a short member ID from a node's public key.
+///
+/// Uses the first 8 hex characters of the SHA-256 hash of the public key bytes.
+/// This gives 4 bytes = 2^32 possibilities, which is sufficient for org membership
+/// sizes (collisions are astronomically unlikely for orgs < 1000 members).
+pub fn member_id_from_public_key(public_key_bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(public_key_bytes);
+    let hash = hasher.finalize();
+    // First 4 bytes -> 8 hex chars
+    hash[..4]
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>()
+}
+
+/// Build an org-prefixed key from a base key and org_hash.
+///
+/// Example: `org_key_prefix("abc123", "atom:uuid-1")` -> `"abc123:atom:uuid-1"`
+pub fn org_key_prefix(org_hash: &str, base_key: &str) -> String {
+    format!("{org_hash}:{base_key}")
+}
+
+/// Strip the org prefix from a key, if present.
+///
+/// Returns `Some((org_hash, base_key))` if the key has an org prefix,
+/// or `None` if it's a personal key.
+pub fn strip_org_prefix(key: &str) -> Option<(&str, &str)> {
+    // Org keys look like: {org_hash}:{rest}
+    // org_hash is a hex SHA256 (64 chars), so we look for a 64-char hex prefix
+    // followed by a colon.
+    if key.len() > 65 {
+        let potential_hash = &key[..64];
+        if key.as_bytes()[64] == b':'
+            && potential_hash
+                .chars()
+                .all(|c| c.is_ascii_hexdigit())
+        {
+            return Some((&key[..64], &key[65..]));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::org::OrgMembership;
+
+    fn make_membership(org_hash: &str, e2e_secret: &str) -> OrgMembership {
+        OrgMembership {
+            org_name: "Test Org".to_string(),
+            org_hash: org_hash.to_string(),
+            org_public_key: "test_pk".to_string(),
+            org_secret_key: None,
+            org_e2e_secret: e2e_secret.to_string(),
+            role: crate::org::OrgRole::Member,
+            members: vec![],
+            created_at: 0,
+            joined_at: 0,
+        }
+    }
+
+    #[test]
+    fn test_sync_partitioner_personal_keys() {
+        let memberships = vec![make_membership("abc123def456", "secret1")];
+        let partitioner = SyncPartitioner::new(&memberships);
+
+        assert_eq!(
+            partitioner.partition("atom:uuid-1"),
+            SyncDestination::Personal
+        );
+        assert_eq!(
+            partitioner.partition("ref:mol-uuid"),
+            SyncDestination::Personal
+        );
+        assert_eq!(
+            partitioner.partition("history:mol:12345"),
+            SyncDestination::Personal
+        );
+    }
+
+    #[test]
+    fn test_sync_partitioner_org_keys() {
+        let memberships = vec![make_membership("abc123def456", "secret1")];
+        let partitioner = SyncPartitioner::new(&memberships);
+
+        assert_eq!(
+            partitioner.partition("abc123def456:atom:uuid-1"),
+            SyncDestination::Org {
+                org_hash: "abc123def456".to_string(),
+                org_e2e_secret: "secret1".to_string(),
+            }
+        );
+        assert_eq!(
+            partitioner.partition("abc123def456:ref:mol-uuid"),
+            SyncDestination::Org {
+                org_hash: "abc123def456".to_string(),
+                org_e2e_secret: "secret1".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_sync_partitioner_multiple_orgs() {
+        let memberships = vec![
+            make_membership("org_alpha", "secret_a"),
+            make_membership("org_beta", "secret_b"),
+        ];
+        let partitioner = SyncPartitioner::new(&memberships);
+
+        assert_eq!(
+            partitioner.partition("org_alpha:atom:uuid-1"),
+            SyncDestination::Org {
+                org_hash: "org_alpha".to_string(),
+                org_e2e_secret: "secret_a".to_string(),
+            }
+        );
+        assert_eq!(
+            partitioner.partition("org_beta:atom:uuid-2"),
+            SyncDestination::Org {
+                org_hash: "org_beta".to_string(),
+                org_e2e_secret: "secret_b".to_string(),
+            }
+        );
+        assert_eq!(
+            partitioner.partition("atom:uuid-3"),
+            SyncDestination::Personal
+        );
+    }
+
+    #[test]
+    fn test_sync_partitioner_empty() {
+        let partitioner = SyncPartitioner::empty();
+        assert_eq!(
+            partitioner.partition("anything:at:all"),
+            SyncDestination::Personal
+        );
+        assert!(!partitioner.has_orgs());
+    }
+
+    #[test]
+    fn test_org_key_prefix_helper() {
+        assert_eq!(
+            org_key_prefix("abc123", "atom:uuid-1"),
+            "abc123:atom:uuid-1"
+        );
+        assert_eq!(
+            org_key_prefix("org_hash", "ref:mol-uuid"),
+            "org_hash:ref:mol-uuid"
+        );
+    }
+
+    #[test]
+    fn test_strip_org_prefix() {
+        // 64-char hex hash prefix
+        let org_hash = "a".repeat(64);
+        let key = format!("{org_hash}:atom:uuid-1");
+        let result = strip_org_prefix(&key);
+        assert_eq!(result, Some((org_hash.as_str(), "atom:uuid-1")));
+
+        // Personal key (no org prefix)
+        assert_eq!(strip_org_prefix("atom:uuid-1"), None);
+
+        // Short key
+        assert_eq!(strip_org_prefix("abc:def"), None);
+    }
+
+    #[test]
+    fn test_member_id_from_public_key() {
+        let pk = b"test-public-key-bytes";
+        let id = member_id_from_public_key(pk);
+        assert_eq!(id.len(), 8); // 4 bytes = 8 hex chars
+        // Deterministic
+        assert_eq!(id, member_id_from_public_key(pk));
+        // Different key gives different ID
+        assert_ne!(id, member_id_from_public_key(b"other-key"));
+    }
+
+    #[test]
+    fn test_org_hashes() {
+        let memberships = vec![
+            make_membership("org_a", "secret_a"),
+            make_membership("org_b", "secret_b"),
+        ];
+        let partitioner = SyncPartitioner::new(&memberships);
+        let hashes = partitioner.org_hashes();
+        assert_eq!(hashes.len(), 2);
+        assert!(hashes.contains(&"org_a".to_string()));
+        assert!(hashes.contains(&"org_b".to_string()));
+        assert!(partitioner.has_orgs());
+    }
+}

--- a/src/sync/org_sync.rs
+++ b/src/sync/org_sync.rs
@@ -166,11 +166,7 @@ pub fn strip_org_prefix(key: &str) -> Option<(&str, &str)> {
     // followed by a colon.
     if key.len() > 65 {
         let potential_hash = &key[..64];
-        if key.as_bytes()[64] == b':'
-            && potential_hash
-                .chars()
-                .all(|c| c.is_ascii_hexdigit())
-        {
+        if key.as_bytes()[64] == b':' && potential_hash.chars().all(|c| c.is_ascii_hexdigit()) {
             return Some((&key[..64], &key[65..]));
         }
     }
@@ -306,7 +302,7 @@ mod tests {
         let pk = b"test-public-key-bytes";
         let id = member_id_from_public_key(pk);
         assert_eq!(id.len(), 8); // 4 bytes = 8 hex chars
-        // Deterministic
+                                 // Deterministic
         assert_eq!(id, member_id_from_public_key(pk));
         // Different key gives different ID
         assert_ne!(id, member_id_from_public_key(b"other-key"));


### PR DESCRIPTION
## Summary

- Implements Phase 2 of org-scoped schema sharing using a **corrected key-prefix design** instead of the previous OrgRouter mapping-table approach
- Org schemas prefix their Sled keys with `{org_hash}:`, and the new `SyncPartitioner` inspects each log entry's key at upload time to route it to personal or org S3 paths
- No device locks for org sync — FoldDB's append-only, LWW-convergent data model handles multi-writer sync naturally
- Extended `SyncEngine` with optional partitioner for org upload (to `/{org_hash}/log/{member_id}/{seq}.enc`) and download (poll all members' sub-prefixes)

## Changes

| File | What |
|------|------|
| `src/sync/org_sync.rs` | **New** — `SyncPartitioner`, `SyncDestination`, `member_id_from_public_key`, `org_key_prefix`, `strip_org_prefix` |
| `src/sync/engine.rs` | Extended `SyncEngine` with org partitioner, org upload/download, entry classification |
| `src/sync/auth.rs` | Added `presign_org_log_upload`, `presign_org_log_download`, `list_org_objects` |
| `src/sync/mod.rs` | Export `org_sync` module and key types |

## Design principles

1. **Key prefix, not metadata tag** — schema identity for org data is `{org_hash}:{key}` in Sled
2. **Local writes identical** — same Sled write path; only the key has an org prefix
3. **Sync partitions at upload time** — `SyncPartitioner` checks key prefix to decide destination
4. **No locks** — append-only atoms + LWW molecule pointers converge without coordination
5. **No OrgRouter** — the key prefix itself routes data (replaces the previous mapping-table approach)

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` (zero warnings)
- [x] `cargo check --workspace --features aws-backend` (compiles)
- [x] `cargo test --workspace --all-targets` (all pass)
- [x] Unit tests: sync partitioner routing, entry classification, key parsing, member ID derivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)