### PR TITLE
chore: remove dead code and fix stale DynamoDB references

### DIFF
--- a/src/db_operations/atom_operations.rs
+++ b/src/db_operations/atom_operations.rs
@@ -36,7 +36,6 @@ impl DbOperations {
     }
 
     /// Batch store multiple atoms efficiently.
-    /// Uses DynamoDB BatchWriteItem to store up to 25 atoms per API call.
     /// Deduplicates by key since atoms with identical content have the same UUID.
     ///
     /// When `org_hash` is `Some`, all keys are prefixed with `{org_hash}:`.
@@ -50,7 +49,6 @@ impl DbOperations {
         }
 
         // Deduplicate by key - atoms with same content have same UUID
-        // DynamoDB batch_write_item doesn't allow duplicate keys in the same batch
         let mut seen_keys = std::collections::HashSet::new();
         let items: Vec<(String, Atom)> = atoms
             .into_iter()
@@ -65,10 +63,7 @@ impl DbOperations {
             })
             .collect();
 
-        log::info!(
-            "💾 Batch storing {} atoms to DynamoDB (after dedup)",
-            items.len()
-        );
+        log::info!("💾 Batch storing {} atoms (after dedup)", items.len());
 
         self.atoms_store()
             .batch_put_items(items)
@@ -84,7 +79,7 @@ impl DbOperations {
 
     /// Batch store multiple molecules efficiently.
     /// Accepts a vector of (molecule_uuid, molecule_data) tuples.
-    /// Deduplicates by key to prevent DynamoDB batch_write_item errors.
+    /// Deduplicates by key to avoid storing the same molecule twice.
     ///
     /// When `org_hash` is `Some`, all keys are prefixed with `{org_hash}:`.
     pub async fn batch_store_molecules(
@@ -96,7 +91,7 @@ impl DbOperations {
             return Ok(());
         }
 
-        // Deduplicate by key - DynamoDB batch_write_item doesn't allow duplicate keys
+        // Deduplicate by key
         let mut seen_keys = std::collections::HashSet::new();
         let items: Vec<(String, serde_json::Value)> = molecules
             .into_iter()
@@ -123,12 +118,9 @@ impl DbOperations {
             })
             .collect();
 
-        log::info!(
-            "💾 Batch storing {} molecules to DynamoDB (after dedup)",
-            items.len()
-        );
+        log::info!("💾 Batch storing {} molecules (after dedup)", items.len());
 
-        self.molecules_store()
+        self.atoms_store()
             .batch_put_items(items)
             .await
             .map_err(|e| {
@@ -143,8 +135,6 @@ impl DbOperations {
     /// Creates and stores an atom for a mutation field with deferred flush.
     /// If an atom with the same content already exists (content-based deduplication),
     /// returns the existing atom instead of creating a duplicate.
-    ///
-    /// This is the async V2 version for use with DbOperations.
     ///
     /// When `org_hash` is `Some`, all keys are prefixed with `{org_hash}:`.
     pub async fn create_and_store_atom_for_mutation_deferred(
@@ -188,7 +178,7 @@ impl DbOperations {
 
         // Store the new atom (deferred - no immediate flush)
         log::info!(
-            "💾 Writing atom to DynamoDB: key={}, uuid={}",
+            "💾 Writing atom: key={}, uuid={}",
             atom_key,
             new_atom.uuid()
         );
@@ -199,7 +189,7 @@ impl DbOperations {
                 log::error!("❌ Failed to store atom '{}': {}", atom_key, e);
                 SchemaError::InvalidData(format!("Failed to store atom: {}", e))
             })?;
-        log::info!("✅ Atom written to DynamoDB: {}", atom_key);
+        log::info!("✅ Atom written: {}", atom_key);
 
         Ok(new_atom)
     }

--- a/src/db_operations/core.rs
+++ b/src/db_operations/core.rs
@@ -4,10 +4,9 @@ use crate::storage::traits::*;
 use crate::storage::{SledNamespacedStore, TypedKvStore};
 use std::sync::Arc;
 
-/// Enhanced database operations with pluggable storage backend
+/// Database operations with pluggable storage backend
 ///
-/// This version uses the storage abstraction layer, allowing the same
-/// DbOperations API to work with different backends (Sled, DynamoDB, etc.)
+/// Uses the storage abstraction layer (Sled locally, with optional cloud sync).
 #[derive(Clone)]
 pub struct DbOperations {
     /// Main storage namespace - using concrete type instead of trait object
@@ -146,11 +145,6 @@ impl DbOperations {
 
     /// Get atoms/molecules store (same as main_store for backward compatibility)
     pub fn atoms_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
-        &self.main_store
-    }
-
-    /// Get molecules store (same as main_store for backward compatibility)
-    pub fn molecules_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.main_store
     }
 

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -43,7 +43,7 @@ pub struct FoldDB {
     /// Tracker for pending background tasks
     pub pending_tasks: Arc<super::infrastructure::pending_task_tracker::PendingTaskTracker>,
     /// Unified progress tracker for all job types (ingestion, indexing, etc.)
-    /// This is the single source of truth for progress - local uses Sled, cloud uses DynamoDB
+    /// This is the single source of truth for progress — uses Sled for persistent storage.
     pub progress_tracker: ProgressTracker,
     /// Optional sync engine for S3 replication.
     /// Present when sync is configured (local mode only).

--- a/src/fold_db_core/infrastructure/message_bus/events.rs
+++ b/src/fold_db_core/infrastructure/message_bus/events.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 pub mod atom_events;
 pub mod query_events;
 pub mod request_events;
-pub mod schema_events;
 
 pub use atom_events::*;
 pub use query_events::*;

--- a/src/fold_db_core/infrastructure/message_bus/events/schema_events.rs
+++ b/src/fold_db_core/infrastructure/message_bus/events/schema_events.rs
@@ -1,2 +1,0 @@
-// Schema events — reserved for future use.
-// Event types will be added here when schema lifecycle notifications are implemented.

--- a/src/fold_db_core/infrastructure/message_bus/mod.rs
+++ b/src/fold_db_core/infrastructure/message_bus/mod.rs
@@ -5,4 +5,4 @@ pub mod events;
 
 pub use async_bus::AsyncMessageBus;
 pub use error_handling::{MessageBusError, MessageBusResult};
-pub use events::{atom_events, query_events, request_events, schema_events, Event};
+pub use events::{atom_events, query_events, request_events, Event};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! * `fold_db_core` - Core database functionality
 //! * `schema` - Schema definition, validation, and execution
 //! * `security` - Cryptographic key management and signing
-//! * `storage` - Storage backend abstraction (Sled, DynamoDB)
+//! * `storage` - Storage backend abstraction (Sled, with optional cloud sync)
 //!
 //! ## Architecture
 //!

--- a/src/logging/core.rs
+++ b/src/logging/core.rs
@@ -1,7 +1,7 @@
-//! Logging abstraction for Lambda deployments
+//! Logging abstraction
 //!
 //! Provides a trait that users can implement with their choice of backend
-//! (DynamoDB, CloudWatch, S3, custom databases, etc.)
+//! (CloudWatch, file, web socket, etc.)
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -143,7 +143,7 @@ impl Logger for MultiAsyncLogger {
         // Query the first logger that supports querying?
         // Or aggregate?
         // For now, let's just query the first one that returns results, or just the first one.
-        // Typically, we only have one "storage" logger (DynamoDB) and one "stream" logger (Web).
+        // Typically, we only have one "storage" logger and one "stream" logger (Web).
         // Web might hold recent logs in memory.
 
         for logger in &self.loggers {

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -253,7 +253,7 @@ impl LoggingSystem {
             None
         };
 
-        // If we have a user_id, try GLOBAL_LOGGER first (e.g., DynamoDB)
+        // If we have a user_id, try GLOBAL_LOGGER first
         if let Some(uid) = &user_id {
             if let Some(logger) = GLOBAL_LOGGER.get() {
                 if let Ok(entries) = logger.query(uid, limit, from_timestamp).await {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,7 +1,7 @@
 //! Generic progress tracking system for FoldDB
 //!
 //! Provides a unified way to track long-running jobs (Ingestion, Indexing, etc.)
-//! with pluggable persistence (InMemory, DynamoDB).
+//! with pluggable persistence (InMemory for tests, Sled for production).
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -280,8 +280,7 @@ pub fn create_tracker_with_sled(pool: Arc<crate::storage::SledPool>) -> Progress
     Arc::new(SledProgressStore::new(pool))
 }
 
-/// Create a progress tracker with optional DynamoDB config
-pub async fn create_tracker(dynamo_config: Option<(String, String)>) -> ProgressTracker {
-    let _ = dynamo_config;
+/// Create an in-memory progress tracker (for testing or single-tenant use)
+pub async fn create_tracker() -> ProgressTracker {
     Arc::new(InMemoryProgressStore::new())
 }

--- a/src/storage/encrypting_namespaced_store.rs
+++ b/src/storage/encrypting_namespaced_store.rs
@@ -33,7 +33,7 @@ pub struct EncryptingNamespacedStore {
 impl EncryptingNamespacedStore {
     /// Create a new encrypting namespaced store.
     ///
-    /// - `inner`: The underlying namespaced store (Sled, DynamoDB, InMemory).
+    /// - `inner`: The underlying namespaced store (Sled, InMemory, etc.).
     /// - `crypto`: The crypto provider to use for encryption/decryption.
     /// - `migration_mode`: When `true`, plaintext reads are permitted (dual-read).
     pub fn new(

--- a/src/storage/encrypting_store.rs
+++ b/src/storage/encrypting_store.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// Prefix marker for encrypted values.
-/// On write: `ENC:` + base64(ciphertext) → valid UTF-8 string for DynamoDB `S` attributes.
+/// On write: `ENC:` + base64(ciphertext) → valid UTF-8 string.
 /// On read: detect prefix → strip → base64-decode → decrypt.
 const ENCRYPTED_PREFIX: &str = "ENC:";
 
@@ -23,13 +23,12 @@ const ENCRYPTED_PREFIX: &str = "ENC:";
 ///       ↓
 /// EncryptingKvStore (encrypt → base64 + prefix → valid UTF-8 string)
 ///       ↓
-/// DynamoDbKvStore / SledKvStore (stores as DynamoDB S attribute)
+/// SledKvStore / ExememApiStore (stores as UTF-8 string)
 /// ```
 ///
 /// Keys are NOT encrypted — only values. This preserves indexing and scan_prefix.
 ///
-/// Encrypted values are stored as `ENC:<base64(ciphertext)>` so they remain valid
-/// UTF-8 strings and survive DynamoDB's `S` attribute type, which requires UTF-8.
+/// Encrypted values are stored as `ENC:<base64(ciphertext)>` so they remain valid UTF-8.
 ///
 /// During migration (dual-read mode), values without the `ENC:` prefix are
 /// treated as pre-migration plaintext and returned as-is.

--- a/src/storage/exemem_api_store.rs
+++ b/src/storage/exemem_api_store.rs
@@ -21,8 +21,8 @@ pub enum ExememAuth {
 /// KvStore implementation that routes operations through the Exemem Storage API.
 ///
 /// Each instance is bound to a specific namespace. All keys and values are
-/// base64-encoded in transit. The Storage API Lambda handles DynamoDB routing,
-/// user isolation, and namespace-to-table mapping.
+/// base64-encoded in transit. The Storage API Lambda handles server-side routing,
+/// user isolation, and namespace mapping.
 pub struct ExememApiStore {
     client: Arc<Client>,
     base_url: String,
@@ -237,7 +237,7 @@ impl KvStore for ExememApiStore {
     }
 
     async fn flush(&self) -> StorageResult<()> {
-        // Storage API is eventually consistent (DynamoDB-backed), no flush needed
+        // Storage API is eventually consistent, no flush needed
         Ok(())
     }
 

--- a/src/storage/exemem_namespaced_store.rs
+++ b/src/storage/exemem_namespaced_store.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 /// `open_namespace` returns an `ExememApiStore` bound to that namespace.
 /// No server call is needed because the namespace is just a field in each
 /// request body — the Storage API Lambda resolves it to the correct
-/// DynamoDB table on the server side.
+/// storage partition on the server side.
 pub struct ExememNamespacedStore {
     client: Arc<Client>,
     base_url: String,

--- a/src/storage/syncing_store.rs
+++ b/src/storage/syncing_store.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 /// A KvStore decorator that records all write operations to the SyncEngine.
 ///
-/// Sits between EncryptingKvStore and the backend (Sled/DynamoDB):
+/// Sits between EncryptingKvStore and the storage backend:
 ///
 /// ```text
 /// TypedKvStore (JSON serialization)

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -7,7 +7,7 @@ use super::error::{StorageError, StorageResult};
 /// Describes how the backend executes operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecutionModel {
-    /// Backend is truly async (network I/O, e.g., DynamoDB)
+    /// Backend is truly async (network I/O, e.g., Exemem API)
     Async,
     /// Backend is sync but wrapped in async (local I/O, e.g., Sled)
     SyncWrapped,
@@ -16,7 +16,7 @@ pub enum ExecutionModel {
 /// Describes flush behavior for the backend
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlushBehavior {
-    /// Flush is a no-op (eventually consistent backend, e.g., DynamoDB)
+    /// Flush is a no-op (eventually consistent backend, e.g., Exemem API)
     NoOp,
     /// Flush performs actual persistence (strongly consistent, e.g., Sled)
     Persists,
@@ -25,7 +25,7 @@ pub enum FlushBehavior {
 /// Core key-value storage trait
 ///
 /// This is the fundamental storage interface that all backends must implement.
-/// Operations are async to support both local (Sled) and remote (DynamoDB) backends.
+/// Operations are async to support both local (Sled) and remote backends.
 #[async_trait]
 pub trait KvStore: Send + Sync {
     /// Get a value by key
@@ -71,7 +71,7 @@ pub trait KvStore: Send + Sync {
 /// Namespace storage trait
 ///
 /// Provides logical separation of data into "namespaces" or "trees"
-/// (like Sled's trees, DynamoDB tables, or Postgres schemas)
+/// (like Sled's trees or logical partitions in remote stores)
 #[async_trait]
 pub trait NamespacedStore: Send + Sync {
     /// Open or create a namespace (like sled::Tree)

--- a/src/storage/upload_storage.rs
+++ b/src/storage/upload_storage.rs
@@ -171,22 +171,6 @@ impl UploadStorage {
         matches!(self, Self::Local { .. })
     }
 
-    /// Returns true if this is S3 storage
-    pub fn is_s3(&self) -> bool {
-        false
-    }
-
-    /// Download a file from an external S3 path (bucket/key)
-    /// This is used for S3 event-triggered ingestion where files come from external buckets
-    pub async fn download_from_s3_path(&self, _bucket: &str, _key: &str) -> StorageResult<Vec<u8>> {
-        match self {
-            Self::Local { .. } => {
-                Err(StorageError::DownloadFailed(
-                    "S3 download not supported in local mode. Configure S3 storage to enable S3 downloads.".to_string()
-                ))
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -264,12 +248,11 @@ mod tests {
     }
 
     #[test]
-    fn test_is_local_and_is_s3() {
+    fn test_is_local() {
         let local = UploadStorage::Local {
             path: PathBuf::from("/tmp"),
         };
         assert!(local.is_local());
-        assert!(!local.is_s3());
     }
 
     #[test]

--- a/src/storage/upload_storage.rs
+++ b/src/storage/upload_storage.rs
@@ -170,7 +170,6 @@ impl UploadStorage {
     pub fn is_local(&self) -> bool {
         matches!(self, Self::Local { .. })
     }
-
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Remove dead `is_s3()` and `download_from_s3_path()` from UploadStorage (S3 variant was removed previously but these methods remained)
- Remove dead `molecules_store()` alias on DbOperations (identical to `atoms_store()`, only 1 internal caller)
- Remove empty `schema_events` module (placeholder with no content)
- Simplify `create_tracker()` — remove ignored `dynamo_config` parameter (always returned InMemory regardless)
- Fix ~20 stale DynamoDB references in comments and log messages across storage, operations, and logging modules

**Note:** `create_tracker()` signature changed (param removed). fold_db_node callers pass `None` today and will need a trivial update.

-38 lines net. Zero clippy warnings, all tests pass.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace --all-targets` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)