### PR TITLE
fix: run sync cycle for org download even without pending writes

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -114,7 +114,11 @@ impl FoldDB {
             let interval = tokio::time::Duration::from_millis(interval_ms);
             loop {
                 tokio::time::sleep(interval).await;
-                if engine.state().await == crate::sync::SyncState::Dirty {
+                // Always run sync — even without pending writes, we need to
+                // download org data from other members.
+                let has_pending = engine.state().await == crate::sync::SyncState::Dirty;
+                let has_orgs = engine.has_org_sync().await;
+                if has_pending || has_orgs {
                     if let Err(e) = engine.sync().await {
                         if let crate::sync::SyncError::OrgMembershipRevoked(org_hash) = &e {
                             log::warn!("🚨 SYSTEM ALERT: You have been removed from organization (hash: {}) by an administrator. Proceeding to securely purge all locally cached copies of its data and schema to prevent orphans.", org_hash);


### PR DESCRIPTION
## Summary
- Sync loop only fired when state was `Dirty` (pending local writes)
- Org members need to download data from other members even without local writes
- Now also triggers sync when `has_org_sync()` is true

## Context
Found during multi-user org dogfooding — User B could never receive org data from User A because the sync loop never ran without local writes.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)