### PR TITLE
fix: face detection model bugs — download hang, path, SCRFD parsing

### DIFF
--- a/src/db_operations/native_index/embedding_index.rs
+++ b/src/db_operations/native_index/embedding_index.rs
@@ -372,7 +372,10 @@ impl EmbeddingIndex {
         let entries = self.entries.read().unwrap();
         entries
             .iter()
-            .filter(|e| e.field_name == FACE_FIELD_NAME && e.schema == schema && e.key == *key)
+            .filter(|e| {
+                e.field_name == FACE_FIELD_NAME && e.schema == schema && e.key.hash == key.hash
+                // Match by hash only (photo filename)
+            })
             .map(|e| (e.fragment_idx, e.embedding.clone()))
             .collect()
     }

--- a/src/db_operations/native_index/face/model.rs
+++ b/src/db_operations/native_index/face/model.rs
@@ -64,19 +64,20 @@ impl ModelManager {
         })?;
 
         log::info!("Downloading face models from {} ...", MODEL_PACK_URL);
-        let response = reqwest::blocking::get(MODEL_PACK_URL)
+
+        // Use ureq (not reqwest::blocking) because reqwest::blocking panics
+        // when called inside a tokio async runtime.
+        let response = ureq::get(MODEL_PACK_URL)
+            .call()
             .map_err(|e| SchemaError::InvalidData(format!("Failed to download models: {e}")))?;
 
-        if !response.status().is_success() {
-            return Err(SchemaError::InvalidData(format!(
-                "Model download failed with status {}",
-                response.status()
-            )));
-        }
-
-        let bytes = response
-            .bytes()
+        let mut bytes = Vec::new();
+        response
+            .into_reader()
+            .read_to_end(&mut bytes)
             .map_err(|e| SchemaError::InvalidData(format!("Failed to read model bytes: {e}")))?;
+
+        log::info!("Downloaded {} bytes", bytes.len());
 
         // Extract ONNX files from the zip
         let cursor = Cursor::new(&bytes);

--- a/src/db_operations/native_index/mod.rs
+++ b/src/db_operations/native_index/mod.rs
@@ -34,7 +34,7 @@ pub struct NativeIndexManager {
     embedding_model: Arc<dyn Embedder>,
     embedding_index: Arc<EmbeddingIndex>,
     #[cfg(feature = "face-detection")]
-    face_processor: Option<Arc<dyn FaceProcessor>>,
+    face_processor: once_cell::sync::OnceCell<Arc<dyn FaceProcessor>>,
 }
 
 impl NativeIndexManager {
@@ -44,7 +44,7 @@ impl NativeIndexManager {
             embedding_model: Arc::new(FastEmbedModel::new()),
             embedding_index: Arc::new(EmbeddingIndex::new(Vec::new())),
             #[cfg(feature = "face-detection")]
-            face_processor: None,
+            face_processor: once_cell::sync::OnceCell::new(),
         }
     }
 
@@ -61,7 +61,7 @@ impl NativeIndexManager {
             embedding_model: model,
             embedding_index: Arc::new(EmbeddingIndex::new(Vec::new())),
             #[cfg(feature = "face-detection")]
-            face_processor: None,
+            face_processor: once_cell::sync::OnceCell::new(),
         }
     }
 
@@ -169,7 +169,7 @@ impl NativeIndexManager {
     pub fn has_face_processor(&self) -> bool {
         #[cfg(feature = "face-detection")]
         {
-            self.face_processor.is_some()
+            self.face_processor.get().is_some()
         }
         #[cfg(not(feature = "face-detection"))]
         {
@@ -179,8 +179,8 @@ impl NativeIndexManager {
 
     /// Set the face processor for face detection and embedding.
     #[cfg(feature = "face-detection")]
-    pub fn set_face_processor(&mut self, processor: Arc<dyn FaceProcessor>) {
-        self.face_processor = Some(processor);
+    pub fn set_face_processor(&self, processor: Arc<dyn FaceProcessor>) {
+        let _ = self.face_processor.set(processor);
     }
 
     /// Detect faces in an image, embed each face, and store the embeddings.
@@ -194,7 +194,7 @@ impl NativeIndexManager {
     ) -> Result<usize, SchemaError> {
         let processor = self
             .face_processor
-            .as_ref()
+            .get()
             .ok_or_else(|| SchemaError::InvalidData("No face processor configured".to_string()))?;
 
         let faces = processor.detect_and_embed(image_bytes)?;

--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -190,15 +190,24 @@ async fn create_local_fold_db(
     // Initialize face detection processor if the feature is enabled
     #[cfg(feature = "face-detection")]
     {
-        let home_path = std::path::Path::new(path_str);
+        // FOLDDB_HOME is the node's root dir; models go in {FOLDDB_HOME}/models/
+        // path_str is the Sled data path ({FOLDDB_HOME}/data), so go up one level
+        let home_path = std::env::var("FOLDDB_HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                std::path::Path::new(path_str)
+                    .parent()
+                    .unwrap_or(std::path::Path::new(path_str))
+                    .to_path_buf()
+            });
         if let Some(mgr) = db_ops.native_index_manager() {
             let processor = std::sync::Arc::new(
-                crate::db_operations::native_index::face::OnnxFaceProcessor::new(home_path),
+                crate::db_operations::native_index::face::OnnxFaceProcessor::new(&home_path),
             );
             mgr.set_face_processor(processor);
             log::info!(
                 "Face detection processor initialized (models at {}/models/)",
-                path_str
+                home_path.display()
             );
         }
     }

--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -187,6 +187,22 @@ async fn create_local_fold_db(
         .await
         .map_err(|e| FoldDbError::Config(e.to_string()))?;
 
+    // Initialize face detection processor if the feature is enabled
+    #[cfg(feature = "face-detection")]
+    {
+        let home_path = std::path::Path::new(path_str);
+        if let Some(mgr) = db_ops.native_index_manager() {
+            let processor = std::sync::Arc::new(
+                crate::db_operations::native_index::face::OnnxFaceProcessor::new(home_path),
+            );
+            mgr.set_face_processor(processor);
+            log::info!(
+                "Face detection processor initialized (models at {}/models/)",
+                path_str
+            );
+        }
+    }
+
     let job_store = crate::progress::create_tracker_with_sled(Arc::clone(&pool));
 
     let mut fold_db = FoldDB::initialize_from_db_ops_with_sled(

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -354,6 +354,19 @@ impl FoldDB {
             "Sled"
         );
 
+        // Initialize face detection processor if the feature is enabled
+        #[cfg(feature = "face-detection")]
+        {
+            let home_path = std::path::Path::new(db_path);
+            if let Some(mgr) = db_ops.native_index_manager() {
+                let processor = std::sync::Arc::new(
+                    crate::db_operations::native_index::face::OnnxFaceProcessor::new(home_path),
+                );
+                mgr.set_face_processor(processor);
+                log::info!("Face detection processor initialized");
+            }
+        }
+
         // For local Sled backend, create persistent progress store
         let job_store: ProgressTracker =
             crate::progress::create_tracker_with_sled(Arc::clone(&pool));

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -357,13 +357,23 @@ impl FoldDB {
         // Initialize face detection processor if the feature is enabled
         #[cfg(feature = "face-detection")]
         {
-            let home_path = std::path::Path::new(db_path);
+            let home_path = std::env::var("FOLDDB_HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| {
+                    std::path::Path::new(db_path)
+                        .parent()
+                        .unwrap_or(std::path::Path::new(db_path))
+                        .to_path_buf()
+                });
             if let Some(mgr) = db_ops.native_index_manager() {
                 let processor = std::sync::Arc::new(
-                    crate::db_operations::native_index::face::OnnxFaceProcessor::new(home_path),
+                    crate::db_operations::native_index::face::OnnxFaceProcessor::new(&home_path),
                 );
                 mgr.set_face_processor(processor);
-                log::info!("Face detection processor initialized");
+                log::info!(
+                    "Face detection processor initialized (models at {}/models/)",
+                    home_path.display()
+                );
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix model download hang: use ureq instead of reqwest::blocking (panics in async runtime)
- Fix model path: use FOLDDB_HOME env var instead of relative data/ path
- Fix SCRFD output parsing: 2D tensors [N, channels], not 3D
- Fix list_faces: match by hash key only (ignore range)
- Init face processor in both factory.rs and fold_db.rs constructors via OnceCell

## Test plan
- [x] cargo test — face detection works on real image (3 faces, 512-dim)
- [x] Verified in dogfood: 2 faces detected in ingested photo

🤖 Generated with [Claude Code](https://claude.com/claude-code)