### PR TITLE
fix: increase SledPool idle reaper timeout from 500ms to 30s

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -81,7 +81,7 @@ async fn create_local_fold_db(
         .ok_or_else(|| FoldDbError::Config("Invalid storage path".to_string()))?;
 
     let pool = Arc::new(SledPool::new(path.to_path_buf()));
-    pool.start_idle_reaper(std::time::Duration::from_millis(500));
+    pool.start_idle_reaper(std::time::Duration::from_secs(30));
 
     // Create the config store for runtime node configuration
     let config_store = NodeConfigStore::new(Arc::clone(&pool))


### PR DESCRIPTION
## Summary
- Increases the SledPool idle reaper timeout from 500ms to 30 seconds
- Fixes flaky `test_query_with_rehydrate_depth_resolves_references` failures in CI where the pool would close the Sled database mid-operation under load
- 30s still reclaims resources when the database is truly idle

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)