### PR TITLE
refactor: extract PermissionsStore and MetadataStore domain stores

### DIFF
--- a/src/db_operations/core.rs
+++ b/src/db_operations/core.rs
@@ -1,4 +1,6 @@
 use super::atom_store::AtomStore;
+use super::metadata_store::MetadataStore;
+use super::permissions_store::PermissionsStore;
 use super::schema_store::SchemaStore;
 use super::view_store::ViewStore;
 use super::NativeIndexManager;
@@ -11,9 +13,9 @@ use std::sync::Arc;
 ///
 /// Uses the storage abstraction layer (Sled locally, with optional cloud sync).
 ///
-/// The three core domains (schemas, atoms, views) are each encapsulated in
-/// a dedicated store struct whose fields are private. External callers
-/// reach them through `schemas()`, `atoms()`, and `views()`.
+/// All persistence is encapsulated in domain store structs whose
+/// namespace fields are private. External callers reach them through
+/// `schemas()`, `atoms()`, `views()`, `permissions()`, and `metadata()`.
 #[derive(Clone)]
 pub struct DbOperations {
     /// Schema / schema-state / superseded-by namespaces
@@ -22,13 +24,10 @@ pub struct DbOperations {
     atom_store: AtomStore,
     /// Transform view definitions, view states, field cache state
     view_store: ViewStore,
-
-    // ----- Remaining raw namespaces not yet wrapped in a domain store -----
-    metadata_store: Arc<TypedKvStore<dyn KvStore>>,
-    permissions_store: Arc<TypedKvStore<dyn KvStore>>,
-    public_keys_store: Arc<TypedKvStore<dyn KvStore>>,
-    idempotency_store: Arc<TypedKvStore<dyn KvStore>>,
-    process_results_store: Arc<TypedKvStore<dyn KvStore>>,
+    /// Permissions + public keys
+    permissions_store: PermissionsStore,
+    /// Metadata + idempotency + process results
+    metadata_store: MetadataStore,
 
     native_index_manager: Option<NativeIndexManager>,
 }
@@ -55,13 +54,13 @@ impl DbOperations {
 
         // Wrap KvStores in TypedKvStore adapters
         let main_store = Arc::new(TypedKvStore::new(main_kv));
-        let metadata_store = Arc::new(TypedKvStore::new(metadata_kv));
-        let permissions_store = Arc::new(TypedKvStore::new(permissions_kv));
+        let metadata_typed = Arc::new(TypedKvStore::new(metadata_kv));
+        let permissions_typed = Arc::new(TypedKvStore::new(permissions_kv));
         let schema_states_store = Arc::new(TypedKvStore::new(schema_states_kv));
         let schemas_store = Arc::new(TypedKvStore::new(schemas_kv));
-        let public_keys_store = Arc::new(TypedKvStore::new(public_keys_kv));
-        let idempotency_store = Arc::new(TypedKvStore::new(idempotency_kv));
-        let process_results_store = Arc::new(TypedKvStore::new(process_results_kv));
+        let public_keys_typed = Arc::new(TypedKvStore::new(public_keys_kv));
+        let idempotency_typed = Arc::new(TypedKvStore::new(idempotency_kv));
+        let process_results_typed = Arc::new(TypedKvStore::new(process_results_kv));
         let superseded_by_store = Arc::new(TypedKvStore::new(superseded_by_kv));
         let views_store = Arc::new(TypedKvStore::new(views_kv));
         let view_states_store = Arc::new(TypedKvStore::new(view_states_kv));
@@ -73,6 +72,9 @@ impl DbOperations {
         let atom_store = AtomStore::new(main_store);
         let view_store =
             ViewStore::new(views_store, view_states_store, transform_field_states_store);
+        let permissions_store = PermissionsStore::new(permissions_typed, public_keys_typed);
+        let metadata_store =
+            MetadataStore::new(metadata_typed, idempotency_typed, process_results_typed);
 
         // Create native index manager and load any previously stored embeddings
         let native_index_manager = NativeIndexManager::new(native_index_kv);
@@ -82,11 +84,8 @@ impl DbOperations {
             schema_store,
             atom_store,
             view_store,
-            metadata_store,
             permissions_store,
-            public_keys_store,
-            idempotency_store,
-            process_results_store,
+            metadata_store,
             native_index_manager: Some(native_index_manager),
         })
     }
@@ -116,31 +115,14 @@ impl DbOperations {
         &self.view_store
     }
 
-    // ===== Non-domain store getters (crate-only) =====
-    //
-    // These namespaces are used by smaller sibling modules
-    // (metadata_operations, trust_operations, public_key_operations,
-    // conflict_operations, org_operations). Wrapping them in their
-    // own domain structs is left for a follow-up refactor.
-
-    pub(crate) fn metadata_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
-        &self.metadata_store
-    }
-
-    pub(crate) fn permissions_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+    /// Access the permissions / public-keys / trust domain store.
+    pub fn permissions(&self) -> &PermissionsStore {
         &self.permissions_store
     }
 
-    pub(crate) fn public_keys_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
-        &self.public_keys_store
-    }
-
-    pub(crate) fn idempotency_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
-        &self.idempotency_store
-    }
-
-    pub(crate) fn process_results_store(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
-        &self.process_results_store
+    /// Access the metadata / idempotency / process-results domain store.
+    pub fn metadata(&self) -> &MetadataStore {
+        &self.metadata_store
     }
 
     /// Access the native index manager for embedding and search operations.
@@ -148,12 +130,12 @@ impl DbOperations {
         self.native_index_manager.as_ref()
     }
 
-    // ===== Public accessors for external callers =====
+    // ===== Public escape hatches =====
 
     /// Get the raw metadata KvStore for external modules that need generic key-value
     /// access (e.g., discovery configs, async queries).
     pub fn raw_metadata_store(&self) -> Arc<dyn KvStore> {
-        self.metadata_store.inner().clone()
+        self.metadata_store.raw_metadata_kv()
     }
 
     /// Flush all pending writes to durable storage

--- a/src/db_operations/metadata_operations.rs
+++ b/src/db_operations/metadata_operations.rs
@@ -1,56 +1,30 @@
+//! Thin delegator methods on `DbOperations` for metadata / idempotency /
+//! process-results. The real implementations live on
+//! [`super::metadata_store::MetadataStore`]; these wrappers exist purely
+//! for backward compatibility with older call sites.
+
 use super::core::DbOperations;
 use crate::schema::SchemaError;
-use crate::storage::traits::TypedStore;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use uuid::Uuid;
 
 impl DbOperations {
     /// Retrieves or generates and persists the node identifier
     pub async fn get_node_id(&self) -> Result<String, SchemaError> {
-        // Try to get existing node_id (handle deserialization errors gracefully)
-        match self.metadata_store().get_item::<String>("node_id").await {
-            Ok(Some(id)) if !id.is_empty() => {
-                return Ok(id);
-            }
-            Ok(Some(_)) | Ok(None) => {
-                // Empty or missing - create new
-            }
-            Err(e) => {
-                // Deserialization error (e.g., old format) - create new node_id
-                log::warn!(
-                    "Failed to deserialize node_id (possibly old format): {}, creating new",
-                    e
-                );
-            }
-        }
-
-        // Generate new node_id
-        let new_id = Uuid::new_v4().to_string();
-        self.set_node_id(&new_id).await?;
-        Ok(new_id)
+        self.metadata().get_node_id().await
     }
 
     /// Sets the node identifier
     pub async fn set_node_id(&self, node_id: &str) -> Result<(), SchemaError> {
-        self.metadata_store()
-            .put_item("node_id", &node_id.to_string())
-            .await?;
-        self.metadata_store().inner().flush().await?;
-        Ok(())
+        self.metadata().set_node_id(node_id).await
     }
-
-    // ===== Idempotency store operations =====
 
     /// Retrieve an item from the idempotency store by key.
     pub async fn get_idempotency_item<T: DeserializeOwned + Send + Sync>(
         &self,
         key: &str,
     ) -> Result<Option<T>, SchemaError> {
-        self.idempotency_store()
-            .get_item::<T>(key)
-            .await
-            .map_err(|e| SchemaError::InvalidData(format!("Failed to get idempotency item: {}", e)))
+        self.metadata().get_idempotency_item::<T>(key).await
     }
 
     /// Store an item in the idempotency store.
@@ -59,20 +33,14 @@ impl DbOperations {
         key: &str,
         item: &T,
     ) -> Result<(), SchemaError> {
-        self.idempotency_store().put_item(key, item).await?;
-        Ok(())
+        self.metadata().put_idempotency_item(key, item).await
     }
-
-    // ===== Process results store operations =====
 
     /// Scan process results by key prefix.
     pub async fn scan_process_results<T: DeserializeOwned + Send + Sync>(
         &self,
         prefix: &str,
     ) -> Result<Vec<(String, T)>, SchemaError> {
-        self.process_results_store()
-            .scan_items_with_prefix(prefix)
-            .await
-            .map_err(|e| SchemaError::InvalidData(format!("Failed to scan process results: {}", e)))
+        self.metadata().scan_process_results::<T>(prefix).await
     }
 }

--- a/src/db_operations/metadata_store.rs
+++ b/src/db_operations/metadata_store.rs
@@ -1,0 +1,152 @@
+//! Metadata domain store.
+//!
+//! Owns the `metadata`, `idempotency`, and `process_results` namespaces.
+//! External callers reach these via `DbOperations::metadata()`.
+//!
+//! Responsibilities:
+//! - Node-level metadata (e.g. `node_id`)
+//! - Idempotency cache for mutations
+//! - Process-result bookkeeping
+
+use std::sync::Arc;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::schema::SchemaError;
+use crate::storage::traits::{KvStore, TypedStore};
+use crate::storage::TypedKvStore;
+
+/// Domain store for node metadata / idempotency / process-results persistence.
+#[derive(Clone)]
+pub struct MetadataStore {
+    metadata_store: Arc<TypedKvStore<dyn KvStore>>,
+    idempotency_store: Arc<TypedKvStore<dyn KvStore>>,
+    process_results_store: Arc<TypedKvStore<dyn KvStore>>,
+}
+
+impl MetadataStore {
+    pub(crate) fn new(
+        metadata_store: Arc<TypedKvStore<dyn KvStore>>,
+        idempotency_store: Arc<TypedKvStore<dyn KvStore>>,
+        process_results_store: Arc<TypedKvStore<dyn KvStore>>,
+    ) -> Self {
+        Self {
+            metadata_store,
+            idempotency_store,
+            process_results_store,
+        }
+    }
+
+    /// Crate-internal access to the raw metadata namespace (used by org purge).
+    pub(crate) fn raw_metadata(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+        &self.metadata_store
+    }
+
+    /// Crate-internal access to the raw idempotency namespace (used by org purge).
+    pub(crate) fn raw_idempotency(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+        &self.idempotency_store
+    }
+
+    /// Crate-internal access to the raw process-results namespace (used by org purge).
+    pub(crate) fn raw_process_results(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+        &self.process_results_store
+    }
+
+    /// Escape hatch for external modules that need generic typed access to the
+    /// metadata namespace (e.g. discovery configs, async queries).
+    pub fn raw_metadata_kv(&self) -> Arc<dyn KvStore> {
+        self.metadata_store.inner().clone()
+    }
+
+    // ===== Node-id =====
+
+    /// Retrieves or generates and persists the node identifier.
+    pub async fn get_node_id(&self) -> Result<String, SchemaError> {
+        match self.metadata_store.get_item::<String>("node_id").await {
+            Ok(Some(id)) if !id.is_empty() => {
+                return Ok(id);
+            }
+            Ok(Some(_)) | Ok(None) => {}
+            Err(e) => {
+                log::warn!(
+                    "Failed to deserialize node_id (possibly old format): {}, creating new",
+                    e
+                );
+            }
+        }
+
+        let new_id = Uuid::new_v4().to_string();
+        self.set_node_id(&new_id).await?;
+        Ok(new_id)
+    }
+
+    /// Sets the node identifier
+    pub async fn set_node_id(&self, node_id: &str) -> Result<(), SchemaError> {
+        self.metadata_store
+            .put_item("node_id", &node_id.to_string())
+            .await?;
+        self.metadata_store.inner().flush().await?;
+        Ok(())
+    }
+
+    // ===== Idempotency store =====
+
+    /// Retrieve an item from the idempotency store by key.
+    pub async fn get_idempotency_item<T: DeserializeOwned + Send + Sync>(
+        &self,
+        key: &str,
+    ) -> Result<Option<T>, SchemaError> {
+        self.idempotency_store
+            .get_item::<T>(key)
+            .await
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to get idempotency item: {}", e)))
+    }
+
+    /// Store an item in the idempotency store.
+    pub async fn put_idempotency_item<T: Serialize + Send + Sync>(
+        &self,
+        key: &str,
+        item: &T,
+    ) -> Result<(), SchemaError> {
+        self.idempotency_store.put_item(key, item).await?;
+        Ok(())
+    }
+
+    /// Batch store idempotency entries (`(key, uuid)` pairs).
+    pub async fn batch_put_idempotency(
+        &self,
+        entries: Vec<(String, String)>,
+    ) -> Result<(), SchemaError> {
+        self.idempotency_store
+            .batch_put_items(entries)
+            .await
+            .map_err(|e| SchemaError::InvalidData(format!("Idempotency store failed: {}", e)))
+    }
+
+    // ===== Process results store =====
+
+    /// Scan process results by key prefix.
+    pub async fn scan_process_results<T: DeserializeOwned + Send + Sync>(
+        &self,
+        prefix: &str,
+    ) -> Result<Vec<(String, T)>, SchemaError> {
+        self.process_results_store
+            .scan_items_with_prefix(prefix)
+            .await
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to scan process results: {}", e)))
+    }
+
+    /// Store a process result.
+    pub async fn put_process_result<T: Serialize + Send + Sync>(
+        &self,
+        key: &str,
+        value: &T,
+    ) -> Result<(), SchemaError> {
+        self.process_results_store
+            .put_item(key, value)
+            .await
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to store process result: {}", e)))
+    }
+}

--- a/src/db_operations/mod.rs
+++ b/src/db_operations/mod.rs
@@ -2,6 +2,8 @@
 pub mod core;
 // Domain stores (private namespace fields, public operation methods)
 pub mod atom_store;
+pub mod metadata_store;
+pub mod permissions_store;
 pub mod schema_store;
 pub mod view_store;
 // Thin delegator impl blocks on DbOperations (backward compat)
@@ -17,6 +19,8 @@ mod view_operations;
 // Re-exports
 pub use atom_store::{AtomStore, MoleculeData};
 pub use core::DbOperations;
+pub use metadata_store::MetadataStore;
 pub use native_index::{IndexResult, NativeIndexManager};
+pub use permissions_store::PermissionsStore;
 pub use schema_store::SchemaStore;
 pub use view_store::ViewStore;

--- a/src/db_operations/org_operations.rs
+++ b/src/db_operations/org_operations.rs
@@ -21,13 +21,13 @@ impl DbOperations {
 
         // Collect all namespace stores
         let stores: Vec<&Arc<TypedKvStore<dyn KvStore>>> = vec![
-            self.metadata_store(),
-            self.permissions_store(),
+            self.metadata().raw_metadata(),
+            self.permissions().raw_permissions(),
             self.schemas().raw_schema_states(),
             self.schemas().raw_schemas(),
-            self.public_keys_store(),
-            self.idempotency_store(),
-            self.process_results_store(),
+            self.permissions().raw_public_keys(),
+            self.metadata().raw_idempotency(),
+            self.metadata().raw_process_results(),
             self.schemas().raw_superseded_by(),
             self.views().raw_views(),
             self.views().raw_view_states(),

--- a/src/db_operations/permissions_store.rs
+++ b/src/db_operations/permissions_store.rs
@@ -1,0 +1,215 @@
+//! Permissions domain store.
+//!
+//! Owns the `node_id_schema_permissions` and `public_keys` namespaces.
+//! External callers reach these via `DbOperations::permissions()`.
+//!
+//! Responsibilities:
+//! - System-wide public key storage
+//! - Trust maps (per domain) and audit log
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::access::types::{TrustMap, DOMAIN_PERSONAL};
+use crate::access::{AuditEvent, AuditLog};
+use crate::constants::SINGLE_PUBLIC_KEY_ID;
+use crate::schema::SchemaError;
+use crate::security::PublicKeyInfo;
+use crate::storage::traits::{KvStore, TypedStore};
+use crate::storage::TypedKvStore;
+
+const TRUST_GRAPH_PREFIX: &str = "trust_graph:";
+const AUDIT_LOG_KEY: &str = "audit_log";
+
+/// Legacy key — migrated to `trust_graph:personal` on first access.
+const LEGACY_TRUST_GRAPH_KEY: &str = "trust_graph";
+
+/// Domain store for permissions / trust / public-key persistence.
+#[derive(Clone)]
+pub struct PermissionsStore {
+    permissions_store: Arc<TypedKvStore<dyn KvStore>>,
+    public_keys_store: Arc<TypedKvStore<dyn KvStore>>,
+}
+
+impl PermissionsStore {
+    pub(crate) fn new(
+        permissions_store: Arc<TypedKvStore<dyn KvStore>>,
+        public_keys_store: Arc<TypedKvStore<dyn KvStore>>,
+    ) -> Self {
+        Self {
+            permissions_store,
+            public_keys_store,
+        }
+    }
+
+    /// Crate-internal access to the raw permissions namespace (used by org purge).
+    pub(crate) fn raw_permissions(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+        &self.permissions_store
+    }
+
+    /// Crate-internal access to the raw public-keys namespace (used by org purge).
+    pub(crate) fn raw_public_keys(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+        &self.public_keys_store
+    }
+
+    // ===== Public key operations =====
+
+    /// Gets the system-wide public key
+    pub async fn get_system_public_key(&self) -> Result<Option<PublicKeyInfo>, SchemaError> {
+        Ok(self
+            .public_keys_store
+            .get_item(SINGLE_PUBLIC_KEY_ID)
+            .await?)
+    }
+
+    /// Stores the system-wide public key
+    pub async fn store_system_public_key(
+        &self,
+        key_info: &PublicKeyInfo,
+    ) -> Result<(), SchemaError> {
+        self.public_keys_store
+            .put_item(SINGLE_PUBLIC_KEY_ID, key_info)
+            .await?;
+        self.public_keys_store.inner().flush().await?;
+        Ok(())
+    }
+
+    /// Deletes the system-wide public key
+    pub async fn delete_system_public_key(&self) -> Result<bool, SchemaError> {
+        Ok(self
+            .public_keys_store
+            .delete_item(SINGLE_PUBLIC_KEY_ID)
+            .await?)
+    }
+
+    // ===== Trust-map operations =====
+
+    fn trust_graph_key(domain: &str) -> String {
+        format!("{}{}", TRUST_GRAPH_PREFIX, domain)
+    }
+
+    /// Load the trust map for a specific domain. Returns empty map if none stored.
+    /// On first call for `personal`, migrates the legacy `trust_graph` key to
+    /// `trust_graph:personal`. If deserialization of old format fails, returns
+    /// an empty map (graceful migration).
+    pub async fn load_trust_map_for_domain(&self, domain: &str) -> Result<TrustMap, SchemaError> {
+        let key = Self::trust_graph_key(domain);
+        match self.permissions_store.get_item::<TrustMap>(&key).await {
+            Ok(Some(map)) => Ok(map),
+            Ok(None) => {
+                if domain == DOMAIN_PERSONAL {
+                    if let Ok(Some(legacy)) = self
+                        .permissions_store
+                        .get_item::<TrustMap>(LEGACY_TRUST_GRAPH_KEY)
+                        .await
+                    {
+                        let _ = self.permissions_store.put_item(&key, &legacy).await;
+                        let _ = self
+                            .permissions_store
+                            .delete_item(LEGACY_TRUST_GRAPH_KEY)
+                            .await;
+                        return Ok(legacy);
+                    }
+                }
+                Ok(HashMap::new())
+            }
+            Err(_) => Ok(HashMap::new()),
+        }
+    }
+
+    /// Load the trust map (default "personal" domain).
+    pub async fn load_trust_map(&self) -> Result<TrustMap, SchemaError> {
+        self.load_trust_map_for_domain(DOMAIN_PERSONAL).await
+    }
+
+    /// Persist the trust map for a specific domain.
+    pub async fn store_trust_map_for_domain(
+        &self,
+        domain: &str,
+        map: &TrustMap,
+    ) -> Result<(), SchemaError> {
+        let key = Self::trust_graph_key(domain);
+        self.permissions_store
+            .put_item(&key, map)
+            .await
+            .map_err(|e| {
+                SchemaError::InvalidData(format!(
+                    "Failed to store trust map for domain '{}': {}",
+                    domain, e
+                ))
+            })
+    }
+
+    /// Persist the trust map (default "personal" domain).
+    pub async fn store_trust_map(&self, map: &TrustMap) -> Result<(), SchemaError> {
+        self.store_trust_map_for_domain(DOMAIN_PERSONAL, map).await
+    }
+
+    /// Delete a trust domain's map entirely.
+    pub async fn delete_trust_domain(&self, domain: &str) -> Result<(), SchemaError> {
+        let key = Self::trust_graph_key(domain);
+        self.permissions_store
+            .delete_item(&key)
+            .await
+            .map_err(|e| {
+                SchemaError::InvalidData(format!(
+                    "Failed to delete trust domain '{}': {}",
+                    domain, e
+                ))
+            })?;
+        Ok(())
+    }
+
+    /// Load the audit log from storage. Returns empty log if none stored.
+    pub async fn load_audit_log(&self) -> Result<AuditLog, SchemaError> {
+        match self
+            .permissions_store
+            .get_item::<AuditLog>(AUDIT_LOG_KEY)
+            .await
+        {
+            Ok(Some(log)) => Ok(log),
+            Ok(None) => Ok(AuditLog::new()),
+            Err(e) => Err(SchemaError::InvalidData(format!(
+                "Failed to load audit log: {}",
+                e
+            ))),
+        }
+    }
+
+    /// Persist the audit log to storage.
+    pub async fn store_audit_log(&self, log: &AuditLog) -> Result<(), SchemaError> {
+        self.permissions_store
+            .put_item(AUDIT_LOG_KEY, log)
+            .await
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to store audit log: {}", e)))
+    }
+
+    /// Append a single audit event and persist. Convenience method.
+    pub async fn append_audit_event(&self, event: AuditEvent) -> Result<(), SchemaError> {
+        let mut log = self.load_audit_log().await?;
+        log.record(event);
+        self.store_audit_log(&log).await
+    }
+
+    /// List all trust domain names that have stored maps.
+    pub async fn list_trust_domains(&self) -> Result<Vec<String>, SchemaError> {
+        let entries = self
+            .permissions_store
+            .inner()
+            .scan_prefix(TRUST_GRAPH_PREFIX.as_bytes())
+            .await
+            .map_err(|e| {
+                SchemaError::InvalidData(format!("Failed to scan trust domains: {}", e))
+            })?;
+
+        let domains: Vec<String> = entries
+            .iter()
+            .filter_map(|(key_bytes, _)| {
+                let key = String::from_utf8_lossy(key_bytes);
+                key.strip_prefix(TRUST_GRAPH_PREFIX).map(|d| d.to_string())
+            })
+            .collect();
+
+        Ok(domains)
+    }
+}

--- a/src/db_operations/public_key_operations.rs
+++ b/src/db_operations/public_key_operations.rs
@@ -1,16 +1,15 @@
+//! Thin delegator methods on `DbOperations` for public-key persistence.
+//! Real implementations live on
+//! [`super::permissions_store::PermissionsStore`].
+
 use super::core::DbOperations;
-use crate::constants::SINGLE_PUBLIC_KEY_ID;
 use crate::schema::SchemaError;
 use crate::security::PublicKeyInfo;
-use crate::storage::traits::TypedStore;
 
 impl DbOperations {
     /// Gets the system-wide public key
     pub async fn get_system_public_key(&self) -> Result<Option<PublicKeyInfo>, SchemaError> {
-        Ok(self
-            .public_keys_store()
-            .get_item(SINGLE_PUBLIC_KEY_ID)
-            .await?)
+        self.permissions().get_system_public_key().await
     }
 
     /// Stores the system-wide public key
@@ -18,18 +17,11 @@ impl DbOperations {
         &self,
         key_info: &PublicKeyInfo,
     ) -> Result<(), SchemaError> {
-        self.public_keys_store()
-            .put_item(SINGLE_PUBLIC_KEY_ID, key_info)
-            .await?;
-        self.public_keys_store().inner().flush().await?;
-        Ok(())
+        self.permissions().store_system_public_key(key_info).await
     }
 
     /// Deletes the system-wide public key
     pub async fn delete_system_public_key(&self) -> Result<bool, SchemaError> {
-        Ok(self
-            .public_keys_store()
-            .delete_item(SINGLE_PUBLIC_KEY_ID)
-            .await?)
+        self.permissions().delete_system_public_key().await
     }
 }

--- a/src/db_operations/trust_operations.rs
+++ b/src/db_operations/trust_operations.rs
@@ -1,60 +1,22 @@
-use std::collections::HashMap;
+//! Thin delegator methods on `DbOperations` for trust-map and audit-log
+//! persistence. Real implementations live on
+//! [`super::permissions_store::PermissionsStore`].
 
-use crate::access::types::{TrustMap, DOMAIN_PERSONAL};
+use crate::access::types::TrustMap;
 use crate::access::{AuditEvent, AuditLog};
-use crate::schema::types::SchemaError;
-use crate::storage::traits::TypedStore;
+use crate::schema::SchemaError;
 
 use super::DbOperations;
 
-const TRUST_GRAPH_PREFIX: &str = "trust_graph:";
-const AUDIT_LOG_KEY: &str = "audit_log";
-
-/// Legacy key — migrated to `trust_graph:personal` on first access.
-const LEGACY_TRUST_GRAPH_KEY: &str = "trust_graph";
-
 impl DbOperations {
-    /// Storage key for a domain's trust map.
-    fn trust_graph_key(domain: &str) -> String {
-        format!("{}{}", TRUST_GRAPH_PREFIX, domain)
-    }
-
-    /// Load the trust map for a specific domain. Returns empty map if none stored.
-    /// On first call, migrates the legacy `trust_graph` key to `trust_graph:personal`.
-    /// If deserialization of old format fails, returns empty map (graceful migration).
+    /// Load the trust map for a specific domain.
     pub async fn load_trust_map_for_domain(&self, domain: &str) -> Result<TrustMap, SchemaError> {
-        let key = Self::trust_graph_key(domain);
-        match self.permissions_store().get_item::<TrustMap>(&key).await {
-            Ok(Some(map)) => Ok(map),
-            Ok(None) => {
-                // Migration: if requesting "personal" and legacy key exists, try to migrate
-                if domain == DOMAIN_PERSONAL {
-                    if let Ok(Some(legacy)) = self
-                        .permissions_store()
-                        .get_item::<TrustMap>(LEGACY_TRUST_GRAPH_KEY)
-                        .await
-                    {
-                        // Migrate: store under new key, delete legacy
-                        let _ = self.permissions_store().put_item(&key, &legacy).await;
-                        let _ = self
-                            .permissions_store()
-                            .delete_item(LEGACY_TRUST_GRAPH_KEY)
-                            .await;
-                        return Ok(legacy);
-                    }
-                }
-                Ok(HashMap::new())
-            }
-            Err(_) => {
-                // Old TrustGraph format can't be deserialized — return empty map
-                Ok(HashMap::new())
-            }
-        }
+        self.permissions().load_trust_map_for_domain(domain).await
     }
 
-    /// Load the trust map (default "personal" domain). Backwards compatible.
+    /// Load the trust map (default "personal" domain).
     pub async fn load_trust_map(&self) -> Result<TrustMap, SchemaError> {
-        self.load_trust_map_for_domain(DOMAIN_PERSONAL).await
+        self.permissions().load_trust_map().await
     }
 
     /// Persist the trust map for a specific domain.
@@ -63,88 +25,38 @@ impl DbOperations {
         domain: &str,
         map: &TrustMap,
     ) -> Result<(), SchemaError> {
-        let key = Self::trust_graph_key(domain);
-        self.permissions_store()
-            .put_item(&key, map)
+        self.permissions()
+            .store_trust_map_for_domain(domain, map)
             .await
-            .map_err(|e| {
-                SchemaError::InvalidData(format!(
-                    "Failed to store trust map for domain '{}': {}",
-                    domain, e
-                ))
-            })
     }
 
-    /// Persist the trust map (default "personal" domain). Backwards compatible.
+    /// Persist the trust map (default "personal" domain).
     pub async fn store_trust_map(&self, map: &TrustMap) -> Result<(), SchemaError> {
-        self.store_trust_map_for_domain(DOMAIN_PERSONAL, map).await
+        self.permissions().store_trust_map(map).await
     }
 
     /// Delete a trust domain's map entirely.
     pub async fn delete_trust_domain(&self, domain: &str) -> Result<(), SchemaError> {
-        let key = Self::trust_graph_key(domain);
-        self.permissions_store()
-            .delete_item(&key)
-            .await
-            .map_err(|e| {
-                SchemaError::InvalidData(format!(
-                    "Failed to delete trust domain '{}': {}",
-                    domain, e
-                ))
-            })?;
-        Ok(())
+        self.permissions().delete_trust_domain(domain).await
     }
 
     /// Load the audit log from storage. Returns empty log if none stored.
     pub async fn load_audit_log(&self) -> Result<AuditLog, SchemaError> {
-        match self
-            .permissions_store()
-            .get_item::<AuditLog>(AUDIT_LOG_KEY)
-            .await
-        {
-            Ok(Some(log)) => Ok(log),
-            Ok(None) => Ok(AuditLog::new()),
-            Err(e) => Err(SchemaError::InvalidData(format!(
-                "Failed to load audit log: {}",
-                e
-            ))),
-        }
+        self.permissions().load_audit_log().await
     }
 
     /// Persist the audit log to storage.
     pub async fn store_audit_log(&self, log: &AuditLog) -> Result<(), SchemaError> {
-        self.permissions_store()
-            .put_item(AUDIT_LOG_KEY, log)
-            .await
-            .map_err(|e| SchemaError::InvalidData(format!("Failed to store audit log: {}", e)))
+        self.permissions().store_audit_log(log).await
     }
 
-    /// Append a single audit event and persist. Convenience method.
+    /// Append a single audit event and persist.
     pub async fn append_audit_event(&self, event: AuditEvent) -> Result<(), SchemaError> {
-        let mut log = self.load_audit_log().await?;
-        log.record(event);
-        self.store_audit_log(&log).await
+        self.permissions().append_audit_event(event).await
     }
 
     /// List all trust domain names that have stored maps.
     pub async fn list_trust_domains(&self) -> Result<Vec<String>, SchemaError> {
-        let entries = self
-            .permissions_store()
-            .inner()
-            .scan_prefix(TRUST_GRAPH_PREFIX.as_bytes())
-            .await
-            .map_err(|e| {
-                SchemaError::InvalidData(format!("Failed to scan trust domains: {}", e))
-            })?;
-
-        let domains: Vec<String> = entries
-            .iter()
-            .filter_map(|(key_bytes, _)| {
-                let key = String::from_utf8_lossy(key_bytes);
-                key.strip_prefix(TRUST_GRAPH_PREFIX).map(|d| d.to_string())
-            })
-            .collect();
-
-        Ok(domains)
+        self.permissions().list_trust_domains().await
     }
 }

--- a/src/fold_db_core/infrastructure/process_results_subscriber.rs
+++ b/src/fold_db_core/infrastructure/process_results_subscriber.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::db_operations::DbOperations;
 use crate::schema::types::KeyValue;
-use crate::storage::traits::TypedStore;
 
 use crate::messaging::events::query_events::MutationExecuted;
 use crate::messaging::{AsyncMessageBus, Event};
@@ -77,7 +76,7 @@ impl ProcessResultsSubscriber {
 
         // Write: key = "{progress_id}:mut:{mutation_id}"
         let key = format!("{}:mut:{}", progress_id, mutation_id);
-        if let Err(e) = db_ops.process_results_store().put_item(&key, &result).await {
+        if let Err(e) = db_ops.metadata().put_process_result(&key, &result).await {
             log::error!(
                 "ProcessResultsSubscriber: failed to write result for key '{}': {}",
                 key,

--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -17,7 +17,6 @@ use crate::messaging::{AsyncMessageBus, Event};
 use crate::schema::types::field::{Field, FieldVariant};
 use crate::schema::types::{KeyValue, Mutation, Schema};
 use crate::schema::{SchemaCore, SchemaError};
-use crate::storage::traits::TypedStore;
 use chrono::Utc;
 use log::{debug, error, warn};
 use sha2::{Digest, Sha256};
@@ -362,8 +361,8 @@ impl MutationManager {
             let key = format!("idem:{}", hash);
             match self
                 .db_ops
-                .idempotency_store()
-                .get_item::<String>(&key)
+                .metadata()
+                .get_idempotency_item::<String>(&key)
                 .await
             {
                 Ok(Some(cached_id)) => {
@@ -770,14 +769,13 @@ impl MutationManager {
             .map(|(hash, uuid)| (format!("idem:{}", hash), uuid.clone()))
             .collect();
         if !idem_entries.is_empty() {
-            use crate::storage::traits::TypedStore;
             self.db_ops
-                .idempotency_store()
-                .batch_put_items(idem_entries)
+                .metadata()
+                .batch_put_idempotency(idem_entries)
                 .await
                 .map_err(|e| {
                     log::error!("Failed to store idempotency entries: {}", e);
-                    SchemaError::InvalidData(format!("Idempotency store failed: {}", e))
+                    e
                 })?;
         }
         timing_breakdown.insert("idempotency_store", idem_store_start.elapsed());


### PR DESCRIPTION
## Summary
- Round 4 item #2: replaces the 5 remaining raw namespace getters on \`DbOperations\` (\`metadata_store\`, \`permissions_store\`, \`public_keys_store\`, \`idempotency_store\`, \`process_results_store\`) with two new domain stores whose namespace fields are private.
- \`PermissionsStore\` wraps the \`permissions\` and \`public_keys\` namespaces and owns trust-map, audit-log, and system public-key persistence.
- \`MetadataStore\` wraps the \`metadata\`, \`idempotency\`, and \`process_results\` namespaces and owns node-id, idempotency cache, and process-result bookkeeping.
- New accessors \`DbOperations::permissions()\` and \`DbOperations::metadata()\` join the existing \`schemas()\` / \`atoms()\` / \`views()\` set. Legacy delegator methods (\`get_node_id\`, \`load_trust_map\`, \`get_system_public_key\`, etc.) are preserved as thin forwarders for backward compatibility. \`raw_metadata_store()\` remains as a public escape hatch used by fold_db_node.
- Internal callers in \`mutation_manager\`, \`process_results_subscriber\`, and \`org_operations\` updated to use the new accessors.

Pure refactor; no behavior changes.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --all-targets\` (all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)