### PR TITLE
fix: sync vector embeddings for org data + reload after sync

### DIFF
--- a/src/db_operations/native_index/embedding_index.rs
+++ b/src/db_operations/native_index/embedding_index.rs
@@ -195,6 +195,45 @@ impl EmbeddingIndex {
         Ok(())
     }
 
+    /// Reload embeddings from the store, adding any entries not already in the in-memory index.
+    /// Returns the number of newly added entries.
+    pub(super) async fn reload_from_store(&self, store: &dyn KvStore) -> usize {
+        let new_entries = Self::load_from_store(store).await;
+        let mut current = self.entries.write().unwrap();
+        let before = current.len();
+
+        // Build a set of existing storage keys for deduplication
+        let existing_keys: std::collections::HashSet<String> = current
+            .iter()
+            .map(|e| {
+                EmbeddingEntry::fragment_storage_key(
+                    &e.schema,
+                    &e.key,
+                    &e.field_name,
+                    e.fragment_idx,
+                )
+            })
+            .collect();
+
+        for entry in new_entries {
+            let key = EmbeddingEntry::fragment_storage_key(
+                &entry.schema,
+                &entry.key,
+                &entry.field_name,
+                entry.fragment_idx,
+            );
+            if !existing_keys.contains(&key) {
+                current.push(entry);
+            }
+        }
+
+        let added = current.len() - before;
+        if added > 0 {
+            log::info!("reload_from_store: added {} new embeddings to index", added);
+        }
+        added
+    }
+
     /// Brute-force cosine similarity search. Returns up to `k` results sorted by score,
     /// deduplicated by (schema, key) — taking the highest-scoring fragment per record.
     pub(super) fn search(&self, query_vec: &[f32], k: usize) -> Vec<IndexResult> {

--- a/src/db_operations/native_index/mod.rs
+++ b/src/db_operations/native_index/mod.rs
@@ -97,6 +97,13 @@ impl NativeIndexManager {
         self.embedding_model.embed_text(text)
     }
 
+    /// Reload embeddings from the persistent store into the in-memory index.
+    /// Called after sync replays new native_index entries. Returns the count of
+    /// newly added embeddings.
+    pub async fn reload_embeddings(&self) -> usize {
+        self.embedding_index.reload_from_store(&*self.store).await
+    }
+
     /// Semantic search: embed the query then return top-50 results by cosine similarity.
     pub async fn search_all_classifications(
         &self,

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -110,6 +110,22 @@ impl FoldDB {
                 })
             }))
             .await;
+
+        // Register embedding reloader so the in-memory EmbeddingIndex is
+        // refreshed after sync replays native_index entries into Sled.
+        if let Some(nim) = self.db_ops.native_index_manager() {
+            let embedding_index = nim.clone();
+            engine
+                .set_embedding_reloader(Arc::new(move || {
+                    let idx = embedding_index.clone();
+                    Box::pin(async move {
+                        let count = idx.reload_embeddings().await;
+                        Ok(count)
+                    })
+                }))
+                .await;
+        }
+
         self.sync_engine = Some(engine);
     }
 

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -102,6 +102,14 @@ pub type SchemaReloadCallback = Arc<
         + Sync,
 >;
 
+/// Callback that reloads embeddings from the persistent store into the in-memory index.
+/// Returns the number of newly added embeddings, or an error string.
+pub type EmbeddingReloadCallback = Arc<
+    dyn Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<usize, String>> + Send>>
+        + Send
+        + Sync,
+>;
+
 /// The sync engine manages replication of a local Sled database to S3.
 ///
 /// Architecture:
@@ -154,6 +162,9 @@ pub struct SyncEngine {
     /// Optional callback invoked after sync replay writes schemas to Sled.
     /// This lets the SchemaCore cache refresh without a hard dependency.
     schema_reloader: Arc<Mutex<Option<SchemaReloadCallback>>>,
+    /// Optional callback invoked after sync replay writes native_index entries to Sled.
+    /// This lets the EmbeddingIndex refresh without a hard dependency.
+    embedding_reloader: Arc<Mutex<Option<EmbeddingReloadCallback>>>,
     /// Optional callback to refresh authentication credentials on 401.
     /// When set, the sync engine will call this on `SyncError::Auth`, update
     /// the `AuthClient`, and retry the sync cycle once before giving up.
@@ -190,6 +201,7 @@ impl SyncEngine {
             }])),
             download_cursors: Arc::new(Mutex::new(std::collections::HashMap::new())),
             schema_reloader: Arc::new(Mutex::new(None)),
+            embedding_reloader: Arc::new(Mutex::new(None)),
             auth_refresh: None,
         }
     }
@@ -245,6 +257,13 @@ impl SyncEngine {
     /// of newly added schemas, or an error string.
     pub async fn set_schema_reloader(&self, reloader: SchemaReloadCallback) {
         *self.schema_reloader.lock().await = Some(reloader);
+    }
+
+    /// Register a callback that reloads the EmbeddingIndex after sync
+    /// replays native_index entries into Sled. The callback returns the number
+    /// of newly added embeddings, or an error string.
+    pub async fn set_embedding_reloader(&self, reloader: EmbeddingReloadCallback) {
+        *self.embedding_reloader.lock().await = Some(reloader);
     }
 
     /// Get the device identifier.
@@ -637,13 +656,16 @@ impl SyncEngine {
         let mut total_replayed = 0u64;
         let mut max_seq = cursor;
         let mut schemas_replayed = false;
+        let mut embeddings_replayed = false;
 
         for (seq, url) in new_seqs.iter().zip(urls.iter()) {
             match self.s3.download(url).await? {
                 Some(bytes) => match LogEntry::unseal(&bytes, &target.crypto).await {
                     Ok(entry) => {
-                        if entry.op.namespace() == "schemas" {
-                            schemas_replayed = true;
+                        match entry.op.namespace() {
+                            "schemas" => schemas_replayed = true,
+                            "native_index" => embeddings_replayed = true,
+                            _ => {}
                         }
                         self.replay_entry(&entry).await?;
                         total_replayed += 1;
@@ -681,6 +703,26 @@ impl SyncEngine {
                     }
                     Err(e) => {
                         log::warn!("failed to reload schemas after sync: {}", e);
+                    }
+                }
+            }
+        }
+
+        // Reload EmbeddingIndex if any native_index entries were replayed
+        if embeddings_replayed {
+            if let Some(reloader) = self.embedding_reloader.lock().await.as_ref() {
+                match reloader().await {
+                    Ok(count) => {
+                        if count > 0 {
+                            log::info!(
+                                "embedding reloader added {} embedding(s) after sync from '{}'",
+                                count,
+                                target.label
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!("failed to reload embeddings after sync: {}", e);
                     }
                 }
             }

--- a/src/sync/org_sync.rs
+++ b/src/sync/org_sync.rs
@@ -127,10 +127,18 @@ impl SyncPartitioner {
             return dest;
         }
 
-        // For schema-level namespaces, the key might be a schema name
-        // that was stored under an org-prefixed schema name
-        // (e.g., key = "{org_hash}:board_meeting" in the "schemas" namespace)
-        let _ = namespace; // namespace used for potential future routing logic
+        // For native_index namespace, embedding keys have format:
+        //   emb:{org_hash}:{schema_hash}:{key_hash}:{field}:{fragment_idx}
+        // The key starts with "emb:", not the org hash, so the plain prefix
+        // check above misses it. Strip the "emb:" prefix and re-check.
+        if namespace == "native_index" {
+            if let Some(after_prefix) = key_str.strip_prefix("emb:") {
+                let dest = self.partition(after_prefix);
+                if dest != SyncDestination::Personal {
+                    return dest;
+                }
+            }
+        }
 
         SyncDestination::Personal
     }
@@ -295,6 +303,41 @@ mod tests {
 
         // Short key
         assert_eq!(strip_org_prefix("abc:def"), None);
+    }
+
+    #[test]
+    fn test_partition_log_key_embedding_with_org_prefix() {
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        let memberships = vec![make_membership("org_alpha", "secret_a")];
+        let partitioner = SyncPartitioner::new(&memberships);
+
+        // Embedding key: emb:{org_hash}:{schema_hash}:{key_hash}:{field}:{fragment}
+        let emb_key = "emb:org_alpha:schema123:keyhash:title:0";
+        let encoded = BASE64.encode(emb_key.as_bytes());
+
+        assert_eq!(
+            partitioner.partition_log_key("native_index", &encoded),
+            SyncDestination::Org {
+                org_hash: "org_alpha".to_string(),
+                org_e2e_secret: "secret_a".to_string(),
+            }
+        );
+
+        // Personal embedding key should remain personal
+        let personal_emb_key = "emb:my_schema:keyhash:title:0";
+        let encoded_personal = BASE64.encode(personal_emb_key.as_bytes());
+        assert_eq!(
+            partitioner.partition_log_key("native_index", &encoded_personal),
+            SyncDestination::Personal
+        );
+
+        // Non native_index namespace should NOT get the emb: stripping
+        let encoded_other = BASE64.encode(emb_key.as_bytes());
+        assert_eq!(
+            partitioner.partition_log_key("molecules", &encoded_other),
+            SyncDestination::Personal
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **Org embedding routing**: `SyncPartitioner::partition_log_key` now strips the `emb:` prefix for `native_index` namespace keys before checking for org hash prefixes. Embedding keys like `emb:{org_hash}:{schema}:...` are correctly routed to the org sync target instead of personal.
- **Embedding reload after sync**: Added `EmbeddingReloadCallback` to `SyncEngine` (same pattern as `SchemaReloadCallback`). After sync downloads replay `native_index` entries, the in-memory `EmbeddingIndex` is refreshed with any new embeddings from the store.
- **New test**: `test_partition_log_key_embedding_with_org_prefix` verifies embedding keys route to org, personal embeddings stay personal, and non-native_index namespaces are unaffected.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo check --workspace --features aws-backend` passes
- [x] `cargo test --workspace --all-targets` passes
- [x] New unit test for partitioner embedding key routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)