### PR TITLE
refactor: deduplicate sync module helpers

### DIFF
--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -180,15 +180,8 @@ impl AuthClient {
 
     /// Presign a single URL: post the body, parse a PresignedResponse, extract one URL.
     async fn presign_single_url(&self, body: serde_json::Value) -> SyncResult<PresignedUrl> {
-        let resp = self.post("/api/sync/presign", body).await?;
-        let parsed: PresignedResponse = serde_json::from_value(resp)?;
-        if !parsed.ok {
-            return Err(SyncError::Auth(
-                parsed.error.unwrap_or_else(|| "presign failed".to_string()),
-            ));
-        }
-        parsed
-            .urls
+        self.presign_urls(body)
+            .await?
             .into_iter()
             .next()
             .ok_or_else(|| SyncError::Auth("no presigned URL returned".to_string()))
@@ -246,21 +239,11 @@ impl AuthClient {
 
     /// Request presigned URLs for deleting log entries.
     pub async fn presign_log_delete(&self, seq_numbers: &[u64]) -> SyncResult<Vec<PresignedUrl>> {
-        let body = serde_json::json!({
+        self.presign_urls(serde_json::json!({
             "action": "presign_log_delete",
             "seq_numbers": seq_numbers,
-        });
-
-        let resp = self.post("/api/sync/presign", body).await?;
-        let parsed: PresignedResponse = serde_json::from_value(resp)?;
-
-        if !parsed.ok {
-            return Err(SyncError::Auth(
-                parsed.error.unwrap_or_else(|| "presign failed".to_string()),
-            ));
-        }
-
-        Ok(parsed.urls)
+        }))
+        .await
     }
 
     /// Acquire the device lock.
@@ -332,29 +315,50 @@ impl AuthClient {
     // Sync operations (unified personal + org)
     // =========================================================================
 
-    /// Presign URLs for uploading log entries to a sync target.
-    pub async fn presign_upload(
-        &self,
-        target: &super::org_sync::SyncTarget,
-        seq_numbers: &[u64],
-    ) -> SyncResult<Vec<PresignedUrl>> {
-        let mut body = serde_json::json!({
-            "action": "presign_log_upload",
-            "seq_numbers": seq_numbers,
-        });
-        if !target.prefix.is_empty() {
-            body["org_hash"] = serde_json::Value::String(target.prefix.clone());
-        }
+    /// Post to the presign endpoint and parse the response, returning all URLs.
+    async fn presign_urls(&self, body: serde_json::Value) -> SyncResult<Vec<PresignedUrl>> {
+        let action = body
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("presign")
+            .to_string();
         let resp = self.post("/api/sync/presign", body).await?;
         let parsed: PresignedResponse = serde_json::from_value(resp)?;
         if !parsed.ok {
             return Err(SyncError::Auth(
                 parsed
                     .error
-                    .unwrap_or_else(|| "presign upload failed".to_string()),
+                    .unwrap_or_else(|| format!("{action} failed")),
             ));
         }
         Ok(parsed.urls)
+    }
+
+    /// Presign multiple URLs for a log action (upload or download) on a sync target.
+    async fn presign_log_urls(
+        &self,
+        action: &str,
+        target: &super::org_sync::SyncTarget,
+        seq_numbers: &[u64],
+    ) -> SyncResult<Vec<PresignedUrl>> {
+        let mut body = serde_json::json!({
+            "action": action,
+            "seq_numbers": seq_numbers,
+        });
+        if !target.prefix.is_empty() {
+            body["org_hash"] = serde_json::Value::String(target.prefix.clone());
+        }
+        self.presign_urls(body).await
+    }
+
+    /// Presign URLs for uploading log entries to a sync target.
+    pub async fn presign_upload(
+        &self,
+        target: &super::org_sync::SyncTarget,
+        seq_numbers: &[u64],
+    ) -> SyncResult<Vec<PresignedUrl>> {
+        self.presign_log_urls("presign_log_upload", target, seq_numbers)
+            .await
     }
 
     /// Presign URLs for downloading log entries from a sync target.
@@ -363,23 +367,8 @@ impl AuthClient {
         target: &super::org_sync::SyncTarget,
         seq_numbers: &[u64],
     ) -> SyncResult<Vec<PresignedUrl>> {
-        let mut body = serde_json::json!({
-            "action": "presign_log_download",
-            "seq_numbers": seq_numbers,
-        });
-        if !target.prefix.is_empty() {
-            body["org_hash"] = serde_json::Value::String(target.prefix.clone());
-        }
-        let resp = self.post("/api/sync/presign", body).await?;
-        let parsed: PresignedResponse = serde_json::from_value(resp)?;
-        if !parsed.ok {
-            return Err(SyncError::Auth(
-                parsed
-                    .error
-                    .unwrap_or_else(|| "presign download failed".to_string()),
-            ));
-        }
-        Ok(parsed.urls)
+        self.presign_log_urls("presign_log_download", target, seq_numbers)
+            .await
     }
 
     /// List log objects for a sync target.

--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -326,9 +326,7 @@ impl AuthClient {
         let parsed: PresignedResponse = serde_json::from_value(resp)?;
         if !parsed.ok {
             return Err(SyncError::Auth(
-                parsed
-                    .error
-                    .unwrap_or_else(|| format!("{action} failed")),
+                parsed.error.unwrap_or_else(|| format!("{action} failed")),
             ));
         }
         Ok(parsed.urls)

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1112,7 +1112,11 @@ impl SyncEngine {
             _ => return None,
         };
         let conflicts = local.merge_into_conflicts(&incoming);
-        Some(serde_json::to_vec(&local).map(|merged| (merged, conflicts)).map_err(Into::into))
+        Some(
+            serde_json::to_vec(&local)
+                .map(|merged| (merged, conflicts))
+                .map_err(Into::into),
+        )
     }
 
     /// Attempt molecule merge by trying each molecule type in order.

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -94,6 +94,39 @@ impl Default for SyncConfig {
 /// Callback for sync status changes.
 pub type StatusCallback = Box<dyn Fn(SyncState, Option<&str>) + Send + Sync>;
 
+/// Unified merge interface for all molecule types.
+///
+/// Each molecule type has a `merge` method but with slightly different return types
+/// (`Vec<MergeConflict>` vs `Option<MergeConflict>`). This trait normalizes them
+/// into a single `Vec<MergeConflict>` so `try_merge` can be generic.
+trait MergeMolecule {
+    fn merge_into_conflicts(&mut self, other: &Self) -> Vec<MergeConflict>;
+}
+
+impl MergeMolecule for MoleculeHash {
+    fn merge_into_conflicts(&mut self, other: &Self) -> Vec<MergeConflict> {
+        self.merge(other)
+    }
+}
+
+impl MergeMolecule for MoleculeRange {
+    fn merge_into_conflicts(&mut self, other: &Self) -> Vec<MergeConflict> {
+        self.merge(other)
+    }
+}
+
+impl MergeMolecule for MoleculeHashRange {
+    fn merge_into_conflicts(&mut self, other: &Self) -> Vec<MergeConflict> {
+        self.merge(other)
+    }
+}
+
+impl MergeMolecule for Molecule {
+    fn merge_into_conflicts(&mut self, other: &Self) -> Vec<MergeConflict> {
+        self.merge(other).into_iter().collect()
+    }
+}
+
 /// Async callback that reloads an in-memory cache from persistent storage.
 /// Returns the number of newly added items, or an error string.
 /// Used for both schema and embedding reloaders — same signature.
@@ -325,31 +358,30 @@ impl SyncEngine {
     // Recording operations
     // =========================================================================
 
-    /// Record a put operation for sync.
-    pub async fn record_put(&self, namespace: &str, key: &[u8], value: &[u8]) {
-        let entry = self
-            .make_entry(LogOp::Put {
-                namespace: namespace.to_string(),
-                key: LogOp::encode_bytes(key),
-                value: LogOp::encode_bytes(value),
-            })
-            .await;
-
+    /// Record an operation: create a log entry, push to pending, mark dirty.
+    async fn record_op(&self, op: LogOp) {
+        let entry = self.make_entry(op).await;
         self.pending.lock().await.push(entry);
         self.set_state(SyncState::Dirty, None).await;
     }
 
+    /// Record a put operation for sync.
+    pub async fn record_put(&self, namespace: &str, key: &[u8], value: &[u8]) {
+        self.record_op(LogOp::Put {
+            namespace: namespace.to_string(),
+            key: LogOp::encode_bytes(key),
+            value: LogOp::encode_bytes(value),
+        })
+        .await;
+    }
+
     /// Record a delete operation for sync.
     pub async fn record_delete(&self, namespace: &str, key: &[u8]) {
-        let entry = self
-            .make_entry(LogOp::Delete {
-                namespace: namespace.to_string(),
-                key: LogOp::encode_bytes(key),
-            })
-            .await;
-
-        self.pending.lock().await.push(entry);
-        self.set_state(SyncState::Dirty, None).await;
+        self.record_op(LogOp::Delete {
+            namespace: namespace.to_string(),
+            key: LogOp::encode_bytes(key),
+        })
+        .await;
     }
 
     /// Record a batch put operation for sync.
@@ -359,30 +391,22 @@ impl SyncEngine {
             .map(|(k, v)| (LogOp::encode_bytes(k), LogOp::encode_bytes(v)))
             .collect();
 
-        let entry = self
-            .make_entry(LogOp::BatchPut {
-                namespace: namespace.to_string(),
-                items: encoded_items,
-            })
-            .await;
-
-        self.pending.lock().await.push(entry);
-        self.set_state(SyncState::Dirty, None).await;
+        self.record_op(LogOp::BatchPut {
+            namespace: namespace.to_string(),
+            items: encoded_items,
+        })
+        .await;
     }
 
     /// Record a batch delete operation for sync.
     pub async fn record_batch_delete(&self, namespace: &str, keys: &[Vec<u8>]) {
         let encoded_keys: Vec<String> = keys.iter().map(|k| LogOp::encode_bytes(k)).collect();
 
-        let entry = self
-            .make_entry(LogOp::BatchDelete {
-                namespace: namespace.to_string(),
-                keys: encoded_keys,
-            })
-            .await;
-
-        self.pending.lock().await.push(entry);
-        self.set_state(SyncState::Dirty, None).await;
+        self.record_op(LogOp::BatchDelete {
+            namespace: namespace.to_string(),
+            keys: encoded_keys,
+        })
+        .await;
     }
 
     async fn make_entry(&self, op: LogOp) -> LogEntry {
@@ -572,33 +596,9 @@ impl SyncEngine {
         // Download from all org targets
         for target in &targets {
             if !target.prefix.is_empty() {
-                match self.download_entries(target).await {
+                match self.download_with_auth_retry(target).await {
                     Ok(n) => downloaded += n,
-                    Err(e) => {
-                        // On auth errors, try refreshing credentials and retry
-                        if matches!(&e, SyncError::Auth(_)) {
-                            if let Some(ref refresh_cb) = self.auth_refresh {
-                                log::info!(
-                                    "org download from '{}' auth failed, refreshing",
-                                    target.label
-                                );
-                                if let Ok(new_auth) = refresh_cb().await {
-                                    self.auth.update_auth(new_auth).await;
-                                    match self.download_entries(target).await {
-                                        Ok(n) => {
-                                            downloaded += n;
-                                            continue;
-                                        }
-                                        Err(retry_err) => log::warn!(
-                                            "org download from '{}' retry failed: {retry_err}",
-                                            target.label
-                                        ),
-                                    }
-                                }
-                            }
-                        }
-                        log::warn!("download from '{}' failed: {e}", target.label);
-                    }
+                    Err(e) => log::warn!("download from '{}' failed: {e}", target.label),
                 }
             }
         }
@@ -705,6 +705,30 @@ impl SyncEngine {
         }
 
         Ok(uploaded_count)
+    }
+
+    /// Download entries from a target, refreshing auth once on 401.
+    async fn download_with_auth_retry(&self, target: &SyncTarget) -> SyncResult<u64> {
+        match self.download_entries(target).await {
+            Ok(n) => Ok(n),
+            Err(ref e) if matches!(e, SyncError::Auth(_)) => {
+                if let Some(ref refresh_cb) = self.auth_refresh {
+                    log::info!(
+                        "org download from '{}' auth failed, refreshing",
+                        target.label
+                    );
+                    if let Ok(new_auth) = refresh_cb().await {
+                        self.auth.update_auth(new_auth).await;
+                        return self.download_entries(target).await;
+                    }
+                }
+                Err(SyncError::Auth(format!(
+                    "download from '{}' failed after auth refresh",
+                    target.label
+                )))
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Download new entries from a sync target.
@@ -1071,51 +1095,43 @@ impl SyncEngine {
         Ok(())
     }
 
+    /// Try to parse both byte slices as type `T`, merge, and serialize back.
+    /// Returns `None` if either side fails to deserialize (caller should try the next type).
+    fn try_merge<T>(
+        local_bytes: &[u8],
+        incoming_bytes: &[u8],
+    ) -> Option<SyncResult<(Vec<u8>, Vec<MergeConflict>)>>
+    where
+        T: serde::de::DeserializeOwned + serde::Serialize + MergeMolecule,
+    {
+        let (mut local, incoming) = match (
+            serde_json::from_slice::<T>(local_bytes),
+            serde_json::from_slice::<T>(incoming_bytes),
+        ) {
+            (Ok(l), Ok(i)) => (l, i),
+            _ => return None,
+        };
+        let conflicts = local.merge_into_conflicts(&incoming);
+        Some(serde_json::to_vec(&local).map(|merged| (merged, conflicts)).map_err(Into::into))
+    }
+
     /// Attempt molecule merge by trying each molecule type in order.
     /// Returns the serialized merged result and any conflicts.
     fn merge_molecules(
         local_bytes: &[u8],
         incoming_bytes: &[u8],
     ) -> SyncResult<(Vec<u8>, Vec<MergeConflict>)> {
-        // Try MoleculeHash (HashMap-based atom_uuids)
-        if let (Ok(mut local), Ok(incoming)) = (
-            serde_json::from_slice::<MoleculeHash>(local_bytes),
-            serde_json::from_slice::<MoleculeHash>(incoming_bytes),
-        ) {
-            let conflicts = local.merge(&incoming);
-            let merged = serde_json::to_vec(&local)?;
-            return Ok((merged, conflicts));
+        if let Some(result) = Self::try_merge::<MoleculeHash>(local_bytes, incoming_bytes) {
+            return result;
         }
-
-        // Try MoleculeRange (BTreeMap-based atom_uuids)
-        if let (Ok(mut local), Ok(incoming)) = (
-            serde_json::from_slice::<MoleculeRange>(local_bytes),
-            serde_json::from_slice::<MoleculeRange>(incoming_bytes),
-        ) {
-            let conflicts = local.merge(&incoming);
-            let merged = serde_json::to_vec(&local)?;
-            return Ok((merged, conflicts));
+        if let Some(result) = Self::try_merge::<MoleculeRange>(local_bytes, incoming_bytes) {
+            return result;
         }
-
-        // Try MoleculeHashRange (nested HashMap<BTreeMap>)
-        if let (Ok(mut local), Ok(incoming)) = (
-            serde_json::from_slice::<MoleculeHashRange>(local_bytes),
-            serde_json::from_slice::<MoleculeHashRange>(incoming_bytes),
-        ) {
-            let conflicts = local.merge(&incoming);
-            let merged = serde_json::to_vec(&local)?;
-            return Ok((merged, conflicts));
+        if let Some(result) = Self::try_merge::<MoleculeHashRange>(local_bytes, incoming_bytes) {
+            return result;
         }
-
-        // Try Molecule (single atom ref)
-        if let (Ok(mut local), Ok(incoming)) = (
-            serde_json::from_slice::<Molecule>(local_bytes),
-            serde_json::from_slice::<Molecule>(incoming_bytes),
-        ) {
-            let conflict = local.merge(&incoming);
-            let conflicts = conflict.into_iter().collect::<Vec<_>>();
-            let merged = serde_json::to_vec(&local)?;
-            return Ok((merged, conflicts));
+        if let Some(result) = Self::try_merge::<Molecule>(local_bytes, incoming_bytes) {
+            return result;
         }
 
         // None of the molecule types matched — just use incoming bytes as-is

--- a/src/sync/s3.rs
+++ b/src/sync/s3.rs
@@ -26,11 +26,7 @@ impl S3Client {
     }
 
     /// Check an S3 response status and return an error with the operation label if it failed.
-    fn check_response(
-        status: reqwest::StatusCode,
-        body: &str,
-        operation: &str,
-    ) -> SyncResult<()> {
+    fn check_response(status: reqwest::StatusCode, body: &str, operation: &str) -> SyncResult<()> {
         if !status.is_success() {
             return Err(SyncError::S3(format!(
                 "{operation} failed: HTTP {status}: {body}"

--- a/src/sync/s3.rs
+++ b/src/sync/s3.rs
@@ -25,6 +25,20 @@ impl S3Client {
         Self { http }
     }
 
+    /// Check an S3 response status and return an error with the operation label if it failed.
+    fn check_response(
+        status: reqwest::StatusCode,
+        body: &str,
+        operation: &str,
+    ) -> SyncResult<()> {
+        if !status.is_success() {
+            return Err(SyncError::S3(format!(
+                "{operation} failed: HTTP {status}: {body}"
+            )));
+        }
+        Ok(())
+    }
+
     /// Upload bytes to S3 using a presigned PUT URL.
     pub async fn upload(&self, presigned: &PresignedUrl, data: Vec<u8>) -> SyncResult<()> {
         let response = self
@@ -35,15 +49,9 @@ impl S3Client {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(SyncError::S3(format!(
-                "upload failed: HTTP {status}: {body}"
-            )));
-        }
-
-        Ok(())
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Self::check_response(status, &body, "upload")
     }
 
     /// Download bytes from S3 using a presigned GET URL.
@@ -56,8 +64,8 @@ impl S3Client {
             return Ok(None);
         }
 
-        if !response.status().is_success() {
-            let status = response.status();
+        let status = response.status();
+        if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
             return Err(SyncError::S3(format!(
                 "download failed: HTTP {status}: {body}"
@@ -72,15 +80,9 @@ impl S3Client {
     pub async fn delete(&self, presigned: &PresignedUrl) -> SyncResult<()> {
         let response = self.http.delete(&presigned.url).send().await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(SyncError::S3(format!(
-                "delete failed: HTTP {status}: {body}"
-            )));
-        }
-
-        Ok(())
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Self::check_response(status, &body, "delete")
     }
 }
 


### PR DESCRIPTION
## Summary
- **auth.rs**: Extract `presign_urls()` and `presign_log_urls()` helpers to eliminate duplicated parse-and-check logic across `presign_upload`, `presign_download`, `presign_log_delete`, and `presign_single_url`
- **engine.rs**: Extract `record_op()` to unify the make_entry/push/set_state pattern across all four `record_*` methods
- **engine.rs**: Introduce `MergeMolecule` trait + generic `try_merge()` to replace four near-identical parse-merge-serialize blocks in `merge_molecules()`
- **engine.rs**: Extract `download_with_auth_retry()` to remove inline auth refresh logic that duplicated the top-level retry pattern
- **s3.rs**: Extract `check_response()` to unify status checking in upload/delete

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace --all-targets` passes (all 49 sync tests green)
- [x] No public API changes — all extractions are internal helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)