### PR TITLE
refactor: extract SchemaInterpreter from SchemaCore

### DIFF
--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -455,9 +455,7 @@ impl SchemaCore {
         }
 
         // Convert declarative schema to Schema
-        let schema = self
-            .interpret_declarative_schema(declarative_schema)
-            .await?;
+        let schema = crate::schema::SchemaInterpreter::interpret(declarative_schema)?;
 
         // Load the schema using the existing method
         self.load_schema_internal(schema).await
@@ -889,10 +887,7 @@ mod tests {
         }"#;
         let declarative: crate::schema::types::DeclarativeSchemaDefinition =
             serde_json::from_str(json).expect("parse");
-        let schema = core
-            .interpret_declarative_schema(declarative)
-            .await
-            .expect("interpret");
+        let schema = crate::schema::SchemaInterpreter::interpret(declarative).expect("interpret");
         db_ops
             .store_schema("SyncedSchema", &schema)
             .await
@@ -972,10 +967,7 @@ mod tests {
         }"#;
         let declarative: crate::schema::types::DeclarativeSchemaDefinition =
             serde_json::from_str(json).expect("parse");
-        let schema = core
-            .interpret_declarative_schema(declarative)
-            .await
-            .expect("interpret");
+        let schema = crate::schema::SchemaInterpreter::interpret(declarative).expect("interpret");
         db_ops
             .store_schema("RuntimeTest", &schema)
             .await

--- a/src/schema/interpreter.rs
+++ b/src/schema/interpreter.rs
@@ -1,0 +1,66 @@
+//! Stateless schema interpretation: `DeclarativeSchemaDefinition` → runtime `Schema`.
+//!
+//! This is a pure ETL operation with no runtime state dependencies. It can be
+//! tested in isolation from the `SchemaCore` cache manager. Extracting this from
+//! `SchemaCore` makes it clear that interpretation is a pure transformation and
+//! not entangled with persistent cache state or in-memory lookup maps.
+
+use crate::schema::types::{DeclarativeSchemaDefinition, Schema, SchemaError};
+
+/// Stateless interpreter that turns a parsed declarative schema definition
+/// into a runtime [`Schema`] with `runtime_fields` populated.
+pub struct SchemaInterpreter;
+
+impl SchemaInterpreter {
+    /// Convert a declarative schema definition into a runtime [`Schema`].
+    ///
+    /// This is a pure function: it does not touch the database, the schema
+    /// cache, or any other shared state. It only materialises the
+    /// `runtime_fields` map on the definition so that downstream query and
+    /// mutation code can look fields up by name.
+    pub fn interpret(
+        mut declarative_schema: DeclarativeSchemaDefinition,
+    ) -> Result<Schema, SchemaError> {
+        declarative_schema.populate_runtime_fields()?;
+        Ok(declarative_schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interpret_populates_runtime_fields() {
+        let json = r#"{
+            "name": "InterpreterTest",
+            "key": { "range_field": "ts" },
+            "fields": { "content": {}, "ts": {} }
+        }"#;
+        let declarative: DeclarativeSchemaDefinition =
+            serde_json::from_str(json).expect("parse declarative schema");
+
+        // Pre-condition: runtime_fields is empty (it's #[serde(skip)]).
+        assert!(declarative.runtime_fields.is_empty());
+
+        let schema = SchemaInterpreter::interpret(declarative).expect("interpret");
+
+        assert_eq!(schema.name, "InterpreterTest");
+        assert!(schema.runtime_fields.contains_key("content"));
+        assert!(schema.runtime_fields.contains_key("ts"));
+    }
+
+    #[test]
+    fn interpret_is_idempotent_on_prepopulated_schema() {
+        let json = r#"{
+            "name": "Idem",
+            "key": { "range_field": "ts" },
+            "fields": { "a": {}, "ts": {} }
+        }"#;
+        let declarative: DeclarativeSchemaDefinition = serde_json::from_str(json).expect("parse");
+        let once = SchemaInterpreter::interpret(declarative).expect("first interpret");
+        let twice = SchemaInterpreter::interpret(once.clone()).expect("second interpret");
+        assert_eq!(once.runtime_fields.len(), twice.runtime_fields.len());
+        assert_eq!(once.name, twice.name);
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -24,6 +24,7 @@
 // Internal modules
 pub mod core;
 pub mod field_mapper;
+pub mod interpreter;
 pub mod persistence;
 pub mod schema_types;
 pub mod types;
@@ -31,6 +32,7 @@ pub mod types;
 // Public re-exports
 pub use core::SchemaCore;
 pub use field_mapper::FieldMapperService;
+pub use interpreter::SchemaInterpreter;
 pub use schema_types::{SchemaState, SchemaWithState};
 pub use types::{Schema, SchemaError};
 

--- a/src/schema/persistence.rs
+++ b/src/schema/persistence.rs
@@ -1,4 +1,4 @@
-use super::SchemaCore;
+use super::{SchemaCore, SchemaInterpreter};
 use crate::schema::types::{DeclarativeSchemaDefinition, Schema, SchemaError};
 use std::path::Path;
 
@@ -19,20 +19,6 @@ impl SchemaCore {
             .map_err(|e| {
                 SchemaError::InvalidData(format!("Failed to parse declarative schema: {}", e))
             })?;
-        Ok(Some(
-            self.interpret_declarative_schema(declarative_schema)
-                .await?,
-        ))
-    }
-
-    /// Interprets a declarative schema definition and populates runtime fields.
-    pub async fn interpret_declarative_schema(
-        &self,
-        mut declarative_schema: DeclarativeSchemaDefinition,
-    ) -> Result<Schema, SchemaError> {
-        // Populate runtime_fields using the method on DeclarativeSchemaDefinition
-        declarative_schema.populate_runtime_fields()?;
-
-        Ok(declarative_schema)
+        Ok(Some(SchemaInterpreter::interpret(declarative_schema)?))
     }
 }


### PR DESCRIPTION
## Summary
- Extract the stateless `DeclarativeSchemaDefinition -> Schema` transformation from `SchemaCore` into a new `src/schema/interpreter.rs` module as `SchemaInterpreter::interpret`.
- The operation only calls `populate_runtime_fields` and never touches `db_ops` or the in-memory cache, so making it a static pure function clarifies the boundary and lets it be tested in isolation.
- Pure refactor, no behavior changes.

## Changes
- New `SchemaInterpreter` in `src/schema/interpreter.rs` (sync, stateless, with unit tests).
- Remove `SchemaCore::interpret_declarative_schema` and update the three in-tree call sites (`persistence.rs` + two tests in `core.rs`) to use the static helper.
- Re-export `SchemaInterpreter` from `src/schema/mod.rs`.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo test --workspace --all-targets` (682 passed, 0 failed)
- [x] New unit tests in `schema::interpreter::tests` verify `runtime_fields` population and idempotency

Round 3 architectural refactor item #5.

Generated with Claude Code