### PR TITLE
feat: org schema sync — dual-write + replay callback

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -170,6 +170,36 @@ async fn create_local_fold_db(
     .map_err(|e| FoldDbError::Config(e.to_string()))?;
 
     if let Some(engine) = sync_engine {
+        // Wire schema replay callback so org sync updates the in-memory cache.
+        // When a schema is replayed from another org member, the SchemaCore
+        // needs to load it — same as what happens after a local mutation.
+        let schema_mgr = Arc::clone(&fold_db.schema_manager);
+        engine
+            .set_on_schema_replayed(Box::new(move |schema_name, schema_bytes| {
+                let mgr = Arc::clone(&schema_mgr);
+                tokio::spawn(async move {
+                    match serde_json::from_slice::<crate::schema::Schema>(&schema_bytes) {
+                        Ok(schema) => {
+                            if let Err(e) = mgr.load_schema_internal(schema).await {
+                                log::warn!(
+                                    "Failed to reload replayed schema '{}': {}",
+                                    schema_name,
+                                    e
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "Failed to deserialize replayed schema '{}': {}",
+                                schema_name,
+                                e
+                            );
+                        }
+                    }
+                });
+            }))
+            .await;
+
         fold_db.set_sync_engine(engine);
         fold_db.start_sync(sync_interval_ms);
     }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -120,7 +120,15 @@ pub struct SyncEngine {
     /// Tracks the last downloaded sequence per org member for incremental download.
     /// Maps `{org_hash}:{member_id}` -> last_seq downloaded from that member.
     org_member_cursors: Arc<Mutex<std::collections::HashMap<String, u64>>>,
+    /// Optional callback fired when a schema is replayed from sync.
+    /// The FoldDB wires this to `schema_manager.load_schema_internal()` so
+    /// the in-memory cache stays up to date after org sync downloads.
+    on_schema_replayed: Arc<Mutex<Option<SchemaReplayCallback>>>,
 }
+
+/// Callback type for schema replay notifications.
+/// Receives the schema name and serialized schema bytes.
+pub type SchemaReplayCallback = Box<dyn Fn(String, Vec<u8>) + Send + Sync>;
 
 impl SyncEngine {
     pub fn new(
@@ -148,6 +156,7 @@ impl SyncEngine {
             member_id: Arc::new(Mutex::new(None)),
             org_crypto: Arc::new(Mutex::new(std::collections::HashMap::new())),
             org_member_cursors: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            on_schema_replayed: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -204,6 +213,12 @@ impl SyncEngine {
     /// Set a callback that fires on state changes.
     pub fn set_status_callback(&mut self, cb: StatusCallback) {
         self.status_callback = Some(cb);
+    }
+
+    /// Set a callback that fires when a schema is replayed from sync.
+    /// Used by FoldDB to update the in-memory schema cache after org sync.
+    pub async fn set_on_schema_replayed(&self, cb: SchemaReplayCallback) {
+        *self.on_schema_replayed.lock().await = Some(cb);
     }
 
     /// Get the device identifier.
@@ -683,12 +698,19 @@ impl SyncEngine {
             kv.put(&key_bytes, value_bytes.clone()).await?;
 
             // For org-prefixed keys in the "schemas" namespace, also write under
-            // the non-prefixed key so local schema lookups find the replayed data.
-            // This mirrors how store_schema writes both keys on the originating node.
+            // the non-prefixed key so local schema lookups find the replayed data,
+            // and notify the schema manager to update its in-memory cache.
             if namespace == "schemas" {
                 if let Ok(key_str) = std::str::from_utf8(&key_bytes) {
                     if let Some((_, base_key)) = crate::sync::org_sync::strip_org_prefix(key_str) {
-                        kv.put(base_key.as_bytes(), value_bytes).await?;
+                        kv.put(base_key.as_bytes(), value_bytes.clone()).await?;
+
+                        // Notify the schema manager so the in-memory cache
+                        // gets the updated schema (with molecule UUIDs).
+                        let cb = self.on_schema_replayed.lock().await;
+                        if let Some(callback) = cb.as_ref() {
+                            callback(base_key.to_string(), value_bytes);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Fixes the last gap in org data sharing: Node 2 couldn't query org data because schema `field_molecule_uuids` never reached it.

**Root cause**: Schema updates went to the personal sync blob (key had no org prefix). Even when we added org-prefixed schema keys (#463), the in-memory SchemaCore cache on the receiving node was stale — it had the original schema from the schema service (no molecule UUIDs).

**Two fixes** that make org schema sync work the same as personal:

1. `store_schema` writes org schemas under both bare key (local lookup) and org-prefixed key (org sync routing). Same pattern as atoms/refs.

2. Schema replay callback: `SyncEngine.on_schema_replayed` fires when an org schema is replayed, calling `schema_manager.load_schema_internal()` to update the in-memory cache. This mirrors what `mutation_manager` does after a local write.

Personal sync doesn't need the callback because bootstrap starts from empty Sled (no stale cache). Org sync replays into a running system.

## Test plan
- [x] `cargo clippy` + `cargo fmt` clean
- [x] All tests pass
- [x] Supersedes #463 (includes those changes + callback fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)