### PR TITLE
fix: reload SchemaCore cache after sync replays schema entries

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -170,7 +170,7 @@ async fn create_local_fold_db(
     .map_err(|e| FoldDbError::Config(e.to_string()))?;
 
     if let Some(engine) = sync_engine {
-        fold_db.set_sync_engine(engine);
+        fold_db.set_sync_engine(engine).await;
         fold_db.start_sync(sync_interval_ms);
     }
 

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -96,7 +96,20 @@ impl FoldDB {
     }
 
     /// Set the sync engine (called by the factory when sync is configured).
-    pub fn set_sync_engine(&mut self, engine: Arc<crate::sync::SyncEngine>) {
+    /// Also registers the schema reloader callback so SchemaCore's in-memory
+    /// cache is refreshed after sync replays schema entries into Sled.
+    pub async fn set_sync_engine(&mut self, engine: Arc<crate::sync::SyncEngine>) {
+        let schema_mgr = Arc::clone(&self.schema_manager);
+        engine
+            .set_schema_reloader(Arc::new(move || {
+                let mgr = Arc::clone(&schema_mgr);
+                Box::pin(async move {
+                    mgr.reload_from_store()
+                        .await
+                        .map_err(|e| format!("SchemaCore reload failed: {e}"))
+                })
+            }))
+            .await;
         self.sync_engine = Some(engine);
     }
 

--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -75,6 +75,38 @@ impl SchemaCore {
         Ok(schema_core)
     }
 
+    /// Reload schemas from the persistent store, merging any newly-discovered
+    /// schemas into the in-memory cache. Existing entries are NOT overwritten
+    /// (additive merge only). Returns the count of newly added schemas.
+    pub async fn reload_from_store(&self) -> Result<usize, SchemaError> {
+        let stored_schemas = self.db_ops.get_all_schemas().await?;
+        let stored_states = self.db_ops.get_all_schema_states().await?;
+
+        let mut schemas = lock_map(&self.schemas, "schemas")?;
+        let mut states = lock_map(&self.schema_states, "schema_states")?;
+
+        let mut added = 0usize;
+        for (name, mut schema) in stored_schemas {
+            if !schemas.contains_key(&name) {
+                // Ensure runtime_fields are populated — schemas coming from
+                // sync replay won't have them (runtime_fields is #[serde(skip)]).
+                if schema.runtime_fields.is_empty() {
+                    schema.populate_runtime_fields()?;
+                }
+                schemas.insert(name.clone(), schema);
+                let state = stored_states.get(&name).copied().unwrap_or_default();
+                states.insert(name, state);
+                added += 1;
+            }
+        }
+
+        if added > 0 {
+            log::info!("reload_from_store: added {} new schema(s) to cache", added);
+        }
+
+        Ok(added)
+    }
+
     pub fn get_schemas(&self) -> Result<HashMap<String, Schema>, SchemaError> {
         Ok(lock_map(&self.schemas, "schemas")?.clone())
     }
@@ -908,5 +940,147 @@ mod tests {
             .expect("get")
             .expect("some");
         assert_eq!(schema.name, "BlogPostWordIndex");
+    }
+
+    #[tokio::test]
+    async fn reload_from_store_adds_new_schemas() {
+        // Create a SchemaCore, store a schema directly to Sled (bypassing
+        // the in-memory cache), then verify reload_from_store picks it up.
+        let db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .expect("open sled");
+        let db_ops = std::sync::Arc::new(
+            crate::db_operations::DbOperations::from_sled(db)
+                .await
+                .expect("db_ops"),
+        );
+        let message_bus = Arc::new(AsyncMessageBus::new());
+        let core = SchemaCore::new(Arc::clone(&db_ops), Arc::clone(&message_bus))
+            .await
+            .expect("init core");
+
+        // Confirm cache is empty
+        assert!(core.get_schemas().unwrap().is_empty());
+
+        // Write a schema directly to Sled (simulating what sync replay does)
+        let json = r#"{
+            "name": "SyncedSchema",
+            "key": { "range_field": "created_at" },
+            "fields": { "title": {}, "created_at": {} }
+        }"#;
+        let declarative: crate::schema::types::DeclarativeSchemaDefinition =
+            serde_json::from_str(json).expect("parse");
+        let schema = core
+            .interpret_declarative_schema(declarative)
+            .await
+            .expect("interpret");
+        db_ops
+            .store_schema("SyncedSchema", &schema)
+            .await
+            .expect("store");
+        db_ops
+            .store_schema_state("SyncedSchema", &SchemaState::Approved)
+            .await
+            .expect("store state");
+
+        // Cache should still be empty (we bypassed it)
+        assert!(!core.get_schemas().unwrap().contains_key("SyncedSchema"));
+
+        // Reload from store
+        let added = core.reload_from_store().await.expect("reload");
+        assert_eq!(added, 1);
+
+        // Now cache should have it
+        assert!(core.get_schemas().unwrap().contains_key("SyncedSchema"));
+        assert_eq!(
+            core.get_schema_states()
+                .unwrap()
+                .get("SyncedSchema")
+                .copied(),
+            Some(SchemaState::Approved)
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_from_store_preserves_existing() {
+        // Verify that reload_from_store does NOT overwrite schemas already in cache.
+        let db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .expect("open sled");
+        let db_ops = std::sync::Arc::new(
+            crate::db_operations::DbOperations::from_sled(db)
+                .await
+                .expect("db_ops"),
+        );
+        let message_bus = Arc::new(AsyncMessageBus::new());
+        let core = SchemaCore::new(Arc::clone(&db_ops), Arc::clone(&message_bus))
+            .await
+            .expect("init core");
+
+        // Load a schema normally (into both cache and Sled)
+        core.load_schema_from_json(&blogpost_schema_json())
+            .await
+            .expect("load");
+
+        // Reload should add 0 new schemas (BlogPost is already in cache)
+        let added = core.reload_from_store().await.expect("reload");
+        assert_eq!(added, 0);
+
+        // Still exactly one schema
+        assert_eq!(core.get_schemas().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn reload_from_store_populates_runtime_fields() {
+        // Schemas written to Sled by sync replay have runtime_fields = {} (#[serde(skip)]).
+        // Verify that reload_from_store populates runtime_fields on load.
+        let db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .expect("open sled");
+        let db_ops = std::sync::Arc::new(
+            crate::db_operations::DbOperations::from_sled(db)
+                .await
+                .expect("db_ops"),
+        );
+        let message_bus = Arc::new(AsyncMessageBus::new());
+        let core = SchemaCore::new(Arc::clone(&db_ops), Arc::clone(&message_bus))
+            .await
+            .expect("init core");
+
+        // Build a schema, then store it directly to Sled
+        let json = r#"{
+            "name": "RuntimeTest",
+            "key": { "range_field": "ts" },
+            "fields": { "content": {}, "ts": {} }
+        }"#;
+        let declarative: crate::schema::types::DeclarativeSchemaDefinition =
+            serde_json::from_str(json).expect("parse");
+        let schema = core
+            .interpret_declarative_schema(declarative)
+            .await
+            .expect("interpret");
+        db_ops
+            .store_schema("RuntimeTest", &schema)
+            .await
+            .expect("store");
+
+        // Reload
+        let added = core.reload_from_store().await.expect("reload");
+        assert_eq!(added, 1);
+
+        // Verify runtime_fields are populated
+        let schemas = core.get_schemas().unwrap();
+        let s = schemas.get("RuntimeTest").expect("exists");
+        assert!(
+            !s.runtime_fields.is_empty(),
+            "runtime_fields should be populated after reload"
+        );
+        assert!(
+            s.runtime_fields.contains_key("content"),
+            "runtime_fields should contain 'content'"
+        );
     }
 }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -94,6 +94,14 @@ impl Default for SyncConfig {
 /// Callback for sync status changes.
 pub type StatusCallback = Box<dyn Fn(SyncState, Option<&str>) + Send + Sync>;
 
+/// Callback that reloads schemas from the persistent store into the in-memory cache.
+/// Returns the number of newly added schemas, or an error string.
+pub type SchemaReloadCallback = Arc<
+    dyn Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<usize, String>> + Send>>
+        + Send
+        + Sync,
+>;
+
 /// The sync engine manages replication of a local Sled database to S3.
 ///
 /// Architecture:
@@ -143,6 +151,9 @@ pub struct SyncEngine {
     targets: Arc<Mutex<Vec<SyncTarget>>>,
     /// Per-prefix download cursor: maps prefix -> last_seq_downloaded.
     download_cursors: Arc<Mutex<std::collections::HashMap<String, u64>>>,
+    /// Optional callback invoked after sync replay writes schemas to Sled.
+    /// This lets the SchemaCore cache refresh without a hard dependency.
+    schema_reloader: Arc<Mutex<Option<SchemaReloadCallback>>>,
 }
 
 impl SyncEngine {
@@ -174,6 +185,7 @@ impl SyncEngine {
                 crypto,
             }])),
             download_cursors: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            schema_reloader: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -212,6 +224,16 @@ impl SyncEngine {
     /// Set a callback that fires on state changes.
     pub fn set_status_callback(&mut self, cb: StatusCallback) {
         self.status_callback = Some(cb);
+    }
+
+    /// Register a callback that reloads the SchemaCore cache after sync
+    /// replays schema entries into Sled. The callback returns the number
+    /// of newly added schemas, or an error string.
+    pub async fn set_schema_reloader(
+        &self,
+        reloader: SchemaReloadCallback,
+    ) {
+        *self.schema_reloader.lock().await = Some(reloader);
     }
 
     /// Get the device identifier.
@@ -568,11 +590,15 @@ impl SyncEngine {
 
         let mut total_replayed = 0u64;
         let mut max_seq = cursor;
+        let mut schemas_replayed = false;
 
         for (seq, url) in new_seqs.iter().zip(urls.iter()) {
             match self.s3.download(url).await? {
                 Some(bytes) => match LogEntry::unseal(&bytes, &target.crypto).await {
                     Ok(entry) => {
+                        if entry.op.namespace() == "schemas" {
+                            schemas_replayed = true;
+                        }
                         self.replay_entry(&entry).await?;
                         total_replayed += 1;
                         if *seq > max_seq {
@@ -590,6 +616,26 @@ impl SyncEngine {
                 },
                 None => {
                     log::warn!("entry not found in '{}' seq={}", target.label, seq);
+                }
+            }
+        }
+
+        // Reload SchemaCore cache if any schema entries were replayed
+        if schemas_replayed {
+            if let Some(reloader) = self.schema_reloader.lock().await.as_ref() {
+                match reloader().await {
+                    Ok(count) => {
+                        if count > 0 {
+                            log::info!(
+                                "schema reloader added {} schema(s) after sync from '{}'",
+                                count,
+                                target.label
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!("failed to reload schemas after sync: {}", e);
+                    }
                 }
             }
         }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -229,10 +229,7 @@ impl SyncEngine {
     /// Register a callback that reloads the SchemaCore cache after sync
     /// replays schema entries into Sled. The callback returns the number
     /// of newly added schemas, or an error string.
-    pub async fn set_schema_reloader(
-        &self,
-        reloader: SchemaReloadCallback,
-    ) {
+    pub async fn set_schema_reloader(&self, reloader: SchemaReloadCallback) {
         *self.schema_reloader.lock().await = Some(reloader);
     }
 

--- a/src/sync/log.rs
+++ b/src/sync/log.rs
@@ -112,6 +112,16 @@ impl LogEntry {
 }
 
 impl LogOp {
+    /// Returns the namespace this operation targets.
+    pub fn namespace(&self) -> &str {
+        match self {
+            LogOp::Put { namespace, .. } => namespace,
+            LogOp::Delete { namespace, .. } => namespace,
+            LogOp::BatchPut { namespace, .. } => namespace,
+            LogOp::BatchDelete { namespace, .. } => namespace,
+        }
+    }
+
     /// Encode key bytes to base64 for storage in the log entry.
     pub fn encode_bytes(bytes: &[u8]) -> String {
         BASE64.encode(bytes)


### PR DESCRIPTION
## Summary
- Add `SchemaCore::reload_from_store()` method that performs additive merge of newly-discovered schemas from Sled into the in-memory cache (does NOT overwrite existing entries)
- Add `SchemaReloadCallback` type and `set_schema_reloader()` to `SyncEngine`, invoked after `download_entries()` replays any entry in the `"schemas"` namespace
- Wire the callback in `FoldDB::set_sync_engine()` so SchemaCore cache is automatically refreshed after org sync downloads
- Add `LogOp::namespace()` helper to extract the namespace from any log op variant
- Add 3 unit tests: additive merge, preservation of existing entries, runtime_fields population

## Context
When Node 2 downloads org data via sync, schemas were written to Sled correctly but SchemaCore's in-memory `HashMap` cache was never updated. Queries would fail with "schema not found" even though the data existed in the persistent store.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo check --workspace --features aws-backend` compiles
- [x] `cargo test --workspace --all-targets` all tests pass (including 3 new tests)
- [ ] Manual dogfood: create org on Node 1, sync, verify Node 2 can query org schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)