### PR TITLE
refactor: remove dead message_bus field from ViewOrchestrator

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -403,7 +403,6 @@ impl FoldDB {
         let view_orchestrator = Arc::new(super::view_orchestrator::ViewOrchestrator::new(
             Arc::clone(&schema_manager),
             Arc::clone(&db_ops),
-            Arc::clone(&message_bus),
         ));
 
         // Create MutationManager for handling all mutation operations

--- a/src/fold_db_core/view_orchestrator.rs
+++ b/src/fold_db_core/view_orchestrator.rs
@@ -13,7 +13,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use crate::db_operations::DbOperations;
-use crate::messaging::AsyncMessageBus;
 use crate::schema::types::Mutation;
 use crate::schema::{SchemaCore, SchemaError};
 use crate::view::resolver::ViewResolver;
@@ -26,21 +25,14 @@ use super::query::StandardSourceQuery;
 pub struct ViewOrchestrator {
     schema_manager: Arc<SchemaCore>,
     db_ops: Arc<DbOperations>,
-    #[allow(dead_code)]
-    message_bus: Arc<AsyncMessageBus>,
 }
 
 impl ViewOrchestrator {
     /// Create a new ViewOrchestrator.
-    pub fn new(
-        schema_manager: Arc<SchemaCore>,
-        db_ops: Arc<DbOperations>,
-        message_bus: Arc<AsyncMessageBus>,
-    ) -> Self {
+    pub fn new(schema_manager: Arc<SchemaCore>, db_ops: Arc<DbOperations>) -> Self {
         Self {
             schema_manager,
             db_ops,
-            message_bus,
         }
     }
 


### PR DESCRIPTION
## Summary
- Drop unused `Arc<AsyncMessageBus>` field (and constructor param) from `ViewOrchestrator`. It was hidden behind `#[allow(dead_code)]` and never read — remove the field, the import, and stop passing it from the `FoldDB` factory.
- Task B (moving `DbOperations::from_namespaced_store` / `from_sled` out of `db_operations/core.rs` into `fold_db_core/factory.rs`) was evaluated and skipped: both constructors build `Self` directly from private domain-store fields, so relocating them to a different module would require widening field visibility. Leaving them as associated functions on `DbOperations` is the cleanest option.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (all green)

Generated with Claude Code