### PR TITLE
fix: correct SCRFD output parsing and model download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -851,6 +854,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1228,7 @@ dependencies = [
  "uuid",
  "wasmtime",
  "wat",
+ "zip",
 ]
 
 [[package]]
@@ -5434,10 +5449,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ ts-bindings = ["ts-rs"]  # Generate TypeScript bindings when enabled
 cli = ["dep:clap", "dep:clap_complete"]  # CLI tooling (clap derives)
 transform-wasm = ["dep:wasmtime"]  # Enable WASM transform execution for views
 test-utils = []  # Expose test helpers (MockEmbeddingModel, etc.) for integration tests
-face-detection = ["dep:ort", "dep:image"]  # Face detection and embedding via ONNX Runtime
+face-detection = ["dep:ort", "dep:image", "dep:zip"]  # Face detection and embedding via ONNX Runtime
 
 [dependencies]
 # Cryptography
@@ -73,6 +73,7 @@ wasmtime = { version = "29", optional = true }
 # Face detection (ONNX runtime + image processing)
 ort = { version = "2.0.0-rc.9", optional = true, default-features = false }
 image = { version = "0.25", optional = true, default-features = false, features = ["png", "jpeg"] }
+zip = { version = "2", optional = true, default-features = false, features = ["deflate"] }
 
 ed25519-compact = "2.2.0"
 

--- a/src/db_operations/native_index/face/detector.rs
+++ b/src/db_operations/native_index/face/detector.rs
@@ -8,7 +8,7 @@ use crate::schema::SchemaError;
 pub struct FaceDetection {
     pub bbox: [f32; 4], // x1, y1, x2, y2 in original image pixels
     pub confidence: f32,
-    /// 5 facial landmarks (used for face alignment in Phase 2).
+    /// 5 facial landmarks (used for face alignment).
     #[allow(dead_code)]
     pub landmarks: Option<[[f32; 2]; 5]>,
 }
@@ -41,7 +41,6 @@ impl ScrfdDetector {
         let (orig_w, orig_h) = image.dimensions();
         let (input_w, input_h) = self.input_size;
 
-        // Resize image to model input size
         let resized = image.resize_exact(input_w, input_h, FilterType::Lanczos3);
 
         // Convert to CHW float tensor [1, 3, H, W]
@@ -50,14 +49,12 @@ impl ScrfdDetector {
             for x in 0..input_w {
                 let pixel = resized.get_pixel(x, y);
                 let idx = (y * input_w + x) as usize;
-                input_tensor[idx] = pixel[0] as f32; // R
-                input_tensor[(input_h * input_w) as usize + idx] = pixel[1] as f32; // G
+                input_tensor[idx] = pixel[0] as f32;
+                input_tensor[(input_h * input_w) as usize + idx] = pixel[1] as f32;
                 input_tensor[2 * (input_h * input_w) as usize + idx] = pixel[2] as f32;
-                // B
             }
         }
 
-        // Run inference
         let input = Tensor::from_array((
             [1usize, 3, input_h as usize, input_w as usize],
             input_tensor.as_slice(),
@@ -72,19 +69,20 @@ impl ScrfdDetector {
             .run(inputs)
             .map_err(|e| SchemaError::InvalidData(format!("SCRFD inference failed: {e}")))?;
 
-        // Parse SCRFD outputs: the model has multiple stride outputs
-        // For scrfd_2.5g_bnkps, outputs are grouped by stride (8, 16, 32):
-        // score_8, bbox_8, kps_8, score_16, bbox_16, kps_16, score_32, bbox_32, kps_32
+        // SCRFD det_500m outputs 9 tensors (3 strides × 3 types):
+        //   [0] scores_8  [N8, 1]    [3] bboxes_8  [N8, 4]    [6] kps_8  [N8, 10]
+        //   [1] scores_16 [N16, 1]   [4] bboxes_16 [N16, 4]   [7] kps_16 [N16, 10]
+        //   [2] scores_32 [N32, 1]   [5] bboxes_32 [N32, 4]   [8] kps_32 [N32, 10]
+        // where N_s = (640/s)^2 * 2 anchors
         let mut detections = Vec::new();
         let strides = [8u32, 16, 32];
-        let num_outputs_per_stride = 3; // score, bbox, kps
 
         for (stride_idx, &stride) in strides.iter().enumerate() {
-            let score_idx = stride_idx * num_outputs_per_stride;
-            let bbox_idx = score_idx + 1;
-            let kps_idx = score_idx + 2;
+            let score_idx = stride_idx; // 0, 1, 2
+            let bbox_idx = stride_idx + 3; // 3, 4, 5
+            let kps_idx = stride_idx + 6; // 6, 7, 8
 
-            if score_idx >= outputs.len() || bbox_idx >= outputs.len() {
+            if bbox_idx >= outputs.len() {
                 continue;
             }
 
@@ -101,50 +99,44 @@ impl ScrfdDetector {
             let feat_h = input_h / stride;
             let feat_w = input_w / stride;
 
-            // SCRFD uses anchor-free detection with distance predictions
             for fy in 0..feat_h {
                 for fx in 0..feat_w {
-                    for anchor_idx in 0..2u32 {
-                        // 2 anchors per position
-                        let idx = ((fy * feat_w + fx) * 2 + anchor_idx) as usize;
-                        if idx >= scores_view.len() {
+                    for anchor in 0..2u32 {
+                        let idx = ((fy * feat_w + fx) * 2 + anchor) as usize;
+                        if idx >= scores_view.shape()[0] {
                             continue;
                         }
 
-                        let score = scores_view[[0, idx, 0]];
+                        let score = scores_view[[idx, 0]];
                         if score < self.conf_threshold {
                             continue;
                         }
 
-                        // Center point
                         let cx = (fx as f32 + 0.5) * stride as f32;
                         let cy = (fy as f32 + 0.5) * stride as f32;
 
-                        // Distance predictions (left, top, right, bottom from center)
-                        let l = bboxes_view[[0, idx, 0]] * stride as f32;
-                        let t = bboxes_view[[0, idx, 1]] * stride as f32;
-                        let r = bboxes_view[[0, idx, 2]] * stride as f32;
-                        let b = bboxes_view[[0, idx, 3]] * stride as f32;
+                        let l = bboxes_view[[idx, 0]] * stride as f32;
+                        let t = bboxes_view[[idx, 1]] * stride as f32;
+                        let r = bboxes_view[[idx, 2]] * stride as f32;
+                        let b = bboxes_view[[idx, 3]] * stride as f32;
 
                         let x1 = (cx - l).max(0.0) / input_w as f32 * orig_w as f32;
                         let y1 = (cy - t).max(0.0) / input_h as f32 * orig_h as f32;
                         let x2 = (cx + r).min(input_w as f32) / input_w as f32 * orig_w as f32;
                         let y2 = (cy + b).min(input_h as f32) / input_h as f32 * orig_h as f32;
 
-                        // Extract landmarks if available
                         let landmarks = if kps_idx < outputs.len() {
-                            let kps = outputs[kps_idx].try_extract_tensor::<f32>().ok();
-                            kps.map(|k| {
+                            outputs[kps_idx].try_extract_tensor::<f32>().ok().map(|k| {
                                 let k_view = k.view();
                                 let mut pts = [[0.0f32; 2]; 5];
                                 for (i, pt) in pts.iter_mut().enumerate() {
-                                    let kx_idx = i * 2;
-                                    let ky_idx = i * 2 + 1;
-                                    if kx_idx + 1 < k_view.shape()[2] {
-                                        pt[0] = (cx + k_view[[0, idx, kx_idx]] * stride as f32)
+                                    let kx = i * 2;
+                                    let ky = i * 2 + 1;
+                                    if ky < k_view.shape()[1] {
+                                        pt[0] = (cx + k_view[[idx, kx]] * stride as f32)
                                             / input_w as f32
                                             * orig_w as f32;
-                                        pt[1] = (cy + k_view[[0, idx, ky_idx]] * stride as f32)
+                                        pt[1] = (cy + k_view[[idx, ky]] * stride as f32)
                                             / input_h as f32
                                             * orig_h as f32;
                                     }
@@ -165,9 +157,7 @@ impl ScrfdDetector {
             }
         }
 
-        // Apply NMS
         self.nms(&mut detections);
-
         Ok(detections)
     }
 

--- a/src/db_operations/native_index/face/embedder.rs
+++ b/src/db_operations/native_index/face/embedder.rs
@@ -63,9 +63,9 @@ impl ArcFaceEmbedder {
                 let pixel = resized.get_pixel(x, y);
                 let idx = (y * w + x) as usize;
                 // Normalize: (pixel / 127.5) - 1.0 maps [0, 255] to [-1, 1]
-                input_tensor[idx] = pixel[0] as f32 / 127.5 - 1.0; // R
-                input_tensor[(h * w) as usize + idx] = pixel[1] as f32 / 127.5 - 1.0; // G
-                input_tensor[2 * (h * w) as usize + idx] = pixel[2] as f32 / 127.5 - 1.0;
+                input_tensor[idx] = (pixel[0] as f32 - 127.5) / 128.0; // R
+                input_tensor[(h * w) as usize + idx] = (pixel[1] as f32 - 127.5) / 128.0; // G
+                input_tensor[2 * (h * w) as usize + idx] = (pixel[2] as f32 - 127.5) / 128.0;
                 // B
             }
         }

--- a/src/db_operations/native_index/face/mod.rs
+++ b/src/db_operations/native_index/face/mod.rs
@@ -64,4 +64,58 @@ mod tests {
         assert_eq!(deserialized.embedding.len(), 512);
         assert_eq!(deserialized.confidence, 0.99);
     }
+
+    /// Integration test: download models and run face detection on a real image.
+    /// Only runs when FACE_TEST_IMAGE env var is set (skipped in CI).
+    #[cfg(feature = "face-detection")]
+    #[test]
+    fn test_face_detection_real_image() {
+        let image_path = match std::env::var("FACE_TEST_IMAGE") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("Skipping face detection test (set FACE_TEST_IMAGE=/path/to/photo.jpg)");
+                return;
+            }
+        };
+
+        let home_path = std::env::var("FOLDDB_HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| tempfile::tempdir().unwrap().into_path());
+        let processor = OnnxFaceProcessor::new(&home_path);
+
+        let image_bytes = std::fs::read(&image_path)
+            .unwrap_or_else(|e| panic!("Failed to read {}: {}", image_path, e));
+
+        let faces = processor
+            .detect_and_embed(&image_bytes)
+            .unwrap_or_else(|e| panic!("Face detection failed: {}", e));
+
+        eprintln!("Detected {} faces in {}", faces.len(), image_path);
+        for (i, face) in faces.iter().enumerate() {
+            eprintln!(
+                "  Face {}: bbox=[{:.2}, {:.2}, {:.2}, {:.2}] conf={:.3} dim={}",
+                i,
+                face.bbox[0],
+                face.bbox[1],
+                face.bbox[2],
+                face.bbox[3],
+                face.confidence,
+                face.embedding.len()
+            );
+            assert_eq!(
+                face.embedding.len(),
+                512,
+                "ArcFace should produce 512-dim vectors"
+            );
+            assert!(face.confidence > 0.0);
+
+            // Check L2 normalization
+            let norm: f32 = face.embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+            assert!(
+                (norm - 1.0).abs() < 0.01,
+                "Embedding should be L2-normalized, got norm={}",
+                norm
+            );
+        }
+    }
 }

--- a/src/db_operations/native_index/face/model.rs
+++ b/src/db_operations/native_index/face/model.rs
@@ -1,17 +1,21 @@
+use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
 
 use crate::schema::SchemaError;
 
 const MODELS_DIR: &str = "models";
 
-/// URLs for ONNX model downloads
-const SCRFD_URL: &str =
-    "https://github.com/nicken/insightface-onnx/raw/refs/heads/master/scrfd_2.5g_bnkps.onnx";
-const ARCFACE_URL: &str =
-    "https://github.com/nicken/insightface-onnx/raw/refs/heads/master/arcface_r100.onnx";
+/// Model pack URL (InsightFace buffalo_sc — smallest pack, ~15MB)
+/// Contains det_500m.onnx (SCRFD, 2.5MB) and w600k_mbf.onnx (MobileFaceNet, 13MB)
+const MODEL_PACK_URL: &str =
+    "https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_sc.zip";
 
 const SCRFD_FILENAME: &str = "scrfd_2.5g_bnkps.onnx";
 const ARCFACE_FILENAME: &str = "arcface_r100.onnx";
+
+// Names inside the zip
+const SCRFD_ZIP_NAME: &str = "det_500m.onnx";
+const ARCFACE_ZIP_NAME: &str = "w600k_mbf.onnx";
 
 pub struct ModelManager {
     models_dir: PathBuf,
@@ -29,8 +33,14 @@ impl ModelManager {
         if path.exists() {
             return Ok(path);
         }
-        self.download(SCRFD_URL, &path)?;
-        Ok(path)
+        self.download_model_pack()?;
+        if path.exists() {
+            Ok(path)
+        } else {
+            Err(SchemaError::InvalidData(
+                "SCRFD model not found after download".to_string(),
+            ))
+        }
     }
 
     pub fn arcface_path(&self) -> Result<PathBuf, SchemaError> {
@@ -38,19 +48,24 @@ impl ModelManager {
         if path.exists() {
             return Ok(path);
         }
-        self.download(ARCFACE_URL, &path)?;
-        Ok(path)
+        self.download_model_pack()?;
+        if path.exists() {
+            Ok(path)
+        } else {
+            Err(SchemaError::InvalidData(
+                "ArcFace model not found after download".to_string(),
+            ))
+        }
     }
 
-    fn download(&self, url: &str, dest: &Path) -> Result<(), SchemaError> {
+    fn download_model_pack(&self) -> Result<(), SchemaError> {
         std::fs::create_dir_all(&self.models_dir).map_err(|e| {
             SchemaError::InvalidData(format!("Failed to create models directory: {e}"))
         })?;
 
-        log::info!("Downloading face model from {} ...", url);
-        let response = reqwest::blocking::get(url).map_err(|e| {
-            SchemaError::InvalidData(format!("Failed to download model from {url}: {e}"))
-        })?;
+        log::info!("Downloading face models from {} ...", MODEL_PACK_URL);
+        let response = reqwest::blocking::get(MODEL_PACK_URL)
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to download models: {e}")))?;
 
         if !response.status().is_success() {
             return Err(SchemaError::InvalidData(format!(
@@ -63,11 +78,41 @@ impl ModelManager {
             .bytes()
             .map_err(|e| SchemaError::InvalidData(format!("Failed to read model bytes: {e}")))?;
 
-        std::fs::write(dest, &bytes).map_err(|e| {
-            SchemaError::InvalidData(format!("Failed to write model to {}: {e}", dest.display()))
-        })?;
+        // Extract ONNX files from the zip
+        let cursor = Cursor::new(&bytes);
+        let mut archive = zip::ZipArchive::new(cursor)
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to open model zip: {e}")))?;
 
-        log::info!("Model saved to {}", dest.display());
+        for i in 0..archive.len() {
+            let mut file = archive
+                .by_index(i)
+                .map_err(|e| SchemaError::InvalidData(format!("Failed to read zip entry: {e}")))?;
+
+            let name = file.name().to_string();
+            if !name.ends_with(".onnx") {
+                continue;
+            }
+
+            // Map zip filenames to our canonical names
+            let dest_name = if name.contains(SCRFD_ZIP_NAME) || name.ends_with(SCRFD_ZIP_NAME) {
+                SCRFD_FILENAME
+            } else if name.contains(ARCFACE_ZIP_NAME) || name.ends_with(ARCFACE_ZIP_NAME) {
+                ARCFACE_FILENAME
+            } else {
+                continue;
+            };
+
+            let dest = self.models_dir.join(dest_name);
+            let mut contents = Vec::new();
+            file.read_to_end(&mut contents).map_err(|e| {
+                SchemaError::InvalidData(format!("Failed to extract {}: {e}", name))
+            })?;
+            std::fs::write(&dest, &contents).map_err(|e| {
+                SchemaError::InvalidData(format!("Failed to write {}: {e}", dest.display()))
+            })?;
+            log::info!("Extracted {} ({} bytes)", dest.display(), contents.len());
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Fix SCRFD detector output parsing (2D tensors, not 3D)
- Fix ArcFace normalization to match InsightFace spec
- Download model pack from InsightFace GitHub releases (buffalo_sc.zip)
- Add zip crate for model extraction
- **Tested: detects 3 faces in a group photo with correct 512-dim embeddings**

## Test plan
- [x] `FACE_TEST_IMAGE=/path/to/photo.jpg cargo test --features face-detection test_face_detection_real_image`
- [x] Detects 3 faces, 512-dim L2-normalized embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)