### PR TITLE
ci: add merge_group trigger to Test Suite

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [mainline]
   pull_request:
+  merge_group:
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
Adds \`merge_group:\` to the Test Suite workflow's event triggers so the required Rust Tests check runs on GitHub's merge queue \`gh-readonly-queue/mainline/...\` refs. Without this, enabling merge queue would cause queued PRs to hang forever waiting on checks that never trigger.

Part of enabling GitHub merge queue across the workspace. Once this lands, the next step is to add a \`merge_queue\` rule to the "basic" ruleset so merges go through the queue automatically — no more manual rebases when mainline moves.

## Test plan
- [ ] CI still runs on this PR (pull_request trigger).
- [ ] Enable merge queue on mainline via ruleset and confirm the next PR merges through the queue cleanly.