### PR TITLE
feat: wire field_access_policies through declarative schema deserialization

### DIFF
--- a/src/access/types.rs
+++ b/src/access/types.rs
@@ -220,7 +220,7 @@ pub fn org_domain(org_hash: &str) -> String {
 
 /// Per-field access policy combining all four access control layers.
 /// Attached to `FieldCommon`. If `None`, field uses legacy behavior (no checks).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FieldAccessPolicy {
     /// Which trust domain governs this field's access.
     /// Default: "personal". Each domain has its own independent TrustGraph.

--- a/src/schema/types/declarative_schemas.rs
+++ b/src/schema/types/declarative_schemas.rs
@@ -136,6 +136,8 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
             identity_hash: Option<String>,
             #[serde(skip_serializing_if = "Option::is_none", default)]
             org_hash: Option<String>,
+            #[serde(default)]
+            field_access_policies: HashMap<String, crate::access::types::FieldAccessPolicy>,
         }
 
         // Deserialize into the helper struct
@@ -219,6 +221,7 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
         schema.field_types = helper.field_types;
         schema.identity_hash = helper.identity_hash;
         schema.org_hash = helper.org_hash;
+        schema.field_access_policies = helper.field_access_policies;
 
         Ok(schema)
     }
@@ -357,6 +360,7 @@ impl PartialEq for DeclarativeSchemaDefinition {
             && self.identity_hash == other.identity_hash
             && self.superseded_by == other.superseded_by
             && self.org_hash == other.org_hash
+            && self.field_access_policies == other.field_access_policies
         // Exclude runtime_fields, inputs_schema_fields, source_schemas, and hash mappings
         // These are derived/runtime state and don't affect schema identity
     }
@@ -857,6 +861,66 @@ mod tests {
         assert_eq!(
             deserialized.descriptive_name, None,
             "Descriptive name should remain None after deserialization"
+        );
+    }
+
+    #[test]
+    fn test_field_access_policies_deserialization() {
+        use crate::access::types::FieldAccessPolicy;
+
+        // Build JSON with field_access_policies
+        let json = serde_json::json!({
+            "name": "SecureNotes",
+            "schema_type": "Single",
+            "fields": ["title", "body"],
+            "field_access_policies": {
+                "body": {
+                    "trust_domain": "personal",
+                    "trust_distance": { "read_max": 0, "write_max": 0 },
+                    "capabilities": [],
+                    "security_label": null
+                }
+            }
+        });
+
+        let mut schema: DeclarativeSchemaDefinition =
+            serde_json::from_value(json).expect("should deserialize with field_access_policies");
+
+        // The declarative field should be present before populate
+        assert_eq!(schema.field_access_policies.len(), 1);
+        assert!(schema.field_access_policies.contains_key("body"));
+
+        // Populate runtime fields — this should copy policies onto runtime fields
+        schema.populate_runtime_fields().unwrap();
+
+        // Verify the runtime field got the policy
+        let body_field = schema.runtime_fields.get("body").expect("body field should exist");
+        let policy = body_field
+            .common()
+            .access_policy
+            .as_ref()
+            .expect("body should have an access policy after populate");
+        assert_eq!(policy.trust_domain, "personal");
+        assert_eq!(policy.trust_distance.read_max, 0);
+        assert_eq!(policy.trust_distance.write_max, 0);
+
+        // title should NOT have a policy (not in field_access_policies)
+        let title_field = schema.runtime_fields.get("title").expect("title field should exist");
+        assert!(
+            title_field.common().access_policy.is_none(),
+            "title should have no access policy"
+        );
+
+        // Verify PartialEq includes field_access_policies
+        let mut schema2 = schema.clone();
+        assert_eq!(schema, schema2, "cloned schemas should be equal");
+        schema2.field_access_policies.insert(
+            "title".to_string(),
+            FieldAccessPolicy::default(),
+        );
+        assert_ne!(
+            schema, schema2,
+            "schemas with different field_access_policies should not be equal"
         );
     }
 }

--- a/src/schema/types/declarative_schemas.rs
+++ b/src/schema/types/declarative_schemas.rs
@@ -894,7 +894,10 @@ mod tests {
         schema.populate_runtime_fields().unwrap();
 
         // Verify the runtime field got the policy
-        let body_field = schema.runtime_fields.get("body").expect("body field should exist");
+        let body_field = schema
+            .runtime_fields
+            .get("body")
+            .expect("body field should exist");
         let policy = body_field
             .common()
             .access_policy
@@ -905,7 +908,10 @@ mod tests {
         assert_eq!(policy.trust_distance.write_max, 0);
 
         // title should NOT have a policy (not in field_access_policies)
-        let title_field = schema.runtime_fields.get("title").expect("title field should exist");
+        let title_field = schema
+            .runtime_fields
+            .get("title")
+            .expect("title field should exist");
         assert!(
             title_field.common().access_policy.is_none(),
             "title should have no access policy"
@@ -914,10 +920,9 @@ mod tests {
         // Verify PartialEq includes field_access_policies
         let mut schema2 = schema.clone();
         assert_eq!(schema, schema2, "cloned schemas should be equal");
-        schema2.field_access_policies.insert(
-            "title".to_string(),
-            FieldAccessPolicy::default(),
-        );
+        schema2
+            .field_access_policies
+            .insert("title".to_string(), FieldAccessPolicy::default());
         assert_ne!(
             schema, schema2,
             "schemas with different field_access_policies should not be equal"


### PR DESCRIPTION
## Summary
- Added `field_access_policies` to the `DeclarativeSchemaDefinitionHelper` struct so policies in JSON are actually deserialized instead of silently dropped
- Wired the deserialized policies through to the `DeclarativeSchemaDefinition` struct
- Added `field_access_policies` to the manual `PartialEq` impl for schema equality checks
- Derived `PartialEq` on `FieldAccessPolicy` (all sub-types already had it)
- Added test verifying JSON -> deserialize -> populate_runtime_fields -> policy on field

## Test plan
- [x] New unit test `test_field_access_policies_deserialization` verifies round-trip
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo check --workspace --features aws-backend` passes
- [x] `cargo test --workspace --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)