### PR TITLE
feat(schema_service): add ExternalSchemaPersistence trait for pluggable backends

### DIFF
--- a/src/schema_service/external_persistence.rs
+++ b/src/schema_service/external_persistence.rs
@@ -1,0 +1,88 @@
+//! External persistence trait for the schema service.
+//!
+//! This trait lets deployments plug in their own storage backend without
+//! the `fold_db` library having to know about any particular cloud service.
+//! The built-in local backend is Sled (see `SchemaStorage::Sled`). Remote
+//! deployments (e.g. the schema-infra Lambda) implement this trait and
+//! construct the schema service via `SchemaServiceState::new_with_external`.
+//!
+//! Design notes:
+//! - All methods are async so implementations can talk to network services
+//!   (S3, DynamoDB, etc.) without blocking the tokio runtime.
+//! - The trait is intentionally low-level: it owns persistence only. The
+//!   schema service in `fold_db` keeps all business logic (canonicalization,
+//!   similarity, expansion, classification) — the implementation only has
+//!   to answer "given this key, save/load these bytes."
+//! - `save_*` methods take already-serialized domain objects. Implementations
+//!   serialize to whatever on-disk format they like (JSON blob, DynamoDB
+//!   attribute map, etc.).
+//! - `load_all_*` methods return the full domain set because the schema
+//!   service caches everything in memory at startup and serves reads from
+//!   the cache.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use super::types::{CanonicalField, StoredView, TransformRecord};
+use crate::error::FoldDbResult;
+use crate::schema::types::Schema;
+
+/// Persistence backend for the schema service.
+///
+/// Implementations live outside `fold_db` (for example, in the
+/// schema-infra Lambda). Each method is a single storage primitive —
+/// no business logic — so backends stay easy to build and test.
+#[async_trait]
+pub trait ExternalSchemaPersistence: Send + Sync {
+    // ============== Schemas ==============
+
+    /// Persist a single schema. Schemas are keyed by `schema.name`
+    /// (which is the content-hash identity).
+    ///
+    /// Must be idempotent: a second call with the same schema must
+    /// succeed as a no-op.
+    async fn save_schema(&self, schema: &Schema) -> FoldDbResult<()>;
+
+    /// Load every schema from storage.
+    ///
+    /// Called once during schema service startup to populate the
+    /// in-memory cache. Returns a map from `schema.name` → Schema.
+    async fn load_all_schemas(&self) -> FoldDbResult<HashMap<String, Schema>>;
+
+    // ============== Canonical fields ==============
+
+    /// Persist a single canonical field entry keyed by `name`.
+    ///
+    /// Must be idempotent.
+    async fn save_canonical_field(&self, name: &str, field: &CanonicalField) -> FoldDbResult<()>;
+
+    /// Load every canonical field from storage.
+    async fn load_all_canonical_fields(&self) -> FoldDbResult<HashMap<String, CanonicalField>>;
+
+    // ============== Views ==============
+
+    /// Persist a single view keyed by `view.name`.
+    async fn save_view(&self, view: &StoredView) -> FoldDbResult<()>;
+
+    /// Load every view from storage.
+    async fn load_all_views(&self) -> FoldDbResult<HashMap<String, StoredView>>;
+
+    // ============== Transforms ==============
+
+    /// Persist a transform record (metadata only — not the WASM bytes).
+    /// Keyed by `record.hash`.
+    async fn save_transform_metadata(&self, record: &TransformRecord) -> FoldDbResult<()>;
+
+    /// Persist the raw WASM bytes for a transform. Stored separately
+    /// from metadata because bytes can be large; backends may choose
+    /// a different storage medium (e.g. S3 alongside DynamoDB metadata).
+    async fn save_transform_wasm(&self, hash: &str, wasm_bytes: &[u8]) -> FoldDbResult<()>;
+
+    /// Load every transform record (metadata only — not the WASM bytes).
+    async fn load_all_transforms(&self) -> FoldDbResult<HashMap<String, TransformRecord>>;
+
+    /// Fetch WASM bytes for a single transform by hash. Returns `None`
+    /// if the hash is unknown.
+    async fn load_transform_wasm(&self, hash: &str) -> FoldDbResult<Option<Vec<u8>>>;
+}

--- a/src/schema_service/mod.rs
+++ b/src/schema_service/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod builtin_schemas;
 pub mod classify;
+pub mod external_persistence;
 pub mod name_validator;
 mod nmi;
 pub mod state;

--- a/src/schema_service/state.rs
+++ b/src/schema_service/state.rs
@@ -7,6 +7,7 @@ use crate::log_feature;
 use crate::logging::features::LogFeature;
 use crate::schema::types::Schema;
 
+use super::external_persistence::ExternalSchemaPersistence;
 use super::state_matching::collect_field_names;
 pub use super::state_matching::jaccard_index;
 use super::types::{
@@ -14,7 +15,14 @@ use super::types::{
     SimilarSchemasResponse, StoredView, TransformRecord, ViewAddOutcome,
 };
 
-/// Storage backend for the schema service
+/// Storage backend for the schema service.
+///
+/// `Sled` is the default local backend used by the self-hosted
+/// binary and by integration tests. `External` plugs in any
+/// backend that implements [`ExternalSchemaPersistence`] — for
+/// example, the S3-backed Lambda deployment lives outside of
+/// `fold_db` and supplies its own implementation so this crate
+/// stays agnostic of any specific cloud service.
 #[derive(Clone)]
 pub enum SchemaStorage {
     /// Local sled database (default)
@@ -22,6 +30,9 @@ pub enum SchemaStorage {
         db: sled::Db,
         schemas_tree: sled::Tree,
     },
+    /// Caller-supplied persistence backend. The schema service
+    /// owns no knowledge of what's behind the trait.
+    External(Arc<dyn ExternalSchemaPersistence>),
 }
 
 /// Shared state for the schema service
@@ -347,7 +358,137 @@ impl SchemaServiceState {
         Ok(state)
     }
 
-    /// Synchronous version of load_schemas for Sled storage
+    /// Create a schema service state backed by a caller-supplied
+    /// persistence implementation.
+    ///
+    /// Used by remote deployments (e.g. the schema-infra Lambda) that
+    /// want to store schema-service data in a cloud service instead
+    /// of a local Sled database. The caller implements
+    /// [`ExternalSchemaPersistence`] and passes it in via `Arc`.
+    ///
+    /// `fold_db` owns no knowledge of what's behind the trait —
+    /// the implementation lives entirely outside this crate.
+    pub async fn new_with_external(
+        backend: Arc<dyn ExternalSchemaPersistence>,
+    ) -> FoldDbResult<Self> {
+        let embedder: Arc<dyn Embedder> = Arc::new(FastEmbedModel::new());
+        let collection_name_anchors = Self::compute_anchor_embeddings(embedder.as_ref());
+
+        let state = Self {
+            schemas: Arc::new(RwLock::new(HashMap::new())),
+            descriptive_name_index: Arc::new(RwLock::new(HashMap::new())),
+            descriptive_name_embeddings: Arc::new(RwLock::new(HashMap::new())),
+            field_embeddings: Arc::new(RwLock::new(HashMap::new())),
+            canonical_fields: Arc::new(RwLock::new(HashMap::new())),
+            canonical_field_embeddings: Arc::new(RwLock::new(HashMap::new())),
+            embedder,
+            storage: SchemaStorage::External(backend),
+            views: Arc::new(RwLock::new(HashMap::new())),
+            transforms: Arc::new(RwLock::new(HashMap::new())),
+            collection_name_anchors,
+        };
+
+        state.load_all_from_external().await?;
+        state.rebuild_descriptive_name_index();
+
+        Ok(state)
+    }
+
+    /// Populate every in-memory cache from the external backend.
+    /// Called from `new_with_external`.
+    async fn load_all_from_external(&self) -> FoldDbResult<()> {
+        let backend = match &self.storage {
+            SchemaStorage::External(b) => b.clone(),
+            SchemaStorage::Sled { .. } => {
+                return Err(FoldDbError::Config(
+                    "load_all_from_external called with non-external storage".to_string(),
+                ));
+            }
+        };
+
+        // Schemas
+        let loaded_schemas = backend.load_all_schemas().await?;
+        {
+            let mut schemas = self.schemas.write().map_err(|_| {
+                FoldDbError::Config("Failed to acquire schemas write lock".to_string())
+            })?;
+            schemas.clear();
+            schemas.extend(loaded_schemas);
+            log_feature!(
+                LogFeature::Schema,
+                info,
+                "Schema service loaded {} schemas from external backend",
+                schemas.len()
+            );
+        }
+
+        // Canonical fields — populate both the registry and the
+        // embeddings cache used for semantic field matching.
+        let loaded_canonical = backend.load_all_canonical_fields().await?;
+        {
+            let mut fields = self.canonical_fields.write().map_err(|_| {
+                FoldDbError::Config("Failed to acquire canonical_fields write lock".to_string())
+            })?;
+            let mut embeddings = self.canonical_field_embeddings.write().map_err(|_| {
+                FoldDbError::Config(
+                    "Failed to acquire canonical_field_embeddings write lock".to_string(),
+                )
+            })?;
+            fields.clear();
+            embeddings.clear();
+            for (name, canonical) in loaded_canonical {
+                let embed_text = Self::build_embedding_text(&name, &canonical.description);
+                if let Ok(vec) = self.embedder.embed_text(&embed_text) {
+                    embeddings.insert(name.clone(), vec);
+                }
+                fields.insert(name, canonical);
+            }
+            log_feature!(
+                LogFeature::Schema,
+                info,
+                "Schema service loaded {} canonical fields from external backend",
+                fields.len()
+            );
+        }
+
+        // Views
+        let loaded_views = backend.load_all_views().await?;
+        {
+            let mut views = self.views.write().map_err(|_| {
+                FoldDbError::Config("Failed to acquire views write lock".to_string())
+            })?;
+            views.clear();
+            views.extend(loaded_views);
+            log_feature!(
+                LogFeature::Schema,
+                info,
+                "Schema service loaded {} views from external backend",
+                views.len()
+            );
+        }
+
+        // Transforms
+        let loaded_transforms = backend.load_all_transforms().await?;
+        {
+            let mut transforms = self.transforms.write().map_err(|_| {
+                FoldDbError::Config("Failed to acquire transforms write lock".to_string())
+            })?;
+            transforms.clear();
+            transforms.extend(loaded_transforms);
+            log_feature!(
+                LogFeature::Schema,
+                info,
+                "Schema service loaded {} transforms from external backend",
+                transforms.len()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Synchronous version of load_schemas for Sled storage.
+    /// External backends must populate via `load_all_from_external`,
+    /// which is called from `new_with_external`.
     fn load_schemas_sync(&self) -> FoldDbResult<()> {
         let mut schemas = self
             .schemas
@@ -385,6 +526,13 @@ impl SchemaServiceState {
                     "Schema service loaded {} schemas from sled",
                     count
                 );
+            }
+            SchemaStorage::External(_) => {
+                return Err(FoldDbError::Config(
+                    "load_schemas_sync is not supported for external storage; \
+                     use new_with_external which loads asynchronously"
+                        .to_string(),
+                ));
             }
         }
 
@@ -432,6 +580,21 @@ impl SchemaServiceState {
                     LogFeature::Schema,
                     info,
                     "Schema service loaded {} schemas from sled",
+                    count
+                );
+            }
+            SchemaStorage::External(backend) => {
+                let loaded = backend.load_all_schemas().await?;
+                let mut schemas = self.schemas.write().map_err(|_| {
+                    FoldDbError::Config("Failed to acquire schemas write lock".to_string())
+                })?;
+                schemas.clear();
+                let count = loaded.len();
+                schemas.extend(loaded);
+                log_feature!(
+                    LogFeature::Schema,
+                    info,
+                    "Schema service reloaded {} schemas from external backend",
                     count
                 );
             }
@@ -585,6 +748,15 @@ impl SchemaServiceState {
                             if let Ok(bytes) = serde_json::to_vec(&*schema) {
                                 let _ = schemas_tree.insert(schema.name.as_bytes(), bytes);
                             }
+                        }
+                        SchemaStorage::External(_) => {
+                            // TODO(s3-backend): schema-level interest category
+                            // backfill is not yet persisted for external backends.
+                            // The primary canonical_fields registry already carries
+                            // the interest category, so queries still work; only the
+                            // cached projection on the Schema itself is skipped here.
+                            // Fixing this requires collecting pending saves outside
+                            // the schemas write lock and awaiting after drop.
                         }
                     }
                     updated += 1;
@@ -1068,6 +1240,15 @@ impl SchemaServiceState {
                     schema.name
                 );
             }
+            SchemaStorage::External(backend) => {
+                backend.save_schema(schema).await?;
+                log_feature!(
+                    LogFeature::Schema,
+                    info,
+                    "Schema '{}' persisted to external backend",
+                    schema.name
+                );
+            }
         }
         Ok(())
     }
@@ -1422,6 +1603,15 @@ impl SchemaServiceState {
                     view.name
                 );
             }
+            SchemaStorage::External(backend) => {
+                backend.save_view(view).await?;
+                log_feature!(
+                    LogFeature::Schema,
+                    info,
+                    "View '{}' persisted to external backend",
+                    view.name
+                );
+            }
         }
         Ok(())
     }
@@ -1473,6 +1663,21 @@ impl SchemaServiceState {
                     FoldDbError::Config(format!("Failed to open views tree: {}", e))
                 })?;
                 self.load_views_from_tree(&views_tree)?;
+            }
+            SchemaStorage::External(backend) => {
+                let loaded = backend.load_all_views().await?;
+                let mut views = self.views.write().map_err(|_| {
+                    FoldDbError::Config("Failed to acquire views write lock".to_string())
+                })?;
+                views.clear();
+                let count = loaded.len();
+                views.extend(loaded);
+                log_feature!(
+                    LogFeature::Schema,
+                    info,
+                    "Schema service reloaded {} views from external backend",
+                    count
+                );
             }
         }
         Ok(())

--- a/src/schema_service/state_fields.rs
+++ b/src/schema_service/state_fields.rs
@@ -154,26 +154,38 @@ impl SchemaServiceState {
             ));
         }
 
-        // Phase 3: Store under write locks
-        let mut fields = self.canonical_fields.write().map_err(|_| {
-            FoldDbError::Config("Failed to acquire canonical_fields write lock".to_string())
-        })?;
-        let mut embeddings = self.canonical_field_embeddings.write().map_err(|_| {
-            FoldDbError::Config(
-                "Failed to acquire canonical_field_embeddings write lock".to_string(),
-            )
-        })?;
+        // Phase 3: Store under write locks. We collect the set that
+        // needs to be persisted in the backend, drop the sync locks,
+        // then await persistence — holding std::sync::RwLockWriteGuard
+        // across an .await is unsound and also deadlocks the external
+        // backend path.
+        let to_persist: Vec<(String, CanonicalField)> = {
+            let mut fields = self.canonical_fields.write().map_err(|_| {
+                FoldDbError::Config("Failed to acquire canonical_fields write lock".to_string())
+            })?;
+            let mut embeddings = self.canonical_field_embeddings.write().map_err(|_| {
+                FoldDbError::Config(
+                    "Failed to acquire canonical_field_embeddings write lock".to_string(),
+                )
+            })?;
 
-        for (field_name, canonical, embedding) in entries {
-            // Re-check in case another thread registered it between phase 1 and 3
-            if fields.contains_key(&field_name) {
-                continue;
+            let mut collected = Vec::new();
+            for (field_name, canonical, embedding) in entries {
+                // Re-check in case another thread registered it between phase 1 and 3
+                if fields.contains_key(&field_name) {
+                    continue;
+                }
+                if let Some(vec) = embedding {
+                    embeddings.insert(field_name.clone(), vec);
+                }
+                collected.push((field_name.clone(), canonical.clone()));
+                fields.insert(field_name, canonical);
             }
-            if let Some(vec) = embedding {
-                embeddings.insert(field_name.clone(), vec);
-            }
-            self.persist_canonical_field(&field_name, &canonical);
-            fields.insert(field_name, canonical);
+            collected
+        };
+
+        for (name, canonical) in to_persist {
+            self.persist_canonical_field(&name, &canonical).await?;
         }
 
         Ok(())
@@ -362,13 +374,30 @@ impl SchemaServiceState {
             let category = super::classify::infer_interest_category(field_name, description).await;
 
             if let Some(ref cat) = category {
-                let mut fields = match self.canonical_fields.write() {
-                    Ok(f) => f,
-                    Err(_) => continue,
+                // Mutate under the write lock, clone the updated entry out,
+                // then drop the lock before awaiting the persistence call.
+                let to_persist: Option<CanonicalField> = {
+                    let mut fields = match self.canonical_fields.write() {
+                        Ok(f) => f,
+                        Err(_) => continue,
+                    };
+                    if let Some(canonical) = fields.get_mut(field_name) {
+                        canonical.interest_category = Some(cat.clone());
+                        Some(canonical.clone())
+                    } else {
+                        None
+                    }
                 };
-                if let Some(canonical) = fields.get_mut(field_name) {
-                    canonical.interest_category = Some(cat.clone());
-                    self.persist_canonical_field(field_name, canonical);
+                if let Some(canonical) = to_persist {
+                    if let Err(e) = self.persist_canonical_field(field_name, &canonical).await {
+                        log_feature!(
+                            LogFeature::Schema,
+                            warn,
+                            "Failed to persist interest category backfill for '{}': {}",
+                            field_name,
+                            e
+                        );
+                    }
                     backfilled += 1;
                 }
             }
@@ -383,15 +412,33 @@ impl SchemaServiceState {
         );
     }
 
-    /// Persist a canonical field to sled storage.
-    pub(super) fn persist_canonical_field(&self, name: &str, canonical: &CanonicalField) {
+    /// Persist a canonical field to the active storage backend.
+    pub(super) async fn persist_canonical_field(
+        &self,
+        name: &str,
+        canonical: &CanonicalField,
+    ) -> FoldDbResult<()> {
         match &self.storage {
             super::state::SchemaStorage::Sled { db, .. } => {
-                if let Ok(tree) = db.open_tree("canonical_fields") {
-                    if let Ok(bytes) = serde_json::to_vec(canonical) {
-                        let _ = tree.insert(name.as_bytes(), bytes);
-                    }
-                }
+                let tree = db.open_tree("canonical_fields").map_err(|e| {
+                    FoldDbError::Config(format!("Failed to open canonical_fields tree: {}", e))
+                })?;
+                let bytes = serde_json::to_vec(canonical).map_err(|e| {
+                    FoldDbError::Serialization(format!(
+                        "Failed to serialize canonical field '{}': {}",
+                        name, e
+                    ))
+                })?;
+                tree.insert(name.as_bytes(), bytes).map_err(|e| {
+                    FoldDbError::Config(format!(
+                        "Failed to insert canonical field '{}' into sled: {}",
+                        name, e
+                    ))
+                })?;
+                Ok(())
+            }
+            super::state::SchemaStorage::External(backend) => {
+                backend.save_canonical_field(name, canonical).await
             }
         }
     }

--- a/src/schema_service/state_transforms.rs
+++ b/src/schema_service/state_transforms.rs
@@ -103,8 +103,9 @@ impl SchemaServiceState {
         };
 
         // Persist metadata and WASM separately
-        self.persist_transform_metadata(&record)?;
-        self.persist_transform_wasm(&hash, &request.wasm_bytes)?;
+        self.persist_transform_metadata(&record).await?;
+        self.persist_transform_wasm(&hash, &request.wasm_bytes)
+            .await?;
 
         // Insert into in-memory cache
         {
@@ -135,8 +136,8 @@ impl SchemaServiceState {
         Ok(transforms.get(hash).cloned())
     }
 
-    /// Get WASM bytes for a transform by hash (from Sled, not cached in memory).
-    pub fn get_transform_wasm(&self, hash: &str) -> FoldDbResult<Option<Vec<u8>>> {
+    /// Get WASM bytes for a transform by hash (not cached in memory).
+    pub async fn get_transform_wasm(&self, hash: &str) -> FoldDbResult<Option<Vec<u8>>> {
         match &self.storage {
             SchemaStorage::Sled { db, .. } => {
                 let wasm_tree = db.open_tree("transform_wasm").map_err(|e| {
@@ -149,6 +150,7 @@ impl SchemaServiceState {
                     None => Ok(None),
                 }
             }
+            SchemaStorage::External(backend) => backend.load_transform_wasm(hash).await,
         }
     }
 
@@ -220,7 +222,7 @@ impl SchemaServiceState {
 
     // ============== Persistence ==============
 
-    fn persist_transform_metadata(&self, record: &TransformRecord) -> FoldDbResult<()> {
+    async fn persist_transform_metadata(&self, record: &TransformRecord) -> FoldDbResult<()> {
         match &self.storage {
             SchemaStorage::Sled { db, .. } => {
                 let meta_tree = db.open_tree("transform_metadata").map_err(|e| {
@@ -243,11 +245,14 @@ impl SchemaServiceState {
                 db.flush()
                     .map_err(|e| FoldDbError::Config(format!("Failed to flush sled: {}", e)))?;
             }
+            SchemaStorage::External(backend) => {
+                backend.save_transform_metadata(record).await?;
+            }
         }
         Ok(())
     }
 
-    fn persist_transform_wasm(&self, hash: &str, wasm_bytes: &[u8]) -> FoldDbResult<()> {
+    async fn persist_transform_wasm(&self, hash: &str, wasm_bytes: &[u8]) -> FoldDbResult<()> {
         match &self.storage {
             SchemaStorage::Sled { db, .. } => {
                 let wasm_tree = db.open_tree("transform_wasm").map_err(|e| {
@@ -261,6 +266,9 @@ impl SchemaServiceState {
                 })?;
                 db.flush()
                     .map_err(|e| FoldDbError::Config(format!("Failed to flush sled: {}", e)))?;
+            }
+            SchemaStorage::External(backend) => {
+                backend.save_transform_wasm(hash, wasm_bytes).await?;
             }
         }
         Ok(())

--- a/tests/transform_registry_test.rs
+++ b/tests/transform_registry_test.rs
@@ -282,16 +282,18 @@ async fn test_get_transform_wasm_after_registration() {
 
     let retrieved = state
         .get_transform_wasm(&record.hash)
+        .await
         .expect("failed to get WASM");
     assert!(retrieved.is_some());
     assert_eq!(retrieved.unwrap(), wasm.to_vec());
 }
 
-#[test]
-fn test_get_transform_wasm_nonexistent() {
+#[tokio::test]
+async fn test_get_transform_wasm_nonexistent() {
     let state = make_test_state();
     let result = state
         .get_transform_wasm("nonexistent_hash")
+        .await
         .expect("should not error");
     assert!(result.is_none());
 }
@@ -685,6 +687,7 @@ async fn test_transforms_persist_across_restart() {
 
         let wasm_bytes = state
             .get_transform_wasm(&hash)
+            .await
             .expect("failed to get WASM")
             .expect("WASM should persist");
         assert_eq!(wasm_bytes, wasm.to_vec());


### PR DESCRIPTION
## Summary
Adds \`SchemaStorage::External(Arc<dyn ExternalSchemaPersistence>)\` alongside the existing Sled variant, so remote deployments can plug in their own storage backend (DynamoDB, S3 blobs, etc.) without \`fold_db\` having to know about any particular cloud service.

The trait is deliberately low-level: implementations own persistence only; all business logic (canonicalization, similarity, expansion, classification) stays in the schema service itself. Lambda / remote callers use the new async \`SchemaServiceState::new_with_external\` constructor.

This is the **fold_db side** of the S3-backed schema service plan — the actual S3 implementation lives in the schema-infra repo alongside the Lambda (follow-up PR). No AWS / S3 / DynamoDB code lives in this crate.

## What changed
- New \`src/schema_service/external_persistence.rs\` — the \`ExternalSchemaPersistence\` async trait with \`save_*\` / \`load_all_*\` methods for schemas, canonical fields, views, transforms (metadata + WASM bytes)
- \`SchemaStorage::External\` variant added to the enum
- \`SchemaServiceState::new_with_external\` async constructor + \`load_all_from_external\` helper
- Match arms extended in \`state.rs\`, \`state_fields.rs\`, \`state_transforms.rs\`
- Async-ified \`persist_canonical_field\`, \`persist_transform_metadata\`, \`persist_transform_wasm\`, \`get_transform_wasm\`
- Fixed lock-across-await hazards in \`register_canonical_fields\` and \`backfill_interest_categories\` (collect pending writes under the sync RwLock, drop the guard, then await persistence)
- \`load_schemas_sync\` explicitly rejects External with a clear error — external backends load through \`new_with_external\`
- Schema-level interest category backfill is skipped for External with a TODO (canonical_fields registry still carries the category, so queries still work)

## Design doc
See \`fold_db_node/docs/designs/schema_service_s3.md\` (in fold_db_node PR #463) for the full S3 design this enables.

## Test plan
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace --all-targets\` — all tests pass (549 unit tests + every integration suite green)
- [x] \`cargo fmt --all --check\` — clean

## Follow-up PRs
1. schema-infra: \`S3BlobSchemaPersistence\` impl, Lambda wiring, CDK changes
2. schema-infra: pre-populated canonical fields seeded at cold start

🤖 Generated with [Claude Code](https://claude.com/claude-code)