### PR TITLE
refactor: make DbOperations store getters pub(crate)

### DIFF
--- a/src/db_operations/atom_operations.rs
+++ b/src/db_operations/atom_operations.rs
@@ -16,6 +16,22 @@ pub enum MoleculeData {
 }
 
 impl DbOperations {
+    /// Retrieve a single atom by its UUID.
+    ///
+    /// When `org_hash` is `Some`, the key is prefixed with `{org_hash}:`.
+    pub async fn get_atom_by_uuid(
+        &self,
+        atom_uuid: &str,
+        org_hash: Option<&str>,
+    ) -> Result<Option<Atom>, SchemaError> {
+        let base_key = format!("atom:{}", atom_uuid);
+        let key = build_storage_key(org_hash, &base_key);
+        self.atoms_store()
+            .get_item::<Atom>(&key)
+            .await
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to fetch atom: {}", e)))
+    }
+
     /// Creates an atom in memory without storing it.
     /// Used for batch operations where atoms are collected first then stored together.
     pub fn create_atom(

--- a/src/db_operations/core.rs
+++ b/src/db_operations/core.rs
@@ -93,59 +93,72 @@ impl DbOperations {
         Self::from_namespaced_store(store).await
     }
 
-    // ===== Namespace-specific store getters =====
+    // ===== Internal store getters (crate-only) =====
+    //
+    // External callers should use the domain operation methods
+    // (atom_operations, schema_operations, etc.) instead of accessing
+    // raw stores directly.
 
-    pub fn metadata_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn metadata_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.metadata_store
     }
 
-    pub fn permissions_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn permissions_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.permissions_store
     }
 
-    pub fn schema_states_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn schema_states_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.schema_states_store
     }
 
-    pub fn schemas_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn schemas_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.schemas_store
     }
 
-    pub fn public_keys_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn public_keys_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.public_keys_store
     }
 
-    pub fn idempotency_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn idempotency_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.idempotency_store
     }
 
-    pub fn process_results_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn process_results_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.process_results_store
     }
 
-    pub fn superseded_by_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn superseded_by_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.superseded_by_store
     }
 
+    /// Access the native index manager for embedding and search operations.
     pub fn native_index_manager(&self) -> Option<&NativeIndexManager> {
         self.native_index_manager.as_ref()
     }
 
-    pub fn views_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn views_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.views_store
     }
 
-    pub fn view_states_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn view_states_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.view_states_store
     }
 
-    pub fn transform_field_states_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn transform_field_states_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.transform_field_states_store
     }
 
     /// Get atoms/molecules store (same as main_store for backward compatibility)
-    pub fn atoms_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    pub(crate) fn atoms_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
         &self.main_store
+    }
+
+    // ===== Public accessors for external callers =====
+
+    /// Get the raw metadata KvStore for external modules that need generic key-value
+    /// access (e.g., discovery configs, async queries).
+    pub fn raw_metadata_store(&self) -> Arc<dyn KvStore> {
+        self.metadata_store.inner().clone()
     }
 
     /// Flush all pending writes to durable storage

--- a/src/db_operations/metadata_operations.rs
+++ b/src/db_operations/metadata_operations.rs
@@ -1,6 +1,8 @@
 use super::core::DbOperations;
 use crate::schema::SchemaError;
 use crate::storage::traits::TypedStore;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use uuid::Uuid;
 
 impl DbOperations {
@@ -36,5 +38,43 @@ impl DbOperations {
             .await?;
         self.metadata_store().inner().flush().await?;
         Ok(())
+    }
+
+    // ===== Idempotency store operations =====
+
+    /// Retrieve an item from the idempotency store by key.
+    pub async fn get_idempotency_item<T: DeserializeOwned + Send + Sync>(
+        &self,
+        key: &str,
+    ) -> Result<Option<T>, SchemaError> {
+        self.idempotency_store()
+            .get_item::<T>(key)
+            .await
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to get idempotency item: {}", e)))
+    }
+
+    /// Store an item in the idempotency store.
+    pub async fn put_idempotency_item<T: Serialize + Send + Sync>(
+        &self,
+        key: &str,
+        item: &T,
+    ) -> Result<(), SchemaError> {
+        self.idempotency_store().put_item(key, item).await?;
+        Ok(())
+    }
+
+    // ===== Process results store operations =====
+
+    /// Scan process results by key prefix.
+    pub async fn scan_process_results<T: DeserializeOwned + Send + Sync>(
+        &self,
+        prefix: &str,
+    ) -> Result<Vec<(String, T)>, SchemaError> {
+        self.process_results_store()
+            .scan_items_with_prefix(prefix)
+            .await
+            .map_err(|e| {
+                SchemaError::InvalidData(format!("Failed to scan process results: {}", e))
+            })
     }
 }

--- a/src/db_operations/metadata_operations.rs
+++ b/src/db_operations/metadata_operations.rs
@@ -73,8 +73,6 @@ impl DbOperations {
         self.process_results_store()
             .scan_items_with_prefix(prefix)
             .await
-            .map_err(|e| {
-                SchemaError::InvalidData(format!("Failed to scan process results: {}", e))
-            })
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to scan process results: {}", e)))
     }
 }

--- a/tests/atom_deduplication_test.rs
+++ b/tests/atom_deduplication_test.rs
@@ -95,19 +95,9 @@ async fn test_atom_deduplication_in_db() {
     );
 
     // Verify only one atom is stored in the database
-    // Use the same pattern as in atom_operations_v2.rs
-    let atom_key = format!("atom:{}", atom1.uuid());
-    // atoms_store() returns &Arc<TypedKvStore>, dereference to get TypedKvStore which implements TypedStore
-    use fold_db::storage::traits::TypedStore;
-    let stored_atom: Option<Atom> = (**db_ops.atoms_store())
-        .get_item::<Atom>(&atom_key)
+    let stored_atom: Option<Atom> = db_ops
+        .get_atom_by_uuid(atom1.uuid(), None)
         .await
-        .map_err(|e| {
-            fold_db::schema::SchemaError::InvalidData(format!(
-                "Failed to check existing atom: {}",
-                e
-            ))
-        })
         .expect("Failed to get atom");
 
     assert!(stored_atom.is_some(), "Atom should be stored in database");


### PR DESCRIPTION
## Summary
- Make 12 raw store namespace getters on `DbOperations` `pub(crate)` instead of `pub` so external callers cannot bypass domain operation methods
- Keep `native_index_manager()` as `pub` since it exposes a full subsystem needed externally
- Add `raw_metadata_store()` for external modules needing generic KV access (discovery configs, async queries)
- Add `get_atom_by_uuid()`, `get_idempotency_item()`/`put_idempotency_item()`, `scan_process_results()` as proper domain operation methods
- Update atom deduplication test to use new `get_atom_by_uuid()` method

Part 1 of 2 — companion PR in fold_db_node updates all call sites.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-targets` passes
- [x] No external callers can access raw stores directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)