### PR TITLE
fix: sync engine upload tracking and cursor persistence

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -536,11 +536,19 @@ impl SyncEngine {
                 ));
             }
 
-            // Clear uploaded entries from pending (only if all uploads succeeded)
-            if uploaded > 0 {
+            // Clear uploaded entries from pending.
+            // Only drain if ALL targets succeeded (uploaded == total entries).
+            // If some targets failed, keep all entries so they retry next cycle.
+            if uploaded >= entries.len() {
                 let mut pending = self.pending.lock().await;
                 let count = entries.len().min(pending.len());
                 pending.drain(..count);
+            } else if uploaded > 0 {
+                log::warn!(
+                    "partial upload: {}/{} entries succeeded, keeping all in pending for retry",
+                    uploaded,
+                    entries.len()
+                );
             }
         }
 
@@ -635,11 +643,13 @@ impl SyncEngine {
             )));
         }
 
+        let mut uploaded_count = 0;
         for ((_seq, s), url) in sealed.into_iter().zip(urls.iter()) {
             self.s3.upload(url, s.bytes).await?;
+            uploaded_count += 1;
         }
 
-        Ok(entries.len())
+        Ok(uploaded_count)
     }
 
     /// Download new entries from a sync target.
@@ -778,10 +788,24 @@ impl SyncEngine {
     /// Persist a download cursor to Sled.
     async fn save_download_cursor(&self, prefix: &str, seq: u64) {
         let cursor_key = format!("cursor:{}", prefix);
-        if let Ok(kv) = self.store.open_namespace("sync_cursors").await {
-            let _ = kv
-                .put(cursor_key.as_bytes(), seq.to_be_bytes().to_vec())
-                .await;
+        match self.store.open_namespace("sync_cursors").await {
+            Ok(kv) => {
+                if let Err(e) = kv
+                    .put(cursor_key.as_bytes(), seq.to_be_bytes().to_vec())
+                    .await
+                {
+                    log::error!(
+                        "failed to save download cursor for '{}' at seq {}: {} — next restart will re-download from last saved cursor",
+                        prefix, seq, e
+                    );
+                }
+            }
+            Err(e) => {
+                log::error!(
+                    "failed to open sync_cursors namespace for '{}': {} — cursor not persisted",
+                    prefix, e
+                );
+            }
         }
     }
 

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -803,7 +803,8 @@ impl SyncEngine {
             Err(e) => {
                 log::error!(
                     "failed to open sync_cursors namespace for '{}': {} — cursor not persisted",
-                    prefix, e
+                    prefix,
+                    e
                 );
             }
         }


### PR DESCRIPTION
## Summary
Three fixes to the sync engine's data integrity:

1. **Fix partial upload drain bug**: When entries are partitioned across multiple sync targets (personal + org), if Target A's upload succeeds but Target B fails, the engine was draining ALL pending entries — orphaning Target B's entries permanently. Now only drains when all targets succeed; logs a warning on partial upload and keeps all entries for retry on the next sync cycle.

2. **Fix silent download cursor failure**: `save_download_cursor()` was discarding errors with `let _ =`. If the cursor fails to persist (disk full, Sled error), the node silently falls back to cursor 0 on restart, causing a full re-download. Now logs at error level with context about what will happen.

3. **Fix upload count accuracy**: `upload_entries()` was returning `entries.len()` (the input count) instead of tracking how many actually uploaded. If an upload fails mid-batch (the `?` early return), the caller would have gotten an inflated count. Now tracks actual successful uploads.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace --all-targets` — all tests pass
- [ ] Manual: simulate partial target failure (mock S3 returning error for org prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)