### PR TITLE
fix: default Ollama model to llama3.1:8b

### DIFF
--- a/src/llm_registry/models.rs
+++ b/src/llm_registry/models.rs
@@ -19,8 +19,10 @@ pub const ANTHROPIC_SONNET_OPENROUTER: &str = "anthropic/claude-sonnet-4-2025051
 // ---- Ollama Models ----
 
 /// Default Ollama model for general text tasks (ingestion, queries).
-/// Used by: `fold_db_node` Ollama backend.
-pub const OLLAMA_DEFAULT: &str = "llama3.3";
+/// Used by: `fold_db_node` Ollama backend, `fold_db` schema service classification.
+/// Must be a model that works on most hardware (8B params).
+/// The ingestion config in `fold_db_node` upgrades to larger models based on system RAM.
+pub const OLLAMA_DEFAULT: &str = "llama3.1:8b";
 
 /// Vision model for image captioning and classification.
 /// Used by: `file_to_markdown` image extraction.


### PR DESCRIPTION
## Summary
- Change `OLLAMA_DEFAULT` from `llama3.3` (70B) to `llama3.1:8b` — the 70B model requires ~42GB VRAM and most users don't have it installed
- Schema service classification falls back to this default when no `OLLAMA_MODEL` env var is set, causing 404 errors
- The ingestion config in fold_db_node still upgrades to `llama3.3` on 64GB+ RAM systems via `default_text_model()`

## Test plan
- [x] Clippy clean
- [x] All llm_registry tests pass
- [x] Dogfood verified: schema service classification works with `llama3.1:8b` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)