### PR TITLE
fix: add org_hash to OrgInviteBundle

### DIFF
--- a/src/org/operations.rs
+++ b/src/org/operations.rs
@@ -257,6 +257,7 @@ pub fn generate_invite(db: &sled::Db, org_hash: &str) -> Result<OrgInviteBundle,
 
     Ok(OrgInviteBundle {
         org_name: membership.org_name,
+        org_hash: org_hash.to_string(),
         org_public_key: membership.org_public_key,
         org_e2e_secret: membership.org_e2e_secret,
         members: membership.members,

--- a/src/org/types.rs
+++ b/src/org/types.rs
@@ -52,6 +52,8 @@ pub enum OrgRole {
 pub struct OrgInviteBundle {
     /// Human-readable organization name
     pub org_name: String,
+    /// Hex-encoded SHA256 hash of the org public key — used for decline and display
+    pub org_hash: String,
     /// Base64-encoded Ed25519 public key for the organization
     pub org_public_key: String,
     /// Base64-encoded AES-256-GCM shared secret for E2E encryption


### PR DESCRIPTION
## Summary
- Added `org_hash: String` field to `OrgInviteBundle` struct so the frontend has it for decline operations and display
- Updated `generate_invite()` to pass through the `org_hash` parameter it already receives
- The TypeScript interface in fold_db_node already has `org_hash` so no frontend change needed

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo check --workspace --features aws-backend` passes
- [x] `cargo test --workspace --all-targets` passes
- [ ] Verify invite generation includes org_hash in the JSON payload
- [ ] Verify frontend decline flow works with the new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)