### PR TITLE
feat(native_index): plumb face bbox + confidence through to list_faces

### DIFF
--- a/src/db_operations/native_index/embedding_index.rs
+++ b/src/db_operations/native_index/embedding_index.rs
@@ -32,6 +32,15 @@ pub(super) struct StoredEmbedding {
     /// Legacy: old format stored all field names here. Kept for deserialization compat.
     #[serde(default)]
     pub field_names: Vec<String>,
+    /// Face-only: bounding box `[x1, y1, x2, y2]` normalized to `[0, 1]`.
+    /// Only populated for entries with `field_name == "__face__"`. Optional so
+    /// pre-bbox entries deserialize cleanly.
+    #[serde(default)]
+    pub face_bbox: Option<[f32; 4]>,
+    /// Face-only: detector confidence score in `[0, 1]`. Optional for
+    /// pre-bbox entries.
+    #[serde(default)]
+    pub face_confidence: Option<f32>,
 }
 
 /// Entry held in the in-memory index.
@@ -45,6 +54,10 @@ pub(super) struct EmbeddingEntry {
     pub embedding: Vec<f32>,
     /// Legacy field names from old-format entries (for backward-compat search expansion).
     pub legacy_field_names: Vec<String>,
+    /// Face-only bbox + confidence. None for text fragments and for face
+    /// entries written before bbox plumbing existed.
+    pub face_bbox: Option<[f32; 4]>,
+    pub face_confidence: Option<f32>,
 }
 
 impl EmbeddingEntry {
@@ -91,6 +104,11 @@ pub(super) struct FragmentInfo<'a> {
     pub field_name: &'a str,
     pub fragment_idx: usize,
     pub fragment_text: Option<String>,
+    /// Face-only: bbox `[x1, y1, x2, y2]` normalized to `[0, 1]`.
+    /// `None` for text fragments.
+    pub face_bbox: Option<[f32; 4]>,
+    /// Face-only: detector confidence in `[0, 1]`. `None` for text fragments.
+    pub face_confidence: Option<f32>,
 }
 
 /// In-memory nearest-neighbour index backed by Sled for persistence.
@@ -128,6 +146,8 @@ impl EmbeddingIndex {
                         fragment_text: stored.fragment_text,
                         embedding: stored.embedding,
                         legacy_field_names: stored.field_names,
+                        face_bbox: stored.face_bbox,
+                        face_confidence: stored.face_confidence,
                     });
                 }
                 Err(e) => log::warn!("Failed to deserialize StoredEmbedding: {}", e),
@@ -153,6 +173,8 @@ impl EmbeddingIndex {
             fragment_text: info.fragment_text.clone(),
             embedding: embedding.clone(),
             field_names: Vec::new(),
+            face_bbox: info.face_bbox,
+            face_confidence: info.face_confidence,
         };
 
         let storage_key = EmbeddingEntry::fragment_storage_key(
@@ -182,6 +204,8 @@ impl EmbeddingIndex {
             fragment_text: info.fragment_text,
             embedding,
             legacy_field_names: Vec::new(),
+            face_bbox: info.face_bbox,
+            face_confidence: info.face_confidence,
         };
 
         let mut entries = self.entries.write().unwrap();
@@ -367,8 +391,10 @@ impl EmbeddingIndex {
     }
 
     /// List all face embeddings stored for a specific record (schema + key).
-    /// Returns each face's embedding, bbox metadata, and fragment index.
-    pub(super) fn list_faces(&self, schema: &str, key: &KeyValue) -> Vec<(usize, Vec<f32>)> {
+    /// Returns each face's fragment_idx, embedding, normalized bbox, and
+    /// detector confidence. bbox/confidence are `None` for legacy entries
+    /// written before the bbox plumbing existed (see StoredEmbedding).
+    pub(super) fn list_faces(&self, schema: &str, key: &KeyValue) -> Vec<FaceListEntry> {
         let entries = self.entries.read().unwrap();
         entries
             .iter()
@@ -376,9 +402,30 @@ impl EmbeddingIndex {
                 e.field_name == FACE_FIELD_NAME && e.schema == schema && e.key.hash == key.hash
                 // Match by hash only (photo filename)
             })
-            .map(|e| (e.fragment_idx, e.embedding.clone()))
+            .map(|e| FaceListEntry {
+                fragment_idx: e.fragment_idx,
+                embedding: e.embedding.clone(),
+                bbox: e.face_bbox,
+                confidence: e.face_confidence,
+            })
             .collect()
     }
+}
+
+/// A single face entry returned by `EmbeddingIndex::list_faces`.
+///
+/// Carries the embedding (for face-search queries) and the bbox + confidence
+/// (for UI overlays / face-index disambiguation). bbox + confidence are
+/// optional because pre-bbox-plumbing entries don't have them — the caller
+/// must handle `None` (e.g. show "—" in the UI rather than failing).
+#[derive(Debug, Clone)]
+pub struct FaceListEntry {
+    pub fragment_idx: usize,
+    pub embedding: Vec<f32>,
+    /// `[x1, y1, x2, y2]` normalized to `[0, 1]` of the source image.
+    pub bbox: Option<[f32; 4]>,
+    /// Detector confidence in `[0, 1]`.
+    pub confidence: Option<f32>,
 }
 
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {

--- a/src/db_operations/native_index/mod.rs
+++ b/src/db_operations/native_index/mod.rs
@@ -10,6 +10,7 @@ mod types;
 mod tests;
 
 pub use embedding_index::cosine_similarity;
+pub use embedding_index::FaceListEntry;
 pub use embedding_model::{Embedder, FastEmbedModel};
 #[cfg(any(test, feature = "test-utils"))]
 pub use embedding_model::{MockEmbeddingModel, ScriptedEmbeddingModel};
@@ -85,6 +86,8 @@ impl NativeIndexManager {
                     field_name,
                     fragment_idx: idx,
                     fragment_text: Some(fragment_text.clone()),
+                    face_bbox: None,
+                    face_confidence: None,
                 };
                 self.embedding_index
                     .insert_fragment(&*self.store, info, embedding)
@@ -207,6 +210,8 @@ impl NativeIndexManager {
                 field_name: FACE_FIELD_NAME,
                 fragment_idx: idx,
                 fragment_text: None,
+                face_bbox: Some(face.bbox),
+                face_confidence: Some(face.confidence),
             };
             self.embedding_index
                 .insert_fragment(&*self.store, info, face.embedding)
@@ -231,9 +236,10 @@ impl NativeIndexManager {
         self.embedding_index.search_faces(query_face_vec, k)
     }
 
-    /// List all face embeddings stored for a specific record.
-    /// Returns (fragment_idx, embedding) pairs.
-    pub fn list_faces(&self, schema: &str, key: &KeyValue) -> Vec<(usize, Vec<f32>)> {
+    /// List all face embeddings stored for a specific record. Each entry
+    /// carries fragment_idx, embedding, optional bbox + confidence (None for
+    /// pre-bbox-plumbing entries).
+    pub fn list_faces(&self, schema: &str, key: &KeyValue) -> Vec<FaceListEntry> {
         self.embedding_index.list_faces(schema, key)
     }
 }


### PR DESCRIPTION
## Summary

The face detector already produces normalized `bbox: [f32; 4]` + `confidence: f32` per detection (see `face/mod.rs::FaceEmbedding`), but `index_faces` was discarding both fields when persisting — only the embedding made it into `EmbeddingEntry` / `StoredEmbedding`. Downstream callers (specifically `fold_db_node`'s `/api/discovery/faces` handler and the React Face Search panel) had no way to tell which `face_index` corresponds to which face in a multi-face photo.

I caught this during a Tom Cruise multi-node face discovery dogfood: Bob's `tom-gs2.jpg` had 5 detected faces, only `face_index=3` was actually Tom — operators were brute-forcing every index until something matched. The docstring on `list_faces` literally claimed bbox metadata was returned, but the code returned `Vec<(usize, Vec<f32>)>`. Stale comment masking a missing feature.

## Plumbing

1. **`StoredEmbedding`** (on-disk shape) gains optional `face_bbox: Option<[f32; 4]>` and `face_confidence: Option<f32>`. Both `#[serde(default)]` so old JSON entries (text fragments and pre-bbox face entries) deserialize cleanly **without migration**.
2. **`EmbeddingEntry`** (in-memory shape) mirrors the same fields, copied through `load_from_store`.
3. **`FragmentInfo`** grows the same two fields. The text caller (`insert_fragments`) passes `None`. The face caller (`index_faces`) plumbs them from `FaceEmbedding`.
4. **New public `FaceListEntry` struct** replaces the bare `Vec<(usize, Vec<f32>)>` returned by `EmbeddingIndex::list_faces` and `NativeIndexManager::list_faces`. Callers now get `{ fragment_idx, embedding, bbox, confidence }`.
5. **Re-exported `FaceListEntry`** from `native_index` so `fold_db_node` can build a typed response without poking into private modules.

## Backward compatibility

Storage is additive only. Old face entries written before this commit still load — they just have `bbox = None, confidence = None`. The companion `fold_db_node` PR will render `"—"` (or hide the overlay) for those, rather than crashing.

## Companion PR (next)

`fold_db_node` will:
- pin the git dep to a commit that includes this
- add `bbox` + `confidence` fields to the `/api/discovery/faces` response shape
- render the list of detected faces in the Face Search panel with bbox + confidence so operators can pick the right index without brute-forcing

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (face feature off, what mainline CI runs) — clean
- [x] `cargo test --workspace --all-targets` — all passing
- [x] `cargo check --features face-detection` — clean
- [x] `cargo test --features face-detection --lib` — 537 passed
- [ ] After merge: bump `fold_db_node` dep + ship the companion PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)