### PR TITLE
fix(face/detector): normalize SCRFD input — was feeding raw 0-255 pixels

### DIFF
--- a/src/db_operations/native_index/face/detector.rs
+++ b/src/db_operations/native_index/face/detector.rs
@@ -43,15 +43,33 @@ impl ScrfdDetector {
 
         let resized = image.resize_exact(input_w, input_h, FilterType::Lanczos3);
 
-        // Convert to CHW float tensor [1, 3, H, W]
+        // Convert to CHW float tensor [1, 3, H, W] with the standard SCRFD
+        // input preprocessing: subtract mean 127.5 and scale by 1/128 so each
+        // channel ends up roughly in [-1, 1]. This matches what insightface
+        // does for the buffalo_sc / scrfd_2.5g_bnkps weights:
+        //
+        //   cv2.dnn.blobFromImage(img, 1.0/128.0, input_size,
+        //                         (127.5, 127.5, 127.5), swapRB=True)
+        //
+        // Without normalization the network sees raw 0–255 pixels, its
+        // activations are wildly off, and it returns a sea of low-confidence
+        // (0.5–0.7) detections at semi-random feature-map positions instead
+        // of the prominent face. Downstream that manifests as bboxes that
+        // are ~0.02–0.05 of the image width regardless of how big the face
+        // actually is, AND face-search across photos of the same person
+        // fails because the embeddings are computed from noise crops, not
+        // actual faces. The cv2 reference also does swapRB=True because cv2
+        // reads BGR; the `image` crate already gives us RGB so we skip the
+        // swap.
         let mut input_tensor = vec![0.0f32; (3 * input_h * input_w) as usize];
+        let plane = (input_h * input_w) as usize;
         for y in 0..input_h {
             for x in 0..input_w {
                 let pixel = resized.get_pixel(x, y);
                 let idx = (y * input_w + x) as usize;
-                input_tensor[idx] = pixel[0] as f32;
-                input_tensor[(input_h * input_w) as usize + idx] = pixel[1] as f32;
-                input_tensor[2 * (input_h * input_w) as usize + idx] = pixel[2] as f32;
+                input_tensor[idx] = (pixel[0] as f32 - 127.5) / 128.0;
+                input_tensor[plane + idx] = (pixel[1] as f32 - 127.5) / 128.0;
+                input_tensor[2 * plane + idx] = (pixel[2] as f32 - 127.5) / 128.0;
             }
         }
 


### PR DESCRIPTION
## Summary

`ScrfdDetector::detect` was building its input tensor with raw `u8 → f32` casts:

```rust
input_tensor[idx] = pixel[0] as f32;  // 0..255
```

But the buffalo_sc / `scrfd_2.5g_bnkps` weights (and every other ONNX SCRFD checkpoint from insightface) expect the standard mean/scale preprocessing:

```python
cv2.dnn.blobFromImage(img, 1.0/128.0, input_size,
                      (127.5, 127.5, 127.5), swapRB=True)
```

i.e. subtract 127.5 per channel then multiply by `1/128` so each channel lands roughly in `[-1, 1]`. The embedder in `face/embedder.rs` already does the equivalent normalization (`(pixel - 127.5) / 128.0`); the **detector** was the only stage missing it.

## Symptoms (caught in a multi-node face-discovery dogfood)

With raw-pixel input the network's activations were wildly off-scale and it returned a sea of low-confidence (0.5–0.7) detections at semi-random positions in the feature map. Downstream:

1. `index_faces` thought every photo had 4–14 faces even when there was one prominent subject.
2. The bbox values plumbed up by the new face bbox API (fold_db [#535](https://github.com/EdgeVector/fold_db/pull/535)) were tiny — 0.02–0.05 of image width — because the detector was locking onto thin bands of noise-correlated feature-map cells, not actual faces.
3. The embedder ran ArcFace over those noise crops, so the embeddings had nothing to do with the real face. Cross-photo matches of the same person fell to ~0.5 cosine (just barely above the 0.5 face threshold) and ran with random clusters instead of real identities.

## Before / after on the same photo (Tom_Cruise_by_Gage_Skidmore.jpg, 640×761)

| Metric | Before fix | After fix |
|---|---|---|
| Faces detected | **5** (mostly noise) | **1** (the real one) |
| Top confidence | 0.60 | **0.880** |
| bbox area / image | 0.0025 | **0.149** (60× larger) |
| bbox center | scattered | (0.51, 0.38) — dead center, upper-half (where the face actually is) |
| bbox | `[0.51,0.32,0.53,0.35]` | `[0.33, 0.18, 0.69, 0.59]` |

## Why this was hiding

The embedder L2-normalizes its 512-d output, so even garbage face crops produce unit-norm vectors that look "valid" to cosine similarity. There's no error, no warning, no exception — just chronically poor recall. The first time it became visible was after fold_db [#535](https://github.com/EdgeVector/fold_db/pull/535) plumbed bbox + confidence to the API and operators could finally **see** that detected "faces" had widths of 0.02 and confidences barely above the 0.5 cutoff.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` all passing (537 lib tests + integration)
- [x] **Manual end-to-end**: spawned a fresh fold_db_node against a patched local fold_db, ingested `Tom_Cruise_by_Gage_Skidmore.jpg`, queried `/api/discovery/faces/...`, confirmed 1 face at conf 0.88 with bbox covering the actual face. Before the fix the same photo produced 5 detections at conf 0.5–0.7 with sub-pixel bboxes.
- [ ] After deploy: re-run the multi-node Tom Cruise dogfood and confirm cross-photo same-person cosine similarities rise from ~0.5 to 0.6+ and start clustering above unrelated faces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)