### PR TITLE
feat(sharing): query path scans from:{sender} namespaces

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -396,7 +396,11 @@ impl FoldDB {
         info!("Started EventMonitor for system-wide event tracking");
 
         // Create QueryExecutor for handling all query operations
-        let query_executor = QueryExecutor::new(Arc::clone(&db_ops), Arc::clone(&schema_manager));
+        let query_executor = QueryExecutor::new(
+            Arc::clone(&db_ops),
+            Arc::clone(&schema_manager),
+            sled_pool.clone(),
+        );
         info!("Created QueryExecutor for query operations");
 
         // Create shared IndexStatusTracker for tracking indexing progress

--- a/src/fold_db_core/query/hash_range_query.rs
+++ b/src/fold_db_core/query/hash_range_query.rs
@@ -1,13 +1,23 @@
 //! HashRange Query Processor
 //!
 //! Handles query processing for HashRange schemas using field resolution.
+//!
+//! For personal-scope schemas (no `org_hash`), the processor also scans
+//! `from:{sender_hash}:` namespaces for each active `ShareSubscription` so
+//! that data received from other users (sync-replayed under the `from:`
+//! prefix by `SyncEngine::rewrite_key_if_needed`) surfaces alongside the
+//! caller's own data. Each received-from row has its `writer_pubkey`
+//! stamped with the sender hash when no molecule-level writer is already
+//! present, providing source attribution to downstream consumers.
 
 use crate::db_operations::DbOperations;
 use crate::schema::types::field::Field;
 use crate::schema::types::field::FieldValue;
+use crate::schema::types::field::FieldVariant;
 use crate::schema::types::field::HashRangeFilter;
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::{Schema, SchemaError};
+use crate::storage::SledPool;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -15,12 +25,15 @@ use std::sync::Arc;
 /// Processor for HashRange schema queries using field resolution
 pub struct HashRangeQueryProcessor {
     db_ops: Arc<DbOperations>,
+    /// Optional Sled pool used to enumerate active `ShareSubscription`s.
+    /// When `None`, received-from namespaces are not scanned.
+    sled_pool: Option<Arc<SledPool>>,
 }
 
 impl HashRangeQueryProcessor {
-    /// Create a new HashRange query processor
-    pub fn new(db_ops: Arc<DbOperations>) -> Self {
-        Self { db_ops }
+    /// Create a new HashRange query processor.
+    pub fn new(db_ops: Arc<DbOperations>, sled_pool: Option<Arc<SledPool>>) -> Self {
+        Self { db_ops, sled_pool }
     }
 
     pub async fn query_with_filter(
@@ -37,21 +50,79 @@ impl HashRangeQueryProcessor {
             filter,
             current_user
         );
-        let mut result = HashMap::new();
+
+        // Gather the list of `from:{sender_hash}` namespaces to scan in
+        // addition to the schema's own namespace. Only applies to personal
+        // schemas; org-scoped schemas have a single defined namespace.
+        let received_from_namespaces: Vec<String> = if schema.org_hash.is_none() {
+            self.collect_received_from_namespaces()
+        } else {
+            Vec::new()
+        };
+
+        let mut result: HashMap<String, HashMap<KeyValue, FieldValue>> = HashMap::new();
         let return_all = fields.is_empty();
         for (field_name, field) in schema.runtime_fields.iter_mut() {
             if !return_all && !fields.contains(field_name) {
                 continue;
             }
             log::debug!("🔍 Resolving field: {}", field_name);
-            let field_value = field
+
+            // Resolve against the schema's native namespace (personal or org).
+            let mut field_value = field
                 .resolve_value(&self.db_ops, filter.clone(), as_of)
                 .await?;
             log::debug!(
-                "✅ Field '{}' resolved {} values",
+                "✅ Field '{}' resolved {} values from own namespace",
                 field_name,
                 field_value.len()
             );
+
+            // Resolve against each `from:{sender}` namespace, if any.
+            for namespace in &received_from_namespaces {
+                match self
+                    .resolve_field_from_namespace(field, namespace, filter.clone(), as_of)
+                    .await
+                {
+                    Ok(mut shared) => {
+                        log::debug!(
+                            "✅ Field '{}' resolved {} values from namespace '{}'",
+                            field_name,
+                            shared.len(),
+                            namespace
+                        );
+                        // Stamp writer_pubkey with the sender hash so downstream
+                        // consumers can distinguish received data. Respect any
+                        // existing molecule-level writer_pubkey (which carries
+                        // the original signer's key — source of truth per PR
+                        // #544) and only fall back to the namespace sender hash
+                        // when unset.
+                        let sender_hash = Self::sender_hash_from_namespace(namespace);
+                        for fv in shared.values_mut() {
+                            if fv.writer_pubkey.is_none() {
+                                fv.writer_pubkey = Some(sender_hash.clone());
+                            }
+                        }
+                        // Merge into the result map. If a key collides across
+                        // namespaces (e.g. both Bob and Alice have a note at
+                        // the same (title, date)), the personal-namespace row
+                        // wins since it was inserted first.
+                        for (k, v) in shared {
+                            field_value.entry(k).or_insert(v);
+                        }
+                    }
+                    Err(e) => {
+                        // Do not swallow: surface this as a hard error so
+                        // data is never silently dropped. Callers can
+                        // re-architect around it if needed.
+                        return Err(SchemaError::InvalidData(format!(
+                            "Failed to resolve field '{}' from namespace '{}': {}",
+                            field_name, namespace, e
+                        )));
+                    }
+                }
+            }
+
             result.insert(field_name.clone(), field_value);
         }
         log::debug!(
@@ -59,5 +130,107 @@ impl HashRangeQueryProcessor {
             result.len()
         );
         Ok(result)
+    }
+
+    /// Look up active `ShareSubscription`s and return a deduped list of
+    /// `from:{sender_hash}` namespace prefixes to scan. Returns an empty
+    /// vector if `sled_pool` is absent or the store has no subscriptions.
+    ///
+    /// Subscriptions with an unparseable `share_prefix` are logged and
+    /// skipped (never silently). Inactive subscriptions are excluded.
+    fn collect_received_from_namespaces(&self) -> Vec<String> {
+        let Some(pool) = self.sled_pool.as_ref() else {
+            return Vec::new();
+        };
+
+        let subs = match crate::sharing::store::list_share_subscriptions(pool) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!(
+                    "HashRangeQueryProcessor: failed to list share subscriptions: {}",
+                    e
+                );
+                return Vec::new();
+            }
+        };
+
+        let mut namespaces: Vec<String> = Vec::new();
+        for sub in subs {
+            if !sub.active {
+                continue;
+            }
+            match Self::parse_sender_hash(&sub.share_prefix) {
+                Some(sender_hash) => {
+                    let ns = format!("from:{}", sender_hash);
+                    if !namespaces.contains(&ns) {
+                        namespaces.push(ns);
+                    }
+                }
+                None => {
+                    log::error!(
+                        "HashRangeQueryProcessor: subscription has unparseable \
+                         share_prefix '{}' (expected 'share:{{sender}}:{{recipient}}'); \
+                         skipping.",
+                        sub.share_prefix
+                    );
+                }
+            }
+        }
+        namespaces
+    }
+
+    /// Parse the sender hash from a share prefix of the form
+    /// `share:{sender_hash}:{recipient_hash}`. Returns `None` if the prefix
+    /// doesn't match this structure.
+    fn parse_sender_hash(share_prefix: &str) -> Option<String> {
+        let mut parts = share_prefix.split(':');
+        let kind = parts.next()?;
+        if kind != "share" {
+            return None;
+        }
+        let sender = parts.next()?;
+        if sender.is_empty() {
+            return None;
+        }
+        Some(sender.to_string())
+    }
+
+    /// Extract the sender hash from a `from:{sender_hash}` namespace prefix.
+    fn sender_hash_from_namespace(namespace: &str) -> String {
+        namespace.strip_prefix("from:").unwrap_or(namespace).to_string()
+    }
+
+    /// Resolve a field's values from a specific storage namespace by
+    /// temporarily rewriting the field's `org_hash`. The field is cloned so
+    /// we don't mutate the caller's schema state.
+    async fn resolve_field_from_namespace(
+        &self,
+        field: &FieldVariant,
+        namespace: &str,
+        filter: Option<HashRangeFilter>,
+        as_of: Option<DateTime<Utc>>,
+    ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
+        let mut cloned = field.clone();
+        // Clear any in-memory molecule cached from a previous resolve so the
+        // next refresh reads from the target namespace. Also drop per-key
+        // metadata that belonged to the previous namespace's molecule.
+        match &mut cloned {
+            FieldVariant::Single(f) => {
+                f.base.molecule = None;
+            }
+            FieldVariant::Hash(f) => {
+                f.base.molecule = None;
+            }
+            FieldVariant::Range(f) => {
+                f.base.molecule = None;
+            }
+            FieldVariant::HashRange(f) => {
+                f.base.molecule = None;
+            }
+        }
+        cloned
+            .common_mut()
+            .set_org_hash(Some(namespace.to_string()));
+        cloned.resolve_value(&self.db_ops, filter, as_of).await
     }
 }

--- a/src/fold_db_core/query/hash_range_query.rs
+++ b/src/fold_db_core/query/hash_range_query.rs
@@ -197,7 +197,10 @@ impl HashRangeQueryProcessor {
 
     /// Extract the sender hash from a `from:{sender_hash}` namespace prefix.
     fn sender_hash_from_namespace(namespace: &str) -> String {
-        namespace.strip_prefix("from:").unwrap_or(namespace).to_string()
+        namespace
+            .strip_prefix("from:")
+            .unwrap_or(namespace)
+            .to_string()
     }
 
     /// Resolve a field's values from a specific storage namespace by

--- a/src/fold_db_core/query/query_executor.rs
+++ b/src/fold_db_core/query/query_executor.rs
@@ -10,6 +10,7 @@ use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::Query;
 use crate::schema::SchemaError;
 use crate::schema::{SchemaCore, SchemaState};
+use crate::storage::SledPool;
 use crate::view::registry::ViewState;
 use crate::view::resolver::ViewResolver;
 use crate::view::types::ViewCacheState;
@@ -28,9 +29,18 @@ pub struct QueryExecutor {
 }
 
 impl QueryExecutor {
-    /// Create a new query executor with storage abstraction
-    pub fn new(db_ops: Arc<DbOperations>, schema_manager: Arc<SchemaCore>) -> Self {
-        let hash_range_processor = HashRangeQueryProcessor::new(Arc::clone(&db_ops));
+    /// Create a new query executor with storage abstraction.
+    ///
+    /// `sled_pool` is optional but required to enable cross-user shared-data
+    /// lookup via ShareSubscriptions. When `None`, queries only scan the
+    /// personal (and org) namespaces.
+    pub fn new(
+        db_ops: Arc<DbOperations>,
+        schema_manager: Arc<SchemaCore>,
+        sled_pool: Option<Arc<SledPool>>,
+    ) -> Self {
+        let hash_range_processor =
+            HashRangeQueryProcessor::new(Arc::clone(&db_ops), sled_pool.clone());
 
         // Get the WASM engine from the view registry
         let wasm_engine = {

--- a/src/fold_db_core/query/source_query.rs
+++ b/src/fold_db_core/query/source_query.rs
@@ -58,7 +58,7 @@ impl StandardSourceQuery {
         db_ops: Arc<DbOperations>,
         view_resolver: ViewResolver,
     ) -> Self {
-        let hash_range_processor = HashRangeQueryProcessor::new(Arc::clone(&db_ops));
+        let hash_range_processor = HashRangeQueryProcessor::new(Arc::clone(&db_ops), None);
         Self {
             schema_manager,
             db_ops,
@@ -74,7 +74,7 @@ impl StandardSourceQuery {
         db_ops: Arc<DbOperations>,
         view_resolver: ViewResolver,
     ) -> Self {
-        let hash_range_processor = HashRangeQueryProcessor::new(Arc::clone(&db_ops));
+        let hash_range_processor = HashRangeQueryProcessor::new(Arc::clone(&db_ops), None);
         Self {
             schema_manager,
             db_ops,
@@ -137,7 +137,7 @@ impl StandardSourceQuery {
         let nested_source = Self {
             schema_manager: Arc::clone(&self.schema_manager),
             db_ops: Arc::clone(&self.db_ops),
-            hash_range_processor: HashRangeQueryProcessor::new(Arc::clone(&self.db_ops)),
+            hash_range_processor: HashRangeQueryProcessor::new(Arc::clone(&self.db_ops), None),
             view_resolver: ViewResolver::new(Arc::clone(self.view_resolver.wasm_engine())),
             mode: self.mode,
         };

--- a/tests/cross_user_sharing_e2e_test.rs
+++ b/tests/cross_user_sharing_e2e_test.rs
@@ -216,12 +216,8 @@ async fn test_alice_shares_notes_with_bob() {
 
     let src_full_prefix = format!("{}:", share_prefix);
     let dst_full_prefix = "from:alice_pubkey:".to_string();
-    let copied = copy_and_rewrite_prefixed_keys(
-        &main_alice,
-        &main_bob,
-        &src_full_prefix,
-        &dst_full_prefix,
-    );
+    let copied =
+        copy_and_rewrite_prefixed_keys(&main_alice, &main_bob, &src_full_prefix, &dst_full_prefix);
     assert!(copied > 0, "Expected to copy some share-prefixed keys");
     println!("Copied + rewrote {} keys into Bob's sled", copied);
 

--- a/tests/cross_user_sharing_e2e_test.rs
+++ b/tests/cross_user_sharing_e2e_test.rs
@@ -1,0 +1,247 @@
+//! End-to-end test for cross-user data sharing (ShareRule / ShareSubscription).
+//!
+//! This test exercises the full Alice -> Bob sharing flow for the feature merged
+//! in PR #545. It's modeled after `org_sync_e2e_test.rs` (key copy simulating
+//! the sync layer) but adds key rewriting from `share:{sender}:{recipient}:`
+//! into `from:{sender}:` (the translation `SyncEngine::rewrite_key_if_needed`
+//! performs at download time).
+//!
+//! The test is deliberately permissive about intermediate steps — its goal is
+//! reconnaissance, i.e. "what actually works and what doesn't" in the current
+//! implementation. When an assertion fails, the test prints enough context to
+//! pinpoint the gap.
+
+use fold_db::access::AccessContext;
+use fold_db::fold_db_core::FoldDB;
+use fold_db::schema::types::operations::{MutationType, Query};
+use fold_db::schema::types::{KeyValue, Mutation};
+use fold_db::schema::SchemaState;
+use fold_db::sharing::store as share_store;
+use fold_db::sharing::types::{ShareRule, ShareScope, ShareSubscription};
+use fold_db::test_helpers::TestSchemaBuilder;
+use serde_json::json;
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Helpers (mirroring org_sync_e2e_test.rs)
+// ---------------------------------------------------------------------------
+
+async fn make_folddb(tmp: &tempfile::TempDir) -> FoldDB {
+    FoldDB::new(tmp.path().to_str().unwrap())
+        .await
+        .expect("Failed to create FoldDB")
+}
+
+async fn register_personal_schema(db: &FoldDB, name: &str) {
+    let json_str = TestSchemaBuilder::new(name)
+        .fields(&["body"])
+        .hash_key("title")
+        .range_key("date")
+        .build_json();
+    db.load_schema_from_json(&json_str).await.unwrap();
+    db.schema_manager()
+        .set_schema_state(name, SchemaState::Approved)
+        .await
+        .unwrap();
+}
+
+async fn write_note(db: &FoldDB, schema: &str, title: &str, date: &str, body: &str) {
+    let mut fields = HashMap::new();
+    fields.insert("title".to_string(), json!(title));
+    fields.insert("body".to_string(), json!(body));
+    fields.insert("date".to_string(), json!(date));
+    let mutation = Mutation::new(
+        schema.to_string(),
+        fields,
+        KeyValue::new(Some(title.to_string()), Some(date.to_string())),
+        "alice_pubkey".to_string(),
+        MutationType::Create,
+    );
+    db.mutation_manager()
+        .write_mutations_batch_async(vec![mutation])
+        .await
+        .expect("Failed to write mutation");
+}
+
+async fn query_bodies(db: &FoldDB, schema: &str) -> Vec<serde_json::Value> {
+    let query = Query::new(schema.to_string(), vec!["body".to_string()]);
+    let access = AccessContext::owner("test-owner");
+    let result = db
+        .query_executor()
+        .query_with_access(query, &access, None)
+        .await
+        .expect("Query failed");
+    match result.get("body") {
+        Some(field_map) => field_map.values().map(|fv| fv.value.clone()).collect(),
+        None => vec![],
+    }
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+/// Copy all keys with the given prefix from src sled into dst sled, optionally
+/// rewriting the prefix. This simulates what `SyncEngine::rewrite_key_if_needed`
+/// does for share: prefixes (translates `share:{sender}:{recipient}:` into
+/// `from:{sender}:` at replay time).
+fn copy_and_rewrite_prefixed_keys(
+    src_tree: &sled::Tree,
+    dst_tree: &sled::Tree,
+    src_prefix: &str,
+    dst_prefix: &str,
+) -> usize {
+    let mut count = 0;
+    for result in src_tree.iter() {
+        let (key, value) = result.expect("Failed to read sled key");
+        let key_str = String::from_utf8_lossy(&key);
+        if let Some(rest) = key_str.strip_prefix(src_prefix) {
+            let new_key = format!("{}{}", dst_prefix, rest);
+            dst_tree
+                .insert(new_key.as_bytes(), value)
+                .expect("Failed to insert key");
+            count += 1;
+        }
+    }
+    count
+}
+
+// ---------------------------------------------------------------------------
+// Test: Alice shares her personal "Notes" schema with Bob
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_alice_shares_notes_with_bob() {
+    // 1. SETUP — two FoldDB instances, each with their own Sled
+    let alice_tmp = tempfile::tempdir().unwrap();
+    let bob_tmp = tempfile::tempdir().unwrap();
+    let alice_db = make_folddb(&alice_tmp).await;
+    let bob_db = make_folddb(&bob_tmp).await;
+
+    let alice_pool = alice_db.sled_pool().cloned().unwrap();
+    let bob_pool = bob_db.sled_pool().cloned().unwrap();
+
+    // 2. SCHEMA — register "Notes" (personal, org_hash = None) on both sides.
+    //    Bob needs to know the schema to decode Alice's molecules.
+    register_personal_schema(&alice_db, "Notes").await;
+    register_personal_schema(&bob_db, "Notes").await;
+
+    // Define the share prefix up front so we can use it for both ends.
+    let share_prefix = "share:alice_pubkey:bob_pubkey".to_string();
+    let share_secret = vec![42u8; 32];
+
+    // 3. ALICE creates a ShareRule for Bob BEFORE writing data so multiplex is active.
+    let rule = ShareRule {
+        rule_id: "rule-1".to_string(),
+        recipient_pubkey: "bob_pubkey".to_string(),
+        recipient_display_name: "Bob".to_string(),
+        scope: ShareScope::Schema("Notes".to_string()),
+        share_prefix: share_prefix.clone(),
+        share_e2e_secret: share_secret.clone(),
+        active: true,
+        created_at: now_secs(),
+        writer_pubkey: "alice_pubkey".to_string(),
+        signature: String::new(),
+    };
+    share_store::create_share_rule(&alice_pool, rule.clone())
+        .expect("Failed to create share rule on Alice");
+
+    // NOTE: there is no `reconfigure_sync` / no way to rebuild an in-memory
+    // partitioner or multiplex table here. The `mutation_manager.rs` lookup
+    // calls `list_share_rules(&pool)` on every batch write, so the rule is
+    // picked up automatically. This is good news.
+
+    // 4. BOB subscribes to Alice's share
+    let sub = ShareSubscription {
+        sender_pubkey: "alice_pubkey".to_string(),
+        share_prefix: share_prefix.clone(),
+        share_e2e_secret: share_secret.clone(),
+        accepted_at: now_secs(),
+        active: true,
+    };
+    share_store::create_share_subscription(&bob_pool, sub)
+        .expect("Failed to create share subscription on Bob");
+
+    // 5. ALICE writes a note
+    write_note(&alice_db, "Notes", "Hello", "2026-04-17", "World").await;
+    write_note(&alice_db, "Notes", "Second", "2026-04-18", "More").await;
+
+    // Sanity: Alice can query her own data
+    let alice_bodies = query_bodies(&alice_db, "Notes").await;
+    assert_eq!(
+        alice_bodies.len(),
+        2,
+        "Alice should see her own 2 notes; got: {:?}",
+        alice_bodies
+    );
+
+    // 6. Verify the multiplex happened — Alice's sled should have BOTH
+    //    the personal atom/ref keys AND the share-prefixed ones.
+    let alice_guard = alice_pool.acquire_arc().unwrap();
+    let alice_sled = alice_guard.db();
+    let main_alice = alice_sled.open_tree("main").unwrap();
+
+    let share_prefixed_keys: Vec<String> = main_alice
+        .iter()
+        .filter_map(|r| r.ok())
+        .map(|(k, _)| String::from_utf8_lossy(&k).to_string())
+        .filter(|k| k.starts_with(&format!("{}:", share_prefix)))
+        .collect();
+    assert!(
+        !share_prefixed_keys.is_empty(),
+        "Expected share-prefixed keys in Alice's sled (mutation_manager multiplex). Got none. \
+         Personal-only keys visible: {:?}",
+        main_alice
+            .iter()
+            .filter_map(|r| r.ok())
+            .map(|(k, _)| String::from_utf8_lossy(&k).to_string())
+            .take(10)
+            .collect::<Vec<_>>()
+    );
+    println!(
+        "Share-prefixed keys in Alice's sled: {} keys, sample: {:?}",
+        share_prefixed_keys.len(),
+        share_prefixed_keys.iter().take(3).collect::<Vec<_>>()
+    );
+
+    // 7. SYNC — simulate the download-side rewrite: copy share-prefixed keys
+    //    from Alice's sled to Bob's sled, translating
+    //    `share:alice_pubkey:bob_pubkey:...` -> `from:alice_pubkey:...`
+    let bob_guard = bob_pool.acquire_arc().unwrap();
+    let bob_sled = bob_guard.db();
+    let main_bob = bob_sled.open_tree("main").unwrap();
+
+    let src_full_prefix = format!("{}:", share_prefix);
+    let dst_full_prefix = "from:alice_pubkey:".to_string();
+    let copied = copy_and_rewrite_prefixed_keys(
+        &main_alice,
+        &main_bob,
+        &src_full_prefix,
+        &dst_full_prefix,
+    );
+    assert!(copied > 0, "Expected to copy some share-prefixed keys");
+    println!("Copied + rewrote {} keys into Bob's sled", copied);
+
+    // 8. BOB queries — this is the moneymaker.
+    //    Does Bob's existing query path find Alice's data under `from:alice_pubkey:`?
+    //    Note: Bob's schema has org_hash=None, so query paths look for bare
+    //    `atom:...` / `ref:...` keys. The rewritten data lives under
+    //    `from:alice_pubkey:atom:...` / `from:alice_pubkey:ref:...`.
+    //    There is no read-side integration yet (ripgrep shows `from:` only
+    //    referenced in sync/engine.rs).
+    let bob_bodies = query_bodies(&bob_db, "Notes").await;
+    println!("Bob queried Notes.body -> {:?}", bob_bodies);
+    assert_eq!(
+        bob_bodies.len(),
+        2,
+        "EXPECTED: Bob to see Alice's 2 shared notes via `from:alice_pubkey:` namespace. \
+         ACTUAL: got {} rows: {:?}. \
+         Gap: there is no read-side integration that routes Bob's queries to the \
+         `from:{{sender}}:` namespace where rewritten data lives.",
+        bob_bodies.len(),
+        bob_bodies
+    );
+}


### PR DESCRIPTION
## Summary
Completes the read half of cross-user sharing. Alice's data was already landing in Bob's Sled correctly (via `SyncEngine::rewrite_key_if_needed` rewriting `share:{sender}:{recipient}:` keys into `from:{sender}:`) but was invisible to Bob's queries. This PR makes it queryable.

## Approach
- Thread `Option<Arc<SledPool>>` into `QueryExecutor` / `HashRangeQueryProcessor`.
- In `query_with_filter`, for personal-scope schemas (no `org_hash`), enumerate active `ShareSubscription`s via `sharing::store::list_share_subscriptions`.
- For each subscription, parse the sender hash from its `share_prefix` and build a `from:{sender_hash}` namespace.
- Clone the field, temporarily set its `org_hash` to that namespace, and call `resolve_value` again — the existing storage-key construction path (`build_storage_key`) picks up the prefix transparently.
- Merge results into the personal-namespace results; personal data wins on collisions.
- Stamp `writer_pubkey` on received rows with the sender hash when no molecule-level signer is already set (per PR #544 writes now carry a writer_pubkey via the signed molecule).
- Unparseable share prefixes are logged as errors and skipped (never silent); inactive subscriptions are excluded. Resolution failures against a `from:` namespace surface as hard errors.

Org-scoped queries and view queries are unchanged.

## Test plan
- [x] `tests/cross_user_sharing_e2e_test.rs` passes end-to-end (brought over from the recon branch)
- [x] Full test suite passes (`cargo test --workspace --all-targets`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)