### PR TITLE
refactor: extract ViewInvalidationService from MutationManager

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -446,11 +446,22 @@ impl FoldDB {
         // Create shared IndexStatusTracker for tracking indexing progress
         let index_status_tracker = IndexStatusTracker::new(Some(progress_tracker.clone()));
 
+        // Create ViewInvalidationService that MutationManager uses for
+        // view lifecycle events (redirect writes, invalidate caches,
+        // precompute dependents).
+        let view_invalidation_service =
+            Arc::new(super::view_invalidation::ViewInvalidationService::new(
+                Arc::clone(&schema_manager),
+                Arc::clone(&db_ops),
+                Arc::clone(&message_bus),
+            ));
+
         // Create MutationManager for handling all mutation operations
         let mutation_manager = MutationManager::new(
             Arc::clone(&db_ops),
             Arc::clone(&schema_manager),
             Arc::clone(&message_bus),
+            Arc::clone(&view_invalidation_service),
             Some(index_status_tracker.clone()),
         );
 

--- a/src/fold_db_core/mod.rs
+++ b/src/fold_db_core/mod.rs
@@ -18,6 +18,7 @@ pub mod query;
 // Core components
 
 pub mod mutation_manager;
+pub mod view_invalidation;
 
 // Re-export key components
 pub use infrastructure::EventMonitor;

--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::orchestration::index_status::IndexStatusTracker;
+use super::view_invalidation::ViewInvalidationService;
 use crate::atom::{Atom, FieldKey, MutationEvent};
 use crate::db_operations::{DbOperations, MoleculeData};
 use crate::messaging::events::query_events::MutationExecuted;
@@ -17,91 +18,10 @@ use crate::schema::types::field::{Field, FieldVariant};
 use crate::schema::types::{KeyValue, Mutation, Schema};
 use crate::schema::{SchemaCore, SchemaError};
 use crate::storage::traits::TypedStore;
-use crate::view::resolver::{SourceQueryFn, ViewResolver};
-use crate::view::types::ViewCacheState;
 use chrono::Utc;
 use log::{debug, error, warn};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
-
-/// Source query implementation for background precomputation.
-/// Resolves sources from schemas or cached views (does NOT recurse into
-/// uncached views — those should already be computed by the time we need them,
-/// since we process in bottom-up order).
-struct PrecomputeSourceQuery {
-    schema_manager: Arc<SchemaCore>,
-    db_ops: Arc<DbOperations>,
-    hash_range_processor: super::query::hash_range_query::HashRangeQueryProcessor,
-    view_resolver: ViewResolver,
-}
-
-#[async_trait::async_trait]
-impl SourceQueryFn for PrecomputeSourceQuery {
-    async fn execute_query(
-        &self,
-        query: &crate::schema::types::operations::Query,
-    ) -> Result<
-        HashMap<String, HashMap<KeyValue, crate::schema::types::field::FieldValue>>,
-        SchemaError,
-    > {
-        // Try as schema first
-        match self.schema_manager.get_schema(&query.schema_name).await? {
-            Some(mut schema) => {
-                self.hash_range_processor
-                    .query_with_filter(
-                        &mut schema,
-                        &query.fields,
-                        query.filter.clone(),
-                        query.as_of,
-                    )
-                    .await
-            }
-            None => {
-                // Try as view — must be cached (computed earlier in bottom-up order)
-                let view = {
-                    let registry =
-                        self.schema_manager.view_registry().lock().map_err(|_| {
-                            SchemaError::InvalidData("view_registry lock".to_string())
-                        })?;
-                    registry
-                        .get_view(&query.schema_name)
-                        .cloned()
-                        .ok_or_else(|| {
-                            SchemaError::NotFound(format!(
-                                "'{}' not found as schema or view during precomputation",
-                                query.schema_name
-                            ))
-                        })?
-                };
-
-                let cache_state = self.db_ops.get_view_cache_state(&view.name).await?;
-
-                // Source view should be Cached (computed earlier in bottom-up order).
-                // If it's still Empty, compute it inline.
-                let effective_cache = if matches!(cache_state, ViewCacheState::Cached { .. }) {
-                    cache_state
-                } else {
-                    ViewCacheState::Empty
-                };
-
-                let (results, new_cache) = self
-                    .view_resolver
-                    .resolve(&view, &query.fields, &effective_cache, self)
-                    .await?;
-
-                // Persist if we just computed it
-                if effective_cache.is_empty() && matches!(new_cache, ViewCacheState::Cached { .. })
-                {
-                    self.db_ops
-                        .set_view_cache_state(&view.name, &new_cache)
-                        .await?;
-                }
-
-                Ok(results)
-            }
-        }
-    }
-}
 
 /// Manages mutation operations for the FoldDB system
 pub struct MutationManager {
@@ -111,6 +31,8 @@ pub struct MutationManager {
     schema_manager: Arc<SchemaCore>,
     /// Message bus for event publishing and listening
     message_bus: Arc<AsyncMessageBus>,
+    /// View lifecycle service (redirect/invalidate/precompute)
+    view_invalidation_service: Arc<ViewInvalidationService>,
     /// Index status tracker for reporting indexing progress
     index_status_tracker: Option<IndexStatusTracker>,
     /// Flag to track if the event listener is running
@@ -123,12 +45,14 @@ impl MutationManager {
         db_ops: Arc<DbOperations>,
         schema_manager: Arc<SchemaCore>,
         message_bus: Arc<AsyncMessageBus>,
+        view_invalidation_service: Arc<ViewInvalidationService>,
         index_status_tracker: Option<IndexStatusTracker>,
     ) -> Self {
         Self {
             db_ops,
             schema_manager,
             message_bus,
+            view_invalidation_service,
             index_status_tracker,
             is_listening: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
@@ -215,7 +139,10 @@ impl MutationManager {
         }
 
         // Phase 0: Redirect identity view mutations to source schemas
-        let mutations = self.redirect_view_mutations(mutations).await?;
+        let mutations = self
+            .view_invalidation_service
+            .redirect_mutation(mutations)
+            .await?;
 
         log::info!(
             "🔄 write_mutations_batch_async: Starting batch of {} mutations",
@@ -367,7 +294,8 @@ impl MutationManager {
                 .collect::<HashSet<_>>()
                 .into_iter()
                 .collect();
-            self.invalidate_dependent_view_caches(&schema_name, &fields_affected)
+            self.view_invalidation_service
+                .invalidate_on_mutation(&schema_name, &fields_affected)
                 .await?;
         }
 
@@ -893,366 +821,6 @@ impl MutationManager {
         Ok(())
     }
 
-    // ========== View mutation rejection + invalidation ==========
-
-    /// Phase 0: Redirect mutations targeting identity views to their source schemas.
-    /// WASM views are not writable (would require inverse transforms).
-    async fn redirect_view_mutations(
-        &self,
-        mutations: Vec<Mutation>,
-    ) -> Result<Vec<Mutation>, SchemaError> {
-        let mut result = Vec::with_capacity(mutations.len());
-
-        for mutation in mutations {
-            let view_info = {
-                let registry = self.schema_manager.view_registry().lock().map_err(|_| {
-                    SchemaError::InvalidData("Failed to acquire view_registry lock".to_string())
-                })?;
-                registry.get_view(&mutation.schema_name).cloned()
-            };
-
-            let Some(view) = view_info else {
-                // Not a view — pass through to normal pipeline
-                result.push(mutation);
-                continue;
-            };
-
-            // Get source field map (only works for identity views)
-            let field_map = view.source_field_map().ok_or_else(|| {
-                SchemaError::InvalidData(format!(
-                    "Cannot write to WASM view '{}'. Write-back through WASM views is not yet supported.",
-                    view.name
-                ))
-            })?;
-
-            // Group mutation fields by target source schema
-            let mut redirected: HashMap<String, HashMap<String, serde_json::Value>> =
-                HashMap::new();
-
-            for (field_name, value) in &mutation.fields_and_values {
-                let (source_schema, source_field) = field_map.get(field_name).ok_or_else(|| {
-                    SchemaError::InvalidField(format!(
-                        "Field '{}' not found in view '{}'",
-                        field_name, view.name
-                    ))
-                })?;
-
-                redirected
-                    .entry(source_schema.clone())
-                    .or_default()
-                    .insert(source_field.clone(), value.clone());
-            }
-
-            // Create one redirected mutation per source schema
-            for (target_schema, fields_and_values) in redirected {
-                result.push(Mutation {
-                    uuid: uuid::Uuid::new_v4().to_string(),
-                    schema_name: target_schema,
-                    fields_and_values,
-                    key_value: mutation.key_value.clone(),
-                    pub_key: mutation.pub_key.clone(),
-                    mutation_type: mutation.mutation_type.clone(),
-                    synchronous: mutation.synchronous,
-                    source_file_name: mutation.source_file_name.clone(),
-                    metadata: mutation.metadata.clone(),
-                });
-            }
-        }
-
-        Ok(result)
-    }
-
-    /// Phase 7.5: Invalidate view caches that depend on mutated source fields.
-    /// Operates at the view level (not per-field).
-    async fn invalidate_dependent_view_caches(
-        &self,
-        schema_name: &str,
-        fields_affected: &[String],
-    ) -> Result<(), SchemaError> {
-        // Collect all view names that depend on any of the affected fields
-        let dependent_views: HashSet<String> = {
-            let registry = self
-                .schema_manager
-                .view_registry()
-                .lock()
-                .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
-
-            let mut views = HashSet::new();
-            for field_name in fields_affected {
-                let deps = registry
-                    .dependency_tracker
-                    .get_dependents(schema_name, field_name);
-                for view_name in deps {
-                    views.insert(view_name.clone());
-                }
-            }
-            views
-        };
-
-        // Collect ALL views to invalidate (direct + transitive) in one pass
-        let mut all_invalidated: Vec<String> = Vec::new();
-        let mut visited = HashSet::new();
-        for view_name in &dependent_views {
-            all_invalidated.push(view_name.clone());
-            self.collect_cascade_views(view_name, &mut visited, &mut all_invalidated)?;
-        }
-
-        // Invalidate all collected views (both Cached and Computing).
-        // Computing views must also be reset: a background precompute task
-        // started before this mutation holds stale source data. Resetting to
-        // Empty ensures the precompute task's check-before-store sees Empty
-        // and the view will be re-precomputed with fresh data.
-        for view_name in &all_invalidated {
-            let current_state = self.db_ops.get_view_cache_state(view_name).await?;
-
-            if !current_state.is_empty() {
-                self.db_ops
-                    .set_view_cache_state(view_name, &ViewCacheState::Empty)
-                    .await?;
-                log::debug!(
-                    "Invalidated view cache '{}' ({:?} → Empty, source {}.{} mutated)",
-                    view_name,
-                    current_state,
-                    schema_name,
-                    fields_affected.first().unwrap_or(&String::new())
-                );
-            }
-        }
-
-        // Identify views deeper than level 1 (depend on other views) and
-        // spawn background precomputation. All invalidated views are passed
-        // in bottom-up order so leaf views compute first, but only deep views
-        // (level 2+) are marked Computing — level 1 views stay Empty and can
-        // also be lazily queried.
-        let (all_ordered, deep_views) =
-            self.partition_views_for_precomputation(&all_invalidated)?;
-        if !deep_views.is_empty() {
-            self.spawn_background_precomputation(all_ordered, deep_views)
-                .await?;
-        }
-
-        Ok(())
-    }
-
-    /// Collect all transitive cascade views in one pass (single lock acquisition).
-    fn collect_cascade_views(
-        &self,
-        view_name: &str,
-        visited: &mut HashSet<String>,
-        result: &mut Vec<String>,
-    ) -> Result<(), SchemaError> {
-        if !visited.insert(view_name.to_string()) {
-            return Ok(());
-        }
-
-        let cascade_views: Vec<String> = {
-            let registry = self
-                .schema_manager
-                .view_registry()
-                .lock()
-                .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
-            registry
-                .dependency_tracker
-                .get_all_dependents_of_schema(view_name)
-        };
-
-        for dep in &cascade_views {
-            if !visited.contains(dep) {
-                result.push(dep.clone());
-                self.collect_cascade_views(dep, visited, result)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Partition invalidated views into:
-    /// - `all_ordered`: all views in bottom-up order (leaves first) for precomputation
-    /// - `deep_only`: subset that depends on other views (level 2+), to be marked Computing
-    fn partition_views_for_precomputation(
-        &self,
-        invalidated: &[String],
-    ) -> Result<(Vec<String>, HashSet<String>), SchemaError> {
-        let registry = self
-            .schema_manager
-            .view_registry()
-            .lock()
-            .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
-
-        let invalidated_set: HashSet<&str> = invalidated.iter().map(|s| s.as_str()).collect();
-
-        // Classify each view as level-1 (only schema sources) or deep (has view sources).
-        // Also build an adjacency map for topological sorting.
-        let mut deep: HashSet<String> = HashSet::new();
-        let mut in_degree: HashMap<String, usize> = HashMap::new();
-        // view_name → list of views that depend on it (within the invalidated set)
-        let mut dependents_of: HashMap<String, Vec<String>> = HashMap::new();
-
-        for view_name in invalidated {
-            if let Some(view) = registry.get_view(view_name) {
-                let view_sources_in_set: Vec<String> = view
-                    .source_schemas()
-                    .into_iter()
-                    .filter(|source| {
-                        registry.get_view(source).is_some()
-                            && invalidated_set.contains(source.as_str())
-                    })
-                    .collect();
-
-                if !view_sources_in_set.is_empty() {
-                    deep.insert(view_name.clone());
-                }
-
-                in_degree.insert(view_name.clone(), view_sources_in_set.len());
-                for source in view_sources_in_set {
-                    dependents_of
-                        .entry(source)
-                        .or_default()
-                        .push(view_name.clone());
-                }
-            }
-        }
-
-        // Kahn's algorithm: topological sort so leaves (in_degree=0) come first
-        let mut queue: std::collections::VecDeque<String> = in_degree
-            .iter()
-            .filter(|(_, &deg)| deg == 0)
-            .map(|(name, _)| name.clone())
-            .collect();
-        let mut all: Vec<String> = Vec::new();
-
-        while let Some(current) = queue.pop_front() {
-            all.push(current.clone());
-            if let Some(deps) = dependents_of.get(&current) {
-                for dep in deps {
-                    if let Some(deg) = in_degree.get_mut(dep) {
-                        *deg = deg.saturating_sub(1);
-                        if *deg == 0 {
-                            queue.push_back(dep.clone());
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok((all, deep))
-    }
-
-    /// Mark deep views as Computing and spawn a background task to precompute
-    /// all views in bottom-up order. Level 1 views are computed first (they
-    /// only depend on schemas) so that deep views can resolve against them.
-    async fn spawn_background_precomputation(
-        &self,
-        all_ordered: Vec<String>,
-        deep_views: HashSet<String>,
-    ) -> Result<(), SchemaError> {
-        // Only mark deep views as Computing (level 1 stays Empty for lazy query)
-        for view_name in &deep_views {
-            self.db_ops
-                .set_view_cache_state(view_name, &ViewCacheState::Computing)
-                .await?;
-            log::debug!(
-                "View '{}' marked as Computing for background precomputation",
-                view_name
-            );
-        }
-
-        // Spawn background task that computes ALL views bottom-up
-        let schema_manager = Arc::clone(&self.schema_manager);
-        let db_ops = Arc::clone(&self.db_ops);
-
-        tokio::spawn(async move {
-            if let Err(e) = Self::precompute_views(schema_manager, db_ops, all_ordered).await {
-                log::error!("Background view precomputation failed: {}", e);
-            }
-        });
-
-        Ok(())
-    }
-
-    /// Background task: precompute views in bottom-up order.
-    /// Each view's sources must be Cached before it can be computed.
-    async fn precompute_views(
-        schema_manager: Arc<SchemaCore>,
-        db_ops: Arc<DbOperations>,
-        views_to_compute: Vec<String>,
-    ) -> Result<(), SchemaError> {
-        use super::query::hash_range_query::HashRangeQueryProcessor;
-
-        let wasm_engine = {
-            let registry = schema_manager
-                .view_registry()
-                .lock()
-                .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
-            Arc::clone(registry.wasm_engine())
-        };
-
-        for view_name in &views_to_compute {
-            // Get view definition
-            let view = {
-                let registry = schema_manager
-                    .view_registry()
-                    .lock()
-                    .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
-                match registry.get_view(view_name) {
-                    Some(v) => v.clone(),
-                    None => {
-                        log::warn!("View '{}' disappeared during precomputation", view_name);
-                        continue;
-                    }
-                }
-            };
-
-            // Check current state:
-            // - Computing: deep view, precompute and store
-            // - Empty: level-1 view, precompute and store (needed by deeper views)
-            // - Cached: already computed (perhaps by a lazy query), skip
-            let state = db_ops.get_view_cache_state(view_name).await?;
-            if matches!(state, ViewCacheState::Cached { .. }) {
-                log::debug!(
-                    "View '{}' already Cached, skipping precomputation",
-                    view_name
-                );
-                continue;
-            }
-
-            // Build source query for resolution
-            let source_query = PrecomputeSourceQuery {
-                schema_manager: Arc::clone(&schema_manager),
-                db_ops: Arc::clone(&db_ops),
-                hash_range_processor: HashRangeQueryProcessor::new(Arc::clone(&db_ops)),
-                view_resolver: ViewResolver::new(Arc::clone(&wasm_engine)),
-            };
-
-            let resolver = ViewResolver::new(Arc::clone(&wasm_engine));
-            match resolver
-                .resolve(&view, &[], &ViewCacheState::Empty, &source_query)
-                .await
-            {
-                Ok((_, new_cache)) => {
-                    // Only store if not re-invalidated since we started
-                    let current = db_ops.get_view_cache_state(view_name).await?;
-                    if !matches!(current, ViewCacheState::Cached { .. }) {
-                        db_ops.set_view_cache_state(view_name, &new_cache).await?;
-                        log::info!("View '{}' precomputed successfully", view_name);
-                    }
-                }
-                Err(e) => {
-                    log::error!("Failed to precompute view '{}': {}", view_name, e);
-                    // Reset Computing to Empty so it can be lazily computed on next query
-                    let current = db_ops.get_view_cache_state(view_name).await?;
-                    if current.is_computing() {
-                        db_ops
-                            .set_view_cache_state(view_name, &ViewCacheState::Empty)
-                            .await?;
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
     /// Start listening for MutationRequest events in a background thread
     pub async fn start_event_listener(&self, user_id: String) -> Result<(), SchemaError> {
         if self.is_listening.load(std::sync::atomic::Ordering::Acquire) {
@@ -1263,6 +831,7 @@ impl MutationManager {
         let db_ops = Arc::clone(&self.db_ops);
         let schema_manager = Arc::clone(&self.schema_manager);
         let message_bus = Arc::clone(&self.message_bus);
+        let view_invalidation_service = Arc::clone(&self.view_invalidation_service);
         let is_listening = Arc::clone(&self.is_listening);
 
         is_listening.store(true, std::sync::atomic::Ordering::Release);
@@ -1283,6 +852,7 @@ impl MutationManager {
                                     Arc::clone(&db_ops),
                                     Arc::clone(&schema_manager),
                                     Arc::clone(&message_bus),
+                                    Arc::clone(&view_invalidation_service),
                                     None,
                                 );
 

--- a/src/fold_db_core/view_invalidation.rs
+++ b/src/fold_db_core/view_invalidation.rs
@@ -1,0 +1,481 @@
+//! View Invalidation Service
+//!
+//! Extracted from MutationManager. Owns all view lifecycle logic triggered by
+//! mutations: redirecting mutations targeting identity views to their source
+//! schemas, invalidating dependent view caches, topologically ordering cascade
+//! views, and spawning background precomputation tasks.
+//!
+//! This is pure graph/view orchestration — it has nothing to do with mutation
+//! execution per se (atoms, molecules, idempotency). It's triggered BY
+//! mutations but is not part of the mutation pipeline.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+
+use crate::db_operations::DbOperations;
+use crate::messaging::AsyncMessageBus;
+use crate::schema::types::{KeyValue, Mutation};
+use crate::schema::{SchemaCore, SchemaError};
+use crate::view::resolver::{SourceQueryFn, ViewResolver};
+use crate::view::types::ViewCacheState;
+
+/// Source query implementation for background precomputation.
+/// Resolves sources from schemas or cached views (does NOT recurse into
+/// uncached views — those should already be computed by the time we need them,
+/// since we process in bottom-up order).
+struct PrecomputeSourceQuery {
+    schema_manager: Arc<SchemaCore>,
+    db_ops: Arc<DbOperations>,
+    hash_range_processor: super::query::hash_range_query::HashRangeQueryProcessor,
+    view_resolver: ViewResolver,
+}
+
+#[async_trait::async_trait]
+impl SourceQueryFn for PrecomputeSourceQuery {
+    async fn execute_query(
+        &self,
+        query: &crate::schema::types::operations::Query,
+    ) -> Result<
+        HashMap<String, HashMap<KeyValue, crate::schema::types::field::FieldValue>>,
+        SchemaError,
+    > {
+        // Try as schema first
+        match self.schema_manager.get_schema(&query.schema_name).await? {
+            Some(mut schema) => {
+                self.hash_range_processor
+                    .query_with_filter(
+                        &mut schema,
+                        &query.fields,
+                        query.filter.clone(),
+                        query.as_of,
+                    )
+                    .await
+            }
+            None => {
+                // Try as view — must be cached (computed earlier in bottom-up order)
+                let view = {
+                    let registry =
+                        self.schema_manager.view_registry().lock().map_err(|_| {
+                            SchemaError::InvalidData("view_registry lock".to_string())
+                        })?;
+                    registry
+                        .get_view(&query.schema_name)
+                        .cloned()
+                        .ok_or_else(|| {
+                            SchemaError::NotFound(format!(
+                                "'{}' not found as schema or view during precomputation",
+                                query.schema_name
+                            ))
+                        })?
+                };
+
+                let cache_state = self.db_ops.get_view_cache_state(&view.name).await?;
+
+                // Source view should be Cached (computed earlier in bottom-up order).
+                // If it's still Empty, compute it inline.
+                let effective_cache = if matches!(cache_state, ViewCacheState::Cached { .. }) {
+                    cache_state
+                } else {
+                    ViewCacheState::Empty
+                };
+
+                let (results, new_cache) = self
+                    .view_resolver
+                    .resolve(&view, &query.fields, &effective_cache, self)
+                    .await?;
+
+                // Persist if we just computed it
+                if effective_cache.is_empty() && matches!(new_cache, ViewCacheState::Cached { .. })
+                {
+                    self.db_ops
+                        .set_view_cache_state(&view.name, &new_cache)
+                        .await?;
+                }
+
+                Ok(results)
+            }
+        }
+    }
+}
+
+/// Service that handles view lifecycle events triggered by mutations.
+pub struct ViewInvalidationService {
+    schema_manager: Arc<SchemaCore>,
+    db_ops: Arc<DbOperations>,
+    #[allow(dead_code)]
+    message_bus: Arc<AsyncMessageBus>,
+}
+
+impl ViewInvalidationService {
+    /// Create a new ViewInvalidationService.
+    pub fn new(
+        schema_manager: Arc<SchemaCore>,
+        db_ops: Arc<DbOperations>,
+        message_bus: Arc<AsyncMessageBus>,
+    ) -> Self {
+        Self {
+            schema_manager,
+            db_ops,
+            message_bus,
+        }
+    }
+
+    /// Redirect mutations targeting identity views to their source schemas.
+    /// WASM views are not writable (would require inverse transforms).
+    pub async fn redirect_mutation(
+        &self,
+        mutations: Vec<Mutation>,
+    ) -> Result<Vec<Mutation>, SchemaError> {
+        let mut result = Vec::with_capacity(mutations.len());
+
+        for mutation in mutations {
+            let view_info = {
+                let registry = self.schema_manager.view_registry().lock().map_err(|_| {
+                    SchemaError::InvalidData("Failed to acquire view_registry lock".to_string())
+                })?;
+                registry.get_view(&mutation.schema_name).cloned()
+            };
+
+            let Some(view) = view_info else {
+                // Not a view — pass through to normal pipeline
+                result.push(mutation);
+                continue;
+            };
+
+            // Get source field map (only works for identity views)
+            let field_map = view.source_field_map().ok_or_else(|| {
+                SchemaError::InvalidData(format!(
+                    "Cannot write to WASM view '{}'. Write-back through WASM views is not yet supported.",
+                    view.name
+                ))
+            })?;
+
+            // Group mutation fields by target source schema
+            let mut redirected: HashMap<String, HashMap<String, serde_json::Value>> =
+                HashMap::new();
+
+            for (field_name, value) in &mutation.fields_and_values {
+                let (source_schema, source_field) = field_map.get(field_name).ok_or_else(|| {
+                    SchemaError::InvalidField(format!(
+                        "Field '{}' not found in view '{}'",
+                        field_name, view.name
+                    ))
+                })?;
+
+                redirected
+                    .entry(source_schema.clone())
+                    .or_default()
+                    .insert(source_field.clone(), value.clone());
+            }
+
+            // Create one redirected mutation per source schema
+            for (target_schema, fields_and_values) in redirected {
+                result.push(Mutation {
+                    uuid: uuid::Uuid::new_v4().to_string(),
+                    schema_name: target_schema,
+                    fields_and_values,
+                    key_value: mutation.key_value.clone(),
+                    pub_key: mutation.pub_key.clone(),
+                    mutation_type: mutation.mutation_type.clone(),
+                    synchronous: mutation.synchronous,
+                    source_file_name: mutation.source_file_name.clone(),
+                    metadata: mutation.metadata.clone(),
+                });
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invalidate view caches that depend on mutated source fields, and spawn
+    /// background precomputation for deep views. Operates at the view level
+    /// (not per-field).
+    pub async fn invalidate_on_mutation(
+        &self,
+        schema_name: &str,
+        fields_affected: &[String],
+    ) -> Result<(), SchemaError> {
+        // Collect all view names that depend on any of the affected fields
+        let dependent_views: HashSet<String> = {
+            let registry = self
+                .schema_manager
+                .view_registry()
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
+
+            let mut views = HashSet::new();
+            for field_name in fields_affected {
+                let deps = registry
+                    .dependency_tracker
+                    .get_dependents(schema_name, field_name);
+                for view_name in deps {
+                    views.insert(view_name.clone());
+                }
+            }
+            views
+        };
+
+        // Collect ALL views to invalidate (direct + transitive) in one pass
+        let mut all_invalidated: Vec<String> = Vec::new();
+        let mut visited = HashSet::new();
+        for view_name in &dependent_views {
+            all_invalidated.push(view_name.clone());
+            self.collect_cascade_views(view_name, &mut visited, &mut all_invalidated)?;
+        }
+
+        // Invalidate all collected views (both Cached and Computing).
+        // Computing views must also be reset: a background precompute task
+        // started before this mutation holds stale source data. Resetting to
+        // Empty ensures the precompute task's check-before-store sees Empty
+        // and the view will be re-precomputed with fresh data.
+        for view_name in &all_invalidated {
+            let current_state = self.db_ops.get_view_cache_state(view_name).await?;
+
+            if !current_state.is_empty() {
+                self.db_ops
+                    .set_view_cache_state(view_name, &ViewCacheState::Empty)
+                    .await?;
+                log::debug!(
+                    "Invalidated view cache '{}' ({:?} → Empty, source {}.{} mutated)",
+                    view_name,
+                    current_state,
+                    schema_name,
+                    fields_affected.first().unwrap_or(&String::new())
+                );
+            }
+        }
+
+        // Identify views deeper than level 1 (depend on other views) and
+        // spawn background precomputation. All invalidated views are passed
+        // in bottom-up order so leaf views compute first, but only deep views
+        // (level 2+) are marked Computing — level 1 views stay Empty and can
+        // also be lazily queried.
+        let (all_ordered, deep_views) =
+            self.partition_views_for_precomputation(&all_invalidated)?;
+        if !deep_views.is_empty() {
+            self.spawn_background_precomputation(all_ordered, deep_views)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Collect all transitive cascade views in one pass (single lock acquisition).
+    fn collect_cascade_views(
+        &self,
+        view_name: &str,
+        visited: &mut HashSet<String>,
+        result: &mut Vec<String>,
+    ) -> Result<(), SchemaError> {
+        if !visited.insert(view_name.to_string()) {
+            return Ok(());
+        }
+
+        let cascade_views: Vec<String> = {
+            let registry = self
+                .schema_manager
+                .view_registry()
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
+            registry
+                .dependency_tracker
+                .get_all_dependents_of_schema(view_name)
+        };
+
+        for dep in &cascade_views {
+            if !visited.contains(dep) {
+                result.push(dep.clone());
+                self.collect_cascade_views(dep, visited, result)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Partition invalidated views into:
+    /// - `all_ordered`: all views in bottom-up order (leaves first) for precomputation
+    /// - `deep_only`: subset that depends on other views (level 2+), to be marked Computing
+    fn partition_views_for_precomputation(
+        &self,
+        invalidated: &[String],
+    ) -> Result<(Vec<String>, HashSet<String>), SchemaError> {
+        let registry = self
+            .schema_manager
+            .view_registry()
+            .lock()
+            .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
+
+        let invalidated_set: HashSet<&str> = invalidated.iter().map(|s| s.as_str()).collect();
+
+        // Classify each view as level-1 (only schema sources) or deep (has view sources).
+        // Also build an adjacency map for topological sorting.
+        let mut deep: HashSet<String> = HashSet::new();
+        let mut in_degree: HashMap<String, usize> = HashMap::new();
+        // view_name → list of views that depend on it (within the invalidated set)
+        let mut dependents_of: HashMap<String, Vec<String>> = HashMap::new();
+
+        for view_name in invalidated {
+            if let Some(view) = registry.get_view(view_name) {
+                let view_sources_in_set: Vec<String> = view
+                    .source_schemas()
+                    .into_iter()
+                    .filter(|source| {
+                        registry.get_view(source).is_some()
+                            && invalidated_set.contains(source.as_str())
+                    })
+                    .collect();
+
+                if !view_sources_in_set.is_empty() {
+                    deep.insert(view_name.clone());
+                }
+
+                in_degree.insert(view_name.clone(), view_sources_in_set.len());
+                for source in view_sources_in_set {
+                    dependents_of
+                        .entry(source)
+                        .or_default()
+                        .push(view_name.clone());
+                }
+            }
+        }
+
+        // Kahn's algorithm: topological sort so leaves (in_degree=0) come first
+        let mut queue: VecDeque<String> = in_degree
+            .iter()
+            .filter(|(_, &deg)| deg == 0)
+            .map(|(name, _)| name.clone())
+            .collect();
+        let mut all: Vec<String> = Vec::new();
+
+        while let Some(current) = queue.pop_front() {
+            all.push(current.clone());
+            if let Some(deps) = dependents_of.get(&current) {
+                for dep in deps {
+                    if let Some(deg) = in_degree.get_mut(dep) {
+                        *deg = deg.saturating_sub(1);
+                        if *deg == 0 {
+                            queue.push_back(dep.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok((all, deep))
+    }
+
+    /// Mark deep views as Computing and spawn a background task to precompute
+    /// all views in bottom-up order. Level 1 views are computed first (they
+    /// only depend on schemas) so that deep views can resolve against them.
+    async fn spawn_background_precomputation(
+        &self,
+        all_ordered: Vec<String>,
+        deep_views: HashSet<String>,
+    ) -> Result<(), SchemaError> {
+        // Only mark deep views as Computing (level 1 stays Empty for lazy query)
+        for view_name in &deep_views {
+            self.db_ops
+                .set_view_cache_state(view_name, &ViewCacheState::Computing)
+                .await?;
+            log::debug!(
+                "View '{}' marked as Computing for background precomputation",
+                view_name
+            );
+        }
+
+        // Spawn background task that computes ALL views bottom-up
+        let schema_manager = Arc::clone(&self.schema_manager);
+        let db_ops = Arc::clone(&self.db_ops);
+
+        tokio::spawn(async move {
+            if let Err(e) = Self::precompute_views(schema_manager, db_ops, all_ordered).await {
+                log::error!("Background view precomputation failed: {}", e);
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Background task: precompute views in bottom-up order.
+    /// Each view's sources must be Cached before it can be computed.
+    async fn precompute_views(
+        schema_manager: Arc<SchemaCore>,
+        db_ops: Arc<DbOperations>,
+        views_to_compute: Vec<String>,
+    ) -> Result<(), SchemaError> {
+        use super::query::hash_range_query::HashRangeQueryProcessor;
+
+        let wasm_engine = {
+            let registry = schema_manager
+                .view_registry()
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
+            Arc::clone(registry.wasm_engine())
+        };
+
+        for view_name in &views_to_compute {
+            // Get view definition
+            let view = {
+                let registry = schema_manager
+                    .view_registry()
+                    .lock()
+                    .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
+                match registry.get_view(view_name) {
+                    Some(v) => v.clone(),
+                    None => {
+                        log::warn!("View '{}' disappeared during precomputation", view_name);
+                        continue;
+                    }
+                }
+            };
+
+            // Check current state:
+            // - Computing: deep view, precompute and store
+            // - Empty: level-1 view, precompute and store (needed by deeper views)
+            // - Cached: already computed (perhaps by a lazy query), skip
+            let state = db_ops.get_view_cache_state(view_name).await?;
+            if matches!(state, ViewCacheState::Cached { .. }) {
+                log::debug!(
+                    "View '{}' already Cached, skipping precomputation",
+                    view_name
+                );
+                continue;
+            }
+
+            // Build source query for resolution
+            let source_query = PrecomputeSourceQuery {
+                schema_manager: Arc::clone(&schema_manager),
+                db_ops: Arc::clone(&db_ops),
+                hash_range_processor: HashRangeQueryProcessor::new(Arc::clone(&db_ops)),
+                view_resolver: ViewResolver::new(Arc::clone(&wasm_engine)),
+            };
+
+            let resolver = ViewResolver::new(Arc::clone(&wasm_engine));
+            match resolver
+                .resolve(&view, &[], &ViewCacheState::Empty, &source_query)
+                .await
+            {
+                Ok((_, new_cache)) => {
+                    // Only store if not re-invalidated since we started
+                    let current = db_ops.get_view_cache_state(view_name).await?;
+                    if !matches!(current, ViewCacheState::Cached { .. }) {
+                        db_ops.set_view_cache_state(view_name, &new_cache).await?;
+                        log::info!("View '{}' precomputed successfully", view_name);
+                    }
+                }
+                Err(e) => {
+                    log::error!("Failed to precompute view '{}': {}", view_name, e);
+                    // Reset Computing to Empty so it can be lazily computed on next query
+                    let current = db_ops.get_view_cache_state(view_name).await?;
+                    if current.is_computing() {
+                        db_ops
+                            .set_view_cache_state(view_name, &ViewCacheState::Empty)
+                            .await?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- Extract ~290 LOC of view lifecycle logic out of `MutationManager` into a new `ViewInvalidationService` (`src/fold_db_core/view_invalidation.rs`)
- `MutationManager` now delegates `redirect_view_mutations` and `invalidate_dependent_view_caches` to the service and no longer owns topological sort / background precomputation / `PrecomputeSourceQuery`
- Shrinks `mutation_manager.rs` from 1316 to 884 LOC. Pure refactor — no behavior changes

## Test plan
- [x] cargo fmt --all
- [x] cargo clippy --workspace --all-targets -- -D warnings (clean)
- [x] cargo test --workspace --all-targets (680 passed, 0 failed)
- [x] View integration tests pass (view_write_test, view_registration_test, view_query_test, etc.)

Round 3 architectural refactor item #1.

Generated with [Claude Code](https://claude.com/claude-code)