### PR TITLE
feat: per-org encryption routing for org-scoped data

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -126,18 +126,30 @@ async fn create_local_fold_db(
         let crypto = Arc::new(crate::crypto::LocalCryptoProvider::from_key(
             e2e_keys.encryption_key(),
         ));
-        let enc_store =
-            Arc::new(crate::storage::EncryptingNamespacedStore::new(mid_store, crypto, true));
+        let enc_store = Arc::new(crate::storage::EncryptingNamespacedStore::new(
+            mid_store, crypto, true,
+        ));
 
-        (enc_store.clone() as Arc<dyn crate::storage::traits::NamespacedStore>, Some(engine), interval_ms, Some(enc_store))
+        (
+            enc_store.clone() as Arc<dyn crate::storage::traits::NamespacedStore>,
+            Some(engine),
+            interval_ms,
+            Some(enc_store),
+        )
     } else {
         // No sync — Sled → EncryptingNamespacedStore
         let crypto = Arc::new(crate::crypto::LocalCryptoProvider::from_key(
             e2e_keys.encryption_key(),
         ));
-        let enc_store =
-            Arc::new(crate::storage::EncryptingNamespacedStore::new(base_store, crypto, true));
-        (enc_store.clone() as Arc<dyn crate::storage::traits::NamespacedStore>, None, 0, Some(enc_store))
+        let enc_store = Arc::new(crate::storage::EncryptingNamespacedStore::new(
+            base_store, crypto, true,
+        ));
+        (
+            enc_store.clone() as Arc<dyn crate::storage::traits::NamespacedStore>,
+            None,
+            0,
+            Some(enc_store),
+        )
     };
 
     let db_ops = DbOperations::from_namespaced_store(store)

--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -81,10 +81,12 @@ async fn create_local_fold_db(
         Arc::new(crate::storage::SledNamespacedStore::new(db));
 
     // Build the store stack, optionally inserting sync layer
-    let (store, sync_engine, sync_interval_ms): (
+    #[allow(clippy::type_complexity)]
+    let (store, sync_engine, sync_interval_ms, enc_store_ref): (
         Arc<dyn crate::storage::traits::NamespacedStore>,
         Option<Arc<crate::sync::SyncEngine>>,
         u64,
+        Option<Arc<crate::storage::EncryptingNamespacedStore>>,
     ) = if let Some(setup) = sync_setup {
         let sync_config = setup.config.unwrap_or_default();
         let interval_ms = sync_config.sync_interval_ms;
@@ -124,16 +126,18 @@ async fn create_local_fold_db(
         let crypto = Arc::new(crate::crypto::LocalCryptoProvider::from_key(
             e2e_keys.encryption_key(),
         ));
-        let enc_store = crate::storage::EncryptingNamespacedStore::new(mid_store, crypto, true);
+        let enc_store =
+            Arc::new(crate::storage::EncryptingNamespacedStore::new(mid_store, crypto, true));
 
-        (Arc::new(enc_store), Some(engine), interval_ms)
+        (enc_store.clone() as Arc<dyn crate::storage::traits::NamespacedStore>, Some(engine), interval_ms, Some(enc_store))
     } else {
         // No sync — Sled → EncryptingNamespacedStore
         let crypto = Arc::new(crate::crypto::LocalCryptoProvider::from_key(
             e2e_keys.encryption_key(),
         ));
-        let enc_store = crate::storage::EncryptingNamespacedStore::new(base_store, crypto, true);
-        (Arc::new(enc_store), None, 0)
+        let enc_store =
+            Arc::new(crate::storage::EncryptingNamespacedStore::new(base_store, crypto, true));
+        (enc_store.clone() as Arc<dyn crate::storage::traits::NamespacedStore>, None, 0, Some(enc_store))
     };
 
     let db_ops = DbOperations::from_namespaced_store(store)
@@ -148,6 +152,7 @@ async fn create_local_fold_db(
         Some(job_store),
         "local".to_string(),
         Some(raw_sled),
+        enc_store_ref,
     )
     .await
     .map_err(|e| FoldDbError::Config(e.to_string()))?;

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -49,6 +49,8 @@ pub struct FoldDB {
     sync_engine: Option<Arc<crate::sync::SyncEngine>>,
     /// Handle for the background sync timer task.
     sync_task: Option<tokio::task::JoinHandle<()>>,
+    /// Optional reference to the encrypting store for org crypto registration.
+    encrypting_store: Option<Arc<crate::storage::EncryptingNamespacedStore>>,
 }
 
 impl FoldDB {
@@ -202,6 +204,23 @@ impl FoldDB {
         self.sync_engine.as_ref()
     }
 
+    /// Register a crypto provider for org-scoped data encryption.
+    ///
+    /// After this call, storage keys starting with `{org_hash}:` will be
+    /// encrypted/decrypted with this provider instead of the node's personal key.
+    /// This enables org members to read each other's shared data.
+    pub async fn register_org_crypto(
+        &self,
+        org_hash: &str,
+        crypto: Arc<dyn crate::crypto::CryptoProvider>,
+    ) {
+        if let Some(enc_store) = &self.encrypting_store {
+            enc_store
+                .register_org_crypto(org_hash.to_string(), crypto)
+                .await;
+        }
+    }
+
     /// Creates a new FoldDB instance with the specified storage path.
     /// All initializations happen here. This is the main entry point for the FoldDB system.
     /// Do not initialize anywhere else.
@@ -255,6 +274,7 @@ impl FoldDB {
             Some(job_store),
             "local".to_string(),
             Some(db),
+            None,
         )
         .await
     }
@@ -266,7 +286,7 @@ impl FoldDB {
         job_store: Option<Arc<dyn JobStore>>,
         user_id: String,
     ) -> Result<Self, StorageError> {
-        Self::initialize_from_db_ops_with_sled(db_ops, db_path, job_store, user_id, None).await
+        Self::initialize_from_db_ops_with_sled(db_ops, db_path, job_store, user_id, None, None).await
     }
 
     /// Internal initializer that optionally retains the raw sled handle.
@@ -277,6 +297,7 @@ impl FoldDB {
         job_store: Option<Arc<dyn JobStore>>,
         user_id: String,
         sled_db: Option<sled::Db>,
+        encrypting_store: Option<Arc<crate::storage::EncryptingNamespacedStore>>,
     ) -> Result<Self, StorageError> {
         // Initialize message bus
         let message_bus = Arc::new(AsyncMessageBus::new());
@@ -352,6 +373,7 @@ impl FoldDB {
             progress_tracker,
             sync_engine: None,
             sync_task: None,
+            encrypting_store,
         })
     }
 

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -286,7 +286,8 @@ impl FoldDB {
         job_store: Option<Arc<dyn JobStore>>,
         user_id: String,
     ) -> Result<Self, StorageError> {
-        Self::initialize_from_db_ops_with_sled(db_ops, db_path, job_store, user_id, None, None).await
+        Self::initialize_from_db_ops_with_sled(db_ops, db_path, job_store, user_id, None, None)
+            .await
     }
 
     /// Internal initializer that optionally retains the raw sled handle.

--- a/src/storage/encrypting_namespaced_store.rs
+++ b/src/storage/encrypting_namespaced_store.rs
@@ -3,8 +3,9 @@ use super::error::StorageResult;
 use super::traits::{KvStore, NamespacedStore};
 use crate::crypto::CryptoProvider;
 use async_trait::async_trait;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 /// Namespaces that contain personal data and are encrypted via E2E encryption.
 ///
@@ -23,6 +24,10 @@ pub struct EncryptingNamespacedStore {
     crypto: Arc<dyn CryptoProvider>,
     encrypted_namespaces: HashSet<String>,
     migration_mode: bool,
+    /// Per-org crypto providers keyed by org_hash. When a storage key starts
+    /// with `{org_hash}:`, the corresponding provider is used instead of the
+    /// default `crypto`. Shared with all child `EncryptingKvStore` instances.
+    org_crypto: Arc<RwLock<HashMap<String, Arc<dyn CryptoProvider>>>>,
 }
 
 impl EncryptingNamespacedStore {
@@ -42,6 +47,7 @@ impl EncryptingNamespacedStore {
             crypto,
             encrypted_namespaces,
             migration_mode,
+            org_crypto: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -57,7 +63,26 @@ impl EncryptingNamespacedStore {
             crypto,
             encrypted_namespaces: namespaces.into_iter().collect(),
             migration_mode,
+            org_crypto: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Register a crypto provider for an organization.
+    ///
+    /// After this call, any storage key starting with `{org_hash}:` in an
+    /// encrypted namespace will use this provider instead of the default.
+    /// This allows org members to share data encrypted with the org's E2E key.
+    pub async fn register_org_crypto(
+        &self,
+        org_hash: String,
+        crypto: Arc<dyn CryptoProvider>,
+    ) {
+        self.org_crypto.write().await.insert(org_hash, crypto);
+    }
+
+    /// Remove a crypto provider for an organization (e.g. after leaving).
+    pub async fn remove_org_crypto(&self, org_hash: &str) {
+        self.org_crypto.write().await.remove(org_hash);
     }
 
     /// Check if a namespace should be encrypted.
@@ -72,10 +97,11 @@ impl NamespacedStore for EncryptingNamespacedStore {
         let inner_store = self.inner.open_namespace(name).await?;
 
         if self.should_encrypt(name) {
-            Ok(Arc::new(EncryptingKvStore::new(
+            Ok(Arc::new(EncryptingKvStore::with_org_crypto(
                 inner_store,
                 self.crypto.clone(),
                 self.migration_mode,
+                self.org_crypto.clone(),
             )))
         } else {
             // Non-sensitive namespaces: pass through without encryption

--- a/src/storage/encrypting_namespaced_store.rs
+++ b/src/storage/encrypting_namespaced_store.rs
@@ -72,11 +72,7 @@ impl EncryptingNamespacedStore {
     /// After this call, any storage key starting with `{org_hash}:` in an
     /// encrypted namespace will use this provider instead of the default.
     /// This allows org members to share data encrypted with the org's E2E key.
-    pub async fn register_org_crypto(
-        &self,
-        org_hash: String,
-        crypto: Arc<dyn CryptoProvider>,
-    ) {
+    pub async fn register_org_crypto(&self, org_hash: String, crypto: Arc<dyn CryptoProvider>) {
         self.org_crypto.write().await.insert(org_hash, crypto);
     }
 

--- a/src/storage/encrypting_store.rs
+++ b/src/storage/encrypting_store.rs
@@ -1,9 +1,12 @@
 use super::error::{StorageError, StorageResult};
 use super::traits::{ExecutionModel, FlushBehavior, KvStore};
 use crate::crypto::CryptoProvider;
+use crate::sync::org_sync::strip_org_prefix;
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD as B64, Engine};
+use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 /// Prefix marker for encrypted values.
 /// On write: `ENC:` + base64(ciphertext) → valid UTF-8 string for DynamoDB `S` attributes.
@@ -36,6 +39,9 @@ pub struct EncryptingKvStore {
     /// When true, if decryption fails, assume data is plaintext and return as-is.
     /// This enables gradual migration from unencrypted to encrypted storage.
     migration_mode: bool,
+    /// Per-org crypto providers. When a key starts with `{org_hash}:`, the
+    /// corresponding provider is used instead of the default `crypto`.
+    org_crypto: Arc<RwLock<HashMap<String, Arc<dyn CryptoProvider>>>>,
 }
 
 impl EncryptingKvStore {
@@ -52,7 +58,40 @@ impl EncryptingKvStore {
             inner,
             crypto,
             migration_mode,
+            org_crypto: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Create with org crypto routing support.
+    pub fn with_org_crypto(
+        inner: Arc<dyn KvStore>,
+        crypto: Arc<dyn CryptoProvider>,
+        migration_mode: bool,
+        org_crypto: Arc<RwLock<HashMap<String, Arc<dyn CryptoProvider>>>>,
+    ) -> Self {
+        Self {
+            inner,
+            crypto,
+            migration_mode,
+            org_crypto,
+        }
+    }
+
+    /// Select the right crypto provider for a key.
+    ///
+    /// If the key starts with a 64-char hex org_hash followed by `:`,
+    /// and we have a registered provider for that org, use it.
+    /// Otherwise fall back to the default (personal) provider.
+    async fn select_crypto(&self, key: &[u8]) -> Arc<dyn CryptoProvider> {
+        if let Ok(key_str) = std::str::from_utf8(key) {
+            if let Some((org_hash, _)) = strip_org_prefix(key_str) {
+                let org_map = self.org_crypto.read().await;
+                if let Some(provider) = org_map.get(org_hash) {
+                    return Arc::clone(provider);
+                }
+            }
+        }
+        Arc::clone(&self.crypto)
     }
 
     /// Encode ciphertext bytes into a UTF-8-safe string with the `ENC:` prefix.
@@ -61,17 +100,21 @@ impl EncryptingKvStore {
         encoded.into_bytes()
     }
 
-    /// Attempt to decrypt stored data. If data has the `ENC:` prefix, decode and
-    /// decrypt. Otherwise fall back to plaintext if in migration mode.
-    async fn decrypt_or_passthrough(&self, data: Vec<u8>) -> StorageResult<Vec<u8>> {
+    /// Attempt to decrypt stored data using the given crypto provider.
+    /// If data has the `ENC:` prefix, decode and decrypt.
+    /// Otherwise fall back to plaintext if in migration mode.
+    async fn decrypt_or_passthrough(
+        &self,
+        data: Vec<u8>,
+        crypto: &dyn CryptoProvider,
+    ) -> StorageResult<Vec<u8>> {
         // Check for the ENC: prefix
         if data.starts_with(ENCRYPTED_PREFIX.as_bytes()) {
             let b64_part = &data[ENCRYPTED_PREFIX.len()..];
             let ciphertext = B64.decode(b64_part).map_err(|e| {
                 StorageError::EncryptionError(format!("Base64 decode failed: {}", e))
             })?;
-            return self
-                .crypto
+            return crypto
                 .decrypt(&ciphertext)
                 .await
                 .map_err(|e| StorageError::EncryptionError(e.to_string()));
@@ -94,7 +137,8 @@ impl KvStore for EncryptingKvStore {
     async fn get(&self, key: &[u8]) -> StorageResult<Option<Vec<u8>>> {
         match self.inner.get(key).await? {
             Some(stored) => {
-                let plaintext = self.decrypt_or_passthrough(stored).await?;
+                let crypto = self.select_crypto(key).await;
+                let plaintext = self.decrypt_or_passthrough(stored, crypto.as_ref()).await?;
                 Ok(Some(plaintext))
             }
             None => Ok(None),
@@ -102,8 +146,8 @@ impl KvStore for EncryptingKvStore {
     }
 
     async fn put(&self, key: &[u8], value: Vec<u8>) -> StorageResult<()> {
-        let ciphertext = self
-            .crypto
+        let crypto = self.select_crypto(key).await;
+        let ciphertext = crypto
             .encrypt(&value)
             .await
             .map_err(|e| StorageError::EncryptionError(e.to_string()))?;
@@ -124,7 +168,8 @@ impl KvStore for EncryptingKvStore {
         let mut decrypted_results = Vec::with_capacity(results.len());
 
         for (key, stored) in results {
-            let plaintext = self.decrypt_or_passthrough(stored).await?;
+            let crypto = self.select_crypto(&key).await;
+            let plaintext = self.decrypt_or_passthrough(stored, crypto.as_ref()).await?;
             decrypted_results.push((key, plaintext));
         }
 
@@ -135,8 +180,8 @@ impl KvStore for EncryptingKvStore {
         let mut encrypted_items = Vec::with_capacity(items.len());
 
         for (key, value) in items {
-            let ciphertext = self
-                .crypto
+            let crypto = self.select_crypto(&key).await;
+            let ciphertext = crypto
                 .encrypt(&value)
                 .await
                 .map_err(|e| StorageError::EncryptionError(e.to_string()))?;


### PR DESCRIPTION
## Summary
- Org-scoped storage keys (`{org_hash}:atom:...`) are now encrypted with the org's shared E2E key instead of the node's personal key
- `EncryptingKvStore` inspects keys for 64-char hex org_hash prefix and routes to the matching org `CryptoProvider`
- `EncryptingNamespacedStore` gains `register_org_crypto()` / `remove_org_crypto()` for dynamic org membership changes
- FoldDB holds an `Arc<EncryptingNamespacedStore>` reference so the node layer can register org crypto providers
- `configure_org_sync_if_needed` now registers org crypto on both the SyncEngine partitioner AND the EncryptingNamespacedStore

This is the final piece needed for org data to be readable by all org members after sync.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] All tests pass including access_control_test (verified no regression from runtime_fields change)
- [x] Verified sync upload works with partitioner (`state=Dirty pending=4 has_orgs=true` → `pending=0`)
- [x] E2E test blocked by backend auth (fresh dogfood nodes generate new identities not registered on Exemem dev) — code is structurally complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)