### PR TITLE
fix: abort sync task on FoldDB drop to prevent tokio panic

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -456,3 +456,13 @@ impl FoldDB {
         Arc::clone(&self.message_bus)
     }
 }
+
+impl Drop for FoldDB {
+    fn drop(&mut self) {
+        // Abort the background sync task to prevent tokio panic:
+        // "Cannot drop a runtime in a context where blocking is not allowed"
+        if let Some(handle) = self.sync_task.take() {
+            handle.abort();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Drop` impl for `FoldDB` that aborts the background sync timer task
- Prevents "Cannot drop a runtime in a context where blocking is not allowed" panic during server shutdown
- `JoinHandle::abort()` is non-blocking and safe from any context

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)