### PR TITLE
feat(sharing): runtime reconfig of sync engine on rule/subscription changes

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1599,30 +1599,71 @@ impl SyncEngine {
     }
 
     // =========================================================================
-    // Org sync configuration
+    // Non-personal sync configuration (orgs + cross-user shares)
     // =========================================================================
 
-    /// Configure org sync partitioning.
+    /// Configure non-personal sync targets (orgs + cross-user shares).
     ///
-    /// Configure org sync targets.
+    /// Replaces all non-personal targets atomically. The personal target at
+    /// index 0 is always preserved. The partitioner classifies pending log
+    /// entries to the correct target by key prefix.
     ///
-    /// Appends org targets after the personal target (index 0). Each target
-    /// has its own R2 prefix and crypto provider. The partitioner classifies
-    /// pending entries to the correct target.
+    /// This is the runtime reconfiguration entry point: callers MUST invoke
+    /// this every time org membership, share rules, or share subscriptions
+    /// change in Sled so the sync engine picks up new upload/download prefixes
+    /// without restarting the node.
+    ///
+    /// `extra_targets` should contain one `SyncTarget` per:
+    /// - active org membership (uploads + downloads under `{org_hash}/log/`)
+    /// - active outbound share rule (uploads under `{share_prefix}/log/`)
+    /// - active inbound share subscription (downloads under
+    ///   `{share_prefix}/log/`)
+    ///
+    /// The `partitioner` must be built from the same memberships + share
+    /// rules so write routing stays consistent with the target list.
     pub async fn configure_org_sync(
         &self,
         partitioner: SyncPartitioner,
-        org_targets: Vec<SyncTarget>,
+        extra_targets: Vec<SyncTarget>,
     ) {
         *self.partitioner.lock().await = Some(partitioner);
         let mut targets = self.targets.lock().await;
         targets.truncate(1); // Keep personal target
-        targets.extend(org_targets);
+        targets.extend(extra_targets);
     }
 
-    /// Check if org sync is configured (any targets beyond personal).
+    /// Alias for [`configure_org_sync`] used by sharing-related call sites.
+    ///
+    /// Semantically identical — provided so callers that are wiring up a
+    /// share rule or subscription can express intent more clearly than
+    /// "configure_org_sync". Both names accept the full set of non-personal
+    /// targets (orgs, outbound shares, inbound shares).
+    pub async fn reconfigure_sharing(
+        &self,
+        partitioner: SyncPartitioner,
+        extra_targets: Vec<SyncTarget>,
+    ) {
+        self.configure_org_sync(partitioner, extra_targets).await;
+    }
+
+    /// Check if any non-personal sync targets (orgs or shares) are configured.
     pub async fn has_org_sync(&self) -> bool {
         self.targets.lock().await.len() > 1
+    }
+
+    /// Return the R2 prefix of every configured sync target, in order.
+    ///
+    /// Index 0 is the personal prefix. Remaining entries are org or share
+    /// prefixes in the order they were registered via `configure_org_sync`
+    /// / `reconfigure_sharing`. Primarily intended for tests and status
+    /// endpoints that need to verify runtime reconfiguration took effect.
+    pub async fn target_prefixes(&self) -> Vec<String> {
+        self.targets
+            .lock()
+            .await
+            .iter()
+            .map(|t| t.prefix.clone())
+            .collect()
     }
 }
 

--- a/tests/sync_integration_test.rs
+++ b/tests/sync_integration_test.rs
@@ -255,3 +255,74 @@ async fn store_with_data_detected_as_non_empty() {
         "store with data should be detected as non-empty"
     );
 }
+
+#[tokio::test]
+async fn reconfigure_sharing_replaces_extra_targets_atomically() {
+    use fold_db::sharing::types::{ShareRule, ShareScope};
+    use fold_db::sync::org_sync::{SyncPartitioner, SyncTarget};
+
+    let base = Arc::new(InMemoryNamespacedStore::new());
+    let crypto = test_crypto();
+    let http = Arc::new(reqwest::Client::new());
+    let s3 = S3Client::new(http.clone());
+    let auth = AuthClient::new(
+        http,
+        "http://localhost:0".to_string(),
+        SyncAuth::ApiKey("test".to_string()),
+    );
+
+    let engine = SyncEngine::new(
+        "test-device".to_string(),
+        crypto.clone(),
+        s3,
+        auth,
+        base.clone() as Arc<dyn NamespacedStore>,
+        SyncConfig::default(),
+    );
+
+    // Personal-only at startup.
+    let prefixes = engine.target_prefixes().await;
+    assert_eq!(prefixes.len(), 1, "only personal target at startup");
+    assert!(!engine.has_org_sync().await);
+
+    // Simulate runtime creation of a share rule (sender side).
+    let rule = ShareRule {
+        rule_id: "r1".to_string(),
+        recipient_pubkey: "alice_pubkey".to_string(),
+        recipient_display_name: "Alice".to_string(),
+        scope: ShareScope::AllSchemas,
+        share_prefix: "share:me:alice".to_string(),
+        share_e2e_secret: vec![7u8; 32],
+        active: true,
+        created_at: 0,
+        writer_pubkey: "me".to_string(),
+        signature: String::new(),
+    };
+
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&rule.share_e2e_secret);
+    let share_crypto = Arc::new(LocalCryptoProvider::from_key(key));
+    let share_target = SyncTarget {
+        label: format!("share -> {}", rule.recipient_display_name),
+        prefix: rule.share_prefix.clone(),
+        crypto: share_crypto,
+    };
+
+    let partitioner = SyncPartitioner::new(&[], std::slice::from_ref(&rule));
+    engine
+        .reconfigure_sharing(partitioner, vec![share_target])
+        .await;
+
+    let prefixes = engine.target_prefixes().await;
+    assert_eq!(prefixes.len(), 2, "personal + share target");
+    assert!(prefixes.contains(&"share:me:alice".to_string()));
+    assert!(engine.has_org_sync().await);
+
+    // Deactivating the rule: caller rebuilds with no extra targets.
+    let empty_partitioner = SyncPartitioner::new(&[], &[]);
+    engine.reconfigure_sharing(empty_partitioner, vec![]).await;
+
+    let prefixes = engine.target_prefixes().await;
+    assert_eq!(prefixes.len(), 1, "back to personal-only after dectivation");
+    assert!(!engine.has_org_sync().await);
+}


### PR DESCRIPTION
## Summary
- Add `SyncEngine::reconfigure_sharing` — a semantic alias for `configure_org_sync` — so sharing call sites can express intent clearly when wiring up a new rule or subscription.
- Document that `configure_org_sync` / `reconfigure_sharing` is the runtime reconfiguration entry point: callers MUST invoke it on every membership / share rule / share subscription change so the next sync cycle uploads/downloads the affected prefix.
- Add `SyncEngine::target_prefixes` so tests and status endpoints can verify the configured prefix set.

Previously the `SyncPartitioner` and target list were built once at node startup (`build_org_sync_config_from_sled`). Share rules created via the API at runtime were not uploaded to S3, and subscriptions accepted at runtime were not downloaded, until the node restarted.

A follow-up `fold_db_node` change will call `reconfigure_sharing` from the sharing handlers (`create_rule`, `deactivate_rule`, `accept_invite`) so share rule and subscription CRUD takes effect immediately.

## Test plan
- [x] `cargo test --test sync_integration_test reconfigure_sharing_replaces_extra_targets_atomically`
- [x] `cargo test --lib sync::`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)