### PR TITLE
refactor: point org management at new org_service Lambda

### DIFF
--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -417,7 +417,11 @@ impl AuthClient {
             .and_then(|v| v.as_str())
             .unwrap_or("org_action")
             .to_string();
-        let resp = self.post("/api/sync/org", body).await?;
+        // Org management is now served by the standalone `org_service`
+        // Lambda (split out of storage_service). The cloud endpoint is
+        // `POST /api/org/{action}` — we post to `/api/org/action` and
+        // the Lambda dispatches by the `action` field in the body.
+        let resp = self.post("/api/org/action", body).await?;
         let ok = resp.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
         if !ok {
             let default_msg = format!("{action} failed");


### PR DESCRIPTION
## Summary
- Org management was split out of `storage_service` into a standalone `org_service` Lambda in exemem-infra#102.
- Cloud route moved from `POST /api/sync/org` to `POST /api/org/*` — update the sync auth client to match.

## Dependency
**Depends on exemem-infra#102 being merged and deployed to dev before this lands.** If this lands first, org management from the client breaks until infra deploys.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -D warnings`
- [ ] After infra deploy: smoke test create_org/list_members end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)