### PR TITLE
refactor: point sync lock endpoint at storage_admin_service

### DIFF
--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -254,7 +254,7 @@ impl AuthClient {
             "ttl_secs": ttl_secs,
         });
 
-        let resp = self.post("/api/sync/lock", body).await?;
+        let resp = self.post("/api/storage-admin/lock", body).await?;
         let parsed: LockResponse = serde_json::from_value(resp)?;
 
         if !parsed.ok {
@@ -279,7 +279,7 @@ impl AuthClient {
             "device_id": device_id,
         });
 
-        let resp = self.post("/api/sync/lock", body).await?;
+        let resp = self.post("/api/storage-admin/lock", body).await?;
         let parsed: LockResponse = serde_json::from_value(resp)?;
 
         if !parsed.ok {
@@ -299,7 +299,7 @@ impl AuthClient {
             "ttl_secs": ttl_secs,
         });
 
-        let resp = self.post("/api/sync/lock", body).await?;
+        let resp = self.post("/api/storage-admin/lock", body).await?;
         let parsed: LockResponse = serde_json::from_value(resp)?;
 
         if !parsed.ok {


### PR DESCRIPTION
## Summary
- Device-lock handlers are moving from `storage_service` to `storage_admin_service` in exemem-infra so the hot presign path stays lean on cold starts.
- Update `src/sync/auth.rs` to call `POST /api/storage-admin/lock` instead of `POST /api/sync/lock` for acquire/release/renew.
- Paired with EdgeVector/exemem-infra#99. Deploy the infra PR before/with this one to avoid a transient 404 on lock requests.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets sync` passes
- [ ] Dogfood dev cloud: confirm acquire/release/renew work end-to-end against deployed storage_admin_service

🤖 Generated with [Claude Code](https://claude.com/claude-code)