### PR TITLE
security: constant-time hash compare + remove unsafe query() bypass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "sled",
+ "subtle",
  "temp-env",
  "tempfile",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ aes-gcm = "0.10"
 hkdf = "0.12"
 hmac = "0.12"
 sha2 = "0.10"
+subtle = "2.5"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/src/fold_db_core/query/query_executor.rs
+++ b/src/fold_db_core/query/query_executor.rs
@@ -50,14 +50,6 @@ impl QueryExecutor {
         }
     }
 
-    /// Query multiple fields from a schema or view (legacy — no access control)
-    pub async fn query(
-        &self,
-        query: Query,
-    ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
-        self.query_internal(query, None, None).await
-    }
-
     /// Query with access control enforcement.
     ///
     /// For schema queries: fields where the caller lacks read access are filtered out.

--- a/src/sync/log.rs
+++ b/src/sync/log.rs
@@ -4,6 +4,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
+use subtle::ConstantTimeEq;
 
 /// A single KvStore operation recorded for sync.
 ///
@@ -99,7 +100,12 @@ impl LogEntry {
         hasher.update(json_bytes);
         let computed_hash: [u8; 32] = hasher.finalize().into();
 
-        if stored_hash != computed_hash.as_slice() {
+        // Constant-time compare to prevent timing oracle on integrity hash.
+        // A byte-by-byte `!=` can leak the position of the first differing byte
+        // via short-circuit timing, letting an attacker incrementally forge a
+        // valid hash for tampered log entries. `ConstantTimeEq::ct_eq` compares
+        // in time independent of the contents.
+        if !bool::from(stored_hash.ct_eq(computed_hash.as_slice())) {
             return Err(SyncError::CorruptEntry {
                 seq: 0,
                 reason: "hash mismatch — data corrupted".to_string(),
@@ -238,6 +244,39 @@ mod tests {
             assert_eq!(items.len(), 2);
         } else {
             panic!("expected BatchPut");
+        }
+    }
+
+    #[tokio::test]
+    async fn flipped_integrity_hash_is_rejected() {
+        // Build a sealed entry by hand with a bit-flipped stored hash so that
+        // the ciphertext decrypts cleanly but the integrity hash does not match.
+        // This exercises the constant-time hash comparison in `unseal`.
+        let crypto = test_crypto();
+        let entry = sample_entry(42);
+        let json = serde_json::to_vec(&entry).unwrap();
+
+        let mut hasher = Sha256::new();
+        hasher.update(&json);
+        let mut hash: [u8; 32] = hasher.finalize().into();
+        // Flip one bit in the stored hash.
+        hash[0] ^= 0x01;
+
+        let mut plaintext = Vec::with_capacity(HASH_SIZE + json.len());
+        plaintext.extend_from_slice(&hash);
+        plaintext.extend_from_slice(&json);
+
+        let ciphertext = crypto.encrypt(&plaintext).await.unwrap();
+        let result = LogEntry::unseal(&ciphertext, &crypto).await;
+
+        match result {
+            Err(SyncError::CorruptEntry { reason, .. }) => {
+                assert!(
+                    reason.contains("hash mismatch"),
+                    "unexpected reason: {reason}"
+                );
+            }
+            other => panic!("expected CorruptEntry hash mismatch, got {other:?}"),
         }
     }
 

--- a/tests/access_control_test.rs
+++ b/tests/access_control_test.rs
@@ -328,7 +328,11 @@ async fn query_with_no_access_context_returns_all_fields() {
         "Notes".to_string(),
         vec!["title".to_string(), "content".to_string()],
     );
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db
+        .query_executor()
+        .query_with_access(query, &fold_db::access::AccessContext::owner("test"), None)
+        .await
+        .unwrap();
 
     assert!(results.contains_key("title"));
     assert!(results.contains_key("content"));

--- a/tests/view_invalidation_test.rs
+++ b/tests/view_invalidation_test.rs
@@ -70,7 +70,7 @@ async fn mutating_source_invalidates_view_cache() {
 
     // First query: populates cache
     let query = Query::new("CV".to_string(), vec!["content".to_string()]);
-    let results = db.query_executor().query(query.clone()).await.unwrap();
+    let results = db.query_executor().query_with_access(query.clone(), &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     let first_value = results["content"].values().next().unwrap().value.clone();
     assert_eq!(first_value, json!("original"));
 
@@ -105,7 +105,7 @@ async fn mutating_source_invalidates_view_cache() {
     );
 
     // Re-query: should fetch fresh data
-    let results2 = db.query_executor().query(query).await.unwrap();
+    let results2 = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     let all_values: Vec<_> = results2["content"]
         .values()
         .map(|fv| fv.value.clone())
@@ -150,7 +150,7 @@ async fn re_query_after_invalidation_re_caches() {
 
     // First query: caches
     let query = Query::new("TV".to_string(), vec!["title".to_string()]);
-    db.query_executor().query(query.clone()).await.unwrap();
+    db.query_executor().query_with_access(query.clone(), &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Invalidate
     let mut fields2 = HashMap::new();
@@ -173,7 +173,7 @@ async fn re_query_after_invalidation_re_caches() {
     ));
 
     // Re-query: should re-cache
-    db.query_executor().query(query).await.unwrap();
+    db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     assert!(matches!(
         db.db_ops().get_view_cache_state("TV").await.unwrap(),
@@ -228,8 +228,8 @@ async fn cascading_invalidation_through_view_chain() {
     // Query both views to populate caches
     let query_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
     let query_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    db.query_executor().query(query_a).await.unwrap();
-    db.query_executor().query(query_b).await.unwrap();
+    db.query_executor().query_with_access(query_a, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
+    db.query_executor().query_with_access(query_b, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Both should be cached
     assert!(matches!(
@@ -326,7 +326,7 @@ async fn view_chain_query_returns_source_data() {
 
     // Query ViewB — should recursively resolve through ViewA to BlogPost
     let query = Query::new("ViewB".to_string(), vec!["title".to_string()]);
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     assert!(results.contains_key("title"));
     let values: Vec<_> = results["title"]
@@ -386,7 +386,7 @@ async fn three_level_chain_resolves_to_source() {
 
     // Query ViewC — resolves through ViewB → ViewA → BlogPost
     let query = Query::new("ViewC".to_string(), vec!["content".to_string()]);
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     let values: Vec<_> = results["content"]
         .values()
@@ -437,7 +437,7 @@ async fn chain_re_query_after_cascade_invalidation_gets_fresh_data() {
 
     // Populate caches
     let query_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    let results = db.query_executor().query(query_b.clone()).await.unwrap();
+    let results = db.query_executor().query_with_access(query_b.clone(), &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     let val = results["content"].values().next().unwrap().value.clone();
     assert_eq!(val, json!("v1"));
 
@@ -460,7 +460,7 @@ async fn chain_re_query_after_cascade_invalidation_gets_fresh_data() {
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     // Re-query ViewB — should get fresh "v2" through the entire chain
-    let results2 = db.query_executor().query(query_b).await.unwrap();
+    let results2 = db.query_executor().query_with_access(query_b, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     let values: Vec<_> = results2["content"]
         .values()
         .map(|fv| fv.value.clone())
@@ -559,7 +559,7 @@ async fn multi_source_view_from_two_views() {
 
     // Query ViewC — should merge data from both source views
     let query = Query::new("ViewC".to_string(), vec![]);
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     assert!(
         results.contains_key("title"),
@@ -619,7 +619,7 @@ async fn three_level_cascade_invalidation() {
     // Populate all caches
     for name in &["ViewA", "ViewB", "ViewC"] {
         let q = Query::new(name.to_string(), vec!["content".to_string()]);
-        db.query_executor().query(q).await.unwrap();
+        db.query_executor().query_with_access(q, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     }
 
     // All should be cached

--- a/tests/view_precomputation_test.rs
+++ b/tests/view_precomputation_test.rs
@@ -87,8 +87,8 @@ async fn deep_view_enters_computing_after_mutation() {
     // Populate caches by querying both
     let q_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
     let q_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    db.query_executor().query(q_a).await.unwrap();
-    db.query_executor().query(q_b).await.unwrap();
+    db.query_executor().query_with_access(q_a, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
+    db.query_executor().query_with_access(q_b, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Both should be Cached
     assert!(matches!(
@@ -153,8 +153,8 @@ async fn deep_view_eventually_becomes_cached() {
     // Populate caches
     let q_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
     let q_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    db.query_executor().query(q_a).await.unwrap();
-    db.query_executor().query(q_b).await.unwrap();
+    db.query_executor().query_with_access(q_a, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
+    db.query_executor().query_with_access(q_b, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Mutate source
     write_blogpost(&db, "updated", "2026-01-02").await;
@@ -163,7 +163,7 @@ async fn deep_view_eventually_becomes_cached() {
     // (ViewA needs to be lazily computed first, then ViewB background task runs)
     // First, lazily compute ViewA so the background task for ViewB can proceed
     let q_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
-    db.query_executor().query(q_a).await.unwrap();
+    db.query_executor().query_with_access(q_a, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Give background task time to complete
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -202,7 +202,7 @@ async fn query_during_computing_returns_error() {
 
     // Query should fail with clear error
     let q = Query::new("ViewA".to_string(), vec!["content".to_string()]);
-    let result = db.query_executor().query(q).await;
+    let result = db.query_executor().query_with_access(q, &fold_db::access::AccessContext::owner("test"), None).await;
 
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
@@ -243,7 +243,7 @@ async fn three_level_chain_precomputes_bottom_up() {
     // Populate all caches
     for name in &["ViewA", "ViewB", "ViewC"] {
         let q = Query::new(name.to_string(), vec!["content".to_string()]);
-        db.query_executor().query(q).await.unwrap();
+        db.query_executor().query_with_access(q, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     }
 
     // Mutate source
@@ -283,7 +283,7 @@ async fn three_level_chain_precomputes_bottom_up() {
 
     // Lazily compute ViewA so background tasks can resolve
     let q = Query::new("ViewA".to_string(), vec!["content".to_string()]);
-    db.query_executor().query(q).await.unwrap();
+    db.query_executor().query_with_access(q, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Wait for background tasks
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
@@ -326,14 +326,14 @@ async fn precomputed_view_has_fresh_data() {
     // Populate caches with v1
     let q_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
     let q_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    db.query_executor().query(q_a.clone()).await.unwrap();
-    db.query_executor().query(q_b.clone()).await.unwrap();
+    db.query_executor().query_with_access(q_a.clone(), &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
+    db.query_executor().query_with_access(q_b.clone(), &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Mutate to v2
     write_blogpost(&db, "v2", "2026-01-01").await;
 
     // Lazily compute ViewA to unblock ViewB's precomputation
-    db.query_executor().query(q_a).await.unwrap();
+    db.query_executor().query_with_access(q_a, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Wait for ViewB precomputation
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -347,7 +347,7 @@ async fn precomputed_view_has_fresh_data() {
     );
 
     // Query ViewB — should have v2 data
-    let results = db.query_executor().query(q_b).await.unwrap();
+    let results = db.query_executor().query_with_access(q_b, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     let values: Vec<_> = results["content"]
         .values()
         .map(|fv| fv.value.clone())

--- a/tests/view_query_test.rs
+++ b/tests/view_query_test.rs
@@ -72,7 +72,7 @@ async fn query_identity_view_returns_source_data() {
 
     // Query the view — should return the source data
     let query = Query::new("ContentView".to_string(), vec!["content".to_string()]);
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     assert!(
         results.contains_key("content"),
@@ -91,7 +91,7 @@ async fn query_nonexistent_name_errors() {
     let db = setup_db().await;
 
     let query = Query::new("DoesNotExist".to_string(), vec![]);
-    let result = db.query_executor().query(query).await;
+    let result = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await;
     assert!(result.is_err());
 }
 
@@ -108,7 +108,7 @@ async fn query_blocked_view_errors() {
     db.schema_manager().block_view("BlockedView").await.unwrap();
 
     let query = Query::new("BlockedView".to_string(), vec!["title".to_string()]);
-    let result = db.query_executor().query(query).await;
+    let result = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await;
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("blocked"));
 }
@@ -159,7 +159,7 @@ async fn query_view_with_empty_fields_returns_all() {
 
     // Query with empty fields — should return all view output fields
     let query = Query::new("FullView".to_string(), vec![]);
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     assert_eq!(results.len(), 2);
     assert!(results.contains_key("title"));
@@ -198,7 +198,7 @@ async fn identity_view_write_redirects_to_source() {
 
     // Query the SOURCE schema to verify the write landed there
     let query = Query::new("BlogPost".to_string(), vec!["content".to_string()]);
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     assert!(results.contains_key("content"));
     let values: Vec<_> = results["content"]
         .values()
@@ -243,7 +243,7 @@ async fn identity_view_write_invalidates_view_cache() {
 
     // Query view to populate cache
     let query = Query::new("CacheView".to_string(), vec!["content".to_string()]);
-    db.query_executor().query(query.clone()).await.unwrap();
+    db.query_executor().query_with_access(query.clone(), &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Write through the view — should invalidate the cache
     let mut mutation_fields = HashMap::new();
@@ -260,7 +260,7 @@ async fn identity_view_write_invalidates_view_cache() {
         .unwrap();
 
     // Re-query view — should return fresh data including the new write
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     let values: Vec<_> = results["content"]
         .values()
         .map(|fv| fv.value.clone())

--- a/tests/view_wasm_integration_test.rs
+++ b/tests/view_wasm_integration_test.rs
@@ -106,7 +106,7 @@ async fn wasm_view_query_returns_transformed_output() {
 
     // Query the view
     let query = Query::new("SummaryView".to_string(), vec!["summary".to_string()]);
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     assert!(results.contains_key("summary"));
     let summary_values = &results["summary"];
@@ -157,7 +157,7 @@ async fn wasm_view_output_type_validation_works() {
 
     // Query should fail with type validation error
     let query = Query::new("BadTypeView".to_string(), vec!["summary".to_string()]);
-    let result = db.query_executor().query(query).await;
+    let result = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await;
     assert!(result.is_err());
     assert!(
         result.unwrap_err().to_string().contains("type validation"),
@@ -207,7 +207,7 @@ async fn wasm_view_cache_invalidation_works() {
 
     // First query: populates cache
     let query = Query::new("WasmCacheView".to_string(), vec!["summary".to_string()]);
-    db.query_executor().query(query.clone()).await.unwrap();
+    db.query_executor().query_with_access(query.clone(), &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Verify cached
     let state = db

--- a/tests/view_write_test.rs
+++ b/tests/view_write_test.rs
@@ -79,7 +79,7 @@ async fn identity_write_redirects_to_source() {
 
     // Query the SOURCE schema to verify the write landed there
     let query = Query::new("BlogPost".to_string(), vec!["title".to_string()]);
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     assert!(
         results.contains_key("title"),
@@ -189,7 +189,7 @@ async fn write_through_view_invalidates_cache() {
 
     // Query the view to populate cache
     let query = Query::new("CacheWrite".to_string(), vec!["content".to_string()]);
-    db.query_executor().query(query.clone()).await.unwrap();
+    db.query_executor().query_with_access(query.clone(), &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Cache should be populated
     assert!(matches!(
@@ -215,7 +215,7 @@ async fn write_through_view_invalidates_cache() {
         .unwrap();
 
     // Re-query — should return fresh data including the new write
-    let results = db.query_executor().query(query).await.unwrap();
+    let results = db.query_executor().query_with_access(query, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     let values: Vec<_> = results["content"]
         .values()
         .map(|fv| fv.value.clone())
@@ -276,8 +276,8 @@ async fn write_through_view_cascades_invalidation() {
     // Populate caches for both views
     let query_a = Query::new("ViewA".to_string(), vec!["content".to_string()]);
     let query_b = Query::new("ViewB".to_string(), vec!["content".to_string()]);
-    db.query_executor().query(query_a).await.unwrap();
-    db.query_executor().query(query_b.clone()).await.unwrap();
+    db.query_executor().query_with_access(query_a, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
+    db.query_executor().query_with_access(query_b.clone(), &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
 
     // Both should be cached
     assert!(matches!(
@@ -307,7 +307,7 @@ async fn write_through_view_cascades_invalidation() {
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     // ViewB (downstream) should also see the new data after cascade invalidation
-    let results = db.query_executor().query(query_b).await.unwrap();
+    let results = db.query_executor().query_with_access(query_b, &fold_db::access::AccessContext::owner("test"), None).await.unwrap();
     let values: Vec<_> = results["content"]
         .values()
         .map(|fv| fv.value.clone())


### PR DESCRIPTION
## Summary

Two security fixes in fold_db (batch 2).

### CRITICAL: Non-constant-time hash comparison in sync log integrity check
- **File**: `src/sync/log.rs`
- The `unseal` path compared the stored SHA-256 hash against the computed hash using `!=`, which short-circuits on the first differing byte. An attacker with a timing oracle can incrementally forge a valid integrity hash for a tampered log entry.
- Fix: add the `subtle` crate and use `ConstantTimeEq::ct_eq`. Added a regression test (`flipped_integrity_hash_is_rejected`) that constructs a sealed entry with a bit-flipped stored hash and confirms `unseal` rejects it with a `CorruptEntry` hash-mismatch error.

### HIGH: Legacy `query()` bypass on `QueryExecutor`
- **File**: `src/fold_db_core/query/query_executor.rs`
- `QueryExecutor` exposed both `query()` (no access context) and `query_with_access()`. Any caller skipping the `_with_access` variant ran queries with zero enforcement — per-field access policies and view blocking were never applied.
- Fix: delete `query()` entirely. All in-crate integration test callers migrated to `query_with_access(..., &AccessContext::owner("test"), None)`.

### Follow-up
External callers in `fold_db_node` (3 sites: `handlers/llm_hydration.rs`, `handlers/discovery/mod.rs`, `fold_node/operation_processor/query_ops.rs`) will be migrated in a follow-up PR against fold_db_node. Until then, fold_db_node's CI will fail against this commit of fold_db mainline — the two PRs need to land together.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --all-targets` — all passing
- [x] New unit test `flipped_integrity_hash_is_rejected` exercises the constant-time compare path

Co-Authored-By: Claude Opus 4.6 (1M context)