### PR TITLE
feat: expose sync_engine() accessor for org sync wiring

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -169,6 +169,13 @@ impl FoldDB {
         self.sync_engine.is_some()
     }
 
+    /// Returns a reference to the sync engine, if configured.
+    ///
+    /// Used by fold_db_node to call `configure_org_sync()` after node startup.
+    pub fn sync_engine(&self) -> Option<&Arc<crate::sync::SyncEngine>> {
+        self.sync_engine.as_ref()
+    }
+
     /// Creates a new FoldDB instance with the specified storage path.
     /// All initializations happen here. This is the main entry point for the FoldDB system.
     /// Do not initialize anywhere else.


### PR DESCRIPTION
## Summary
- Adds a public `sync_engine()` getter on `FoldDB` that returns `Option<&Arc<SyncEngine>>`
- Needed by fold_db_node to call `configure_org_sync()` on the engine after node startup
- Part of Phase 3: org sync wiring (see fold_db_node PR)

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` passes
- Trivial accessor — no behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)