### PR TITLE
fix: mutation type error message now lists valid options

### DIFF
--- a/src/schema/types/operations.rs
+++ b/src/schema/types/operations.rs
@@ -150,7 +150,9 @@ impl<'de> Deserialize<'de> for MutationType {
             "create" => Ok(MutationType::Create),
             "update" => Ok(MutationType::Update),
             "delete" => Ok(MutationType::Delete),
-            _ => Err(serde::de::Error::custom("unknown mutation type, expected one of: create, update, delete")),
+            _ => Err(serde::de::Error::custom(
+                "unknown mutation type, expected one of: create, update, delete",
+            )),
         }
     }
 }

--- a/src/schema/types/operations.rs
+++ b/src/schema/types/operations.rs
@@ -150,7 +150,7 @@ impl<'de> Deserialize<'de> for MutationType {
             "create" => Ok(MutationType::Create),
             "update" => Ok(MutationType::Update),
             "delete" => Ok(MutationType::Delete),
-            _ => Err(serde::de::Error::custom("unknown mutation type")),
+            _ => Err(serde::de::Error::custom("unknown mutation type, expected one of: create, update, delete")),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Improved the MutationType deserialization error message to list valid options (`create`, `update`, `delete`) instead of just saying "unknown mutation type"

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)