### PR TITLE
refactor: dedupe source query implementations into StandardSourceQuery

### DIFF
--- a/src/fold_db_core/query/mod.rs
+++ b/src/fold_db_core/query/mod.rs
@@ -6,6 +6,7 @@
 pub mod formatter;
 pub mod hash_range_query;
 pub mod query_executor;
+pub mod source_query;
 
 // Re-export main query functionality
 pub use formatter::{
@@ -13,3 +14,4 @@ pub use formatter::{
 };
 pub use hash_range_query::HashRangeQueryProcessor;
 pub use query_executor::QueryExecutor;
+pub use source_query::{SourceQueryMode, StandardSourceQuery};

--- a/src/fold_db_core/query/query_executor.rs
+++ b/src/fold_db_core/query/query_executor.rs
@@ -11,13 +11,13 @@ use crate::schema::types::Query;
 use crate::schema::SchemaError;
 use crate::schema::{SchemaCore, SchemaState};
 use crate::view::registry::ViewState;
-use crate::view::resolver::{SourceQueryFn, ViewResolver};
+use crate::view::resolver::ViewResolver;
 use crate::view::types::ViewCacheState;
-use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::hash_range_query::HashRangeQueryProcessor;
+use super::source_query::StandardSourceQuery;
 
 /// Main query executor that handles all query operations
 pub struct QueryExecutor {
@@ -25,96 +25,6 @@ pub struct QueryExecutor {
     db_ops: Arc<DbOperations>,
     hash_range_processor: HashRangeQueryProcessor,
     view_resolver: ViewResolver,
-}
-
-/// Implements SourceQueryFn by delegating back to the query executor's query path.
-/// This supports recursive resolution: views can query other views or schemas.
-struct RecursiveSourceQuery {
-    schema_manager: Arc<SchemaCore>,
-    db_ops: Arc<DbOperations>,
-    hash_range_processor: HashRangeQueryProcessor,
-    view_resolver: ViewResolver,
-}
-
-#[async_trait]
-impl SourceQueryFn for RecursiveSourceQuery {
-    async fn execute_query(
-        &self,
-        query: &Query,
-    ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
-        // First try as schema
-        match self.schema_manager.get_schema(&query.schema_name).await? {
-            Some(mut schema) => {
-                self.hash_range_processor
-                    .query_with_filter(
-                        &mut schema,
-                        &query.fields,
-                        query.filter.clone(),
-                        query.as_of,
-                    )
-                    .await
-            }
-            None => {
-                // Try as view (recursive)
-                self.try_query_view(query).await
-            }
-        }
-    }
-}
-
-impl RecursiveSourceQuery {
-    async fn try_query_view(
-        &self,
-        query: &Query,
-    ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
-        let view = {
-            let registry = self.schema_manager.view_registry().lock().map_err(|_| {
-                SchemaError::InvalidData("Failed to acquire view_registry lock".to_string())
-            })?;
-
-            registry
-                .get_view(&query.schema_name)
-                .cloned()
-                .ok_or_else(|| {
-                    SchemaError::NotFound(format!(
-                        "'{}' not found as schema or view",
-                        query.schema_name
-                    ))
-                })?
-        };
-
-        // Load cache state
-        let cache_state = self.db_ops.get_view_cache_state(&view.name).await?;
-
-        if cache_state.is_computing() {
-            return Err(SchemaError::InvalidData(format!(
-                "View '{}' is currently being precomputed and is not ready for queries",
-                view.name
-            )));
-        }
-
-        // Create a nested source query for this view's input queries
-        let nested_source = RecursiveSourceQuery {
-            schema_manager: Arc::clone(&self.schema_manager),
-            db_ops: Arc::clone(&self.db_ops),
-            hash_range_processor: HashRangeQueryProcessor::new(Arc::clone(&self.db_ops)),
-            view_resolver: ViewResolver::new(Arc::clone(self.view_resolver.wasm_engine())),
-        };
-
-        let (results, new_cache) = self
-            .view_resolver
-            .resolve(&view, &query.fields, &cache_state, &nested_source)
-            .await?;
-
-        // Persist cache if it changed from Empty to Cached
-        if cache_state.is_empty() && matches!(new_cache, ViewCacheState::Cached { .. }) {
-            self.db_ops
-                .set_view_cache_state(&view.name, &new_cache)
-                .await?;
-        }
-
-        Ok(results)
-    }
 }
 
 impl QueryExecutor {
@@ -297,12 +207,11 @@ impl QueryExecutor {
         }
 
         // Create source query implementation for recursive resolution
-        let source_query = RecursiveSourceQuery {
-            schema_manager: Arc::clone(&self.schema_manager),
-            db_ops: Arc::clone(&self.db_ops),
-            hash_range_processor: HashRangeQueryProcessor::new(Arc::clone(&self.db_ops)),
-            view_resolver: ViewResolver::new(Arc::clone(self.view_resolver.wasm_engine())),
-        };
+        let source_query = StandardSourceQuery::new_recursive(
+            Arc::clone(&self.schema_manager),
+            Arc::clone(&self.db_ops),
+            ViewResolver::new(Arc::clone(self.view_resolver.wasm_engine())),
+        );
 
         let (results, new_cache) = self
             .view_resolver

--- a/src/fold_db_core/query/source_query.rs
+++ b/src/fold_db_core/query/source_query.rs
@@ -1,0 +1,182 @@
+//! Shared source query implementation for view resolution.
+//!
+//! Implements [`SourceQueryFn`] for resolving a view's input queries against
+//! either schemas or other views. Used by both [`QueryExecutor`] (user-facing
+//! query path) and [`ViewOrchestrator`] (background precomputation), which
+//! differ only in how they handle views that are not yet cached.
+//!
+//! [`QueryExecutor`]: crate::fold_db_core::query::query_executor::QueryExecutor
+//! [`ViewOrchestrator`]: crate::fold_db_core::view_orchestrator::ViewOrchestrator
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::db_operations::DbOperations;
+use crate::schema::types::field::FieldValue;
+use crate::schema::types::key_value::KeyValue;
+use crate::schema::types::operations::Query;
+use crate::schema::{SchemaCore, SchemaError};
+use crate::view::resolver::{SourceQueryFn, ViewResolver};
+use crate::view::types::ViewCacheState;
+
+use super::hash_range_query::HashRangeQueryProcessor;
+
+/// Behavior mode for [`StandardSourceQuery`].
+///
+/// Controls how views whose caches are not yet `Cached` are handled.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceQueryMode {
+    /// User-facing query path. Rejects views in the `Computing` state
+    /// (a background precompute is in flight) and otherwise resolves the
+    /// view via its input queries, persisting the resulting cache if the
+    /// view transitioned from `Empty` to `Cached`.
+    Recursive,
+    /// Background precomputation path. Treats any non-`Cached` state
+    /// (including `Computing`) as `Empty` and inline-computes the view.
+    /// This is safe because precomputation walks the dependency graph
+    /// in bottom-up order, so callers are already precomputing deeper
+    /// views first.
+    Precompute,
+}
+
+/// Shared [`SourceQueryFn`] implementation used by both the user-facing
+/// query executor and the background view orchestrator.
+pub struct StandardSourceQuery {
+    schema_manager: Arc<SchemaCore>,
+    db_ops: Arc<DbOperations>,
+    hash_range_processor: HashRangeQueryProcessor,
+    view_resolver: ViewResolver,
+    mode: SourceQueryMode,
+}
+
+impl StandardSourceQuery {
+    /// Construct a [`StandardSourceQuery`] in [`SourceQueryMode::Recursive`] mode.
+    pub fn new_recursive(
+        schema_manager: Arc<SchemaCore>,
+        db_ops: Arc<DbOperations>,
+        view_resolver: ViewResolver,
+    ) -> Self {
+        let hash_range_processor = HashRangeQueryProcessor::new(Arc::clone(&db_ops));
+        Self {
+            schema_manager,
+            db_ops,
+            hash_range_processor,
+            view_resolver,
+            mode: SourceQueryMode::Recursive,
+        }
+    }
+
+    /// Construct a [`StandardSourceQuery`] in [`SourceQueryMode::Precompute`] mode.
+    pub fn new_precompute(
+        schema_manager: Arc<SchemaCore>,
+        db_ops: Arc<DbOperations>,
+        view_resolver: ViewResolver,
+    ) -> Self {
+        let hash_range_processor = HashRangeQueryProcessor::new(Arc::clone(&db_ops));
+        Self {
+            schema_manager,
+            db_ops,
+            hash_range_processor,
+            view_resolver,
+            mode: SourceQueryMode::Precompute,
+        }
+    }
+
+    async fn query_view(
+        &self,
+        query: &Query,
+    ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
+        let view = {
+            let registry = self.schema_manager.view_registry().lock().map_err(|_| {
+                SchemaError::InvalidData("Failed to acquire view_registry lock".to_string())
+            })?;
+            registry
+                .get_view(&query.schema_name)
+                .cloned()
+                .ok_or_else(|| {
+                    SchemaError::NotFound(format!(
+                        "'{}' not found as schema or view",
+                        query.schema_name
+                    ))
+                })?
+        };
+
+        let cache_state = self.db_ops.get_view_cache_state(&view.name).await?;
+
+        // Determine the effective cache state to hand to the resolver.
+        let effective_cache = match self.mode {
+            SourceQueryMode::Recursive => {
+                // Recursive mode rejects views that are currently being
+                // precomputed in the background — the user-facing query
+                // path should never race with the precomputer.
+                if cache_state.is_computing() {
+                    return Err(SchemaError::InvalidData(format!(
+                        "View '{}' is currently being precomputed and is not ready for queries",
+                        view.name
+                    )));
+                }
+                cache_state
+            }
+            SourceQueryMode::Precompute => {
+                // Precompute mode inline-computes any non-Cached view
+                // (including Computing), because the orchestrator walks
+                // the view graph bottom-up and already holds the semantics
+                // that deeper views must be materialized first.
+                if matches!(cache_state, ViewCacheState::Cached { .. }) {
+                    cache_state
+                } else {
+                    ViewCacheState::Empty
+                }
+            }
+        };
+
+        // Nested recursion uses the same mode so that the entire resolution
+        // walk shares identical semantics.
+        let nested_source = Self {
+            schema_manager: Arc::clone(&self.schema_manager),
+            db_ops: Arc::clone(&self.db_ops),
+            hash_range_processor: HashRangeQueryProcessor::new(Arc::clone(&self.db_ops)),
+            view_resolver: ViewResolver::new(Arc::clone(self.view_resolver.wasm_engine())),
+            mode: self.mode,
+        };
+
+        let (results, new_cache) = self
+            .view_resolver
+            .resolve(&view, &query.fields, &effective_cache, &nested_source)
+            .await?;
+
+        // Persist cache if it transitioned from Empty to Cached during this call.
+        if effective_cache.is_empty() && matches!(new_cache, ViewCacheState::Cached { .. }) {
+            self.db_ops
+                .set_view_cache_state(&view.name, &new_cache)
+                .await?;
+        }
+
+        Ok(results)
+    }
+}
+
+#[async_trait]
+impl SourceQueryFn for StandardSourceQuery {
+    async fn execute_query(
+        &self,
+        query: &Query,
+    ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
+        // Try as schema first.
+        match self.schema_manager.get_schema(&query.schema_name).await? {
+            Some(mut schema) => {
+                self.hash_range_processor
+                    .query_with_filter(
+                        &mut schema,
+                        &query.fields,
+                        query.filter.clone(),
+                        query.as_of,
+                    )
+                    .await
+            }
+            None => self.query_view(query).await,
+        }
+    }
+}

--- a/src/fold_db_core/view_orchestrator.rs
+++ b/src/fold_db_core/view_orchestrator.rs
@@ -14,89 +14,12 @@ use std::sync::Arc;
 
 use crate::db_operations::DbOperations;
 use crate::messaging::AsyncMessageBus;
-use crate::schema::types::{KeyValue, Mutation};
+use crate::schema::types::Mutation;
 use crate::schema::{SchemaCore, SchemaError};
-use crate::view::resolver::{SourceQueryFn, ViewResolver};
+use crate::view::resolver::ViewResolver;
 use crate::view::types::ViewCacheState;
 
-/// Source query implementation for background precomputation.
-/// Resolves sources from schemas or cached views (does NOT recurse into
-/// uncached views — those should already be computed by the time we need them,
-/// since we process in bottom-up order).
-struct PrecomputeSourceQuery {
-    schema_manager: Arc<SchemaCore>,
-    db_ops: Arc<DbOperations>,
-    hash_range_processor: super::query::hash_range_query::HashRangeQueryProcessor,
-    view_resolver: ViewResolver,
-}
-
-#[async_trait::async_trait]
-impl SourceQueryFn for PrecomputeSourceQuery {
-    async fn execute_query(
-        &self,
-        query: &crate::schema::types::operations::Query,
-    ) -> Result<
-        HashMap<String, HashMap<KeyValue, crate::schema::types::field::FieldValue>>,
-        SchemaError,
-    > {
-        // Try as schema first
-        match self.schema_manager.get_schema(&query.schema_name).await? {
-            Some(mut schema) => {
-                self.hash_range_processor
-                    .query_with_filter(
-                        &mut schema,
-                        &query.fields,
-                        query.filter.clone(),
-                        query.as_of,
-                    )
-                    .await
-            }
-            None => {
-                // Try as view — must be cached (computed earlier in bottom-up order)
-                let view = {
-                    let registry =
-                        self.schema_manager.view_registry().lock().map_err(|_| {
-                            SchemaError::InvalidData("view_registry lock".to_string())
-                        })?;
-                    registry
-                        .get_view(&query.schema_name)
-                        .cloned()
-                        .ok_or_else(|| {
-                            SchemaError::NotFound(format!(
-                                "'{}' not found as schema or view during precomputation",
-                                query.schema_name
-                            ))
-                        })?
-                };
-
-                let cache_state = self.db_ops.get_view_cache_state(&view.name).await?;
-
-                // Source view should be Cached (computed earlier in bottom-up order).
-                // If it's still Empty, compute it inline.
-                let effective_cache = if matches!(cache_state, ViewCacheState::Cached { .. }) {
-                    cache_state
-                } else {
-                    ViewCacheState::Empty
-                };
-
-                let (results, new_cache) = self
-                    .view_resolver
-                    .resolve(&view, &query.fields, &effective_cache, self)
-                    .await?;
-
-                // Persist if we just computed it
-                if effective_cache.is_empty() && matches!(new_cache, ViewCacheState::Cached { .. })
-                {
-                    self.db_ops
-                        .set_view_cache_state(&view.name, &new_cache)
-                        .await?;
-                }
-
-                Ok(results)
-            }
-        }
-    }
-}
+use super::query::StandardSourceQuery;
 
 /// Orchestrates view lifecycle: dependency-graph traversal, invalidation,
 /// and precomputation of derived views triggered by mutations.
@@ -404,8 +327,6 @@ impl ViewOrchestrator {
         db_ops: Arc<DbOperations>,
         views_to_compute: Vec<String>,
     ) -> Result<(), SchemaError> {
-        use super::query::hash_range_query::HashRangeQueryProcessor;
-
         let wasm_engine = {
             let registry = schema_manager
                 .view_registry()
@@ -444,12 +365,11 @@ impl ViewOrchestrator {
             }
 
             // Build source query for resolution
-            let source_query = PrecomputeSourceQuery {
-                schema_manager: Arc::clone(&schema_manager),
-                db_ops: Arc::clone(&db_ops),
-                hash_range_processor: HashRangeQueryProcessor::new(Arc::clone(&db_ops)),
-                view_resolver: ViewResolver::new(Arc::clone(&wasm_engine)),
-            };
+            let source_query = StandardSourceQuery::new_precompute(
+                Arc::clone(&schema_manager),
+                Arc::clone(&db_ops),
+                ViewResolver::new(Arc::clone(&wasm_engine)),
+            );
 
             let resolver = ViewResolver::new(Arc::clone(&wasm_engine));
             match resolver


### PR DESCRIPTION
## Summary
- Extracts the two near-duplicate `SourceQueryFn` implementations (`RecursiveSourceQuery` in `query_executor.rs` and `PrecomputeSourceQuery` in `view_orchestrator.rs`) into a single `StandardSourceQuery` under `src/fold_db_core/query/source_query.rs`.
- A `SourceQueryMode` enum (`Recursive` | `Precompute`) controls how views that are not already `Cached` are handled — this is the only real behavioral difference between the two original structs.
- Pure refactor: behavior is preserved exactly for both call sites. Recursive mode still rejects `Computing` views; Precompute mode still treats any non-Cached state as `Empty` and inline-computes, relying on the orchestrator's bottom-up dependency walk.

Round 4 architectural refactor item #6.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --all-targets` — all tests pass, including:
  - `tests/precompute_test.rs` (bottom-up precompute path — `StandardSourceQuery::new_precompute`)
  - `tests/view_query_test.rs` (user query path — `StandardSourceQuery::new_recursive`)
  - `tests/view_write_test.rs` (write-through and cascade invalidation)

Generated with Claude Code