### PR TITLE
feat: default access policy to owner-only

### DIFF
--- a/src/access/mod.rs
+++ b/src/access/mod.rs
@@ -27,7 +27,7 @@ pub use types::{
 
 /// Check all four access control layers for a **read** operation on a single field.
 ///
-/// If `policy` is `None`, the field has no access control (legacy behavior) and access is granted.
+/// If `policy` is `None`, the field defaults to owner-only access.
 /// Payment gates are checked at the schema level (passed separately).
 pub fn check_read_access(
     policy: Option<&FieldAccessPolicy>,
@@ -35,11 +35,8 @@ pub fn check_read_access(
     schema_name: &str,
     payment_gate: Option<&PaymentGate>,
 ) -> AccessDecision {
-    // No policy = legacy behavior, grant access
-    let policy = match policy {
-        Some(p) => p,
-        None => return AccessDecision::Granted,
-    };
+    let default_policy = FieldAccessPolicy::default();
+    let policy = policy.unwrap_or(&default_policy);
 
     // Resolve trust distance for this field's domain
     let trust_distance = match context.distance_for_domain(&policy.trust_domain) {
@@ -91,10 +88,8 @@ pub fn check_write_access(
     schema_name: &str,
     payment_gate: Option<&PaymentGate>,
 ) -> AccessDecision {
-    let policy = match policy {
-        Some(p) => p,
-        None => return AccessDecision::Granted,
-    };
+    let default_policy = FieldAccessPolicy::default();
+    let policy = policy.unwrap_or(&default_policy);
 
     // Resolve trust distance for this field's domain
     let trust_distance = match context.distance_for_domain(&policy.trust_domain) {
@@ -156,10 +151,16 @@ mod tests {
     }
 
     #[test]
-    fn test_no_policy_grants_access() {
+    fn test_no_policy_defaults_to_owner_only() {
+        // Remote caller is denied — no policy means owner-only
         let ctx = AccessContext::remote("bob", 100);
-        assert!(check_read_access(None, &ctx, "schema", None).is_granted());
-        assert!(check_write_access(None, &ctx, "schema", None).is_granted());
+        assert!(check_read_access(None, &ctx, "schema", None).is_denied());
+        assert!(check_write_access(None, &ctx, "schema", None).is_denied());
+
+        // Owner is still granted
+        let owner_ctx = AccessContext::owner("alice");
+        assert!(check_read_access(None, &owner_ctx, "schema", None).is_granted());
+        assert!(check_write_access(None, &owner_ctx, "schema", None).is_granted());
     }
 
     #[test]

--- a/src/schema/types/declarative_schemas.rs
+++ b/src/schema/types/declarative_schemas.rs
@@ -436,6 +436,22 @@ impl DeclarativeSchemaDefinition {
             }
         }
 
+        // Apply default access policy (owner-only) to any field that lacks one.
+        // Uses the schema's trust_domain if set, otherwise "personal".
+        {
+            use crate::access::types::FieldAccessPolicy;
+            let schema_domain = self.trust_domain.clone();
+            for field in self.runtime_fields.values_mut() {
+                if field.common().access_policy.is_none() {
+                    let mut policy = FieldAccessPolicy::default();
+                    if let Some(ref domain) = schema_domain {
+                        policy.trust_domain = domain.clone();
+                    }
+                    field.common_mut().access_policy = Some(policy);
+                }
+            }
+        }
+
         // Regenerate transform metadata that isn't persisted (marked with #[serde(skip)])
         // This is needed when schemas are loaded from the database
         self.regenerate_metadata();

--- a/tests/access_control_test.rs
+++ b/tests/access_control_test.rs
@@ -98,10 +98,10 @@ async fn query_with_no_access_context_returns_all_fields() {
 }
 
 #[tokio::test]
-async fn query_with_no_policy_returns_all_fields() {
+async fn query_with_no_explicit_policy_defaults_to_owner_only() {
     let db = setup_db_with_notes().await;
 
-    // No policies set — legacy behavior, all fields accessible even for remote users
+    // No explicit policies set — defaults to owner-only, remote users denied
     let ctx = AccessContext::remote("bob", 5);
     let query = Query::new(
         "Notes".to_string(),
@@ -110,6 +110,21 @@ async fn query_with_no_policy_returns_all_fields() {
     let results = db
         .query_executor
         .query_with_access(query, &ctx, None)
+        .await
+        .unwrap();
+
+    assert!(!results.contains_key("title"));
+    assert!(!results.contains_key("content"));
+
+    // Owner still has access
+    let owner_ctx = AccessContext::owner("owner");
+    let query = Query::new(
+        "Notes".to_string(),
+        vec!["title".to_string(), "content".to_string()],
+    );
+    let results = db
+        .query_executor
+        .query_with_access(query, &owner_ctx, None)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary
- Fields with no access policy now default to **owner-only** (read_max=0, write_max=0) instead of granting access to everyone
- `populate_runtime_fields()` applies an explicit `FieldAccessPolicy::default()` to every field at schema load time, inheriting the schema-level `trust_domain` if set
- Closes the gap where schemas had no policies from creation through approval

## Test plan
- [x] Unit test updated: `test_no_policy_defaults_to_owner_only` verifies remote denied, owner granted
- [x] Integration test updated: `query_with_no_explicit_policy_defaults_to_owner_only` verifies end-to-end
- [x] All 517+ tests pass, clippy clean, `aws-backend` feature compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)