### PR TITLE
simplify: clean up sync module (round 25)

### DIFF
--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -138,11 +138,8 @@ impl AuthClient {
             ));
         }
 
-        // Let HTTP 403 pass through to be handled by the caller, so we can discern
-        // if it's a global ban vs an organizational-level ban.
-        if status == reqwest::StatusCode::FORBIDDEN {
-            // we try to parse it as JSON if it has an error payload, otherwise bubble it
-        }
+        // HTTP 403 falls through to JSON parsing below, so the caller can
+        // distinguish a global ban from an org-level ban via the error payload.
 
         if status.is_server_error() {
             let body = response.text().await.unwrap_or_default();

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -465,12 +465,12 @@ impl SyncEngine {
     /// Record a sync failure: store the error message and transition state.
     async fn record_sync_failure(&self, err: &SyncError) {
         let msg = err.to_string();
-        *self.last_error.lock().await = Some(msg.clone());
         let new_state = match err {
             SyncError::Network(_) => SyncState::Offline,
             _ => SyncState::Dirty,
         };
         self.set_state(new_state, Some(&msg)).await;
+        *self.last_error.lock().await = Some(msg);
     }
 
     /// Run one sync cycle: upload pending log entries, compact if needed.
@@ -1056,8 +1056,7 @@ impl SyncEngine {
                 key,
                 value,
             } => {
-                self.replay_put(namespace, key, value, entry.timestamp_ms, &entry.device_id)
-                    .await?;
+                self.replay_put(namespace, key, value).await?;
             }
             LogOp::Delete { namespace, key } => {
                 let kv = self.store.open_namespace(namespace).await?;
@@ -1066,8 +1065,7 @@ impl SyncEngine {
             }
             LogOp::BatchPut { namespace, items } => {
                 for (key, value) in items {
-                    self.replay_put(namespace, key, value, entry.timestamp_ms, &entry.device_id)
-                        .await?;
+                    self.replay_put(namespace, key, value).await?;
                 }
             }
             LogOp::BatchDelete { namespace, keys } => {
@@ -1088,11 +1086,10 @@ impl SyncEngine {
         namespace: &str,
         key_b64: &str,
         value_b64: &str,
-        _timestamp_ms: u64,
-        _device_id: &str,
     ) -> SyncResult<()> {
         let key_bytes = LogOp::decode_bytes(key_b64)?;
         let value_bytes = LogOp::decode_bytes(value_b64)?;
+        let kv = self.store.open_namespace(namespace).await?;
 
         let is_ref_key = key_bytes.starts_with(b"ref:")
             || std::str::from_utf8(&key_bytes)
@@ -1108,7 +1105,6 @@ impl SyncEngine {
                 .unwrap_or(key_str)
                 .to_string();
 
-            let kv = self.store.open_namespace(namespace).await?;
             let local_bytes = kv.get(&key_bytes).await?;
 
             match local_bytes {
@@ -1128,8 +1124,7 @@ impl SyncEngine {
                 }
             }
         } else {
-            let kv = self.store.open_namespace(namespace).await?;
-            kv.put(&key_bytes, value_bytes.clone()).await?;
+            kv.put(&key_bytes, value_bytes).await?;
         }
 
         Ok(())

--- a/src/sync/error.rs
+++ b/src/sync/error.rs
@@ -26,17 +26,11 @@ pub enum SyncError {
     #[error("corrupt log entry at seq {seq}: {reason}")]
     CorruptEntry { seq: u64, reason: String },
 
-    #[error("sequence gap: expected {expected}, found {found}")]
-    SequenceGap { expected: u64, found: u64 },
-
     #[error("device locked by {device_id}, expires at {expires_at}")]
     DeviceLocked {
         device_id: String,
         expires_at: String,
     },
-
-    #[error("snapshot too large: {size_bytes} bytes")]
-    SnapshotTooLarge { size_bytes: u64 },
 
     #[error("wrong encryption key")]
     WrongKey,


### PR DESCRIPTION
## Summary
- Remove unused `SyncError::SequenceGap` and `SyncError::SnapshotTooLarge` variants (dead code, never constructed)
- Remove unused `_timestamp_ms` and `_device_id` params from `replay_put` (carried through 3 call sites but never read)
- Hoist `open_namespace` call above the ref-key branch in `replay_put` to eliminate duplicate call
- Remove unnecessary `value_bytes.clone()` in non-ref replay path (owned value consumed on last use)
- Eliminate unnecessary `msg.clone()` in `record_sync_failure` by reordering operations
- Replace dead 403 if-block in `auth.rs` (empty body, misleading comment) with a clear explanatory comment

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` passes (all existing sync tests)
- [x] No behavioral changes -- all changes are dead code removal, parameter cleanup, and clone elimination

🤖 Generated with [Claude Code](https://claude.com/claude-code)