### PR TITLE
feat: add birthday field to NodeConfigStore

### DIFF
--- a/src/storage/node_config_store.rs
+++ b/src/storage/node_config_store.rs
@@ -104,6 +104,14 @@ impl NodeConfigStore {
         self.set("identity:contact_hint", hint)
     }
 
+    pub fn get_birthday(&self) -> Option<String> {
+        self.get("identity:birthday")
+    }
+
+    pub fn set_birthday(&self, birthday: &str) -> Result<(), sled::Error> {
+        self.set("identity:birthday", birthday)
+    }
+
     // --- AI config ---
 
     pub fn get_ai_config(&self) -> Option<AiConfig> {


### PR DESCRIPTION
## Summary
- Add `get_birthday()` / `set_birthday()` methods to `NodeConfigStore`
- Stores as `identity:birthday` key in Sled config tree
- Used by IdentityCard for MM-DD birthday in peer verification

## Test plan
- [x] Clippy clean
- [x] Follows existing pattern (identical to display_name/contact_hint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)