### PR TITLE
security(mutation): validate org membership before org mutations

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -405,13 +405,17 @@ impl FoldDB {
             Arc::clone(&db_ops),
         ));
 
-        // Create MutationManager for handling all mutation operations
+        // Create MutationManager for handling all mutation operations.
+        // The sled_pool is plumbed through so the manager can consult the
+        // org memberships tree and reject mutations against org-scoped
+        // schemas the node is not a member of.
         let mutation_manager = MutationManager::new(
             Arc::clone(&db_ops),
             Arc::clone(&schema_manager),
             Arc::clone(&message_bus),
             Arc::clone(&view_orchestrator),
             Some(index_status_tracker.clone()),
+            sled_pool.clone(),
         );
 
         info!("Created MutationManager for mutation operations");

--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -17,6 +17,7 @@ use crate::messaging::{AsyncMessageBus, Event};
 use crate::schema::types::field::{Field, FieldVariant};
 use crate::schema::types::{KeyValue, Mutation, Schema};
 use crate::schema::{SchemaCore, SchemaError};
+use crate::storage::SledPool;
 use chrono::Utc;
 use log::{debug, error, warn};
 use sha2::{Digest, Sha256};
@@ -34,6 +35,11 @@ pub struct MutationManager {
     view_orchestrator: Arc<ViewOrchestrator>,
     /// Index status tracker for reporting indexing progress
     index_status_tracker: Option<IndexStatusTracker>,
+    /// Sled pool for on-demand access to the org memberships tree.
+    /// When present, mutations against org-scoped schemas are gated on
+    /// the node actually being a member of that org. When absent (e.g.
+    /// non-Sled backends, some unit tests), the check is skipped.
+    sled_pool: Option<Arc<SledPool>>,
     /// Flag to track if the event listener is running
     is_listening: Arc<std::sync::atomic::AtomicBool>,
 }
@@ -46,6 +52,7 @@ impl MutationManager {
         message_bus: Arc<AsyncMessageBus>,
         view_orchestrator: Arc<ViewOrchestrator>,
         index_status_tracker: Option<IndexStatusTracker>,
+        sled_pool: Option<Arc<SledPool>>,
     ) -> Self {
         Self {
             db_ops,
@@ -53,7 +60,38 @@ impl MutationManager {
             message_bus,
             view_orchestrator,
             index_status_tracker,
+            sled_pool,
             is_listening: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
+
+    /// Validate that the node is a member of the given org before allowing
+    /// writes against it. Returns `Ok(())` if the membership exists (or if
+    /// membership validation is disabled because no sled pool is available).
+    ///
+    /// This is the authoritative check for org-scoped mutations: a local
+    /// attacker cannot inject writes for an arbitrary `org_hash` they are
+    /// not a member of, because those writes would otherwise get prefixed
+    /// with that org hash and queued for sync.
+    fn validate_org_membership(&self, org_hash: &str) -> Result<(), SchemaError> {
+        let Some(pool) = self.sled_pool.as_ref() else {
+            // No sled pool means we cannot consult the org_memberships tree.
+            // This path is only hit in limited test/non-Sled configurations
+            // where org sync is not in play. Fail-open here would be unsafe
+            // in production, but in production the pool is always present.
+            return Ok(());
+        };
+
+        match crate::org::operations::get_org(pool, org_hash) {
+            Ok(Some(_)) => Ok(()),
+            Ok(None) => Err(SchemaError::PermissionDenied(format!(
+                "Mutation rejected: node is not a member of org '{}'",
+                org_hash
+            ))),
+            Err(e) => Err(SchemaError::InvalidData(format!(
+                "Failed to check org membership for '{}': {}",
+                org_hash, e
+            ))),
         }
     }
 
@@ -95,6 +133,14 @@ impl MutationManager {
                 .ok_or_else(|| {
                     SchemaError::InvalidData(format!("Schema '{}' not found", mutation.schema_name))
                 })?;
+
+            // Security check: org-scoped schemas may only be written by
+            // members of the org. `write_mutations_batch_async` re-checks
+            // this as a defense-in-depth chokepoint, but we fail fast here
+            // so the caller gets a clear error before any side effects.
+            if let Some(org_hash) = schema.org_hash.as_deref() {
+                self.validate_org_membership(org_hash)?;
+            }
 
             for field_name in mutation.fields_and_values.keys() {
                 let policy = schema
@@ -199,6 +245,14 @@ impl MutationManager {
             *timing_breakdown
                 .entry("schema_load")
                 .or_insert(std::time::Duration::ZERO) += load_start.elapsed();
+
+            // Security check: if this schema is org-scoped, verify the node
+            // is a member of the org before persisting. Writes to org-scoped
+            // schemas produce `{org_hash}:`-prefixed sled keys which would
+            // otherwise be queued for sync under that org's prefix.
+            if let Some(org_hash) = schema.org_hash.as_deref() {
+                self.validate_org_membership(org_hash)?;
+            }
 
             // Phase 2: Create atoms and compute key values
             let phase1_start = std::time::Instant::now();
@@ -827,6 +881,7 @@ impl MutationManager {
         let schema_manager = Arc::clone(&self.schema_manager);
         let message_bus = Arc::clone(&self.message_bus);
         let view_orchestrator = Arc::clone(&self.view_orchestrator);
+        let sled_pool = self.sled_pool.clone();
         let is_listening = Arc::clone(&self.is_listening);
 
         is_listening.store(true, std::sync::atomic::Ordering::Release);
@@ -849,6 +904,7 @@ impl MutationManager {
                                     Arc::clone(&message_bus),
                                     Arc::clone(&view_orchestrator),
                                     None,
+                                    sled_pool.clone(),
                                 );
 
                                 if let Err(e) = temp_manager

--- a/src/org/operations.rs
+++ b/src/org/operations.rs
@@ -278,6 +278,40 @@ pub fn generate_invite(
     })
 }
 
+/// Test helper: insert a pre-built membership under an arbitrary org_hash.
+///
+/// Real code must go through `create_org` / `join_org` which derive the org_hash
+/// from an Ed25519 public key. Tests that work with a fixed, hard-coded hash use
+/// this helper to populate the org_memberships tree directly.
+///
+/// This is always compiled (to keep integration tests simple) but is only
+/// useful for tests — the inserted membership has dummy crypto material.
+pub fn insert_test_membership(
+    pool: &Arc<SledPool>,
+    org_hash: &str,
+) -> Result<OrgMembership, FoldDbError> {
+    let ts = now_secs();
+    let membership = OrgMembership {
+        org_name: format!("Test Org {}", org_hash),
+        org_hash: org_hash.to_string(),
+        org_public_key: "test_pk".to_string(),
+        org_secret_key: None,
+        org_e2e_secret: "test_e2e_secret".to_string(),
+        role: OrgRole::Member,
+        members: Vec::new(),
+        created_at: ts,
+        joined_at: ts,
+    };
+
+    let tree = org_tree(pool)?;
+    let key = org_key(org_hash);
+    let value = serde_json::to_vec(&membership)?;
+    tree.insert(key.as_bytes(), value)
+        .map_err(|e| FoldDbError::Database(format!("Failed to store org membership: {}", e)))?;
+
+    Ok(membership)
+}
+
 /// Delete an organization from local storage.
 pub fn delete_org(pool: &Arc<SledPool>, org_hash: &str) -> Result<(), FoldDbError> {
     let tree = org_tree(pool)?;

--- a/tests/org_key_prefixing_test.rs
+++ b/tests/org_key_prefixing_test.rs
@@ -24,6 +24,14 @@ async fn make_folddb(tmp: &tempfile::TempDir) -> FoldDB {
         .expect("Failed to create FoldDB")
 }
 
+/// Helper: register a fake org membership under `ORG_HASH` so mutations
+/// against org-scoped schemas pass the membership check in MutationManager.
+fn register_test_org(db: &FoldDB, org_hash: &str) {
+    let pool = db.sled_pool().expect("Expected sled backend").clone();
+    fold_db::org::operations::insert_test_membership(&pool, org_hash)
+        .expect("Failed to insert test org membership");
+}
+
 /// Helper: register a HashRange schema with optional org_hash via JSON.
 async fn register_schema(db: &FoldDB, name: &str, org_hash: Option<&str>) {
     let mut builder = TestSchemaBuilder::new(name)
@@ -102,6 +110,7 @@ async fn test_org_mutation_produces_prefixed_keys() {
     let tmp = tempfile::tempdir().unwrap();
     let db = make_folddb(&tmp).await;
 
+    register_test_org(&db, ORG_HASH);
     register_schema(&db, "org_notes", Some(ORG_HASH)).await;
     write_mutation(&db, "org_notes", "meeting", "2026-01-01", "org body").await;
 
@@ -147,6 +156,7 @@ async fn test_org_query_reads_from_prefixed_keys() {
     let tmp = tempfile::tempdir().unwrap();
     let db = make_folddb(&tmp).await;
 
+    register_test_org(&db, ORG_HASH);
     register_schema(&db, "org_events", Some(ORG_HASH)).await;
     write_mutation(&db, "org_events", "standup", "2026-03-01", "org event body").await;
 
@@ -183,7 +193,8 @@ async fn test_personal_and_org_data_do_not_collide() {
     register_schema(&db, "notes", None).await;
     write_mutation(&db, "notes", "personal-key", "2026-01-01", "personal body").await;
 
-    // Register org schema with different name
+    // Register org membership + org schema with different name
+    register_test_org(&db, ORG_HASH);
     register_schema(&db, "org_notes", Some(ORG_HASH)).await;
     write_mutation(&db, "org_notes", "org-key", "2026-01-01", "org body").await;
 
@@ -310,4 +321,110 @@ fn test_personal_schema_has_no_org_hash_on_fields() {
             field_name
         );
     }
+}
+
+// === Security test: org membership is required for org-scoped mutations ===
+
+/// Low-level helper that returns the raw Result so tests can assert on errors.
+async fn try_write_mutation(
+    db: &FoldDB,
+    schema_name: &str,
+    title: &str,
+    date: &str,
+    body: &str,
+) -> Result<Vec<String>, fold_db::schema::SchemaError> {
+    let mut fields = HashMap::new();
+    fields.insert("title".to_string(), json!(title));
+    fields.insert("body".to_string(), json!(body));
+    fields.insert("date".to_string(), json!(date));
+
+    let mutation = Mutation::new(
+        schema_name.to_string(),
+        fields,
+        KeyValue::new(Some(title.to_string()), Some(date.to_string())),
+        "attacker-pub-key".to_string(),
+        MutationType::Create,
+    );
+    db.mutation_manager()
+        .write_mutations_batch_async(vec![mutation])
+        .await
+}
+
+/// A local attacker must not be able to inject writes against an org-scoped
+/// schema for an org they are not a member of. Those writes would otherwise
+/// be prefixed with `{org_hash}:` and queued for sync, polluting local Sled
+/// state and attempting to upload under an unauthorized prefix.
+#[tokio::test]
+async fn test_org_mutation_denied_when_not_a_member() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = make_folddb(&tmp).await;
+
+    // NOTE: no register_test_org — the node is deliberately not a member.
+    register_schema(&db, "stranger_notes", Some(ORG_HASH)).await;
+
+    let err = try_write_mutation(&db, "stranger_notes", "meeting", "2026-01-01", "leaked")
+        .await
+        .expect_err("mutation must be rejected — node is not a member of the org");
+
+    match err {
+        fold_db::schema::SchemaError::PermissionDenied(msg) => {
+            assert!(
+                msg.contains(ORG_HASH),
+                "PermissionDenied message should mention the org hash: {}",
+                msg
+            );
+            assert!(
+                msg.to_lowercase().contains("not a member"),
+                "PermissionDenied message should explain membership failure: {}",
+                msg
+            );
+        }
+        other => panic!("expected SchemaError::PermissionDenied, got {:?}", other),
+    }
+
+    // Also verify no org-prefixed keys were written to the underlying sled store.
+    let pool = db.sled_pool().expect("Expected sled backend");
+    let guard = pool.acquire_arc().unwrap();
+    let main_tree = guard.db().open_tree("main").unwrap();
+
+    let org_prefix = format!("{ORG_HASH}:");
+    let leaked: Vec<String> = main_tree
+        .iter()
+        .filter_map(|r| r.ok())
+        .map(|(k, _)| String::from_utf8_lossy(&k).to_string())
+        .filter(|k| k.starts_with(&org_prefix))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "Rejected mutation must not leave any org-prefixed keys in sled: {:?}",
+        leaked
+    );
+}
+
+/// Once a membership is registered for the same org hash, previously-denied
+/// writes are accepted. This verifies the gate is gating on membership state,
+/// not on schema shape.
+#[tokio::test]
+async fn test_org_mutation_allowed_after_joining_org() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = make_folddb(&tmp).await;
+
+    register_schema(&db, "joined_notes", Some(ORG_HASH)).await;
+
+    // Before joining — denied.
+    let err = try_write_mutation(&db, "joined_notes", "m", "2026-01-01", "pre-join").await;
+    assert!(
+        matches!(err, Err(fold_db::schema::SchemaError::PermissionDenied(_))),
+        "expected PermissionDenied before membership, got {:?}",
+        err
+    );
+
+    // Join.
+    register_test_org(&db, ORG_HASH);
+
+    // After joining — allowed.
+    let ids = try_write_mutation(&db, "joined_notes", "m", "2026-01-01", "post-join")
+        .await
+        .expect("mutation must succeed after org membership is registered");
+    assert_eq!(ids.len(), 1);
 }


### PR DESCRIPTION
## Severity: HIGH

MutationManager previously had no check that the writer is a member of an org before allowing mutations with an \`org_hash:\` prefix. A local attacker could inject mutations targeting an org they don't belong to, polluting local Sled state.

## Fix
MutationManager now validates org membership via \`validate_org_membership()\` in two places:
- \`write_mutations_with_access\` pre-check loop (fast fail, clear error)
- \`write_mutations_batch_async\` after loading schema — authoritative chokepoint

\`org_hash\` is attached to Schema (not Mutation), so the check looks at \`schema.org_hash\` after load and consults \`org::operations::get_org()\` for membership.

## Tests
- \`test_org_mutation_denied_when_not_a_member\` — asserts PermissionDenied + no org-prefixed keys written
- \`test_org_mutation_allowed_after_joining_org\` — denied pre-join, accepted post-join
- Updated 3 existing tests to register fake membership before writing

## Test plan
- [x] cargo fmt --all
- [x] cargo clippy --workspace --all-targets -- -D warnings (clean)
- [x] cargo test --workspace --all-targets (all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)