### PR TITLE
fix: SledPool idle reaper + retry on lock contention

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -81,6 +81,7 @@ async fn create_local_fold_db(
         .ok_or_else(|| FoldDbError::Config("Invalid storage path".to_string()))?;
 
     let pool = Arc::new(SledPool::new(path.to_path_buf()));
+    pool.start_idle_reaper(std::time::Duration::from_millis(500));
 
     // Create the config store for runtime node configuration
     let config_store = NodeConfigStore::new(Arc::clone(&pool))

--- a/src/storage/sled_pool.rs
+++ b/src/storage/sled_pool.rs
@@ -69,18 +69,57 @@ impl SledPool {
     }
 
     /// Acquire a Sled handle. Opens the database if not already open.
-    /// The returned guard keeps the database alive until dropped.
+    /// If another process holds the lock, retries with exponential backoff
+    /// (up to ~5s total) to wait for the other process's idle release.
     pub fn acquire_arc(self: &Arc<Self>) -> StorageResult<SledGuard> {
         let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
 
         let db = if let Some(ref db) = inner.db {
             db.clone()
         } else {
-            let db = sled::open(&self.path).map_err(|e| {
-                StorageError::ConfigurationError(format!("Failed to open sled database: {}", e))
-            })?;
-            inner.db = Some(db.clone());
-            db
+            let mut last_err = String::new();
+            let mut db_result = None;
+            for attempt in 0..10 {
+                match sled::open(&self.path) {
+                    Ok(db) => {
+                        db_result = Some(db);
+                        break;
+                    }
+                    Err(e) => {
+                        last_err = e.to_string();
+                        if last_err.contains("WouldBlock")
+                            || last_err.contains("acquire lock")
+                            || last_err.contains("Resource temporarily unavailable")
+                        {
+                            // Lock held by another process — wait and retry
+                            drop(inner);
+                            let delay = Duration::from_millis(100 * (1 << attempt.min(4)));
+                            std::thread::sleep(delay);
+                            inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+                            // Check if another thread opened it while we waited
+                            if let Some(ref db) = inner.db {
+                                db_result = Some(db.clone());
+                                break;
+                            }
+                            continue;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            match db_result {
+                Some(db) => {
+                    inner.db = Some(db.clone());
+                    db
+                }
+                None => {
+                    return Err(StorageError::ConfigurationError(format!(
+                        "Failed to open sled database after retries: {}",
+                        last_err
+                    )));
+                }
+            }
         };
 
         inner.active_ops += 1;


### PR DESCRIPTION
## Summary

Dogfood testing (2 processes sharing same Sled database) revealed two critical issues in the SledPool implementation:

1. **Missing idle reaper** — `start_idle_reaper()` was never called in the factory, so the cached Sled handle was held forever (defeating the entire purpose of SledPool)
2. **No retry on lock contention** — `acquire_arc()` failed immediately when another process held the lock, instead of waiting for the idle release

## Fixes

- Start idle reaper with **500ms timeout** in `factory.rs`
- Add **exponential backoff retry** (up to 10 attempts, ~5s total) in `acquire_arc()` when `sled::open()` fails with `WouldBlock`

## Test plan

- [x] All SledPool unit tests pass
- [x] Clippy clean
- [x] Dogfood: 2 folddb_server processes sharing same data dir, 10/10 alternating reads passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)