### PR TITLE
refactor: extract SyncCoordinator from FoldDB

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -21,6 +21,7 @@ use super::infrastructure::{AsyncMessageBus, EventMonitor};
 use super::mutation_manager::MutationManager;
 use super::orchestration::index_status::IndexStatusTracker;
 use super::query::QueryExecutor;
+use super::sync_coordinator::SyncCoordinator;
 use crate::progress::ProgressStore as JobStore;
 use crate::progress::ProgressTracker;
 
@@ -45,12 +46,9 @@ pub struct FoldDB {
     /// Unified progress tracker for all job types (ingestion, indexing, etc.)
     /// This is the single source of truth for progress — uses Sled for persistent storage.
     pub(crate) progress_tracker: ProgressTracker,
-    /// Optional sync engine for S3 replication.
-    /// Present when sync is configured (local mode only).
-    /// Uses RwLock for interior mutability so FoldDB doesn't need &mut self.
-    sync_engine: std::sync::RwLock<Option<Arc<crate::sync::SyncEngine>>>,
-    /// Handle for the background sync timer task.
-    sync_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Coordinates the optional cloud sync engine lifecycle.
+    /// In local mode this holds no engine and all sync operations are no-ops.
+    sync_coordinator: SyncCoordinator,
     /// Optional reference to the encrypting store for org crypto registration.
     encrypting_store: Option<Arc<crate::storage::EncryptingNamespacedStore>>,
     /// Optional Sled-backed configuration store for runtime node config.
@@ -86,9 +84,20 @@ impl FoldDB {
         self.flush().await
     }
 
+    /// Returns a reference to the sync coordinator.
+    pub fn sync_coordinator(&self) -> &SyncCoordinator {
+        &self.sync_coordinator
+    }
+
     /// Set the sync engine (called by the factory when sync is configured).
     /// Also registers the schema reloader callback so SchemaCore's in-memory
-    /// cache is refreshed after sync replays schema entries into Sled.
+    /// cache is refreshed after sync replays schema entries into Sled, and
+    /// the embedding reloader so the in-memory EmbeddingIndex is refreshed
+    /// after sync replays native_index entries.
+    ///
+    /// Registration lives here because it needs access to FoldDB-owned
+    /// components (SchemaCore, NativeIndexManager); engine storage is then
+    /// delegated to the SyncCoordinator.
     pub async fn set_sync_engine(&self, engine: Arc<crate::sync::SyncEngine>) {
         let schema_mgr = Arc::clone(&self.schema_manager);
         engine
@@ -117,112 +126,54 @@ impl FoldDB {
                 .await;
         }
 
-        *self.sync_engine.write().unwrap() = Some(engine);
+        self.sync_coordinator.set_engine(engine);
     }
 
-    /// Start the background sync timer.
-    ///
-    /// Spawns a tokio task that calls `sync()` every `interval_ms` when the
-    /// engine is dirty. Does nothing if no sync engine is configured.
+    /// Start the background sync timer. Delegates to the coordinator.
     pub fn start_sync(&self, interval_ms: u64) {
-        let engine = match &*self.sync_engine.read().unwrap() {
-            Some(e) => Arc::clone(e),
-            None => return,
-        };
-        let db_ops = Arc::clone(&self.db_ops);
-        let sled_pool = self.sled_pool.clone();
-
-        let handle = tokio::spawn(async move {
-            let interval = tokio::time::Duration::from_millis(interval_ms);
-            loop {
-                tokio::time::sleep(interval).await;
-                // Always run sync — even without pending writes, we need to
-                // download org data from other members.
-                let has_pending = engine.state().await == crate::sync::SyncState::Dirty;
-                let has_orgs = engine.has_org_sync().await;
-                if has_pending || has_orgs {
-                    if let Err(e) = engine.sync().await {
-                        if let crate::sync::SyncError::OrgMembershipRevoked(ref org_hash) = e {
-                            log::warn!("🚨 SYSTEM ALERT: You have been removed from organization (hash: {}) by an administrator. Proceeding to securely purge all locally cached copies of its data and schema to prevent orphans.", org_hash);
-
-                            // 1. Delete membership structure locally (if running on Sled backend)
-                            if let Some(pool) = &sled_pool {
-                                let _ = crate::org::operations::delete_org(pool, org_hash).map_err(
-                                    |err| log::error!("Failed to delete org structure: {}", err),
-                                );
-                            }
-
-                            // 2. Erase the orphaned physical footprints in local DB
-                            let _ = db_ops
-                                .purge_org_data(org_hash)
-                                .await
-                                .map_err(|err| log::error!("Failed to purge org data: {}", err));
-                        } else {
-                            log::warn!("sync cycle failed: {e}");
-                        }
-                    }
-                }
-            }
-        });
-
-        *self.sync_task.lock().unwrap() = Some(handle);
+        self.sync_coordinator.start_background_sync(
+            interval_ms,
+            Arc::clone(&self.db_ops),
+            self.sled_pool.clone(),
+        );
     }
 
     /// Force an immediate sync (e.g. on shutdown).
     pub async fn force_sync(&self) -> Result<(), crate::sync::SyncError> {
-        let engine = self.sync_engine.read().unwrap().clone();
-        if let Some(engine) = engine {
-            engine.sync().await?;
-        }
-        Ok(())
+        self.sync_coordinator.force_sync().await
     }
 
     /// Stop the background sync timer and run a final sync.
     pub async fn stop_sync(&self) -> Result<(), crate::sync::SyncError> {
-        if let Some(handle) = self.sync_task.lock().unwrap().take() {
-            handle.abort();
-        }
-        self.force_sync().await
+        self.sync_coordinator.stop().await
     }
 
     /// Get the sync engine state, if sync is configured.
     pub async fn sync_state(&self) -> Option<crate::sync::SyncState> {
-        let engine = self.sync_engine.read().unwrap().clone();
-        match engine {
-            Some(engine) => Some(engine.state().await),
-            None => None,
-        }
+        self.sync_coordinator.state().await
     }
 
     /// Get a full sync status snapshot, if sync is configured.
     pub async fn sync_status(&self) -> Option<crate::sync::SyncStatus> {
-        let engine = self.sync_engine.read().unwrap().clone();
-        match engine {
-            Some(engine) => Some(engine.status().await),
-            None => None,
-        }
+        self.sync_coordinator.status().await
     }
 
     /// Get the number of pending (unsynced) log entries.
     /// Returns None if sync is not configured.
     pub async fn sync_pending_count(&self) -> Option<usize> {
-        let engine = self.sync_engine.read().unwrap().clone();
-        match engine {
-            Some(engine) => Some(engine.pending_count().await),
-            None => None,
-        }
+        self.sync_coordinator.pending_count().await
     }
 
     /// Returns true if the sync engine is configured.
     pub fn is_sync_enabled(&self) -> bool {
-        self.sync_engine.read().unwrap().is_some()
+        self.sync_coordinator.is_enabled()
     }
 
     /// Returns a clone of the sync engine Arc, if configured.
     ///
     /// Used by fold_db_node to call `configure_org_sync()` after node startup.
     pub fn sync_engine(&self) -> Option<Arc<crate::sync::SyncEngine>> {
-        self.sync_engine.read().unwrap().clone()
+        self.sync_coordinator.engine()
     }
 
     /// Returns a clone of the Sled-backed config store, if available.
@@ -247,7 +198,7 @@ impl FoldDB {
     ) -> crate::error::FoldDbResult<()> {
         use crate::error::FoldDbError;
 
-        if self.sync_engine.read().unwrap().is_some() {
+        if self.sync_coordinator.is_enabled() {
             return Ok(()); // already running
         }
 
@@ -501,8 +452,7 @@ impl FoldDB {
             mutation_manager,
             pending_tasks,
             progress_tracker,
-            sync_engine: std::sync::RwLock::new(None),
-            sync_task: std::sync::Mutex::new(None),
+            sync_coordinator: SyncCoordinator::new(),
             encrypting_store,
             config_store: std::sync::RwLock::new(None),
         })
@@ -629,8 +579,6 @@ impl Drop for FoldDB {
     fn drop(&mut self) {
         // Abort the background sync task to prevent tokio panic:
         // "Cannot drop a runtime in a context where blocking is not allowed"
-        if let Some(handle) = self.sync_task.get_mut().unwrap().take() {
-            handle.abort();
-        }
+        self.sync_coordinator.abort_task();
     }
 }

--- a/src/fold_db_core/mod.rs
+++ b/src/fold_db_core/mod.rs
@@ -18,6 +18,7 @@ pub mod query;
 // Core components
 
 pub mod mutation_manager;
+pub mod sync_coordinator;
 pub mod view_invalidation;
 
 // Re-export key components
@@ -27,6 +28,7 @@ pub use query::QueryExecutor;
 // Re-export core components
 
 pub use mutation_manager::MutationManager;
+pub use sync_coordinator::SyncCoordinator;
 
 // Re-export the main FoldDB struct
 pub use fold_db::FoldDB;

--- a/src/fold_db_core/sync_coordinator.rs
+++ b/src/fold_db_core/sync_coordinator.rs
@@ -1,0 +1,158 @@
+//! SyncCoordinator - manages the optional cloud sync engine lifecycle.
+//!
+//! Sync is opt-in. In local mode, the coordinator holds no engine and all
+//! operations are no-ops (or return None). This type encapsulates the
+//! interior mutability (RwLock + Mutex) needed so FoldDB can expose sync
+//! operations via `&self`.
+
+use std::sync::{Mutex, RwLock};
+
+use log::{debug, warn};
+use tokio::task::JoinHandle;
+
+use std::sync::Arc;
+
+use crate::db_operations::DbOperations;
+use crate::storage::SledPool;
+use crate::sync::{SyncEngine, SyncError, SyncState, SyncStatus};
+
+/// Coordinates the optional cloud sync engine lifecycle.
+pub struct SyncCoordinator {
+    engine: RwLock<Option<Arc<SyncEngine>>>,
+    task: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl SyncCoordinator {
+    pub fn new() -> Self {
+        Self {
+            engine: RwLock::new(None),
+            task: Mutex::new(None),
+        }
+    }
+
+    /// Store the sync engine. Caller is responsible for registering any
+    /// reloader callbacks on the engine before calling this.
+    pub fn set_engine(&self, engine: Arc<SyncEngine>) {
+        *self.engine.write().unwrap() = Some(engine);
+    }
+
+    /// Returns a clone of the sync engine Arc, if configured.
+    pub fn engine(&self) -> Option<Arc<SyncEngine>> {
+        self.engine.read().unwrap().clone()
+    }
+
+    /// Returns true if a sync engine is configured.
+    pub fn is_enabled(&self) -> bool {
+        self.engine.read().unwrap().is_some()
+    }
+
+    /// Spawn the background sync timer task. No-op if no engine is configured.
+    ///
+    /// `db_ops` and `sled_pool` are needed to purge org data when the engine
+    /// reports that the local node has been removed from an organization.
+    pub fn start_background_sync(
+        &self,
+        interval_ms: u64,
+        db_ops: Arc<DbOperations>,
+        sled_pool: Option<Arc<SledPool>>,
+    ) {
+        let engine = match &*self.engine.read().unwrap() {
+            Some(e) => Arc::clone(e),
+            None => return,
+        };
+
+        let handle = tokio::spawn(async move {
+            let interval = tokio::time::Duration::from_millis(interval_ms);
+            loop {
+                tokio::time::sleep(interval).await;
+                // Always run sync — even without pending writes, we need to
+                // download org data from other members.
+                let has_pending = engine.state().await == SyncState::Dirty;
+                let has_orgs = engine.has_org_sync().await;
+                if has_pending || has_orgs {
+                    if let Err(e) = engine.sync().await {
+                        if let SyncError::OrgMembershipRevoked(ref org_hash) = e {
+                            warn!("🚨 SYSTEM ALERT: You have been removed from organization (hash: {}) by an administrator. Proceeding to securely purge all locally cached copies of its data and schema to prevent orphans.", org_hash);
+
+                            // 1. Delete membership structure locally (if running on Sled backend)
+                            if let Some(pool) = &sled_pool {
+                                let _ = crate::org::operations::delete_org(pool, org_hash).map_err(
+                                    |err| log::error!("Failed to delete org structure: {}", err),
+                                );
+                            }
+
+                            // 2. Erase the orphaned physical footprints in local DB
+                            let _ = db_ops
+                                .purge_org_data(org_hash)
+                                .await
+                                .map_err(|err| log::error!("Failed to purge org data: {}", err));
+                        } else {
+                            warn!("sync cycle failed: {e}");
+                        }
+                    }
+                }
+            }
+        });
+
+        *self.task.lock().unwrap() = Some(handle);
+    }
+
+    /// Force an immediate sync. No-op if no engine is configured.
+    pub async fn force_sync(&self) -> Result<(), SyncError> {
+        let engine = self.engine.read().unwrap().clone();
+        if let Some(engine) = engine {
+            engine.sync().await?;
+        }
+        Ok(())
+    }
+
+    /// Stop the background sync task and run a final sync.
+    pub async fn stop(&self) -> Result<(), SyncError> {
+        if let Some(handle) = self.task.lock().unwrap().take() {
+            handle.abort();
+        }
+        self.force_sync().await
+    }
+
+    /// Get the sync engine state, if configured.
+    pub async fn state(&self) -> Option<SyncState> {
+        let engine = self.engine.read().unwrap().clone();
+        match engine {
+            Some(engine) => Some(engine.state().await),
+            None => None,
+        }
+    }
+
+    /// Get a full sync status snapshot, if configured.
+    pub async fn status(&self) -> Option<SyncStatus> {
+        let engine = self.engine.read().unwrap().clone();
+        match engine {
+            Some(engine) => Some(engine.status().await),
+            None => None,
+        }
+    }
+
+    /// Get the number of pending (unsynced) log entries, if configured.
+    pub async fn pending_count(&self) -> Option<usize> {
+        let engine = self.engine.read().unwrap().clone();
+        match engine {
+            Some(engine) => Some(engine.pending_count().await),
+            None => None,
+        }
+    }
+
+    /// Abort the background task without running a final sync.
+    /// Called from Drop to avoid tokio panics.
+    pub(crate) fn abort_task(&self) {
+        if let Some(handle) = self.task.lock().unwrap().take() {
+            debug!("SyncCoordinator: aborting background sync task on drop");
+            handle.abort();
+        }
+    }
+}
+
+impl Default for SyncCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Summary
- Extract sync engine lifecycle (storage, background timer, status queries) from FoldDB into a new SyncCoordinator in fold_db_core.
- FoldDB now owns a SyncCoordinator directly; the RwLock<Option<Arc<SyncEngine>>> + Mutex<Option<JoinHandle>> fields are gone, encapsulated inside the coordinator.
- All existing FoldDB sync methods (set_sync_engine, start_sync, stop_sync, force_sync, sync_status, sync_engine, etc.) preserved as thin delegating wrappers so fold_db_node callers don't change.
- Schema + embedding reloader registration stays on FoldDB.set_sync_engine() because it needs SchemaCore + NativeIndexManager, then delegates engine storage to the coordinator.
- Drop impl now calls SyncCoordinator::abort_task() to preserve the tokio-panic fix.

Round 3 architectural refactor item #4. Pure refactor — no behavior changes.

## Test plan
- [x] cargo fmt --all
- [x] cargo clippy --workspace --all-targets -- -D warnings (clean)
- [x] cargo test --workspace --all-targets (680 passed, 0 failed)