### PR TITLE
fix: log org download errors instead of silently swallowing

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -386,7 +386,13 @@ impl SyncEngine {
         let has_pending = !self.pending.lock().await.is_empty();
         if !has_pending {
             // Even with no pending entries, we may need to download org entries
-            let org_downloaded = self.sync_org_download().await.unwrap_or(0);
+            let org_downloaded = match self.sync_org_download().await {
+                Ok(n) => n,
+                Err(e) => {
+                    log::warn!("org download failed: {e}");
+                    0
+                }
+            };
             return Ok(org_downloaded > 0);
         }
 
@@ -395,7 +401,13 @@ impl SyncEngine {
         if has_partitioner {
             let uploaded = self.sync_org_entries().await?;
             // Also download from org members
-            let downloaded = self.sync_org_download().await.unwrap_or(0);
+            let downloaded = match self.sync_org_download().await {
+                Ok(n) => n,
+                Err(e) => {
+                    log::warn!("org download failed: {e}");
+                    0
+                }
+            };
 
             // Check if compaction is needed (personal entries only)
             let current_seq = *self.seq.lock().await;


### PR DESCRIPTION
## Summary
- `sync_org_download()` errors were silently swallowed by `.unwrap_or(0)` in two places in `do_sync()`
- Replaced with `match` that logs the error at `warn` level before returning 0
- Found during dogfooding: org sync appeared to work (no errors) but downloads produced no data, making it impossible to diagnose

## Test plan
- [x] `cargo clippy` clean
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)