### PR TITLE
refactor: make FoldDB fields pub(crate) with accessor methods

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -26,25 +26,25 @@ use crate::progress::ProgressTracker;
 
 /// The main database coordinator that manages schemas, permissions, and data storage.
 pub struct FoldDB {
-    pub schema_manager: Arc<SchemaCore>,
+    pub(crate) schema_manager: Arc<SchemaCore>,
     /// Shared database operations with storage abstraction
-    pub db_ops: Arc<DbOperations>,
+    pub(crate) db_ops: Arc<DbOperations>,
     /// SledPool for on-demand Sled access (e.g., org operations, config store).
     /// Only present when using the Sled backend.
     sled_pool: Option<Arc<SledPool>>,
     /// Query executor for handling all query operations
-    pub query_executor: QueryExecutor,
+    pub(crate) query_executor: QueryExecutor,
     /// Message bus for event-driven communication (held for Arc lifetime)
-    pub message_bus: Arc<AsyncMessageBus>,
+    pub(crate) message_bus: Arc<AsyncMessageBus>,
     /// Event monitor for system-wide observability
-    pub event_monitor: Arc<EventMonitor>,
+    pub(crate) event_monitor: Arc<EventMonitor>,
     /// Mutation manager for handling all mutation operations
-    pub mutation_manager: MutationManager,
+    pub(crate) mutation_manager: MutationManager,
     /// Tracker for pending background tasks
-    pub pending_tasks: Arc<super::infrastructure::pending_task_tracker::PendingTaskTracker>,
+    pub(crate) pending_tasks: Arc<super::infrastructure::pending_task_tracker::PendingTaskTracker>,
     /// Unified progress tracker for all job types (ingestion, indexing, etc.)
     /// This is the single source of truth for progress — uses Sled for persistent storage.
-    pub progress_tracker: ProgressTracker,
+    pub(crate) progress_tracker: ProgressTracker,
     /// Optional sync engine for S3 replication.
     /// Present when sync is configured (local mode only).
     /// Uses RwLock for interior mutability so FoldDB doesn't need &mut self.
@@ -549,9 +549,29 @@ impl FoldDB {
         self.schema_manager.load_schema_from_file(path).await
     }
 
-    /// Provides access to the underlying database operations
+    /// Provides access to the underlying database operations (cloned Arc)
     pub fn get_db_ops(&self) -> Arc<DbOperations> {
         Arc::clone(&self.db_ops)
+    }
+
+    /// Returns a reference to the database operations Arc
+    pub fn db_ops(&self) -> &Arc<DbOperations> {
+        &self.db_ops
+    }
+
+    /// Returns a reference to the query executor
+    pub fn query_executor(&self) -> &QueryExecutor {
+        &self.query_executor
+    }
+
+    /// Returns a reference to the event monitor
+    pub fn event_monitor(&self) -> &EventMonitor {
+        &self.event_monitor
+    }
+
+    /// Returns a reference to the pending task tracker
+    pub fn pending_tasks(&self) -> &Arc<super::infrastructure::pending_task_tracker::PendingTaskTracker> {
+        &self.pending_tasks
     }
 
     /// Get current event statistics from the event monitor

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -570,7 +570,9 @@ impl FoldDB {
     }
 
     /// Returns a reference to the pending task tracker
-    pub fn pending_tasks(&self) -> &Arc<super::infrastructure::pending_task_tracker::PendingTaskTracker> {
+    pub fn pending_tasks(
+        &self,
+    ) -> &Arc<super::infrastructure::pending_task_tracker::PendingTaskTracker> {
         &self.pending_tasks
     }
 

--- a/tests/access_control_test.rs
+++ b/tests/access_control_test.rs
@@ -29,7 +29,7 @@ async fn setup_db_with_notes() -> FoldDB {
     db.load_schema_from_json(&notes_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("Notes", SchemaState::Approved)
         .await
         .unwrap();
@@ -46,7 +46,7 @@ async fn setup_db_with_notes() -> FoldDB {
         "owner_pub_key".to_string(),
         MutationType::Create,
     );
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await
         .unwrap();
@@ -62,7 +62,7 @@ async fn set_field_policy(
     policy: FieldAccessPolicy,
 ) {
     let mut schema = db
-        .schema_manager
+        .schema_manager()
         .get_schema(schema_name)
         .await
         .unwrap()
@@ -73,8 +73,8 @@ async fn set_field_policy(
     }
 
     // Persist and reload
-    db.db_ops.store_schema(schema_name, &schema).await.unwrap();
-    db.schema_manager
+    db.db_ops().store_schema(schema_name, &schema).await.unwrap();
+    db.schema_manager()
         .load_schema_internal(schema)
         .await
         .unwrap();
@@ -325,7 +325,7 @@ async fn query_with_no_access_context_returns_all_fields() {
         "Notes".to_string(),
         vec!["title".to_string(), "content".to_string()],
     );
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
 
     assert!(results.contains_key("title"));
     assert!(results.contains_key("content"));
@@ -342,7 +342,7 @@ async fn query_default_policy_owner_only() {
         vec!["title".to_string(), "content".to_string()],
     );
     let results = db
-        .query_executor
+        .query_executor()
         .query_with_access(query, &ctx, None)
         .await
         .unwrap();
@@ -357,7 +357,7 @@ async fn query_default_policy_owner_only() {
         vec!["title".to_string(), "content".to_string()],
     );
     let results = db
-        .query_executor
+        .query_executor()
         .query_with_access(query, &owner_ctx, None)
         .await
         .unwrap();
@@ -389,7 +389,7 @@ async fn query_owner_always_has_access() {
         vec!["title".to_string(), "content".to_string()],
     );
     let results = db
-        .query_executor
+        .query_executor()
         .query_with_access(query, &ctx, None)
         .await
         .unwrap();
@@ -436,7 +436,7 @@ async fn query_remote_filtered_by_trust_tier() {
         vec!["title".to_string(), "content".to_string()],
     );
     let results = db
-        .query_executor
+        .query_executor()
         .query_with_access(query, &ctx, None)
         .await
         .unwrap();
@@ -468,7 +468,7 @@ async fn query_payment_gate_blocks_unpaid() {
 
     let query = Query::new("Notes".to_string(), vec!["content".to_string()]);
     let results = db
-        .query_executor
+        .query_executor()
         .query_with_access(query, &ctx, Some(&gate))
         .await
         .unwrap();
@@ -509,7 +509,7 @@ async fn mutation_blocked_by_insufficient_tier() {
     );
 
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_with_access(vec![mutation], &ctx, None)
         .await;
 
@@ -552,7 +552,7 @@ async fn mutation_allowed_for_owner() {
     );
 
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_with_access(vec![mutation], &ctx, None)
         .await;
 
@@ -584,7 +584,7 @@ async fn mutation_without_access_context_bypasses_checks() {
     );
 
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await;
     assert!(result.is_ok());

--- a/tests/access_control_test.rs
+++ b/tests/access_control_test.rs
@@ -73,7 +73,10 @@ async fn set_field_policy(
     }
 
     // Persist and reload
-    db.db_ops().store_schema(schema_name, &schema).await.unwrap();
+    db.db_ops()
+        .store_schema(schema_name, &schema)
+        .await
+        .unwrap();
     db.schema_manager()
         .load_schema_internal(schema)
         .await

--- a/tests/field_type_validation_test.rs
+++ b/tests/field_type_validation_test.rs
@@ -36,7 +36,7 @@ async fn typed_schema_accepts_valid_mutation() {
     db.load_schema_from_json(&typed_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("Person", SchemaState::Approved)
         .await
         .unwrap();
@@ -56,7 +56,7 @@ async fn typed_schema_accepts_valid_mutation() {
         MutationType::Create,
     );
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await;
     assert!(result.is_ok(), "Valid typed mutation should succeed");
@@ -68,7 +68,7 @@ async fn typed_schema_rejects_wrong_type() {
     db.load_schema_from_json(&typed_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("Person", SchemaState::Approved)
         .await
         .unwrap();
@@ -87,7 +87,7 @@ async fn typed_schema_rejects_wrong_type() {
         MutationType::Create,
     );
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await;
     assert!(result.is_err(), "Wrong type should be rejected");
@@ -110,7 +110,7 @@ async fn typed_schema_rejects_wrong_array_element_type() {
     db.load_schema_from_json(&typed_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("Person", SchemaState::Approved)
         .await
         .unwrap();
@@ -130,7 +130,7 @@ async fn typed_schema_rejects_wrong_array_element_type() {
         MutationType::Create,
     );
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await;
     assert!(
@@ -147,7 +147,7 @@ async fn untyped_schema_accepts_anything() {
     db.load_schema_from_json(&untyped_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("Freeform", SchemaState::Approved)
         .await
         .unwrap();
@@ -165,7 +165,7 @@ async fn untyped_schema_accepts_anything() {
         MutationType::Create,
     );
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await;
     assert!(
@@ -185,7 +185,7 @@ async fn schema_ref_type_enforced() {
         .range_key("id")
         .build_json();
     db.load_schema_from_json(&post_json).await.unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("Post", SchemaState::Approved)
         .await
         .unwrap();
@@ -200,7 +200,7 @@ async fn schema_ref_type_enforced() {
         .ref_field("posts", "Post")
         .build_json();
     db.load_schema_from_json(&user_json).await.unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("User", SchemaState::Approved)
         .await
         .unwrap();
@@ -215,7 +215,7 @@ async fn schema_ref_type_enforced() {
     fields.insert("id".to_string(), json!("u1"));
 
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "User".to_string(),
             fields,
@@ -240,7 +240,7 @@ async fn schema_ref_type_enforced() {
     bad_fields.insert("id".to_string(), json!("u2"));
 
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "User".to_string(),
             bad_fields,

--- a/tests/org_database_test.rs
+++ b/tests/org_database_test.rs
@@ -34,7 +34,7 @@ async fn register_schema(db: &FoldDB, name: &str, org_hash: Option<&str>) {
     }
     let json_str = builder.build_json();
     db.load_schema_from_json(&json_str).await.unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state(name, SchemaState::Approved)
         .await
         .unwrap();
@@ -59,7 +59,7 @@ async fn write_mutation(
         "test-pub-key".to_string(),
         MutationType::Create,
     );
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await
         .expect("Failed to write mutation")
@@ -84,7 +84,7 @@ async fn write_mutation_update(
         "test-pub-key".to_string(),
         MutationType::Update,
     );
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await
         .expect("Failed to write update mutation")
@@ -95,7 +95,7 @@ async fn query_field_values(db: &FoldDB, schema_name: &str, field: &str) -> Vec<
     let query = Query::new(schema_name.to_string(), vec![field.to_string()]);
     let access = AccessContext::owner("test-owner");
     let result = db
-        .query_executor
+        .query_executor()
         .query_with_access(query, &access, None)
         .await
         .expect("Query failed");
@@ -113,7 +113,7 @@ async fn query_full(
 ) -> HashMap<String, HashMap<KeyValue, fold_db::schema::types::field::FieldValue>> {
     let query = Query::new(schema_name.to_string(), vec![]);
     let access = AccessContext::owner("test-owner");
-    db.query_executor
+    db.query_executor()
         .query_with_access(query, &access, None)
         .await
         .expect("Query failed")
@@ -188,11 +188,11 @@ async fn test_full_org_lifecycle() {
     let db_ops = db.get_db_ops();
     let purged = db_ops.purge_org_data(org_hash).await.unwrap();
     assert!(purged > 0, "Expected to purge at least 1 key");
-    let removed_schemas = db.schema_manager.purge_org_schemas(org_hash).await.unwrap();
+    let removed_schemas = db.schema_manager().purge_org_schemas(org_hash).await.unwrap();
     assert_eq!(removed_schemas, vec!["corp_notes"]);
 
     // Schema should be gone from the manager
-    let schema = db.schema_manager.get_schema("corp_notes").await.unwrap();
+    let schema = db.schema_manager().get_schema("corp_notes").await.unwrap();
     assert!(schema.is_none(), "Schema should be purged");
 
     // No org-prefixed keys remain
@@ -272,7 +272,7 @@ async fn test_multi_org_data_isolation() {
     // Purge alpha (data + schemas)
     let db_ops = db.get_db_ops();
     db_ops.purge_org_data(&org_alpha.org_hash).await.unwrap();
-    db.schema_manager
+    db.schema_manager()
         .purge_org_schemas(&org_alpha.org_hash)
         .await
         .unwrap();
@@ -280,7 +280,7 @@ async fn test_multi_org_data_isolation() {
     // Alpha is fully purged — sled keys gone and schema removed
     assert_eq!(count_org_prefixed_keys(&db, &org_alpha.org_hash), 0);
     assert!(
-        db.schema_manager
+        db.schema_manager()
             .get_schema("alpha_notes")
             .await
             .unwrap()

--- a/tests/org_database_test.rs
+++ b/tests/org_database_test.rs
@@ -188,7 +188,11 @@ async fn test_full_org_lifecycle() {
     let db_ops = db.get_db_ops();
     let purged = db_ops.purge_org_data(org_hash).await.unwrap();
     assert!(purged > 0, "Expected to purge at least 1 key");
-    let removed_schemas = db.schema_manager().purge_org_schemas(org_hash).await.unwrap();
+    let removed_schemas = db
+        .schema_manager()
+        .purge_org_schemas(org_hash)
+        .await
+        .unwrap();
     assert_eq!(removed_schemas, vec!["corp_notes"]);
 
     // Schema should be gone from the manager

--- a/tests/org_key_prefixing_test.rs
+++ b/tests/org_key_prefixing_test.rs
@@ -35,7 +35,7 @@ async fn register_schema(db: &FoldDB, name: &str, org_hash: Option<&str>) {
     }
     let json_str = builder.build_json();
     db.load_schema_from_json(&json_str).await.unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state(name, SchemaState::Approved)
         .await
         .unwrap();
@@ -61,7 +61,7 @@ async fn write_mutation(
         "test-pub-key".to_string(),
         MutationType::Create,
     );
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await
         .expect("Failed to write mutation")
@@ -107,7 +107,7 @@ async fn test_org_mutation_produces_prefixed_keys() {
 
     // The schema should have org_hash set
     let schema = db
-        .schema_manager
+        .schema_manager()
         .get_schema("org_notes")
         .await
         .unwrap()
@@ -154,7 +154,7 @@ async fn test_org_query_reads_from_prefixed_keys() {
     let query = Query::new("org_events".to_string(), vec![]);
     let access = AccessContext::owner("test-owner");
     let result = db
-        .query_executor
+        .query_executor()
         .query_with_access(query, &access, None)
         .await
         .expect("Query failed");
@@ -192,7 +192,7 @@ async fn test_personal_and_org_data_do_not_collide() {
     // Query personal schema
     let personal_query = Query::new("notes".to_string(), vec!["body".to_string()]);
     let personal_result = db
-        .query_executor
+        .query_executor()
         .query_with_access(personal_query, &access, None)
         .await
         .expect("Personal query failed");
@@ -200,7 +200,7 @@ async fn test_personal_and_org_data_do_not_collide() {
     // Query org schema
     let org_query = Query::new("org_notes".to_string(), vec!["body".to_string()]);
     let org_result = db
-        .query_executor
+        .query_executor()
         .query_with_access(org_query, &access, None)
         .await
         .expect("Org query failed");

--- a/tests/org_sync_e2e_test.rs
+++ b/tests/org_sync_e2e_test.rs
@@ -35,7 +35,7 @@ async fn register_schema(db: &FoldDB, name: &str, org_hash: Option<&str>) {
     }
     let json_str = builder.build_json();
     db.load_schema_from_json(&json_str).await.unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state(name, SchemaState::Approved)
         .await
         .unwrap();
@@ -60,7 +60,7 @@ async fn write_mutation(
         "test-pub-key".to_string(),
         MutationType::Create,
     );
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await
         .expect("Failed to write mutation")
@@ -70,7 +70,7 @@ async fn query_field_values(db: &FoldDB, schema_name: &str, field: &str) -> Vec<
     let query = Query::new(schema_name.to_string(), vec![field.to_string()]);
     let access = AccessContext::owner("test-owner");
     let result = db
-        .query_executor
+        .query_executor()
         .query_with_access(query, &access, None)
         .await
         .expect("Query failed");
@@ -189,12 +189,12 @@ async fn test_org_data_sync_between_two_nodes() {
     let schema: fold_db::schema::Schema =
         serde_json::from_slice(&schema_bytes).expect("Failed to deserialize schema");
     node2
-        .schema_manager
+        .schema_manager()
         .load_schema_internal(schema)
         .await
         .expect("Failed to load schema on node2");
     node2
-        .schema_manager
+        .schema_manager()
         .set_schema_state("sync_notes", SchemaState::Approved)
         .await
         .unwrap();
@@ -263,7 +263,7 @@ async fn test_org_sync_with_updates() {
         MutationType::Update,
     );
     node1
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_batch_async(vec![update])
         .await
         .unwrap();
@@ -308,12 +308,12 @@ async fn test_org_sync_with_updates() {
     let schema: fold_db::schema::Schema =
         serde_json::from_slice(&schema_bytes).expect("Failed to deserialize schema");
     node2
-        .schema_manager
+        .schema_manager()
         .load_schema_internal(schema)
         .await
         .unwrap();
     node2
-        .schema_manager
+        .schema_manager()
         .set_schema_state("update_notes", SchemaState::Approved)
         .await
         .unwrap();
@@ -418,12 +418,12 @@ async fn test_org_sync_does_not_leak_personal_data() {
     let schema: fold_db::schema::Schema =
         serde_json::from_slice(&schema_bytes).expect("Failed to deserialize");
     node2
-        .schema_manager
+        .schema_manager()
         .load_schema_internal(schema)
         .await
         .unwrap();
     node2
-        .schema_manager
+        .schema_manager()
         .set_schema_state("org_shared", SchemaState::Approved)
         .await
         .unwrap();
@@ -435,7 +435,7 @@ async fn test_org_sync_does_not_leak_personal_data() {
 
     // Node 2 should NOT have the personal schema or data
     let personal_schema = node2
-        .schema_manager
+        .schema_manager()
         .get_schema("personal_diary")
         .await
         .unwrap();

--- a/tests/org_sync_encrypted_e2e_test.rs
+++ b/tests/org_sync_encrypted_e2e_test.rs
@@ -49,7 +49,7 @@ async fn register_schema(db: &FoldDB, name: &str, org_hash: Option<&str>) {
     }
     let json_str = builder.build_json();
     db.load_schema_from_json(&json_str).await.unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state(name, SchemaState::Approved)
         .await
         .unwrap();
@@ -68,7 +68,7 @@ async fn write_mutation(db: &FoldDB, schema_name: &str, title: &str, date: &str,
         "test-pub-key".to_string(),
         MutationType::Create,
     );
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await
         .expect("Failed to write mutation");
@@ -78,7 +78,7 @@ async fn query_field_values(db: &FoldDB, schema_name: &str, field: &str) -> Vec<
     let query = Query::new(schema_name.to_string(), vec![field.to_string()]);
     let access = AccessContext::owner("test-owner");
     let result = db
-        .query_executor
+        .query_executor()
         .query_with_access(query, &access, None)
         .await
         .expect("Query failed");
@@ -289,12 +289,12 @@ async fn test_org_sync_with_encryption_roundtrip() {
     let schema: fold_db::schema::Schema =
         serde_json::from_slice(&schema_bytes).expect("Failed to deserialize schema");
     node2
-        .schema_manager
+        .schema_manager()
         .load_schema_internal(schema)
         .await
         .expect("Failed to load schema on node2");
     node2
-        .schema_manager
+        .schema_manager()
         .set_schema_state("enc_notes", SchemaState::Approved)
         .await
         .unwrap();

--- a/tests/range_molecule_persistence_test.rs
+++ b/tests/range_molecule_persistence_test.rs
@@ -88,7 +88,7 @@ async fn mutations_work_after_simulated_restart() {
 
     // Simulate restart: reload schema from DB (which calls populate_runtime_fields)
     let reloaded = fold_db
-        .db_ops
+        .db_ops()
         .get_schema("FileRecords")
         .await
         .unwrap()
@@ -171,7 +171,7 @@ async fn molecule_uuid_stays_consistent_across_batches() {
 
     let mol_uuid_first = {
         let schema = fold_db
-            .db_ops
+            .db_ops()
             .get_schema("FileRecords")
             .await
             .unwrap()
@@ -195,7 +195,7 @@ async fn molecule_uuid_stays_consistent_across_batches() {
 
     let mol_uuid_second = {
         let schema = fold_db
-            .db_ops
+            .db_ops()
             .get_schema("FileRecords")
             .await
             .unwrap()

--- a/tests/view_invalidation_test.rs
+++ b/tests/view_invalidation_test.rs
@@ -44,7 +44,7 @@ async fn mutating_source_invalidates_view_cache() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -52,7 +52,7 @@ async fn mutating_source_invalidates_view_cache() {
     let mut fields = HashMap::new();
     fields.insert("content".to_string(), json!("original"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -63,19 +63,19 @@ async fn mutating_source_invalidates_view_cache() {
         .await
         .unwrap();
 
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("CV", "BlogPost", "content"))
         .await
         .unwrap();
 
     // First query: populates cache
     let query = Query::new("CV".to_string(), vec!["content".to_string()]);
-    let results = db.query_executor.query(query.clone()).await.unwrap();
+    let results = db.query_executor().query(query.clone()).await.unwrap();
     let first_value = results["content"].values().next().unwrap().value.clone();
     assert_eq!(first_value, json!("original"));
 
     // Verify cache state is Cached
-    let state = db.db_ops.get_view_cache_state("CV").await.unwrap();
+    let state = db.db_ops().get_view_cache_state("CV").await.unwrap();
     assert!(
         matches!(state, ViewCacheState::Cached { .. }),
         "View should be cached after first query"
@@ -85,7 +85,7 @@ async fn mutating_source_invalidates_view_cache() {
     let mut fields2 = HashMap::new();
     fields2.insert("content".to_string(), json!("updated"));
     fields2.insert("publish_date".to_string(), json!("2026-01-02"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields2,
@@ -97,7 +97,7 @@ async fn mutating_source_invalidates_view_cache() {
         .unwrap();
 
     // Verify cache state was invalidated to Empty
-    let state_after = db.db_ops.get_view_cache_state("CV").await.unwrap();
+    let state_after = db.db_ops().get_view_cache_state("CV").await.unwrap();
     assert!(
         matches!(state_after, ViewCacheState::Empty),
         "View cache should be invalidated after source mutation, got {:?}",
@@ -105,7 +105,7 @@ async fn mutating_source_invalidates_view_cache() {
     );
 
     // Re-query: should fetch fresh data
-    let results2 = db.query_executor.query(query).await.unwrap();
+    let results2 = db.query_executor().query(query).await.unwrap();
     let all_values: Vec<_> = results2["content"]
         .values()
         .map(|fv| fv.value.clone())
@@ -124,7 +124,7 @@ async fn re_query_after_invalidation_re_caches() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -132,7 +132,7 @@ async fn re_query_after_invalidation_re_caches() {
     let mut fields = HashMap::new();
     fields.insert("title".to_string(), json!("Hello"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -143,20 +143,20 @@ async fn re_query_after_invalidation_re_caches() {
         .await
         .unwrap();
 
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("TV", "BlogPost", "title"))
         .await
         .unwrap();
 
     // First query: caches
     let query = Query::new("TV".to_string(), vec!["title".to_string()]);
-    db.query_executor.query(query.clone()).await.unwrap();
+    db.query_executor().query(query.clone()).await.unwrap();
 
     // Invalidate
     let mut fields2 = HashMap::new();
     fields2.insert("title".to_string(), json!("Updated"));
     fields2.insert("publish_date".to_string(), json!("2026-01-02"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields2,
@@ -168,15 +168,15 @@ async fn re_query_after_invalidation_re_caches() {
         .unwrap();
 
     assert!(matches!(
-        db.db_ops.get_view_cache_state("TV").await.unwrap(),
+        db.db_ops().get_view_cache_state("TV").await.unwrap(),
         ViewCacheState::Empty
     ));
 
     // Re-query: should re-cache
-    db.query_executor.query(query).await.unwrap();
+    db.query_executor().query(query).await.unwrap();
 
     assert!(matches!(
-        db.db_ops.get_view_cache_state("TV").await.unwrap(),
+        db.db_ops().get_view_cache_state("TV").await.unwrap(),
         ViewCacheState::Cached { .. }
     ));
 }
@@ -189,7 +189,7 @@ async fn cascading_invalidation_through_view_chain() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -197,7 +197,7 @@ async fn cascading_invalidation_through_view_chain() {
     let mut fields = HashMap::new();
     fields.insert("content".to_string(), json!("original"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -209,7 +209,7 @@ async fn cascading_invalidation_through_view_chain() {
         .unwrap();
 
     // ViewA reads from BlogPost.content
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "content"))
         .await
         .unwrap();
@@ -223,21 +223,21 @@ async fn cascading_invalidation_through_view_chain() {
         None,
         HashMap::from([("content".to_string(), FieldValueType::Any)]),
     );
-    db.schema_manager.register_view(view_b).await.unwrap();
+    db.schema_manager().register_view(view_b).await.unwrap();
 
     // Query both views to populate caches
     let query_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
     let query_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    db.query_executor.query(query_a).await.unwrap();
-    db.query_executor.query(query_b).await.unwrap();
+    db.query_executor().query(query_a).await.unwrap();
+    db.query_executor().query(query_b).await.unwrap();
 
     // Both should be cached
     assert!(matches!(
-        db.db_ops.get_view_cache_state("ViewA").await.unwrap(),
+        db.db_ops().get_view_cache_state("ViewA").await.unwrap(),
         ViewCacheState::Cached { .. }
     ));
     assert!(matches!(
-        db.db_ops.get_view_cache_state("ViewB").await.unwrap(),
+        db.db_ops().get_view_cache_state("ViewB").await.unwrap(),
         ViewCacheState::Cached { .. }
     ));
 
@@ -245,7 +245,7 @@ async fn cascading_invalidation_through_view_chain() {
     let mut fields2 = HashMap::new();
     fields2.insert("content".to_string(), json!("updated"));
     fields2.insert("publish_date".to_string(), json!("2026-01-02"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields2,
@@ -258,7 +258,7 @@ async fn cascading_invalidation_through_view_chain() {
 
     // ViewA (direct dependency) is invalidated. May already be re-Cached
     // by background precomputation task.
-    let state_a = db.db_ops.get_view_cache_state("ViewA").await.unwrap();
+    let state_a = db.db_ops().get_view_cache_state("ViewA").await.unwrap();
     assert!(
         matches!(
             state_a,
@@ -270,7 +270,7 @@ async fn cascading_invalidation_through_view_chain() {
 
     // ViewB should ALSO be invalidated (cascade: ViewB depends on ViewA)
     // Deep views transition to Computing for background precomputation
-    let state_b = db.db_ops.get_view_cache_state("ViewB").await.unwrap();
+    let state_b = db.db_ops().get_view_cache_state("ViewB").await.unwrap();
     assert!(
         matches!(
             state_b,
@@ -288,7 +288,7 @@ async fn view_chain_query_returns_source_data() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -296,7 +296,7 @@ async fn view_chain_query_returns_source_data() {
     let mut fields = HashMap::new();
     fields.insert("title".to_string(), json!("Chain Test"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -308,7 +308,7 @@ async fn view_chain_query_returns_source_data() {
         .unwrap();
 
     // ViewA reads from BlogPost.title
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "title"))
         .await
         .unwrap();
@@ -322,11 +322,11 @@ async fn view_chain_query_returns_source_data() {
         None,
         HashMap::from([("title".to_string(), FieldValueType::Any)]),
     );
-    db.schema_manager.register_view(view_b).await.unwrap();
+    db.schema_manager().register_view(view_b).await.unwrap();
 
     // Query ViewB — should recursively resolve through ViewA to BlogPost
     let query = Query::new("ViewB".to_string(), vec!["title".to_string()]);
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
 
     assert!(results.contains_key("title"));
     let values: Vec<_> = results["title"]
@@ -347,7 +347,7 @@ async fn three_level_chain_resolves_to_source() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -355,7 +355,7 @@ async fn three_level_chain_resolves_to_source() {
     let mut fields = HashMap::new();
     fields.insert("content".to_string(), json!("deep chain"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -367,26 +367,26 @@ async fn three_level_chain_resolves_to_source() {
         .unwrap();
 
     // ViewA → BlogPost
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "content"))
         .await
         .unwrap();
 
     // ViewB → ViewA
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewB", "ViewA", "content"))
         .await
         .unwrap();
 
     // ViewC → ViewB
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewC", "ViewB", "content"))
         .await
         .unwrap();
 
     // Query ViewC — resolves through ViewB → ViewA → BlogPost
     let query = Query::new("ViewC".to_string(), vec!["content".to_string()]);
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
 
     let values: Vec<_> = results["content"]
         .values()
@@ -406,7 +406,7 @@ async fn chain_re_query_after_cascade_invalidation_gets_fresh_data() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -414,7 +414,7 @@ async fn chain_re_query_after_cascade_invalidation_gets_fresh_data() {
     let mut fields = HashMap::new();
     fields.insert("content".to_string(), json!("v1"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -426,18 +426,18 @@ async fn chain_re_query_after_cascade_invalidation_gets_fresh_data() {
         .unwrap();
 
     // ViewA → BlogPost, ViewB → ViewA
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "content"))
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewB", "ViewA", "content"))
         .await
         .unwrap();
 
     // Populate caches
     let query_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    let results = db.query_executor.query(query_b.clone()).await.unwrap();
+    let results = db.query_executor().query(query_b.clone()).await.unwrap();
     let val = results["content"].values().next().unwrap().value.clone();
     assert_eq!(val, json!("v1"));
 
@@ -445,7 +445,7 @@ async fn chain_re_query_after_cascade_invalidation_gets_fresh_data() {
     let mut fields2 = HashMap::new();
     fields2.insert("content".to_string(), json!("v2"));
     fields2.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields2,
@@ -460,7 +460,7 @@ async fn chain_re_query_after_cascade_invalidation_gets_fresh_data() {
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     // Re-query ViewB — should get fresh "v2" through the entire chain
-    let results2 = db.query_executor.query(query_b).await.unwrap();
+    let results2 = db.query_executor().query(query_b).await.unwrap();
     let values: Vec<_> = results2["content"]
         .values()
         .map(|fv| fv.value.clone())
@@ -480,7 +480,7 @@ async fn multi_source_view_from_two_views() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -490,7 +490,7 @@ async fn multi_source_view_from_two_views() {
         .range_key("publish_date")
         .build_json();
     db.load_schema_from_json(&author_json).await.unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("Author", SchemaState::Approved)
         .await
         .unwrap();
@@ -499,7 +499,7 @@ async fn multi_source_view_from_two_views() {
     let mut bp_fields = HashMap::new();
     bp_fields.insert("title".to_string(), json!("Hello"));
     bp_fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             bp_fields,
@@ -513,7 +513,7 @@ async fn multi_source_view_from_two_views() {
     let mut author_fields = HashMap::new();
     author_fields.insert("name".to_string(), json!("Tom"));
     author_fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "Author".to_string(),
             author_fields,
@@ -525,7 +525,7 @@ async fn multi_source_view_from_two_views() {
         .unwrap();
 
     // ViewA → BlogPost.title, ViewB → Author.name
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "title"))
         .await
         .unwrap();
@@ -538,7 +538,7 @@ async fn multi_source_view_from_two_views() {
         None,
         HashMap::from([("name".to_string(), FieldValueType::Any)]),
     );
-    db.schema_manager.register_view(view_b).await.unwrap();
+    db.schema_manager().register_view(view_b).await.unwrap();
 
     // ViewC reads from both ViewA and ViewB
     let view_c = TransformView::new(
@@ -555,11 +555,11 @@ async fn multi_source_view_from_two_views() {
             ("name".to_string(), FieldValueType::Any),
         ]),
     );
-    db.schema_manager.register_view(view_c).await.unwrap();
+    db.schema_manager().register_view(view_c).await.unwrap();
 
     // Query ViewC — should merge data from both source views
     let query = Query::new("ViewC".to_string(), vec![]);
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
 
     assert!(
         results.contains_key("title"),
@@ -583,7 +583,7 @@ async fn three_level_cascade_invalidation() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -591,7 +591,7 @@ async fn three_level_cascade_invalidation() {
     let mut fields = HashMap::new();
     fields.insert("content".to_string(), json!("original"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -603,15 +603,15 @@ async fn three_level_cascade_invalidation() {
         .unwrap();
 
     // ViewA → BlogPost, ViewB → ViewA, ViewC → ViewB
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "content"))
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewB", "ViewA", "content"))
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewC", "ViewB", "content"))
         .await
         .unwrap();
@@ -619,14 +619,14 @@ async fn three_level_cascade_invalidation() {
     // Populate all caches
     for name in &["ViewA", "ViewB", "ViewC"] {
         let q = Query::new(name.to_string(), vec!["content".to_string()]);
-        db.query_executor.query(q).await.unwrap();
+        db.query_executor().query(q).await.unwrap();
     }
 
     // All should be cached
     for name in &["ViewA", "ViewB", "ViewC"] {
         assert!(
             matches!(
-                db.db_ops.get_view_cache_state(name).await.unwrap(),
+                db.db_ops().get_view_cache_state(name).await.unwrap(),
                 ViewCacheState::Cached { .. }
             ),
             "{} should be cached",
@@ -638,7 +638,7 @@ async fn three_level_cascade_invalidation() {
     let mut fields2 = HashMap::new();
     fields2.insert("content".to_string(), json!("changed"));
     fields2.insert("publish_date".to_string(), json!("2026-01-02"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields2,
@@ -653,7 +653,7 @@ async fn three_level_cascade_invalidation() {
     // Deep views (ViewB, ViewC) may be Computing or already re-Cached
     // via background precomputation.
     for name in &["ViewA", "ViewB", "ViewC"] {
-        let state = db.db_ops.get_view_cache_state(name).await.unwrap();
+        let state = db.db_ops().get_view_cache_state(name).await.unwrap();
         assert!(
             matches!(
                 state,

--- a/tests/view_precomputation_test.rs
+++ b/tests/view_precomputation_test.rs
@@ -46,7 +46,7 @@ async fn write_blogpost(db: &FoldDB, content: &str, date: &str) {
     let mut fields = HashMap::new();
     fields.insert("content".to_string(), json!(content));
     fields.insert("publish_date".to_string(), json!(date));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -66,20 +66,20 @@ async fn deep_view_enters_computing_after_mutation() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
     write_blogpost(&db, "original", "2026-01-01").await;
 
     // ViewA → BlogPost (level 1, direct)
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "content"))
         .await
         .unwrap();
 
     // ViewB → ViewA (level 2, deep)
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewB", "ViewA", "content"))
         .await
         .unwrap();
@@ -87,16 +87,16 @@ async fn deep_view_enters_computing_after_mutation() {
     // Populate caches by querying both
     let q_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
     let q_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    db.query_executor.query(q_a).await.unwrap();
-    db.query_executor.query(q_b).await.unwrap();
+    db.query_executor().query(q_a).await.unwrap();
+    db.query_executor().query(q_b).await.unwrap();
 
     // Both should be Cached
     assert!(matches!(
-        db.db_ops.get_view_cache_state("ViewA").await.unwrap(),
+        db.db_ops().get_view_cache_state("ViewA").await.unwrap(),
         ViewCacheState::Cached { .. }
     ));
     assert!(matches!(
-        db.db_ops.get_view_cache_state("ViewB").await.unwrap(),
+        db.db_ops().get_view_cache_state("ViewB").await.unwrap(),
         ViewCacheState::Cached { .. }
     ));
 
@@ -105,7 +105,7 @@ async fn deep_view_enters_computing_after_mutation() {
 
     // ViewA (level 1) may be Empty or already precomputed by the background
     // task (which computes all views bottom-up to unblock deep views).
-    let state_a = db.db_ops.get_view_cache_state("ViewA").await.unwrap();
+    let state_a = db.db_ops().get_view_cache_state("ViewA").await.unwrap();
     assert!(
         matches!(
             state_a,
@@ -117,7 +117,7 @@ async fn deep_view_enters_computing_after_mutation() {
 
     // ViewB (level 2) should be Computing or already Cached
     // (background task may complete very fast)
-    let state_b = db.db_ops.get_view_cache_state("ViewB").await.unwrap();
+    let state_b = db.db_ops().get_view_cache_state("ViewB").await.unwrap();
     assert!(
         matches!(
             state_b,
@@ -135,17 +135,17 @@ async fn deep_view_eventually_becomes_cached() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
     write_blogpost(&db, "original", "2026-01-01").await;
 
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "content"))
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewB", "ViewA", "content"))
         .await
         .unwrap();
@@ -153,8 +153,8 @@ async fn deep_view_eventually_becomes_cached() {
     // Populate caches
     let q_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
     let q_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    db.query_executor.query(q_a).await.unwrap();
-    db.query_executor.query(q_b).await.unwrap();
+    db.query_executor().query(q_a).await.unwrap();
+    db.query_executor().query(q_b).await.unwrap();
 
     // Mutate source
     write_blogpost(&db, "updated", "2026-01-02").await;
@@ -163,12 +163,12 @@ async fn deep_view_eventually_becomes_cached() {
     // (ViewA needs to be lazily computed first, then ViewB background task runs)
     // First, lazily compute ViewA so the background task for ViewB can proceed
     let q_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
-    db.query_executor.query(q_a).await.unwrap();
+    db.query_executor().query(q_a).await.unwrap();
 
     // Give background task time to complete
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    let state_b = db.db_ops.get_view_cache_state("ViewB").await.unwrap();
+    let state_b = db.db_ops().get_view_cache_state("ViewB").await.unwrap();
     assert!(
         matches!(state_b, ViewCacheState::Cached { .. }),
         "ViewB should eventually become Cached after precomputation, got {:?}",
@@ -183,26 +183,26 @@ async fn query_during_computing_returns_error() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
     write_blogpost(&db, "original", "2026-01-01").await;
 
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "content"))
         .await
         .unwrap();
 
     // Manually set ViewA to Computing to simulate in-progress precomputation
-    db.db_ops
+    db.db_ops()
         .set_view_cache_state("ViewA", &ViewCacheState::Computing)
         .await
         .unwrap();
 
     // Query should fail with clear error
     let q = Query::new("ViewA".to_string(), vec!["content".to_string()]);
-    let result = db.query_executor.query(q).await;
+    let result = db.query_executor().query(q).await;
 
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
@@ -220,22 +220,22 @@ async fn three_level_chain_precomputes_bottom_up() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
     write_blogpost(&db, "deep", "2026-01-01").await;
 
     // ViewA → BlogPost, ViewB → ViewA, ViewC → ViewB
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "content"))
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewB", "ViewA", "content"))
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewC", "ViewB", "content"))
         .await
         .unwrap();
@@ -243,7 +243,7 @@ async fn three_level_chain_precomputes_bottom_up() {
     // Populate all caches
     for name in &["ViewA", "ViewB", "ViewC"] {
         let q = Query::new(name.to_string(), vec!["content".to_string()]);
-        db.query_executor.query(q).await.unwrap();
+        db.query_executor().query(q).await.unwrap();
     }
 
     // Mutate source
@@ -251,7 +251,7 @@ async fn three_level_chain_precomputes_bottom_up() {
 
     // ViewA (level 1) is Empty initially but may be precomputed by the
     // background task (which computes all views bottom-up). Either state is valid.
-    let state_a = db.db_ops.get_view_cache_state("ViewA").await.unwrap();
+    let state_a = db.db_ops().get_view_cache_state("ViewA").await.unwrap();
     assert!(
         matches!(
             state_a,
@@ -262,8 +262,8 @@ async fn three_level_chain_precomputes_bottom_up() {
     );
 
     // ViewB and ViewC should be Computing or Cached
-    let state_b = db.db_ops.get_view_cache_state("ViewB").await.unwrap();
-    let state_c = db.db_ops.get_view_cache_state("ViewC").await.unwrap();
+    let state_b = db.db_ops().get_view_cache_state("ViewB").await.unwrap();
+    let state_c = db.db_ops().get_view_cache_state("ViewC").await.unwrap();
     assert!(
         matches!(
             state_b,
@@ -283,7 +283,7 @@ async fn three_level_chain_precomputes_bottom_up() {
 
     // Lazily compute ViewA so background tasks can resolve
     let q = Query::new("ViewA".to_string(), vec!["content".to_string()]);
-    db.query_executor.query(q).await.unwrap();
+    db.query_executor().query(q).await.unwrap();
 
     // Wait for background tasks
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
@@ -292,7 +292,7 @@ async fn three_level_chain_precomputes_bottom_up() {
     for name in &["ViewA", "ViewB", "ViewC"] {
         assert!(
             matches!(
-                db.db_ops.get_view_cache_state(name).await.unwrap(),
+                db.db_ops().get_view_cache_state(name).await.unwrap(),
                 ViewCacheState::Cached { .. }
             ),
             "{} should be Cached after precomputation",
@@ -308,17 +308,17 @@ async fn precomputed_view_has_fresh_data() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
     write_blogpost(&db, "v1", "2026-01-01").await;
 
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "content"))
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewB", "ViewA", "content"))
         .await
         .unwrap();
@@ -326,20 +326,20 @@ async fn precomputed_view_has_fresh_data() {
     // Populate caches with v1
     let q_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
     let q_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    db.query_executor.query(q_a.clone()).await.unwrap();
-    db.query_executor.query(q_b.clone()).await.unwrap();
+    db.query_executor().query(q_a.clone()).await.unwrap();
+    db.query_executor().query(q_b.clone()).await.unwrap();
 
     // Mutate to v2
     write_blogpost(&db, "v2", "2026-01-01").await;
 
     // Lazily compute ViewA to unblock ViewB's precomputation
-    db.query_executor.query(q_a).await.unwrap();
+    db.query_executor().query(q_a).await.unwrap();
 
     // Wait for ViewB precomputation
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     // ViewB should be Cached with fresh data
-    let state = db.db_ops.get_view_cache_state("ViewB").await.unwrap();
+    let state = db.db_ops().get_view_cache_state("ViewB").await.unwrap();
     assert!(
         matches!(state, ViewCacheState::Cached { .. }),
         "ViewB should be Cached, got {:?}",
@@ -347,7 +347,7 @@ async fn precomputed_view_has_fresh_data() {
     );
 
     // Query ViewB — should have v2 data
-    let results = db.query_executor.query(q_b).await.unwrap();
+    let results = db.query_executor().query(q_b).await.unwrap();
     let values: Vec<_> = results["content"]
         .values()
         .map(|fv| fv.value.clone())

--- a/tests/view_query_test.rs
+++ b/tests/view_query_test.rs
@@ -44,7 +44,7 @@ async fn query_identity_view_returns_source_data() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -61,18 +61,18 @@ async fn query_identity_view_returns_source_data() {
         "test_pub_key".to_string(),
         MutationType::Create,
     );
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await
         .unwrap();
 
     // Register a view over BlogPost.content
     let view = identity_view("ContentView", "BlogPost", "content");
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // Query the view — should return the source data
     let query = Query::new("ContentView".to_string(), vec!["content".to_string()]);
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
 
     assert!(
         results.contains_key("content"),
@@ -91,7 +91,7 @@ async fn query_nonexistent_name_errors() {
     let db = setup_db().await;
 
     let query = Query::new("DoesNotExist".to_string(), vec![]);
-    let result = db.query_executor.query(query).await;
+    let result = db.query_executor().query(query).await;
     assert!(result.is_err());
 }
 
@@ -104,11 +104,11 @@ async fn query_blocked_view_errors() {
         .unwrap();
 
     let view = identity_view("BlockedView", "BlogPost", "title");
-    db.schema_manager.register_view(view).await.unwrap();
-    db.schema_manager.block_view("BlockedView").await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
+    db.schema_manager().block_view("BlockedView").await.unwrap();
 
     let query = Query::new("BlockedView".to_string(), vec!["title".to_string()]);
-    let result = db.query_executor.query(query).await;
+    let result = db.query_executor().query(query).await;
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("blocked"));
 }
@@ -120,7 +120,7 @@ async fn query_view_with_empty_fields_returns_all() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -129,7 +129,7 @@ async fn query_view_with_empty_fields_returns_all() {
     fields.insert("title".to_string(), json!("Title"));
     fields.insert("content".to_string(), json!("Body"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -155,11 +155,11 @@ async fn query_view_with_empty_fields_returns_all() {
             ("content".to_string(), FieldValueType::Any),
         ]),
     );
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // Query with empty fields — should return all view output fields
     let query = Query::new("FullView".to_string(), vec![]);
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
 
     assert_eq!(results.len(), 2);
     assert!(results.contains_key("title"));
@@ -173,13 +173,13 @@ async fn identity_view_write_redirects_to_source() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
 
     let view = identity_view("MyView", "BlogPost", "content");
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // Write through the view — should redirect to BlogPost.content
     let mut mutation_fields = HashMap::new();
@@ -191,14 +191,14 @@ async fn identity_view_write_redirects_to_source() {
         "pk".to_string(),
         MutationType::Create,
     );
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await
         .unwrap();
 
     // Query the SOURCE schema to verify the write landed there
     let query = Query::new("BlogPost".to_string(), vec!["content".to_string()]);
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
     assert!(results.contains_key("content"));
     let values: Vec<_> = results["content"]
         .values()
@@ -218,7 +218,7 @@ async fn identity_view_write_invalidates_view_cache() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -227,7 +227,7 @@ async fn identity_view_write_invalidates_view_cache() {
     let mut fields = HashMap::new();
     fields.insert("content".to_string(), json!("original"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -239,16 +239,16 @@ async fn identity_view_write_invalidates_view_cache() {
         .unwrap();
 
     let view = identity_view("CacheView", "BlogPost", "content");
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // Query view to populate cache
     let query = Query::new("CacheView".to_string(), vec!["content".to_string()]);
-    db.query_executor.query(query.clone()).await.unwrap();
+    db.query_executor().query(query.clone()).await.unwrap();
 
     // Write through the view — should invalidate the cache
     let mut mutation_fields = HashMap::new();
     mutation_fields.insert("content".to_string(), json!("updated via view"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "CacheView".to_string(),
             mutation_fields,
@@ -260,7 +260,7 @@ async fn identity_view_write_invalidates_view_cache() {
         .unwrap();
 
     // Re-query view — should return fresh data including the new write
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
     let values: Vec<_> = results["content"]
         .values()
         .map(|fv| fv.value.clone())
@@ -279,7 +279,7 @@ async fn wasm_view_write_is_rejected() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -296,7 +296,7 @@ async fn wasm_view_write_is_rejected() {
         Some(vec![0, 1, 2]), // Placeholder WASM — won't be executed
         HashMap::from([("out".to_string(), FieldValueType::String)]),
     );
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // Try to mutate the WASM view — should be rejected
     let mut mutation_fields = HashMap::new();
@@ -309,7 +309,7 @@ async fn wasm_view_write_is_rejected() {
         MutationType::Create,
     );
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await;
     assert!(result.is_err());

--- a/tests/view_wasm_integration_test.rs
+++ b/tests/view_wasm_integration_test.rs
@@ -70,7 +70,7 @@ async fn wasm_view_query_returns_transformed_output() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -79,7 +79,7 @@ async fn wasm_view_query_returns_transformed_output() {
     fields.insert("title".to_string(), json!("Hello World"));
     fields.insert("content".to_string(), json!("Test content"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -102,11 +102,11 @@ async fn wasm_view_query_returns_transformed_output() {
         Some(hardcoded_wasm()),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // Query the view
     let query = Query::new("SummaryView".to_string(), vec!["summary".to_string()]);
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
 
     assert!(results.contains_key("summary"));
     let summary_values = &results["summary"];
@@ -122,7 +122,7 @@ async fn wasm_view_output_type_validation_works() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -130,7 +130,7 @@ async fn wasm_view_output_type_validation_works() {
     let mut fields = HashMap::new();
     fields.insert("title".to_string(), json!("Hello"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -153,11 +153,11 @@ async fn wasm_view_output_type_validation_works() {
         Some(hardcoded_wasm()), // Returns {"summary": {"k1": "hardcoded"}} — a String
         HashMap::from([("summary".to_string(), FieldValueType::Integer)]), // Declared as Integer
     );
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // Query should fail with type validation error
     let query = Query::new("BadTypeView".to_string(), vec!["summary".to_string()]);
-    let result = db.query_executor.query(query).await;
+    let result = db.query_executor().query(query).await;
     assert!(result.is_err());
     assert!(
         result.unwrap_err().to_string().contains("type validation"),
@@ -172,7 +172,7 @@ async fn wasm_view_cache_invalidation_works() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -180,7 +180,7 @@ async fn wasm_view_cache_invalidation_works() {
     let mut fields = HashMap::new();
     fields.insert("title".to_string(), json!("Original"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -203,15 +203,15 @@ async fn wasm_view_cache_invalidation_works() {
         Some(hardcoded_wasm()),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // First query: populates cache
     let query = Query::new("WasmCacheView".to_string(), vec!["summary".to_string()]);
-    db.query_executor.query(query.clone()).await.unwrap();
+    db.query_executor().query(query.clone()).await.unwrap();
 
     // Verify cached
     let state = db
-        .db_ops
+        .db_ops()
         .get_view_cache_state("WasmCacheView")
         .await
         .unwrap();
@@ -224,7 +224,7 @@ async fn wasm_view_cache_invalidation_works() {
     let mut fields2 = HashMap::new();
     fields2.insert("title".to_string(), json!("Updated"));
     fields2.insert("publish_date".to_string(), json!("2026-01-02"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields2,
@@ -237,7 +237,7 @@ async fn wasm_view_cache_invalidation_works() {
 
     // Cache should be invalidated
     let state2 = db
-        .db_ops
+        .db_ops()
         .get_view_cache_state("WasmCacheView")
         .await
         .unwrap();

--- a/tests/view_write_test.rs
+++ b/tests/view_write_test.rs
@@ -45,16 +45,16 @@ async fn identity_write_redirects_to_source() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
 
     let view = identity_view("WriteView", "BlogPost", "title");
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // Verify the view is identity and has a valid source_field_map
-    let stored_view = db.schema_manager.get_view("WriteView").unwrap().unwrap();
+    let stored_view = db.schema_manager().get_view("WriteView").unwrap().unwrap();
     assert!(stored_view.is_identity());
     let field_map = stored_view.source_field_map().unwrap();
     assert_eq!(
@@ -72,14 +72,14 @@ async fn identity_write_redirects_to_source() {
         "pk".to_string(),
         MutationType::Create,
     );
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await
         .unwrap();
 
     // Query the SOURCE schema to verify the write landed there
     let query = Query::new("BlogPost".to_string(), vec!["title".to_string()]);
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
 
     assert!(
         results.contains_key("title"),
@@ -107,7 +107,7 @@ async fn wasm_view_write_is_rejected() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -124,10 +124,10 @@ async fn wasm_view_write_is_rejected() {
         Some(vec![0, 1, 2]), // Placeholder WASM — won't be executed
         HashMap::from([("out".to_string(), FieldValueType::String)]),
     );
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // WASM view should not expose a source_field_map (no inverse)
-    let stored = db.schema_manager.get_view("WasmView").unwrap().unwrap();
+    let stored = db.schema_manager().get_view("WasmView").unwrap().unwrap();
     assert!(!stored.is_identity());
     assert!(
         stored.source_field_map().is_none(),
@@ -145,7 +145,7 @@ async fn wasm_view_write_is_rejected() {
         MutationType::Create,
     );
     let result = db
-        .mutation_manager
+        .mutation_manager()
         .write_mutations_batch_async(vec![mutation])
         .await;
     assert!(result.is_err());
@@ -164,7 +164,7 @@ async fn write_through_view_invalidates_cache() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -173,7 +173,7 @@ async fn write_through_view_invalidates_cache() {
     let mut fields = HashMap::new();
     fields.insert("content".to_string(), json!("original"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -185,22 +185,22 @@ async fn write_through_view_invalidates_cache() {
         .unwrap();
 
     let view = identity_view("CacheWrite", "BlogPost", "content");
-    db.schema_manager.register_view(view).await.unwrap();
+    db.schema_manager().register_view(view).await.unwrap();
 
     // Query the view to populate cache
     let query = Query::new("CacheWrite".to_string(), vec!["content".to_string()]);
-    db.query_executor.query(query.clone()).await.unwrap();
+    db.query_executor().query(query.clone()).await.unwrap();
 
     // Cache should be populated
     assert!(matches!(
-        db.db_ops.get_view_cache_state("CacheWrite").await.unwrap(),
+        db.db_ops().get_view_cache_state("CacheWrite").await.unwrap(),
         ViewCacheState::Cached { .. }
     ));
 
     // Write through the view — should invalidate cache
     let mut mutation_fields = HashMap::new();
     mutation_fields.insert("content".to_string(), json!("updated via view"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "CacheWrite".to_string(),
             mutation_fields,
@@ -212,7 +212,7 @@ async fn write_through_view_invalidates_cache() {
         .unwrap();
 
     // Re-query — should return fresh data including the new write
-    let results = db.query_executor.query(query).await.unwrap();
+    let results = db.query_executor().query(query).await.unwrap();
     let values: Vec<_> = results["content"]
         .values()
         .map(|fv| fv.value.clone())
@@ -233,7 +233,7 @@ async fn write_through_view_cascades_invalidation() {
     db.load_schema_from_json(&blogpost_schema_json())
         .await
         .unwrap();
-    db.schema_manager
+    db.schema_manager()
         .set_schema_state("BlogPost", SchemaState::Approved)
         .await
         .unwrap();
@@ -242,7 +242,7 @@ async fn write_through_view_cascades_invalidation() {
     let mut fields = HashMap::new();
     fields.insert("content".to_string(), json!("v1"));
     fields.insert("publish_date".to_string(), json!("2026-01-01"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "BlogPost".to_string(),
             fields,
@@ -254,7 +254,7 @@ async fn write_through_view_cascades_invalidation() {
         .unwrap();
 
     // ViewA → BlogPost.content
-    db.schema_manager
+    db.schema_manager()
         .register_view(identity_view("ViewA", "BlogPost", "content"))
         .await
         .unwrap();
@@ -268,28 +268,28 @@ async fn write_through_view_cascades_invalidation() {
         None,
         HashMap::from([("content".to_string(), FieldValueType::Any)]),
     );
-    db.schema_manager.register_view(view_b).await.unwrap();
+    db.schema_manager().register_view(view_b).await.unwrap();
 
     // Populate caches for both views
     let query_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
     let query_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    db.query_executor.query(query_a).await.unwrap();
-    db.query_executor.query(query_b.clone()).await.unwrap();
+    db.query_executor().query(query_a).await.unwrap();
+    db.query_executor().query(query_b.clone()).await.unwrap();
 
     // Both should be cached
     assert!(matches!(
-        db.db_ops.get_view_cache_state("ViewA").await.unwrap(),
+        db.db_ops().get_view_cache_state("ViewA").await.unwrap(),
         ViewCacheState::Cached { .. }
     ));
     assert!(matches!(
-        db.db_ops.get_view_cache_state("ViewB").await.unwrap(),
+        db.db_ops().get_view_cache_state("ViewB").await.unwrap(),
         ViewCacheState::Cached { .. }
     ));
 
     // Write through ViewA (identity → BlogPost.content)
     let mut mutation_fields = HashMap::new();
     mutation_fields.insert("content".to_string(), json!("v2"));
-    db.mutation_manager
+    db.mutation_manager()
         .write_mutations_batch_async(vec![Mutation::new(
             "ViewA".to_string(),
             mutation_fields,
@@ -304,7 +304,7 @@ async fn write_through_view_cascades_invalidation() {
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     // ViewB (downstream) should also see the new data after cascade invalidation
-    let results = db.query_executor.query(query_b).await.unwrap();
+    let results = db.query_executor().query(query_b).await.unwrap();
     let values: Vec<_> = results["content"]
         .values()
         .map(|fv| fv.value.clone())

--- a/tests/view_write_test.rs
+++ b/tests/view_write_test.rs
@@ -193,7 +193,10 @@ async fn write_through_view_invalidates_cache() {
 
     // Cache should be populated
     assert!(matches!(
-        db.db_ops().get_view_cache_state("CacheWrite").await.unwrap(),
+        db.db_ops()
+            .get_view_cache_state("CacheWrite")
+            .await
+            .unwrap(),
         ViewCacheState::Cached { .. }
     ));
 


### PR DESCRIPTION
## Summary
- Make all 9 public fields on `FoldDB` struct `pub(crate)` instead of `pub`
- Add public accessor methods: `db_ops()`, `query_executor()`, `event_monitor()`, `pending_tasks()` (existing: `schema_manager()`, `mutation_manager()`, `message_bus()`, `config_store()`, `get_db_ops()`)
- Update all integration tests to use accessor methods instead of direct field access

## Motivation
External crates (fold_db_node) were reaching directly into FoldDB internals, bypassing the query/mutation API. This encapsulates the struct so future internal refactors don't break external callers.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` passes (all integration tests updated)
- [x] Companion PR in fold_db_node confirms external callers compile with new accessors

> **Note**: fold_db_node PR depends on this merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)