### PR TITLE
fix: three bugs blocking org data sync between nodes

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -72,6 +72,11 @@ async fn create_local_fold_db(
         .open_tree("progress")
         .map_err(|e| FoldDbError::Config(format!("Failed to open progress tree: {}", e)))?;
 
+    // Retain the raw sled handle so FoldDB::sled_db() can return it.
+    // This is needed by org operations (which store memberships directly in
+    // Sled trees) and by configure_org_sync_if_needed().
+    let raw_sled = db.clone();
+
     let base_store: Arc<dyn crate::storage::traits::NamespacedStore> =
         Arc::new(crate::storage::SledNamespacedStore::new(db));
 
@@ -137,11 +142,12 @@ async fn create_local_fold_db(
 
     let job_store = crate::progress::create_tracker_with_sled(progress_tree);
 
-    let mut fold_db = FoldDB::initialize_from_db_ops(
+    let mut fold_db = FoldDB::initialize_from_db_ops_with_sled(
         Arc::new(db_ops),
         path_str,
         Some(job_store),
         "local".to_string(),
+        Some(raw_sled),
     )
     .await
     .map_err(|e| FoldDbError::Config(e.to_string()))?;

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -270,7 +270,8 @@ impl FoldDB {
     }
 
     /// Internal initializer that optionally retains the raw sled handle.
-    async fn initialize_from_db_ops_with_sled(
+    /// The raw handle is needed by org operations and org sync configuration.
+    pub async fn initialize_from_db_ops_with_sled(
         db_ops: Arc<DbOperations>,
         _db_path: &str,
         job_store: Option<Arc<dyn JobStore>>,

--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -405,6 +405,16 @@ impl SchemaCore {
     }
 
     pub async fn load_schema_internal(&self, schema: Schema) -> Result<(), SchemaError> {
+        // Ensure runtime_fields are populated. Schemas arriving from the schema
+        // service have runtime_fields empty (it's #[serde(skip)]). Without this
+        // call, mutations fail with "Field not found in runtime_fields".
+        // Only populate if empty — callers like interpret_declarative_schema may
+        // have already populated and set additional state (molecule UUIDs, policies).
+        let mut schema = schema;
+        if schema.runtime_fields.is_empty() {
+            schema.populate_runtime_fields()?;
+        }
+
         let name = schema.name.clone();
 
         // Check if schema exists in database

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -328,10 +328,20 @@ impl SyncEngine {
     /// Returns Ok(true) if all pending entries were uploaded,
     /// Ok(false) if there was nothing to sync.
     pub async fn sync(&self) -> SyncResult<bool> {
+        // Check org sync before acquiring state lock to avoid holding state
+        // across an await on the partitioner lock.
+        let has_orgs = self.has_org_sync().await;
+
         // Atomic check-and-set: hold the lock for both the state check and transition
         {
             let mut state = self.state.lock().await;
-            if *state == SyncState::Syncing || *state == SyncState::Idle {
+            if *state == SyncState::Syncing {
+                return Ok(false);
+            }
+            // When Idle with no pending writes, we still need to proceed if org
+            // sync is configured — other members may have uploaded data we need
+            // to download. Skip only when Idle AND no org memberships.
+            if *state == SyncState::Idle && !has_orgs {
                 return Ok(false);
             }
             *state = SyncState::Syncing;


### PR DESCRIPTION
## Summary
Found during multi-node dogfooding with Exemem dev endpoints. Three bugs that together prevented org-scoped data from syncing between nodes:

- **Factory didn't retain sled_db handle** — `create_local_fold_db` moved `sled::Db` into `SledNamespacedStore` without cloning. `FoldDB::sled_db()` returned `None` → `configure_org_sync_if_needed()` silently bailed → SyncPartitioner never configured → org data uploaded to personal prefix instead of org prefix.
- **Schema runtime_fields not populated** — `load_schema_internal()` didn't call `populate_runtime_fields()` for schemas arriving from the schema service (`runtime_fields` is `#[serde(skip)]`). Mutations failed with "Field not found in runtime_fields".
- **Sync skipped org download when Idle** — `sync()` returned immediately when state was `Idle`, even with org memberships. Org data downloads never ran.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` all pass
- [x] Multi-node dogfood: org create, join, invite, org-scoped schema creation, mutation, partitioned upload (verified `do_sync: partitioned upload=12 download=3`)
- [x] Remaining gap: org E2E encryption mismatch (EncryptingNamespacedStore uses node key, not org key) — tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)