### PR TITLE
fix: add automatic session token refresh to sync engine

### DIFF
--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -2,7 +2,10 @@ use super::error::{SyncError, SyncResult};
 use super::s3::PresignedUrl;
 use reqwest::Client;
 use serde::Deserialize;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 /// Authentication method for the sync auth Lambda.
 #[derive(Clone)]
@@ -19,6 +22,13 @@ impl std::fmt::Debug for SyncAuth {
         }
     }
 }
+
+/// Callback type for refreshing authentication credentials.
+///
+/// Called when the sync engine receives a 401 from the auth Lambda.
+/// Should return a fresh `SyncAuth` (e.g., by re-registering with Exemem).
+pub type AuthRefreshCallback =
+    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Result<SyncAuth, String>> + Send>> + Send + Sync>;
 
 /// Response from the auth Lambda listing available S3 objects.
 #[derive(Debug, Deserialize)]
@@ -70,7 +80,7 @@ pub struct LockResponse {
 pub struct AuthClient {
     http: Arc<Client>,
     base_url: String,
-    auth: SyncAuth,
+    auth: Arc<RwLock<SyncAuth>>,
 }
 
 impl AuthClient {
@@ -78,21 +88,40 @@ impl AuthClient {
         Self {
             http,
             base_url,
-            auth,
+            auth: Arc::new(RwLock::new(auth)),
         }
     }
 
-    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        match &self.auth {
-            SyncAuth::ApiKey(key) => req.header("X-API-Key", key),
-            SyncAuth::BearerToken(token) => req.header("Authorization", format!("Bearer {token}")),
+    /// Replace the current authentication credential with a fresh one.
+    ///
+    /// Called after a successful token refresh to update the in-memory credential
+    /// so subsequent requests use the new token.
+    pub async fn update_auth(&self, new_auth: SyncAuth) {
+        *self.auth.write().await = new_auth;
+    }
+
+    /// Check if the current auth credential is a bearer token.
+    ///
+    /// Useful for callers to decide whether a refresh is needed (bearer tokens
+    /// expire, API keys do not).
+    pub async fn is_bearer_token(&self) -> bool {
+        matches!(&*self.auth.read().await, SyncAuth::BearerToken(_))
+    }
+
+    async fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let auth = self.auth.read().await;
+        match &*auth {
+            SyncAuth::ApiKey(key) => req.header("X-API-Key", key.clone()),
+            SyncAuth::BearerToken(token) => {
+                req.header("Authorization", format!("Bearer {token}"))
+            }
         }
     }
 
     async fn post(&self, path: &str, body: serde_json::Value) -> SyncResult<serde_json::Value> {
         let url = format!("{}{}", self.base_url, path);
         let req = self.http.post(&url).json(&body);
-        let req = self.apply_auth(req);
+        let req = self.apply_auth(req).await;
 
         let response = req.send().await.map_err(|e| {
             if e.is_timeout() {
@@ -565,5 +594,57 @@ impl AuthClient {
             return Err(SyncError::Auth(err.to_string()));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_update_auth_replaces_credential() {
+        let http = Arc::new(Client::new());
+        let client =
+            AuthClient::new(http, "http://localhost".to_string(), SyncAuth::ApiKey("old".into()));
+
+        // Starts as API key
+        assert!(!client.is_bearer_token().await);
+
+        // Update to bearer token
+        client
+            .update_auth(SyncAuth::BearerToken("new-token".into()))
+            .await;
+        assert!(client.is_bearer_token().await);
+
+        // Update back to API key
+        client
+            .update_auth(SyncAuth::ApiKey("new-key".into()))
+            .await;
+        assert!(!client.is_bearer_token().await);
+    }
+
+    #[tokio::test]
+    async fn test_auth_refresh_callback_type() {
+        // Verify the callback type compiles and can return SyncAuth
+        let cb: AuthRefreshCallback = Arc::new(|| {
+            Box::pin(async { Ok(SyncAuth::BearerToken("refreshed-token".into())) })
+        });
+
+        let result = cb().await;
+        assert!(result.is_ok());
+        match result.unwrap() {
+            SyncAuth::BearerToken(t) => assert_eq!(t, "refreshed-token"),
+            SyncAuth::ApiKey(_) => panic!("expected BearerToken"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_auth_refresh_callback_error() {
+        let cb: AuthRefreshCallback =
+            Arc::new(|| Box::pin(async { Err("network down".to_string()) }));
+
+        let result = cb().await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "network down");
     }
 }

--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -112,9 +112,7 @@ impl AuthClient {
         let auth = self.auth.read().await;
         match &*auth {
             SyncAuth::ApiKey(key) => req.header("X-API-Key", key.clone()),
-            SyncAuth::BearerToken(token) => {
-                req.header("Authorization", format!("Bearer {token}"))
-            }
+            SyncAuth::BearerToken(token) => req.header("Authorization", format!("Bearer {token}")),
         }
     }
 
@@ -604,8 +602,11 @@ mod tests {
     #[tokio::test]
     async fn test_update_auth_replaces_credential() {
         let http = Arc::new(Client::new());
-        let client =
-            AuthClient::new(http, "http://localhost".to_string(), SyncAuth::ApiKey("old".into()));
+        let client = AuthClient::new(
+            http,
+            "http://localhost".to_string(),
+            SyncAuth::ApiKey("old".into()),
+        );
 
         // Starts as API key
         assert!(!client.is_bearer_token().await);
@@ -617,18 +618,14 @@ mod tests {
         assert!(client.is_bearer_token().await);
 
         // Update back to API key
-        client
-            .update_auth(SyncAuth::ApiKey("new-key".into()))
-            .await;
+        client.update_auth(SyncAuth::ApiKey("new-key".into())).await;
         assert!(!client.is_bearer_token().await);
     }
 
     #[tokio::test]
     async fn test_auth_refresh_callback_type() {
-        // Verify the callback type compiles and can return SyncAuth
-        let cb: AuthRefreshCallback = Arc::new(|| {
-            Box::pin(async { Ok(SyncAuth::BearerToken("refreshed-token".into())) })
-        });
+        let cb: AuthRefreshCallback =
+            Arc::new(|| Box::pin(async { Ok(SyncAuth::BearerToken("refreshed-token".into())) }));
 
         let result = cb().await;
         assert!(result.is_ok());

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -434,9 +434,8 @@ impl SyncEngine {
                                     }
                                     Err(retry_err) => {
                                         let msg = retry_err.to_string();
-                                        log::warn!(
-                                            "sync retry after token refresh failed: {msg}"
-                                        );
+                                        log::warn!("sync retry after token refresh failed: {msg}");
+
                                         *self.last_error.lock().await = Some(msg.clone());
                                         self.set_state(SyncState::Dirty, Some(&msg)).await;
                                         return Err(retry_err);

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1,4 +1,4 @@
-use super::auth::AuthClient;
+use super::auth::{AuthClient, AuthRefreshCallback};
 use super::error::{SyncError, SyncResult};
 use super::log::{LogEntry, LogOp};
 use super::org_sync::{SyncDestination, SyncPartitioner, SyncTarget};
@@ -154,6 +154,10 @@ pub struct SyncEngine {
     /// Optional callback invoked after sync replay writes schemas to Sled.
     /// This lets the SchemaCore cache refresh without a hard dependency.
     schema_reloader: Arc<Mutex<Option<SchemaReloadCallback>>>,
+    /// Optional callback to refresh authentication credentials on 401.
+    /// When set, the sync engine will call this on `SyncError::Auth`, update
+    /// the `AuthClient`, and retry the sync cycle once before giving up.
+    auth_refresh: Option<AuthRefreshCallback>,
 }
 
 impl SyncEngine {
@@ -186,6 +190,7 @@ impl SyncEngine {
             }])),
             download_cursors: Arc::new(Mutex::new(std::collections::HashMap::new())),
             schema_reloader: Arc::new(Mutex::new(None)),
+            auth_refresh: None,
         }
     }
 
@@ -224,6 +229,15 @@ impl SyncEngine {
     /// Set a callback that fires on state changes.
     pub fn set_status_callback(&mut self, cb: StatusCallback) {
         self.status_callback = Some(cb);
+    }
+
+    /// Set a callback that refreshes authentication credentials on 401.
+    ///
+    /// When the sync engine encounters an auth error (expired token, etc.),
+    /// it calls this callback to obtain fresh credentials, updates the
+    /// `AuthClient`, and retries the sync cycle once.
+    pub fn set_auth_refresh(&mut self, cb: AuthRefreshCallback) {
+        self.auth_refresh = Some(cb);
     }
 
     /// Register a callback that reloads the SchemaCore cache after sync
@@ -397,14 +411,50 @@ impl SyncEngine {
                 Ok(synced)
             }
             Err(e) => {
+                // On auth errors, attempt to refresh credentials and retry once.
+                if matches!(&e, SyncError::Auth(_)) {
+                    if let Some(ref refresh_cb) = self.auth_refresh {
+                        log::info!("sync auth failed, attempting token refresh");
+                        match refresh_cb().await {
+                            Ok(new_auth) => {
+                                self.auth.update_auth(new_auth).await;
+                                log::info!("token refreshed, retrying sync");
+                                match self.do_sync().await {
+                                    Ok(synced) => {
+                                        if synced {
+                                            let now = std::time::SystemTime::now()
+                                                .duration_since(std::time::UNIX_EPOCH)
+                                                .unwrap_or_default()
+                                                .as_secs();
+                                            *self.last_sync_at.lock().await = Some(now);
+                                            *self.last_error.lock().await = None;
+                                        }
+                                        self.set_state(SyncState::Idle, None).await;
+                                        return Ok(synced);
+                                    }
+                                    Err(retry_err) => {
+                                        let msg = retry_err.to_string();
+                                        log::warn!(
+                                            "sync retry after token refresh failed: {msg}"
+                                        );
+                                        *self.last_error.lock().await = Some(msg.clone());
+                                        self.set_state(SyncState::Dirty, Some(&msg)).await;
+                                        return Err(retry_err);
+                                    }
+                                }
+                            }
+                            Err(refresh_err) => {
+                                log::warn!("token refresh failed: {refresh_err}");
+                            }
+                        }
+                    }
+                }
+
                 let msg = e.to_string();
                 *self.last_error.lock().await = Some(msg.clone());
                 match &e {
                     SyncError::Network(_) => {
                         self.set_state(SyncState::Offline, Some(&msg)).await;
-                    }
-                    SyncError::Auth(_) => {
-                        self.set_state(SyncState::Dirty, Some(&msg)).await;
                     }
                     _ => {
                         self.set_state(SyncState::Dirty, Some(&msg)).await;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -68,6 +68,7 @@ pub mod org_sync;
 pub mod s3;
 pub mod snapshot;
 
+pub use auth::AuthRefreshCallback;
 pub use engine::{SyncConfig, SyncConflict, SyncEngine, SyncState, SyncStatus};
 pub use error::{SyncError, SyncResult};
 pub use org_sync::{SyncDestination, SyncPartitioner};
@@ -76,7 +77,7 @@ pub use org_sync::{SyncDestination, SyncPartitioner};
 ///
 /// Derived automatically from the Exemem credentials — no extra config needed.
 /// The sync auth Lambda shares the same API URL and API key as the Exemem platform.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SyncSetup {
     /// Exemem API base URL (sync routes live at /api/sync/*).
     pub auth_url: String,
@@ -86,6 +87,22 @@ pub struct SyncSetup {
     pub device_id: String,
     /// Sync tuning parameters. Uses defaults if None.
     pub config: Option<SyncConfig>,
+    /// Optional callback to refresh authentication on 401.
+    /// When provided, the sync engine will attempt to refresh credentials
+    /// and retry once before giving up.
+    pub auth_refresh: Option<AuthRefreshCallback>,
+}
+
+impl std::fmt::Debug for SyncSetup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SyncSetup")
+            .field("auth_url", &self.auth_url)
+            .field("auth", &self.auth)
+            .field("device_id", &self.device_id)
+            .field("config", &self.config)
+            .field("auth_refresh", &self.auth_refresh.as_ref().map(|_| "..."))
+            .finish()
+    }
 }
 
 impl SyncSetup {
@@ -106,6 +123,7 @@ impl SyncSetup {
             auth: auth::SyncAuth::ApiKey(api_key.to_string()),
             device_id,
             config: None,
+            auth_refresh: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Makes `AuthClient.auth` use `Arc<RwLock<SyncAuth>>` so credentials can be updated at runtime without recreating the client
- Adds `AuthRefreshCallback` type and `set_auth_refresh()` on `SyncEngine` -- when a 401 is received during sync, the callback is invoked to get fresh credentials, the auth client is updated, and the sync cycle is retried once
- Adds `auth_refresh` field to `SyncSetup` so callers (fold_db_node) can wire up the refresh logic at construction time

## Test plan
- [x] 3 new unit tests: `test_update_auth_replaces_credential`, `test_auth_refresh_callback_type`, `test_auth_refresh_callback_error`
- [x] All 512 existing tests pass
- [x] clippy clean (`-D warnings`)
- [x] `cargo check --features aws-backend` passes
- [x] fold_db_node compiles against updated fold_db

## Follow-up
- Wire the refresh callback in fold_db_node to call `signed_register` (the existing token refresh logic) when constructing the sync engine

Generated with [Claude Code](https://claude.com/claude-code)