### PR TITLE
fix: prefer Sled cloud credentials over config file on startup

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -87,21 +87,20 @@ async fn create_local_fold_db(
     let config_store = NodeConfigStore::new(Arc::clone(&pool))
         .map_err(|e| FoldDbError::Config(format!("Failed to open config store: {}", e)))?;
 
-    // If no sync_setup provided but Sled has cloud credentials, build sync from Sled
-    let sync_setup = if sync_setup.is_none() {
-        if let Some(cloud_creds) = config_store.get_cloud_config() {
-            let data_dir = path_str;
-            log::info!("found cloud credentials in Sled config store — enabling sync");
-            Some(SyncSetup::from_exemem(
-                &cloud_creds.api_url,
-                &cloud_creds.api_key,
-                data_dir,
-            ))
-        } else {
-            None
-        }
+    // Resolve sync setup: prefer Sled credentials over config file.
+    // The Sled config store has the latest API key from the most recent registration.
+    // The config file may contain a stale (deactivated) key if the node was re-registered.
+    let sync_setup = if let Some(cloud_creds) = config_store.get_cloud_config() {
+        log::info!("Using cloud credentials from Sled config store (latest API key)");
+        Some(SyncSetup::from_exemem(
+            &cloud_creds.api_url,
+            &cloud_creds.api_key,
+            path_str,
+        ))
+    } else if let Some(setup) = sync_setup {
+        Some(setup)
     } else {
-        sync_setup
+        None
     };
 
     let base_store: Arc<dyn crate::storage::traits::NamespacedStore> =

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -636,6 +636,36 @@ impl SyncEngine {
         0 // Default to personal target
     }
 
+    /// Retry an S3 operation with exponential backoff.
+    /// Auth errors are NOT retried (they need token refresh at a higher level).
+    async fn retry_s3<F, Fut, T>(&self, label: &str, mut op: F) -> SyncResult<T>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = SyncResult<T>>,
+    {
+        let max_retries = self.config.max_retries;
+        for attempt in 0..max_retries {
+            match op().await {
+                Ok(v) => return Ok(v),
+                Err(e) if matches!(&e, SyncError::Auth(_)) => return Err(e),
+                Err(e) => {
+                    let delay_ms = 500 * 2u64.pow(attempt);
+                    log::warn!(
+                        "{}: attempt {}/{} failed ({}), retrying in {}ms",
+                        label,
+                        attempt + 1,
+                        max_retries + 1,
+                        e,
+                        delay_ms
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                }
+            }
+        }
+        // Final attempt — no retry, just propagate
+        op().await
+    }
+
     /// Upload entries to a single sync target.
     async fn upload_entries(&self, target: &SyncTarget, entries: &[LogEntry]) -> SyncResult<usize> {
         if entries.is_empty() {
@@ -661,8 +691,16 @@ impl SyncEngine {
         }
 
         let mut uploaded_count = 0;
-        for ((_seq, s), url) in sealed.into_iter().zip(urls.iter()) {
-            self.s3.upload(url, s.bytes).await?;
+        for ((seq, s), url) in sealed.into_iter().zip(urls.iter()) {
+            let url = url.clone();
+            let s3 = &self.s3;
+            let bytes = s.bytes;
+            self.retry_s3(&format!("upload seq {}", seq), || {
+                let url = url.clone();
+                let bytes = bytes.clone();
+                async move { s3.upload(&url, bytes).await }
+            })
+            .await?;
             uploaded_count += 1;
         }
 


### PR DESCRIPTION
## Summary
On startup, prefer Sled config store credentials over node_config.json.
The Sled store has the latest API key from the most recent registration.
The config file may contain a stale (deactivated) key.

## Test plan
- [x] cargo clippy — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)