### PR TITLE
fix: remove OnceLock from MoleculeVariant::get_atom_uuid

### DIFF
--- a/src/atom/molecule_hash_range.rs
+++ b/src/atom/molecule_hash_range.rs
@@ -84,6 +84,12 @@ impl MoleculeHashRange {
         &self.uuid
     }
 
+    /// Returns the UUID as a `&String` reference.
+    #[must_use]
+    pub fn uuid_string(&self) -> &String {
+        &self.uuid
+    }
+
     /// Returns the timestamp of the last update.
     #[must_use]
     pub fn updated_at(&self) -> DateTime<Utc> {

--- a/src/atom/molecule_range.rs
+++ b/src/atom/molecule_range.rs
@@ -35,6 +35,12 @@ impl MoleculeRange {
         &self.uuid
     }
 
+    /// Returns the UUID as a `&String` reference.
+    #[must_use]
+    pub fn uuid_string(&self) -> &String {
+        &self.uuid
+    }
+
     /// Returns the timestamp of the last update.
     #[must_use]
     pub fn updated_at(&self) -> DateTime<Utc> {

--- a/src/schema/molecule_variants.rs
+++ b/src/schema/molecule_variants.rs
@@ -34,19 +34,14 @@ impl MoleculeVariant {
         }
     }
 
-    /// Returns the atom UUID for this molecule variant
-    /// Note: For Range and HashRange, this returns the molecule's own UUID, not a contained atom UUID
+    /// Returns the atom UUID for this molecule variant.
+    /// For Single, returns the referenced atom UUID.
+    /// For Range and HashRange, returns the molecule's own UUID (not a contained atom UUID).
     pub fn get_atom_uuid(&self) -> &String {
         match self {
             MoleculeVariant::Single(m) => m.get_atom_uuid(),
-            MoleculeVariant::Range(m) => {
-                static RANGE_UUID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-                RANGE_UUID.get_or_init(|| m.uuid().to_string())
-            }
-            MoleculeVariant::HashRange(m) => {
-                static HASH_RANGE_UUID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-                HASH_RANGE_UUID.get_or_init(|| m.uuid().to_string())
-            }
+            MoleculeVariant::Range(m) => m.uuid_string(),
+            MoleculeVariant::HashRange(m) => m.uuid_string(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove static `OnceLock` from `MoleculeVariant::get_atom_uuid()` that cached the first molecule's UUID globally
- Add `uuid_string()` to `MoleculeRange` and `MoleculeHashRange` to return `&String` directly from the struct field
- Eliminates cross-instance contamination when multiple FoldDB instances share a process

## Context
The `OnceLock` was introduced to avoid allocating a String on each call, but it cached the UUID from the **first** molecule ever created and returned it for all subsequent molecules. This caused test failures when parallel tests created separate FoldDB instances.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)