### PR TITLE
refactor: enforce field classifications + TestSchemaBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,11 @@ pub mod security;
 pub mod storage;
 pub mod sync;
 pub mod testing_utils;
+
+/// Test utilities for building schemas with proper classifications.
+/// Always compiled (zero runtime cost when unused). Downstream crates
+/// can also access this via the `test-utils` feature.
+pub mod test_helpers;
 pub mod view;
 
 // Re-export main types for convenience

--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -520,6 +520,26 @@ impl SchemaCore {
                 SchemaError::InvalidData(format!("Failed to parse declarative schema: {}", e))
             })?;
 
+        // Validate all fields have data classifications
+        if let Some(ref fields) = declarative_schema.fields {
+            let unclassified: Vec<&str> = fields
+                .iter()
+                .filter(|f| {
+                    !declarative_schema
+                        .field_data_classifications
+                        .contains_key(*f)
+                })
+                .map(|f| f.as_str())
+                .collect();
+            if !unclassified.is_empty() {
+                return Err(SchemaError::InvalidData(format!(
+                    "Schema '{}' has unclassified fields: {}. All fields must have a DataClassification.",
+                    declarative_schema.name,
+                    unclassified.join(", ")
+                )));
+            }
+        }
+
         // Convert declarative schema to Schema
         let schema = self
             .interpret_declarative_schema(declarative_schema)
@@ -688,33 +708,20 @@ impl SchemaCore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::TestSchemaBuilder;
 
     fn blogpost_schema_json() -> String {
-        // Declarative schema format used in available_schemas
-        // Minimal fields map is acceptable per current parser
-        r#"{
-            "name": "BlogPost",
-            "key": { "range_field": "publish_date" },
-            "fields": {
-                "title": {},
-                "content": {},
-                "author": {},
-                "publish_date": {}
-            }
-        }"#
-        .to_string()
+        TestSchemaBuilder::new("BlogPost")
+            .fields(&["title", "content", "author"])
+            .range_key("publish_date")
+            .build_json()
     }
 
     fn wordindex_schema_json() -> String {
-        r#"{
-            "name": "BlogPostWordIndex",
-            "key": { "hash_field": "word", "range_field": "publish_date" },
-            "fields": {
-                "word": {},
-                "publish_date": {}
-            }
-        }"#
-        .to_string()
+        TestSchemaBuilder::new("BlogPostWordIndex")
+            .hash_key("word")
+            .range_key("publish_date")
+            .build_json()
     }
 
     #[tokio::test]

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,205 @@
+//! Test utilities for building schemas with proper classifications.
+//! Gated behind the `test-utils` cargo feature (or `#[cfg(test)]`).
+
+use serde_json::json;
+use std::collections::HashMap;
+
+/// Builder for test schemas with automatic field classification.
+/// Every field gets a DataClassification so schemas pass validation.
+pub struct TestSchemaBuilder {
+    name: String,
+    descriptive_name: Option<String>,
+    fields: Vec<String>,
+    hash_field: Option<String>,
+    range_field: Option<String>,
+    sensitivity: u8,
+    data_domain: String,
+    field_classifications: HashMap<String, (u8, String)>,
+    field_mappers: HashMap<String, String>,
+    field_types: HashMap<String, serde_json::Value>,
+    ref_fields: HashMap<String, String>,
+    org_hash: Option<String>,
+}
+
+impl TestSchemaBuilder {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            descriptive_name: None,
+            fields: Vec::new(),
+            hash_field: None,
+            range_field: None,
+            sensitivity: 0,
+            data_domain: "general".to_string(),
+            field_classifications: HashMap::new(),
+            field_mappers: HashMap::new(),
+            field_types: HashMap::new(),
+            ref_fields: HashMap::new(),
+            org_hash: None,
+        }
+    }
+
+    pub fn descriptive_name(mut self, name: &str) -> Self {
+        self.descriptive_name = Some(name.to_string());
+        self
+    }
+
+    pub fn field(mut self, name: &str) -> Self {
+        if !self.fields.contains(&name.to_string()) {
+            self.fields.push(name.to_string());
+        }
+        self
+    }
+
+    pub fn fields(mut self, names: &[&str]) -> Self {
+        for name in names {
+            if !self.fields.contains(&name.to_string()) {
+                self.fields.push(name.to_string());
+            }
+        }
+        self
+    }
+
+    pub fn range_key(mut self, field: &str) -> Self {
+        self.range_field = Some(field.to_string());
+        if !self.fields.contains(&field.to_string()) {
+            self.fields.push(field.to_string());
+        }
+        self
+    }
+
+    pub fn hash_key(mut self, field: &str) -> Self {
+        self.hash_field = Some(field.to_string());
+        if !self.fields.contains(&field.to_string()) {
+            self.fields.push(field.to_string());
+        }
+        self
+    }
+
+    /// Set default sensitivity for all fields (0=Public, 4=HighlyRestricted)
+    pub fn sensitivity(mut self, level: u8) -> Self {
+        self.sensitivity = level;
+        self
+    }
+
+    /// Set default data domain for all fields
+    pub fn domain(mut self, domain: &str) -> Self {
+        self.data_domain = domain.to_string();
+        self
+    }
+
+    /// Override classification for a specific field
+    pub fn classify(mut self, field: &str, sensitivity: u8, domain: &str) -> Self {
+        self.field_classifications
+            .insert(field.to_string(), (sensitivity, domain.to_string()));
+        self
+    }
+
+    /// Add a field mapper (e.g. "id" -> "User.id")
+    pub fn field_mapper(mut self, field: &str, source: &str) -> Self {
+        self.field_mappers
+            .insert(field.to_string(), source.to_string());
+        self
+    }
+
+    /// Add a typed field (e.g. "age" -> json!("Integer"))
+    pub fn field_type(mut self, field: &str, typ: serde_json::Value) -> Self {
+        self.field_types.insert(field.to_string(), typ);
+        self
+    }
+
+    /// Add a ref field (e.g. "posts" -> "Post")
+    pub fn ref_field(mut self, field: &str, target_schema: &str) -> Self {
+        self.ref_fields
+            .insert(field.to_string(), target_schema.to_string());
+        self
+    }
+
+    /// Set org_hash for org schemas
+    pub fn org_hash(mut self, hash: &str) -> Self {
+        self.org_hash = Some(hash.to_string());
+        self
+    }
+
+    /// Build the schema as a JSON string suitable for load_schema_from_json
+    pub fn build_json(&self) -> String {
+        let mut classifications = serde_json::Map::new();
+        for field in &self.fields {
+            let (sens, domain) = self
+                .field_classifications
+                .get(field)
+                .cloned()
+                .unwrap_or((self.sensitivity, self.data_domain.clone()));
+            classifications.insert(
+                field.clone(),
+                json!({
+                    "sensitivity_level": sens,
+                    "data_domain": domain
+                }),
+            );
+        }
+
+        let mut key = serde_json::Map::new();
+        if let Some(ref h) = self.hash_field {
+            key.insert("hash_field".to_string(), json!(h));
+        }
+        if let Some(ref r) = self.range_field {
+            key.insert("range_field".to_string(), json!(r));
+        }
+
+        let mut fields_map = serde_json::Map::new();
+        for field in &self.fields {
+            fields_map.insert(field.clone(), json!({}));
+        }
+
+        let mut schema = json!({
+            "name": self.name,
+            "fields": fields_map,
+            "field_data_classifications": classifications,
+        });
+
+        if !key.is_empty() {
+            schema
+                .as_object_mut()
+                .unwrap()
+                .insert("key".to_string(), serde_json::Value::Object(key));
+        }
+
+        if let Some(ref dn) = self.descriptive_name {
+            schema
+                .as_object_mut()
+                .unwrap()
+                .insert("descriptive_name".to_string(), json!(dn));
+        }
+
+        if !self.field_mappers.is_empty() {
+            schema
+                .as_object_mut()
+                .unwrap()
+                .insert("field_mappers".to_string(), json!(self.field_mappers));
+        }
+
+        if !self.field_types.is_empty() {
+            schema
+                .as_object_mut()
+                .unwrap()
+                .insert("field_types".to_string(), json!(self.field_types));
+        }
+
+        if !self.ref_fields.is_empty() {
+            schema
+                .as_object_mut()
+                .unwrap()
+                .insert("ref_fields".to_string(), json!(self.ref_fields));
+        }
+
+        if let Some(ref org) = self.org_hash {
+            schema
+                .as_object_mut()
+                .unwrap()
+                .insert("org_hash".to_string(), json!(org));
+        }
+
+        serde_json::to_string_pretty(&schema).unwrap()
+    }
+}

--- a/tests/access_control_test.rs
+++ b/tests/access_control_test.rs
@@ -7,6 +7,7 @@ use fold_db::schema::types::field::Field;
 use fold_db::schema::types::operations::{MutationType, Query};
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
+use fold_db::test_helpers::TestSchemaBuilder;
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -15,22 +16,19 @@ async fn setup_db() -> FoldDB {
     FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
 }
 
-fn notes_schema_json() -> &'static str {
-    r#"{
-        "name": "Notes",
-        "key": { "range_field": "created_at" },
-        "fields": {
-            "title": {},
-            "content": {},
-            "created_at": {}
-        }
-    }"#
+fn notes_schema_json() -> String {
+    TestSchemaBuilder::new("Notes")
+        .fields(&["title", "content"])
+        .range_key("created_at")
+        .build_json()
 }
 
 async fn setup_db_with_notes() -> FoldDB {
     let db = setup_db().await;
 
-    db.load_schema_from_json(notes_schema_json()).await.unwrap();
+    db.load_schema_from_json(&notes_schema_json())
+        .await
+        .unwrap();
     db.schema_manager
         .set_schema_state("Notes", SchemaState::Approved)
         .await

--- a/tests/field_mapper_approval_test.rs
+++ b/tests/field_mapper_approval_test.rs
@@ -1,36 +1,22 @@
 use fold_db::atom::deterministic_molecule_uuid;
 use fold_db::schema::types::field::Field;
 use fold_db::schema::{SchemaCore, SchemaState};
+use fold_db::test_helpers::TestSchemaBuilder;
 
 fn user_schema_json() -> String {
-    r#"{
-        "name": "User",
-        "key": { "range_field": "created_at" },
-        "fields": {
-            "id": {},
-            "name": {},
-            "created_at": {}
-        }
-    }"#
-    .to_string()
+    TestSchemaBuilder::new("User")
+        .fields(&["id", "name"])
+        .range_key("created_at")
+        .build_json()
 }
 
 fn user_public_schema_json() -> String {
-    r#"{
-        "name": "UserPublic",
-        "key": { "range_field": "created_at" },
-        "fields": {
-            "id": {},
-            "display_name": {},
-            "view_count": {},
-            "is_featured": {}
-        },
-        "field_mappers": {
-            "id": "User.id",
-            "display_name": "User.name"
-        }
-    }"#
-    .to_string()
+    TestSchemaBuilder::new("UserPublic")
+        .fields(&["id", "display_name", "view_count", "is_featured"])
+        .range_key("created_at")
+        .field_mapper("id", "User.id")
+        .field_mapper("display_name", "User.name")
+        .build_json()
 }
 
 #[tokio::test]

--- a/tests/field_type_validation_test.rs
+++ b/tests/field_type_validation_test.rs
@@ -2,6 +2,7 @@ use fold_db::fold_db_core::FoldDB;
 use fold_db::schema::types::operations::MutationType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
+use fold_db::test_helpers::TestSchemaBuilder;
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -10,42 +11,31 @@ async fn setup_db() -> FoldDB {
     FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
 }
 
-fn typed_schema_json() -> &'static str {
-    r#"{
-        "name": "Person",
-        "key": { "range_field": "created_at" },
-        "fields": {
-            "name": {},
-            "age": {},
-            "email": {},
-            "tags": {},
-            "created_at": {}
-        },
-        "field_types": {
-            "name": "String",
-            "age": "Integer",
-            "email": "String",
-            "tags": { "Array": "String" },
-            "created_at": "String"
-        }
-    }"#
+fn typed_schema_json() -> String {
+    TestSchemaBuilder::new("Person")
+        .fields(&["name", "age", "email", "tags"])
+        .range_key("created_at")
+        .field_type("name", json!("String"))
+        .field_type("age", json!("Integer"))
+        .field_type("email", json!("String"))
+        .field_type("tags", json!({"Array": "String"}))
+        .field_type("created_at", json!("String"))
+        .build_json()
 }
 
-fn untyped_schema_json() -> &'static str {
-    r#"{
-        "name": "Freeform",
-        "key": { "range_field": "id" },
-        "fields": {
-            "data": {},
-            "id": {}
-        }
-    }"#
+fn untyped_schema_json() -> String {
+    TestSchemaBuilder::new("Freeform")
+        .field("data")
+        .range_key("id")
+        .build_json()
 }
 
 #[tokio::test]
 async fn typed_schema_accepts_valid_mutation() {
     let db = setup_db().await;
-    db.load_schema_from_json(typed_schema_json()).await.unwrap();
+    db.load_schema_from_json(&typed_schema_json())
+        .await
+        .unwrap();
     db.schema_manager
         .set_schema_state("Person", SchemaState::Approved)
         .await
@@ -75,7 +65,9 @@ async fn typed_schema_accepts_valid_mutation() {
 #[tokio::test]
 async fn typed_schema_rejects_wrong_type() {
     let db = setup_db().await;
-    db.load_schema_from_json(typed_schema_json()).await.unwrap();
+    db.load_schema_from_json(&typed_schema_json())
+        .await
+        .unwrap();
     db.schema_manager
         .set_schema_state("Person", SchemaState::Approved)
         .await
@@ -115,7 +107,9 @@ async fn typed_schema_rejects_wrong_type() {
 #[tokio::test]
 async fn typed_schema_rejects_wrong_array_element_type() {
     let db = setup_db().await;
-    db.load_schema_from_json(typed_schema_json()).await.unwrap();
+    db.load_schema_from_json(&typed_schema_json())
+        .await
+        .unwrap();
     db.schema_manager
         .set_schema_state("Person", SchemaState::Approved)
         .await
@@ -150,7 +144,7 @@ async fn typed_schema_rejects_wrong_array_element_type() {
 #[tokio::test]
 async fn untyped_schema_accepts_anything() {
     let db = setup_db().await;
-    db.load_schema_from_json(untyped_schema_json())
+    db.load_schema_from_json(&untyped_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -186,36 +180,26 @@ async fn schema_ref_type_enforced() {
     let db = setup_db().await;
 
     // Create a child schema
-    db.load_schema_from_json(
-        r#"{
-            "name": "Post",
-            "key": { "range_field": "id" },
-            "fields": { "title": {}, "id": {} }
-        }"#,
-    )
-    .await
-    .unwrap();
+    let post_json = TestSchemaBuilder::new("Post")
+        .field("title")
+        .range_key("id")
+        .build_json();
+    db.load_schema_from_json(&post_json).await.unwrap();
     db.schema_manager
         .set_schema_state("Post", SchemaState::Approved)
         .await
         .unwrap();
 
     // Create a parent schema with a typed ref field
-    db.load_schema_from_json(
-        r#"{
-            "name": "User",
-            "key": { "range_field": "id" },
-            "fields": { "name": {}, "posts": {}, "id": {} },
-            "field_types": {
-                "name": "String",
-                "posts": { "SchemaRef": "Post" },
-                "id": "String"
-            },
-            "ref_fields": { "posts": "Post" }
-        }"#,
-    )
-    .await
-    .unwrap();
+    let user_json = TestSchemaBuilder::new("User")
+        .fields(&["name", "posts"])
+        .range_key("id")
+        .field_type("name", json!("String"))
+        .field_type("posts", json!({"SchemaRef": "Post"}))
+        .field_type("id", json!("String"))
+        .ref_field("posts", "Post")
+        .build_json();
+    db.load_schema_from_json(&user_json).await.unwrap();
     db.schema_manager
         .set_schema_state("User", SchemaState::Approved)
         .await

--- a/tests/org_database_test.rs
+++ b/tests/org_database_test.rs
@@ -10,6 +10,7 @@ use fold_db::schema::types::operations::{MutationType, Query, SortOrder};
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
 use fold_db::sync::org_sync::{SyncDestination, SyncPartitioner};
+use fold_db::test_helpers::TestSchemaBuilder;
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -24,19 +25,14 @@ async fn make_folddb(tmp: &tempfile::TempDir) -> FoldDB {
 }
 
 async fn register_schema(db: &FoldDB, name: &str, org_hash: Option<&str>) {
-    let org_hash_json = match org_hash {
-        Some(h) => format!(r#", "org_hash": "{}""#, h),
-        None => String::new(),
-    };
-    let json_str = format!(
-        r#"{{
-            "name": "{}",
-            "key": {{ "hash_field": "title", "range_field": "date" }},
-            "fields": {{ "title": {{}}, "body": {{}}, "date": {{}} }}
-            {}
-        }}"#,
-        name, org_hash_json
-    );
+    let mut builder = TestSchemaBuilder::new(name)
+        .fields(&["body"])
+        .hash_key("title")
+        .range_key("date");
+    if let Some(h) = org_hash {
+        builder = builder.org_hash(h);
+    }
+    let json_str = builder.build_json();
     db.load_schema_from_json(&json_str).await.unwrap();
     db.schema_manager
         .set_schema_state(name, SchemaState::Approved)

--- a/tests/org_key_prefixing_test.rs
+++ b/tests/org_key_prefixing_test.rs
@@ -11,6 +11,7 @@ use fold_db::schema::types::{
     DeclarativeSchemaDefinition, KeyConfig, KeyValue, Mutation, SchemaType,
 };
 use fold_db::schema::SchemaState;
+use fold_db::test_helpers::TestSchemaBuilder;
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -25,19 +26,14 @@ async fn make_folddb(tmp: &tempfile::TempDir) -> FoldDB {
 
 /// Helper: register a HashRange schema with optional org_hash via JSON.
 async fn register_schema(db: &FoldDB, name: &str, org_hash: Option<&str>) {
-    let org_hash_json = match org_hash {
-        Some(h) => format!(r#", "org_hash": "{}""#, h),
-        None => String::new(),
-    };
-    let json_str = format!(
-        r#"{{
-            "name": "{}",
-            "key": {{ "hash_field": "title", "range_field": "date" }},
-            "fields": {{ "title": {{}}, "body": {{}}, "date": {{}} }}
-            {}
-        }}"#,
-        name, org_hash_json
-    );
+    let mut builder = TestSchemaBuilder::new(name)
+        .fields(&["body"])
+        .hash_key("title")
+        .range_key("date");
+    if let Some(h) = org_hash {
+        builder = builder.org_hash(h);
+    }
+    let json_str = builder.build_json();
     db.load_schema_from_json(&json_str).await.unwrap();
     db.schema_manager
         .set_schema_state(name, SchemaState::Approved)

--- a/tests/org_sync_e2e_test.rs
+++ b/tests/org_sync_e2e_test.rs
@@ -11,6 +11,7 @@ use fold_db::schema::types::operations::MutationType;
 use fold_db::schema::types::operations::Query;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
+use fold_db::test_helpers::TestSchemaBuilder;
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -25,19 +26,14 @@ async fn make_folddb(tmp: &tempfile::TempDir) -> FoldDB {
 }
 
 async fn register_schema(db: &FoldDB, name: &str, org_hash: Option<&str>) {
-    let org_hash_json = match org_hash {
-        Some(h) => format!(r#", "org_hash": "{}""#, h),
-        None => String::new(),
-    };
-    let json_str = format!(
-        r#"{{
-            "name": "{}",
-            "key": {{ "hash_field": "title", "range_field": "date" }},
-            "fields": {{ "title": {{}}, "body": {{}}, "date": {{}} }}
-            {}
-        }}"#,
-        name, org_hash_json
-    );
+    let mut builder = TestSchemaBuilder::new(name)
+        .fields(&["body"])
+        .hash_key("title")
+        .range_key("date");
+    if let Some(h) = org_hash {
+        builder = builder.org_hash(h);
+    }
+    let json_str = builder.build_json();
     db.load_schema_from_json(&json_str).await.unwrap();
     db.schema_manager
         .set_schema_state(name, SchemaState::Approved)

--- a/tests/org_sync_encrypted_e2e_test.rs
+++ b/tests/org_sync_encrypted_e2e_test.rs
@@ -24,6 +24,7 @@ use fold_db::sync::auth::{AuthClient, SyncAuth};
 use fold_db::sync::log::{LogEntry, LogOp};
 use fold_db::sync::s3::S3Client;
 use fold_db::sync::{SyncConfig, SyncEngine};
+use fold_db::test_helpers::TestSchemaBuilder;
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -39,19 +40,14 @@ async fn make_folddb(tmp: &tempfile::TempDir) -> FoldDB {
 }
 
 async fn register_schema(db: &FoldDB, name: &str, org_hash: Option<&str>) {
-    let org_hash_json = match org_hash {
-        Some(h) => format!(r#", "org_hash": "{}""#, h),
-        None => String::new(),
-    };
-    let json_str = format!(
-        r#"{{
-            "name": "{}",
-            "key": {{ "hash_field": "title", "range_field": "date" }},
-            "fields": {{ "title": {{}}, "body": {{}}, "date": {{}} }}
-            {}
-        }}"#,
-        name, org_hash_json
-    );
+    let mut builder = TestSchemaBuilder::new(name)
+        .fields(&["body"])
+        .hash_key("title")
+        .range_key("date");
+    if let Some(h) = org_hash {
+        builder = builder.org_hash(h);
+    }
+    let json_str = builder.build_json();
     db.load_schema_from_json(&json_str).await.unwrap();
     db.schema_manager
         .set_schema_state(name, SchemaState::Approved)

--- a/tests/range_molecule_persistence_test.rs
+++ b/tests/range_molecule_persistence_test.rs
@@ -13,18 +13,17 @@ use fold_db::schema::types::field::Field;
 use fold_db::schema::types::key_value::KeyValue;
 use fold_db::schema::types::mutation::Mutation;
 use fold_db::schema::SchemaState;
+use fold_db::test_helpers::TestSchemaBuilder;
 use fold_db::MutationType;
 use serde_json::json;
 use std::collections::HashMap;
 use tempfile::TempDir;
 
 fn file_records_schema_json() -> String {
-    serde_json::to_string(&json!({
-        "name": "FileRecords",
-        "key": { "range_field": "source_file" },
-        "fields": ["source_file", "content", "file_type"]
-    }))
-    .unwrap()
+    TestSchemaBuilder::new("FileRecords")
+        .fields(&["content", "file_type"])
+        .range_key("source_file")
+        .build_json()
 }
 
 fn make_mutation(source_file: &str, content: &str, file_type: &str) -> Mutation {

--- a/tests/repro_schema_error.rs
+++ b/tests/repro_schema_error.rs
@@ -1,4 +1,5 @@
 use fold_db::fold_db_core::fold_db::FoldDB;
+use fold_db::test_helpers::TestSchemaBuilder;
 
 #[tokio::test]
 async fn test_reproduce_schema_mismatch() {
@@ -10,14 +11,13 @@ async fn test_reproduce_schema_mismatch() {
     let db_path = temp_dir.path().to_str().expect("failed to get path");
     let db = FoldDB::new(db_path).await.expect("Failed to create DB");
 
-    let schema_json = r#"{
-        "name": "lowercase_hash",
-        "key": { "hash_field": "id" },
-        "fields": { "id": {}, "data": {} }
-    }"#;
+    let schema_json = TestSchemaBuilder::new("lowercase_hash")
+        .hash_key("id")
+        .field("data")
+        .build_json();
 
     // 2. Load "lowercase_hash"
-    db.load_schema_from_json(schema_json)
+    db.load_schema_from_json(&schema_json)
         .await
         .expect("Failed to load schema");
     db.schema_manager()

--- a/tests/schema_superseded_by_test.rs
+++ b/tests/schema_superseded_by_test.rs
@@ -1,45 +1,25 @@
 use fold_db::schema::{SchemaCore, SchemaState};
+use fold_db::test_helpers::TestSchemaBuilder;
 
 fn schema_a_json() -> String {
-    r#"{
-        "name": "ContactV1",
-        "key": { "range_field": "created_at" },
-        "fields": {
-            "name": {},
-            "email": {},
-            "created_at": {}
-        }
-    }"#
-    .to_string()
+    TestSchemaBuilder::new("ContactV1")
+        .fields(&["name", "email"])
+        .range_key("created_at")
+        .build_json()
 }
 
 fn schema_b_json() -> String {
-    r#"{
-        "name": "ContactV2",
-        "key": { "range_field": "created_at" },
-        "fields": {
-            "name": {},
-            "email": {},
-            "phone": {},
-            "created_at": {}
-        }
-    }"#
-    .to_string()
+    TestSchemaBuilder::new("ContactV2")
+        .fields(&["name", "email", "phone"])
+        .range_key("created_at")
+        .build_json()
 }
 
 fn schema_c_json() -> String {
-    r#"{
-        "name": "ContactV3",
-        "key": { "range_field": "created_at" },
-        "fields": {
-            "name": {},
-            "email": {},
-            "phone": {},
-            "address": {},
-            "created_at": {}
-        }
-    }"#
-    .to_string()
+    TestSchemaBuilder::new("ContactV3")
+        .fields(&["name", "email", "phone", "address"])
+        .range_key("created_at")
+        .build_json()
 }
 
 #[tokio::test]

--- a/tests/view_invalidation_test.rs
+++ b/tests/view_invalidation_test.rs
@@ -5,6 +5,7 @@ use fold_db::schema::types::operations::{MutationType, Query};
 use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
+use fold_db::test_helpers::TestSchemaBuilder;
 use fold_db::view::types::{TransformView, ViewCacheState};
 use serde_json::json;
 use std::collections::HashMap;
@@ -14,16 +15,11 @@ async fn setup_db() -> FoldDB {
     FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
 }
 
-fn blogpost_schema_json() -> &'static str {
-    r#"{
-        "name": "BlogPost",
-        "key": { "range_field": "publish_date" },
-        "fields": {
-            "title": {},
-            "content": {},
-            "publish_date": {}
-        }
-    }"#
+fn blogpost_schema_json() -> String {
+    TestSchemaBuilder::new("BlogPost")
+        .fields(&["title", "content"])
+        .range_key("publish_date")
+        .build_json()
 }
 
 fn identity_view(name: &str, source_schema: &str, source_field: &str) -> TransformView {
@@ -45,7 +41,7 @@ async fn mutating_source_invalidates_view_cache() {
     let db = setup_db().await;
 
     // Setup: schema + data + view
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -125,7 +121,7 @@ async fn mutating_source_invalidates_view_cache() {
 async fn re_query_after_invalidation_re_caches() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -190,7 +186,7 @@ async fn cascading_invalidation_through_view_chain() {
     let db = setup_db().await;
 
     // Setup: schema + data
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -289,7 +285,7 @@ async fn cascading_invalidation_through_view_chain() {
 async fn view_chain_query_returns_source_data() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -348,7 +344,7 @@ async fn view_chain_query_returns_source_data() {
 async fn three_level_chain_resolves_to_source() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -407,7 +403,7 @@ async fn three_level_chain_resolves_to_source() {
 async fn chain_re_query_after_cascade_invalidation_gets_fresh_data() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -481,7 +477,7 @@ async fn multi_source_view_from_two_views() {
     let db = setup_db().await;
 
     // Create two source schemas
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -489,15 +485,11 @@ async fn multi_source_view_from_two_views() {
         .await
         .unwrap();
 
-    db.load_schema_from_json(
-        r#"{
-            "name": "Author",
-            "key": { "range_field": "publish_date" },
-            "fields": { "name": {}, "publish_date": {} }
-        }"#,
-    )
-    .await
-    .unwrap();
+    let author_json = TestSchemaBuilder::new("Author")
+        .field("name")
+        .range_key("publish_date")
+        .build_json();
+    db.load_schema_from_json(&author_json).await.unwrap();
     db.schema_manager
         .set_schema_state("Author", SchemaState::Approved)
         .await
@@ -588,7 +580,7 @@ async fn multi_source_view_from_two_views() {
 async fn three_level_cascade_invalidation() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager

--- a/tests/view_precomputation_test.rs
+++ b/tests/view_precomputation_test.rs
@@ -11,6 +11,7 @@ use fold_db::schema::types::operations::{MutationType, Query};
 use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
+use fold_db::test_helpers::TestSchemaBuilder;
 use fold_db::view::types::{TransformView, ViewCacheState};
 use serde_json::json;
 use std::collections::HashMap;
@@ -20,16 +21,11 @@ async fn setup_db() -> FoldDB {
     FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
 }
 
-fn blogpost_schema_json() -> &'static str {
-    r#"{
-        "name": "BlogPost",
-        "key": { "range_field": "publish_date" },
-        "fields": {
-            "title": {},
-            "content": {},
-            "publish_date": {}
-        }
-    }"#
+fn blogpost_schema_json() -> String {
+    TestSchemaBuilder::new("BlogPost")
+        .fields(&["title", "content"])
+        .range_key("publish_date")
+        .build_json()
 }
 
 fn identity_view(name: &str, source_schema: &str, source_field: &str) -> TransformView {
@@ -67,7 +63,7 @@ async fn deep_view_enters_computing_after_mutation() {
     let db = setup_db().await;
 
     // Setup: schema + data + 2-level view chain
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -136,7 +132,7 @@ async fn deep_view_enters_computing_after_mutation() {
 async fn deep_view_eventually_becomes_cached() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -184,7 +180,7 @@ async fn deep_view_eventually_becomes_cached() {
 async fn query_during_computing_returns_error() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -221,7 +217,7 @@ async fn query_during_computing_returns_error() {
 async fn three_level_chain_precomputes_bottom_up() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -309,7 +305,7 @@ async fn three_level_chain_precomputes_bottom_up() {
 async fn precomputed_view_has_fresh_data() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager

--- a/tests/view_query_test.rs
+++ b/tests/view_query_test.rs
@@ -5,6 +5,7 @@ use fold_db::schema::types::operations::{MutationType, Query};
 use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
+use fold_db::test_helpers::TestSchemaBuilder;
 use fold_db::view::types::TransformView;
 use serde_json::json;
 use std::collections::HashMap;
@@ -14,16 +15,11 @@ async fn setup_db() -> FoldDB {
     FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
 }
 
-fn blogpost_schema_json() -> &'static str {
-    r#"{
-        "name": "BlogPost",
-        "key": { "range_field": "publish_date" },
-        "fields": {
-            "title": {},
-            "content": {},
-            "publish_date": {}
-        }
-    }"#
+fn blogpost_schema_json() -> String {
+    TestSchemaBuilder::new("BlogPost")
+        .fields(&["title", "content"])
+        .range_key("publish_date")
+        .build_json()
 }
 
 fn identity_view(name: &str, source_schema: &str, source_field: &str) -> TransformView {
@@ -45,7 +41,7 @@ async fn query_identity_view_returns_source_data() {
     let db = setup_db().await;
 
     // Load and approve a schema
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -103,7 +99,7 @@ async fn query_nonexistent_name_errors() {
 async fn query_blocked_view_errors() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
 
@@ -121,7 +117,7 @@ async fn query_blocked_view_errors() {
 async fn query_view_with_empty_fields_returns_all() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -174,7 +170,7 @@ async fn query_view_with_empty_fields_returns_all() {
 async fn identity_view_write_redirects_to_source() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -219,7 +215,7 @@ async fn identity_view_write_redirects_to_source() {
 async fn identity_view_write_invalidates_view_cache() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -280,7 +276,7 @@ async fn identity_view_write_invalidates_view_cache() {
 async fn wasm_view_write_is_rejected() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager

--- a/tests/view_registration_test.rs
+++ b/tests/view_registration_test.rs
@@ -2,33 +2,23 @@ use fold_db::schema::types::field_value_type::FieldValueType;
 use fold_db::schema::types::operations::Query;
 use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::SchemaCore;
+use fold_db::test_helpers::TestSchemaBuilder;
 use fold_db::view::registry::ViewState;
 use fold_db::view::types::TransformView;
 use std::collections::HashMap;
 
 fn blogpost_schema_json() -> String {
-    r#"{
-        "name": "BlogPost",
-        "key": { "range_field": "publish_date" },
-        "fields": {
-            "title": {},
-            "content": {},
-            "publish_date": {}
-        }
-    }"#
-    .to_string()
+    TestSchemaBuilder::new("BlogPost")
+        .fields(&["title", "content"])
+        .range_key("publish_date")
+        .build_json()
 }
 
 fn weather_schema_json() -> String {
-    r#"{
-        "name": "Weather",
-        "key": { "range_field": "date" },
-        "fields": {
-            "temp_celsius": {},
-            "date": {}
-        }
-    }"#
-    .to_string()
+    TestSchemaBuilder::new("Weather")
+        .field("temp_celsius")
+        .range_key("date")
+        .build_json()
 }
 
 fn identity_view(name: &str, source_schema: &str, source_field: &str) -> TransformView {

--- a/tests/view_wasm_integration_test.rs
+++ b/tests/view_wasm_integration_test.rs
@@ -8,6 +8,7 @@ use fold_db::schema::types::operations::{MutationType, Query};
 use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
+use fold_db::test_helpers::TestSchemaBuilder;
 use fold_db::view::types::TransformView;
 use serde_json::json;
 use std::collections::HashMap;
@@ -54,16 +55,11 @@ async fn setup_db() -> FoldDB {
     FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
 }
 
-fn blogpost_schema_json() -> &'static str {
-    r#"{
-        "name": "BlogPost",
-        "key": { "range_field": "publish_date" },
-        "fields": {
-            "title": {},
-            "content": {},
-            "publish_date": {}
-        }
-    }"#
+fn blogpost_schema_json() -> String {
+    TestSchemaBuilder::new("BlogPost")
+        .fields(&["title", "content"])
+        .range_key("publish_date")
+        .build_json()
 }
 
 #[tokio::test]
@@ -71,7 +67,7 @@ async fn wasm_view_query_returns_transformed_output() {
     let db = setup_db().await;
 
     // Setup schema with data
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -123,7 +119,7 @@ async fn wasm_view_query_returns_transformed_output() {
 async fn wasm_view_output_type_validation_works() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -173,7 +169,7 @@ async fn wasm_view_output_type_validation_works() {
 async fn wasm_view_cache_invalidation_works() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager

--- a/tests/view_write_test.rs
+++ b/tests/view_write_test.rs
@@ -5,6 +5,7 @@ use fold_db::schema::types::operations::{MutationType, Query};
 use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
+use fold_db::test_helpers::TestSchemaBuilder;
 use fold_db::view::types::{TransformView, ViewCacheState};
 use serde_json::json;
 use std::collections::HashMap;
@@ -14,16 +15,11 @@ async fn setup_db() -> FoldDB {
     FoldDB::new(dir.path().to_str().unwrap()).await.unwrap()
 }
 
-fn blogpost_schema_json() -> &'static str {
-    r#"{
-        "name": "BlogPost",
-        "key": { "range_field": "publish_date" },
-        "fields": {
-            "title": {},
-            "content": {},
-            "publish_date": {}
-        }
-    }"#
+fn blogpost_schema_json() -> String {
+    TestSchemaBuilder::new("BlogPost")
+        .fields(&["title", "content"])
+        .range_key("publish_date")
+        .build_json()
 }
 
 fn identity_view(name: &str, source_schema: &str, source_field: &str) -> TransformView {
@@ -46,7 +42,7 @@ fn identity_view(name: &str, source_schema: &str, source_field: &str) -> Transfo
 async fn identity_write_redirects_to_source() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -108,7 +104,7 @@ async fn identity_write_redirects_to_source() {
 async fn wasm_view_write_is_rejected() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -165,7 +161,7 @@ async fn wasm_view_write_is_rejected() {
 async fn write_through_view_invalidates_cache() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager
@@ -234,7 +230,7 @@ async fn write_through_view_invalidates_cache() {
 async fn write_through_view_cascades_invalidation() {
     let db = setup_db().await;
 
-    db.load_schema_from_json(blogpost_schema_json())
+    db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
     db.schema_manager


### PR DESCRIPTION
## Summary
- `load_schema_from_json` now validates that every field has a `DataClassification` in `field_data_classifications` before loading the schema. Missing classifications produce a clear error listing the unclassified fields.
- New `TestSchemaBuilder` in `src/test_helpers.rs` auto-assigns default classifications (sensitivity=0, domain="general") for all fields, eliminating boilerplate in tests.
- All 17 test files and 2 inline test helper functions updated to use the builder pattern.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` passes (all tests green)
- [x] fold_db_node builds and tests pass against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)