### PR TITLE
fix: remove dead bare-key dual-write in schema sync replay

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -938,17 +938,6 @@ impl SyncEngine {
         } else {
             let kv = self.store.open_namespace(namespace).await?;
             kv.put(&key_bytes, value_bytes.clone()).await?;
-
-            // When a schema is replayed (from personal sync between devices
-            // OR from org sync), write org-prefixed keys under the bare key
-            // so get_schema finds them by name.
-            if namespace == "schemas" {
-                if let Ok(key_str) = std::str::from_utf8(&key_bytes) {
-                    if let Some((_, base_key)) = crate::sync::org_sync::strip_org_prefix(key_str) {
-                        kv.put(base_key.as_bytes(), value_bytes.clone()).await?;
-                    }
-                }
-            }
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
- Removes dead code in `replay_put` that wrote a second copy of org-prefixed schemas under the bare key (without org prefix)
- Nothing looks up schemas by bare name — all org operations use the full org-prefixed name, so this write was wasted work

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo check --workspace --features aws-backend` passes
- [x] `cargo test --workspace --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)