### PR TITLE
refactor(access): migrate fold_db call sites to AccessTier (slice 2/N)

### DIFF
--- a/src/access/audit.rs
+++ b/src/access/audit.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::types::{AccessDecision, TrustTier};
+use super::types::{AccessDecision, AccessTier};
 
 /// What kind of action was audited
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,7 +21,7 @@ pub enum AuditAction {
     },
     TrustGrant {
         user_id: String,
-        tier: TrustTier,
+        tier: AccessTier,
     },
     TrustRevoke {
         user_id: String,
@@ -35,7 +35,7 @@ pub struct AuditEvent {
     pub timestamp: DateTime<Utc>,
     pub user_id: String,
     pub action: AuditAction,
-    pub trust_tier: Option<TrustTier>,
+    pub trust_tier: Option<AccessTier>,
     pub decision_granted: bool,
 }
 
@@ -43,7 +43,7 @@ impl AuditEvent {
     pub fn new(
         user_id: impl Into<String>,
         action: AuditAction,
-        trust_tier: Option<TrustTier>,
+        trust_tier: Option<AccessTier>,
         decision: &AccessDecision,
     ) -> Self {
         Self {
@@ -63,7 +63,7 @@ impl AuditEvent {
             timestamp: Utc::now(),
             user_id: user_id.into(),
             action,
-            trust_tier: Some(TrustTier::Owner),
+            trust_tier: Some(AccessTier::Owner),
             decision_granted: true,
         }
     }
@@ -132,7 +132,7 @@ mod tests {
                 schema_name: "contacts".into(),
                 fields: vec!["name".into(), "email".into()],
             },
-            Some(TrustTier::Owner),
+            Some(AccessTier::Owner),
             &AccessDecision::Granted,
         ));
 
@@ -142,11 +142,11 @@ mod tests {
                 schema_name: "contacts".into(),
                 reason: "insufficient trust tier".into(),
             },
-            Some(TrustTier::Outer),
+            Some(AccessTier::Outer),
             &AccessDecision::Denied(super::super::types::AccessDenialReason::InsufficientTrust {
                 domain: "personal".into(),
-                required: TrustTier::Trusted,
-                actual: TrustTier::Outer,
+                required: AccessTier::Trusted,
+                actual: AccessTier::Outer,
             }),
         ));
 
@@ -164,11 +164,11 @@ mod tests {
             "alice",
             AuditAction::TrustGrant {
                 user_id: "bob".into(),
-                tier: TrustTier::Trusted,
+                tier: AccessTier::Trusted,
             },
         );
         assert!(event.decision_granted);
-        assert_eq!(event.trust_tier, Some(TrustTier::Owner));
+        assert_eq!(event.trust_tier, Some(AccessTier::Owner));
     }
 
     #[test]
@@ -181,7 +181,7 @@ mod tests {
                     schema_name: "test".into(),
                     fields: vec![],
                 },
-                Some(TrustTier::Owner),
+                Some(AccessTier::Owner),
                 &AccessDecision::Granted,
             ));
         }
@@ -198,7 +198,7 @@ mod tests {
                 schema_name: "notes".into(),
                 fields: vec!["content".into()],
             },
-            Some(TrustTier::Owner),
+            Some(AccessTier::Owner),
             &AccessDecision::Granted,
         ));
 

--- a/src/access/mod.rs
+++ b/src/access/mod.rs
@@ -16,7 +16,7 @@ pub use capability::{CapabilityConstraint, CapabilityKind};
 pub use payment::PaymentGate;
 pub use types::{
     org_domain, trust_domain_for_data_domain, AccessContext, AccessDecision, AccessDenialReason,
-    FieldAccessPolicy, TrustMap, TrustTier, DOMAIN_FAMILY, DOMAIN_FINANCIAL, DOMAIN_HEALTH,
+    AccessMap, AccessTier, FieldAccessPolicy, DOMAIN_FAMILY, DOMAIN_FINANCIAL, DOMAIN_HEALTH,
     DOMAIN_MEDICAL, DOMAIN_PERSONAL,
 };
 
@@ -83,8 +83,8 @@ mod tests {
 
     fn policy_public_read() -> FieldAccessPolicy {
         FieldAccessPolicy {
-            min_read_tier: TrustTier::Public,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Public,
+            min_write_tier: AccessTier::Owner,
             ..Default::default()
         }
     }
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_no_policy_defaults_to_owner_only() {
-        let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Trusted);
+        let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Trusted);
         assert!(check_access(None, &ctx, "schema", None, false).is_denied());
         assert!(check_access(None, &ctx, "schema", None, true).is_denied());
 
@@ -114,24 +114,24 @@ mod tests {
 
     #[test]
     fn test_public_read_allows_any_tier() {
-        let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Public);
+        let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Public);
         let policy = policy_public_read();
         assert!(check_access(Some(&policy), &ctx, "schema", None, false).is_granted());
     }
 
     #[test]
     fn test_owner_only_blocks_remote_read() {
-        let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Inner);
+        let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Inner);
         let policy = policy_owner_only();
         assert!(check_access(Some(&policy), &ctx, "schema", None, false).is_denied());
     }
 
     #[test]
     fn test_write_requires_higher_tier() {
-        let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Trusted);
+        let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Trusted);
         let policy = FieldAccessPolicy {
-            min_read_tier: TrustTier::Outer,
-            min_write_tier: TrustTier::Inner,
+            min_read_tier: AccessTier::Outer,
+            min_write_tier: AccessTier::Inner,
             ..Default::default()
         };
         // Trusted (2) >= Outer (1) → read granted
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_payment_gate_blocks_unpaid() {
-        let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Inner);
+        let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Inner);
         let policy = policy_public_read();
         let gate = PaymentGate::Fixed(5.0);
         assert!(check_access(Some(&policy), &ctx, "paid_schema", Some(&gate), false).is_denied());
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_payment_gate_allows_paid() {
-        let mut ctx = AccessContext::remote_single("bob", "personal", TrustTier::Inner);
+        let mut ctx = AccessContext::remote_single("bob", "personal", AccessTier::Inner);
         ctx.paid_schemas.insert("paid_schema".to_string());
         let policy = policy_public_read();
         let gate = PaymentGate::Fixed(5.0);
@@ -176,15 +176,15 @@ mod tests {
     #[test]
     fn test_domain_aware_access_check() {
         let mut tiers = HashMap::new();
-        tiers.insert("health".to_string(), TrustTier::Inner);
-        tiers.insert("personal".to_string(), TrustTier::Trusted);
+        tiers.insert("health".to_string(), AccessTier::Inner);
+        tiers.insert("personal".to_string(), AccessTier::Trusted);
         let ctx = AccessContext::remote("bob", tiers);
 
         // Health field with min Trusted → Bob at Inner(3) → granted
         let health_policy = FieldAccessPolicy {
             trust_domain: "health".to_string(),
-            min_read_tier: TrustTier::Trusted,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Trusted,
+            min_write_tier: AccessTier::Owner,
             capabilities: vec![],
         };
         assert!(check_access(Some(&health_policy), &ctx, "schema", None, false).is_granted());
@@ -192,8 +192,8 @@ mod tests {
         // Personal field with min Inner → Bob at Trusted(2) → denied
         let personal_policy = FieldAccessPolicy {
             trust_domain: "personal".to_string(),
-            min_read_tier: TrustTier::Inner,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Inner,
+            min_write_tier: AccessTier::Owner,
             capabilities: vec![],
         };
         assert!(check_access(Some(&personal_policy), &ctx, "schema", None, false).is_denied());
@@ -201,8 +201,8 @@ mod tests {
         // Financial field → Bob not in financial domain → denied
         let financial_policy = FieldAccessPolicy {
             trust_domain: "financial".to_string(),
-            min_read_tier: TrustTier::Outer,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Outer,
+            min_write_tier: AccessTier::Owner,
             capabilities: vec![],
         };
         assert!(check_access(Some(&financial_policy), &ctx, "schema", None, false).is_denied());
@@ -211,8 +211,8 @@ mod tests {
     #[test]
     fn test_all_layers_combined() {
         let policy = FieldAccessPolicy {
-            min_read_tier: TrustTier::Outer,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Outer,
+            min_write_tier: AccessTier::Owner,
             capabilities: vec![CapabilityConstraint::new(
                 "pk_bob",
                 CapabilityKind::Read,
@@ -222,7 +222,7 @@ mod tests {
         };
         let gate = PaymentGate::Fixed(1.0);
 
-        let mut ctx = AccessContext::remote_single("bob", "personal", TrustTier::Inner);
+        let mut ctx = AccessContext::remote_single("bob", "personal", AccessTier::Inner);
         ctx.public_keys = vec!["pk_bob".to_string()];
         ctx.paid_schemas.insert("schema".to_string());
 

--- a/src/schema/types/data_classification.rs
+++ b/src/schema/types/data_classification.rs
@@ -1,4 +1,4 @@
-use crate::access::{trust_domain_for_data_domain, TrustTier};
+use crate::access::{trust_domain_for_data_domain, AccessTier};
 use serde::Serialize;
 
 /// Standard sensitivity levels for data classification.
@@ -123,8 +123,8 @@ impl DataClassification {
     }
 
     /// Returns the default trust tier for this classification's sensitivity level.
-    pub fn default_trust_tier(&self) -> TrustTier {
-        TrustTier::from_sensitivity(self.sensitivity_level)
+    pub fn default_trust_tier(&self) -> AccessTier {
+        AccessTier::from_sensitivity(self.sensitivity_level)
     }
 
     /// Returns the trust domain that governs access for this classification's data domain.
@@ -232,14 +232,14 @@ mod tests {
 
     #[test]
     fn test_default_trust_tier() {
-        use crate::access::TrustTier;
+        use crate::access::AccessTier;
 
         let cases = [
-            (0, TrustTier::Public),
-            (1, TrustTier::Outer),
-            (2, TrustTier::Trusted),
-            (3, TrustTier::Inner),
-            (4, TrustTier::Owner),
+            (0, AccessTier::Public),
+            (1, AccessTier::Outer),
+            (2, AccessTier::Trusted),
+            (3, AccessTier::Inner),
+            (4, AccessTier::Owner),
         ];
         for (level, expected_tier) in cases {
             let c = DataClassification::new(level, "general").unwrap();

--- a/src/schema/types/declarative_schemas.rs
+++ b/src/schema/types/declarative_schemas.rs
@@ -906,8 +906,8 @@ mod tests {
             .as_ref()
             .expect("body should have an access policy after populate");
         assert_eq!(policy.trust_domain, "personal");
-        assert_eq!(policy.min_read_tier, crate::access::TrustTier::Owner);
-        assert_eq!(policy.min_write_tier, crate::access::TrustTier::Owner);
+        assert_eq!(policy.min_read_tier, crate::access::AccessTier::Owner);
+        assert_eq!(policy.min_write_tier, crate::access::AccessTier::Owner);
 
         // title should NOT have a policy (not in field_access_policies)
         let title_field = schema

--- a/tests/access_control_test.rs
+++ b/tests/access_control_test.rs
@@ -1,6 +1,6 @@
 use fold_db::access::{
-    check_access, AccessContext, AccessDecision, AccessDenialReason, CapabilityConstraint,
-    CapabilityKind, FieldAccessPolicy, PaymentGate, TrustTier,
+    check_access, AccessContext, AccessDecision, AccessDenialReason, AccessTier,
+    CapabilityConstraint, CapabilityKind, FieldAccessPolicy, PaymentGate,
 };
 use fold_db::fold_db_core::FoldDB;
 use fold_db::schema::types::field::Field;
@@ -97,8 +97,8 @@ fn owner_always_has_access_in_any_domain() {
     // Health domain policy requiring Inner
     let health_policy = FieldAccessPolicy {
         trust_domain: "health".to_string(),
-        min_read_tier: TrustTier::Inner,
-        min_write_tier: TrustTier::Inner,
+        min_read_tier: AccessTier::Inner,
+        min_write_tier: AccessTier::Inner,
         capabilities: vec![],
     };
     assert!(check_access(Some(&health_policy), &ctx, "schema", None, false).is_granted());
@@ -111,22 +111,22 @@ fn owner_always_has_access_in_any_domain() {
 
 #[test]
 fn remote_caller_granted_when_tier_gte_min() {
-    let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Trusted);
+    let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Trusted);
 
     let policy = FieldAccessPolicy {
         trust_domain: "personal".to_string(),
-        min_read_tier: TrustTier::Trusted, // exact match
-        min_write_tier: TrustTier::Owner,
+        min_read_tier: AccessTier::Trusted, // exact match
+        min_write_tier: AccessTier::Owner,
         capabilities: vec![],
     };
     assert!(check_access(Some(&policy), &ctx, "schema", None, false).is_granted());
 
     // Higher tier than required
-    let ctx_inner = AccessContext::remote_single("bob", "personal", TrustTier::Inner);
+    let ctx_inner = AccessContext::remote_single("bob", "personal", AccessTier::Inner);
     let policy_outer = FieldAccessPolicy {
         trust_domain: "personal".to_string(),
-        min_read_tier: TrustTier::Outer,
-        min_write_tier: TrustTier::Owner,
+        min_read_tier: AccessTier::Outer,
+        min_write_tier: AccessTier::Owner,
         capabilities: vec![],
     };
     assert!(check_access(Some(&policy_outer), &ctx_inner, "schema", None, false).is_granted());
@@ -134,12 +134,12 @@ fn remote_caller_granted_when_tier_gte_min() {
 
 #[test]
 fn remote_caller_denied_when_tier_lt_min() {
-    let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Outer);
+    let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Outer);
 
     let policy = FieldAccessPolicy {
         trust_domain: "personal".to_string(),
-        min_read_tier: TrustTier::Trusted, // Outer(1) < Trusted(2)
-        min_write_tier: TrustTier::Owner,
+        min_read_tier: AccessTier::Trusted, // Outer(1) < Trusted(2)
+        min_write_tier: AccessTier::Owner,
         capabilities: vec![],
     };
     let result = check_access(Some(&policy), &ctx, "schema", None, false);
@@ -151,8 +151,8 @@ fn remote_caller_denied_when_tier_lt_min() {
     }) = result
     {
         assert_eq!(domain, "personal");
-        assert_eq!(required, TrustTier::Trusted);
-        assert_eq!(actual, TrustTier::Outer);
+        assert_eq!(required, AccessTier::Trusted);
+        assert_eq!(actual, AccessTier::Outer);
     } else {
         panic!("expected InsufficientTrust denial");
     }
@@ -165,8 +165,8 @@ fn remote_caller_denied_when_no_domain_entry() {
 
     let policy = FieldAccessPolicy {
         trust_domain: "personal".to_string(),
-        min_read_tier: TrustTier::Public,
-        min_write_tier: TrustTier::Owner,
+        min_read_tier: AccessTier::Public,
+        min_write_tier: AccessTier::Owner,
         capabilities: vec![],
     };
     let result = check_access(Some(&policy), &ctx, "schema", None, false);
@@ -181,15 +181,15 @@ fn remote_caller_denied_when_no_domain_entry() {
 #[test]
 fn multi_domain_context_independence() {
     let mut tiers = HashMap::new();
-    tiers.insert("health".to_string(), TrustTier::Inner);
-    tiers.insert("personal".to_string(), TrustTier::Trusted);
+    tiers.insert("health".to_string(), AccessTier::Inner);
+    tiers.insert("personal".to_string(), AccessTier::Trusted);
     let ctx = AccessContext::remote("bob", tiers);
 
     // Health field requiring Trusted — Bob has Inner(3) >= Trusted(2) -> granted
     let health_policy = FieldAccessPolicy {
         trust_domain: "health".to_string(),
-        min_read_tier: TrustTier::Trusted,
-        min_write_tier: TrustTier::Owner,
+        min_read_tier: AccessTier::Trusted,
+        min_write_tier: AccessTier::Owner,
         capabilities: vec![],
     };
     assert!(check_access(Some(&health_policy), &ctx, "schema", None, false).is_granted());
@@ -197,8 +197,8 @@ fn multi_domain_context_independence() {
     // Personal field requiring Inner — Bob has Trusted(2) < Inner(3) -> denied
     let personal_policy = FieldAccessPolicy {
         trust_domain: "personal".to_string(),
-        min_read_tier: TrustTier::Inner,
-        min_write_tier: TrustTier::Owner,
+        min_read_tier: AccessTier::Inner,
+        min_write_tier: AccessTier::Owner,
         capabilities: vec![],
     };
     assert!(check_access(Some(&personal_policy), &ctx, "schema", None, false).is_denied());
@@ -206,8 +206,8 @@ fn multi_domain_context_independence() {
     // Financial field — Bob has no entry -> NoDomainTrust
     let financial_policy = FieldAccessPolicy {
         trust_domain: "financial".to_string(),
-        min_read_tier: TrustTier::Outer,
-        min_write_tier: TrustTier::Owner,
+        min_read_tier: AccessTier::Outer,
+        min_write_tier: AccessTier::Owner,
         capabilities: vec![],
     };
     let result = check_access(Some(&financial_policy), &ctx, "schema", None, false);
@@ -219,11 +219,11 @@ fn multi_domain_context_independence() {
 
 #[test]
 fn unified_check_access_read_vs_write() {
-    let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Trusted);
+    let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Trusted);
     let policy = FieldAccessPolicy {
         trust_domain: "personal".to_string(),
-        min_read_tier: TrustTier::Outer,  // Trusted(2) >= Outer(1)
-        min_write_tier: TrustTier::Inner, // Trusted(2) < Inner(3)
+        min_read_tier: AccessTier::Outer,  // Trusted(2) >= Outer(1)
+        min_write_tier: AccessTier::Inner, // Trusted(2) < Inner(3)
         capabilities: vec![],
     };
 
@@ -236,8 +236,8 @@ fn unified_check_access_read_vs_write() {
         required, actual, ..
     }) = result
     {
-        assert_eq!(required, TrustTier::Inner);
-        assert_eq!(actual, TrustTier::Trusted);
+        assert_eq!(required, AccessTier::Inner);
+        assert_eq!(actual, AccessTier::Trusted);
     } else {
         panic!("expected InsufficientTrust for write");
     }
@@ -245,11 +245,11 @@ fn unified_check_access_read_vs_write() {
 
 #[test]
 fn payment_gate_fixed_blocks_unpaid() {
-    let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Inner);
+    let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Inner);
     let policy = FieldAccessPolicy {
         trust_domain: "personal".to_string(),
-        min_read_tier: TrustTier::Public,
-        min_write_tier: TrustTier::Owner,
+        min_read_tier: AccessTier::Public,
+        min_write_tier: AccessTier::Owner,
         capabilities: vec![],
     };
     let gate = PaymentGate::Fixed(5.0);
@@ -264,7 +264,7 @@ fn payment_gate_fixed_blocks_unpaid() {
     }
 
     // Paid -> granted
-    let mut paid_ctx = AccessContext::remote_single("bob", "personal", TrustTier::Inner);
+    let mut paid_ctx = AccessContext::remote_single("bob", "personal", AccessTier::Inner);
     paid_ctx.paid_schemas.insert("paid_schema".to_string());
     assert!(check_access(Some(&policy), &paid_ctx, "paid_schema", Some(&gate), false).is_granted());
 }
@@ -273,8 +273,8 @@ fn payment_gate_fixed_blocks_unpaid() {
 fn combined_trust_capability_payment() {
     let policy = FieldAccessPolicy {
         trust_domain: "personal".to_string(),
-        min_read_tier: TrustTier::Outer,
-        min_write_tier: TrustTier::Owner,
+        min_read_tier: AccessTier::Outer,
+        min_write_tier: AccessTier::Owner,
         capabilities: vec![CapabilityConstraint::new(
             "pk_bob",
             CapabilityKind::Read,
@@ -284,7 +284,7 @@ fn combined_trust_capability_payment() {
     let gate = PaymentGate::Fixed(1.0);
 
     // All three layers satisfied
-    let mut ctx = AccessContext::remote_single("bob", "personal", TrustTier::Inner);
+    let mut ctx = AccessContext::remote_single("bob", "personal", AccessTier::Inner);
     ctx.public_keys = vec!["pk_bob".to_string()];
     ctx.paid_schemas.insert("schema".to_string());
     assert!(check_access(Some(&policy), &ctx, "schema", Some(&gate), false).is_granted());
@@ -309,7 +309,7 @@ fn combined_trust_capability_payment() {
     // Restore capability, drop tier below min -> denied (InsufficientTrust)
     ctx.public_keys = vec!["pk_bob".to_string()];
     let mut low_tiers = HashMap::new();
-    low_tiers.insert("personal".to_string(), TrustTier::Public);
+    low_tiers.insert("personal".to_string(), AccessTier::Public);
     ctx.tiers = low_tiers;
     let result = check_access(Some(&policy), &ctx, "schema", Some(&gate), false);
     assert!(matches!(
@@ -339,7 +339,7 @@ async fn query_default_policy_owner_only() {
     let db = setup_db_with_notes().await;
 
     // No explicit policies — defaults to owner-only, remote users denied
-    let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Trusted);
+    let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Trusted);
     let query = Query::new(
         "Notes".to_string(),
         vec!["title".to_string(), "content".to_string()],
@@ -379,8 +379,8 @@ async fn query_owner_always_has_access() {
         "content",
         FieldAccessPolicy {
             trust_domain: "personal".to_string(),
-            min_read_tier: TrustTier::Owner,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Owner,
+            min_write_tier: AccessTier::Owner,
             capabilities: vec![],
         },
     )
@@ -412,8 +412,8 @@ async fn query_remote_filtered_by_trust_tier() {
         "content",
         FieldAccessPolicy {
             trust_domain: "personal".to_string(),
-            min_read_tier: TrustTier::Owner,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Owner,
+            min_write_tier: AccessTier::Owner,
             capabilities: vec![],
         },
     )
@@ -426,14 +426,14 @@ async fn query_remote_filtered_by_trust_tier() {
         "title",
         FieldAccessPolicy {
             trust_domain: "personal".to_string(),
-            min_read_tier: TrustTier::Public,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Public,
+            min_write_tier: AccessTier::Owner,
             capabilities: vec![],
         },
     )
     .await;
 
-    let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Trusted);
+    let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Trusted);
     let query = Query::new(
         "Notes".to_string(),
         vec!["title".to_string(), "content".to_string()],
@@ -459,15 +459,15 @@ async fn query_payment_gate_blocks_unpaid() {
         "content",
         FieldAccessPolicy {
             trust_domain: "personal".to_string(),
-            min_read_tier: TrustTier::Public,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Public,
+            min_write_tier: AccessTier::Owner,
             capabilities: vec![],
         },
     )
     .await;
 
     let gate = PaymentGate::Fixed(5.0);
-    let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Inner);
+    let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Inner);
 
     let query = Query::new("Notes".to_string(), vec!["content".to_string()]);
     let results = db
@@ -493,14 +493,14 @@ async fn mutation_blocked_by_insufficient_tier() {
         "content",
         FieldAccessPolicy {
             trust_domain: "personal".to_string(),
-            min_read_tier: TrustTier::Public,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Public,
+            min_write_tier: AccessTier::Owner,
             capabilities: vec![],
         },
     )
     .await;
 
-    let ctx = AccessContext::remote_single("bob", "personal", TrustTier::Inner);
+    let ctx = AccessContext::remote_single("bob", "personal", AccessTier::Inner);
     let mut fields = HashMap::new();
     fields.insert("content".to_string(), json!("hacked!"));
     let mutation = Mutation::new(
@@ -535,8 +535,8 @@ async fn mutation_allowed_for_owner() {
         "content",
         FieldAccessPolicy {
             trust_domain: "personal".to_string(),
-            min_read_tier: TrustTier::Public,
-            min_write_tier: TrustTier::Owner,
+            min_read_tier: AccessTier::Public,
+            min_write_tier: AccessTier::Owner,
             capabilities: vec![],
         },
     )

--- a/tests/trust_domains_test.rs
+++ b/tests/trust_domains_test.rs
@@ -1,15 +1,15 @@
 //! Trust domains integration tests.
 //!
-//! Verifies that TrustMap (HashMap<String, TrustTier>) per-domain storage works:
+//! Verifies that AccessMap (HashMap<String, AccessTier>) per-domain storage works:
 //! grant/revoke trust, domain independence, well-known constants, org domains.
 
 use std::collections::HashMap;
 
 use fold_db::access::types::{
-    org_domain, TrustTier, DOMAIN_FAMILY, DOMAIN_FINANCIAL, DOMAIN_HEALTH, DOMAIN_MEDICAL,
+    org_domain, AccessTier, DOMAIN_FAMILY, DOMAIN_FINANCIAL, DOMAIN_HEALTH, DOMAIN_MEDICAL,
     DOMAIN_PERSONAL,
 };
-use fold_db::access::TrustMap;
+use fold_db::access::AccessMap;
 use fold_db::fold_db_core::FoldDB;
 
 async fn make_folddb(tmp: &tempfile::TempDir) -> FoldDB {
@@ -18,7 +18,7 @@ async fn make_folddb(tmp: &tempfile::TempDir) -> FoldDB {
         .expect("Failed to create FoldDB")
 }
 
-// ===== Load/Store TrustMap =====
+// ===== Load/Store AccessMap =====
 
 #[tokio::test]
 async fn load_empty_trust_map_returns_empty() {
@@ -39,9 +39,9 @@ async fn store_and_load_trust_map() {
     let db = make_folddb(&tmp).await;
     let ops = db.get_db_ops();
 
-    let mut map: TrustMap = HashMap::new();
-    map.insert("bob".to_string(), TrustTier::Trusted);
-    map.insert("charlie".to_string(), TrustTier::Inner);
+    let mut map: AccessMap = HashMap::new();
+    map.insert("bob".to_string(), AccessTier::Trusted);
+    map.insert("charlie".to_string(), AccessTier::Inner);
 
     ops.store_trust_map_for_domain(DOMAIN_PERSONAL, &map)
         .await
@@ -51,8 +51,8 @@ async fn store_and_load_trust_map() {
         .load_trust_map_for_domain(DOMAIN_PERSONAL)
         .await
         .unwrap();
-    assert_eq!(loaded.get("bob"), Some(&TrustTier::Trusted));
-    assert_eq!(loaded.get("charlie"), Some(&TrustTier::Inner));
+    assert_eq!(loaded.get("bob"), Some(&AccessTier::Trusted));
+    assert_eq!(loaded.get("charlie"), Some(&AccessTier::Inner));
     assert_eq!(loaded.get("dave"), None);
 }
 
@@ -64,17 +64,17 @@ async fn grant_trust_inserts_into_map() {
     let db = make_folddb(&tmp).await;
     let ops = db.get_db_ops();
 
-    let mut map: TrustMap = ops.load_trust_map_for_domain(DOMAIN_HEALTH).await.unwrap();
+    let mut map: AccessMap = ops.load_trust_map_for_domain(DOMAIN_HEALTH).await.unwrap();
     assert!(map.is_empty());
 
     // Grant trust
-    map.insert("doctor".to_string(), TrustTier::Inner);
+    map.insert("doctor".to_string(), AccessTier::Inner);
     ops.store_trust_map_for_domain(DOMAIN_HEALTH, &map)
         .await
         .unwrap();
 
     let loaded = ops.load_trust_map_for_domain(DOMAIN_HEALTH).await.unwrap();
-    assert_eq!(loaded.get("doctor"), Some(&TrustTier::Inner));
+    assert_eq!(loaded.get("doctor"), Some(&AccessTier::Inner));
 }
 
 #[tokio::test]
@@ -83,9 +83,9 @@ async fn revoke_trust_removes_from_map() {
     let db = make_folddb(&tmp).await;
     let ops = db.get_db_ops();
 
-    let mut map: TrustMap = HashMap::new();
-    map.insert("bob".to_string(), TrustTier::Trusted);
-    map.insert("charlie".to_string(), TrustTier::Outer);
+    let mut map: AccessMap = HashMap::new();
+    map.insert("bob".to_string(), AccessTier::Trusted);
+    map.insert("charlie".to_string(), AccessTier::Outer);
     ops.store_trust_map_for_domain(DOMAIN_PERSONAL, &map)
         .await
         .unwrap();
@@ -101,7 +101,7 @@ async fn revoke_trust_removes_from_map() {
         .await
         .unwrap();
     assert_eq!(loaded.get("bob"), None);
-    assert_eq!(loaded.get("charlie"), Some(&TrustTier::Outer));
+    assert_eq!(loaded.get("charlie"), Some(&AccessTier::Outer));
 }
 
 // ===== Multiple Domains Stored Independently =====
@@ -113,15 +113,15 @@ async fn domains_are_independent() {
     let ops = db.get_db_ops();
 
     // Grant trust in personal domain
-    let mut personal: TrustMap = HashMap::new();
-    personal.insert("bob".to_string(), TrustTier::Trusted);
+    let mut personal: AccessMap = HashMap::new();
+    personal.insert("bob".to_string(), AccessTier::Trusted);
     ops.store_trust_map_for_domain(DOMAIN_PERSONAL, &personal)
         .await
         .unwrap();
 
     // Grant trust in health domain
-    let mut health: TrustMap = HashMap::new();
-    health.insert("doctor".to_string(), TrustTier::Inner);
+    let mut health: AccessMap = HashMap::new();
+    health.insert("doctor".to_string(), AccessTier::Inner);
     ops.store_trust_map_for_domain(DOMAIN_HEALTH, &health)
         .await
         .unwrap();
@@ -131,12 +131,12 @@ async fn domains_are_independent() {
         .load_trust_map_for_domain(DOMAIN_PERSONAL)
         .await
         .unwrap();
-    assert_eq!(personal_loaded.get("bob"), Some(&TrustTier::Trusted));
+    assert_eq!(personal_loaded.get("bob"), Some(&AccessTier::Trusted));
     assert_eq!(personal_loaded.get("doctor"), None);
 
     // Verify: doctor is in health, not in personal
     let health_loaded = ops.load_trust_map_for_domain(DOMAIN_HEALTH).await.unwrap();
-    assert_eq!(health_loaded.get("doctor"), Some(&TrustTier::Inner));
+    assert_eq!(health_loaded.get("doctor"), Some(&AccessTier::Inner));
     assert_eq!(health_loaded.get("bob"), None);
 }
 
@@ -156,15 +156,15 @@ async fn many_domains_coexist() {
 
     // Store distinct users in each domain with different tiers
     let tiers = [
-        TrustTier::Outer,
-        TrustTier::Trusted,
-        TrustTier::Inner,
-        TrustTier::Trusted,
-        TrustTier::Inner,
+        AccessTier::Outer,
+        AccessTier::Trusted,
+        AccessTier::Inner,
+        AccessTier::Trusted,
+        AccessTier::Inner,
     ];
 
     for (i, domain) in domains.iter().enumerate() {
-        let mut map: TrustMap = HashMap::new();
+        let mut map: AccessMap = HashMap::new();
         let user = format!("user_{}", i);
         map.insert(user, tiers[i]);
         ops.store_trust_map_for_domain(domain, &map).await.unwrap();
@@ -217,7 +217,7 @@ async fn list_domains_after_storing() {
     let db = make_folddb(&tmp).await;
     let ops = db.get_db_ops();
 
-    let empty: TrustMap = HashMap::new();
+    let empty: AccessMap = HashMap::new();
     ops.store_trust_map_for_domain(DOMAIN_PERSONAL, &empty)
         .await
         .unwrap();
@@ -241,15 +241,15 @@ async fn delete_domain_removes_it() {
     let db = make_folddb(&tmp).await;
     let ops = db.get_db_ops();
 
-    let mut map: TrustMap = HashMap::new();
-    map.insert("bob".to_string(), TrustTier::Inner);
+    let mut map: AccessMap = HashMap::new();
+    map.insert("bob".to_string(), AccessTier::Inner);
     ops.store_trust_map_for_domain(DOMAIN_HEALTH, &map)
         .await
         .unwrap();
 
     // Verify it exists
     let loaded = ops.load_trust_map_for_domain(DOMAIN_HEALTH).await.unwrap();
-    assert_eq!(loaded.get("bob"), Some(&TrustTier::Inner));
+    assert_eq!(loaded.get("bob"), Some(&AccessTier::Inner));
 
     // Delete it
     ops.delete_trust_domain(DOMAIN_HEALTH).await.unwrap();
@@ -285,15 +285,15 @@ async fn org_domain_stored_and_listed() {
     let ops = db.get_db_ops();
 
     let domain = org_domain("my_org_hash");
-    let mut map: TrustMap = HashMap::new();
-    map.insert("member1".to_string(), TrustTier::Trusted);
-    map.insert("member2".to_string(), TrustTier::Inner);
+    let mut map: AccessMap = HashMap::new();
+    map.insert("member1".to_string(), AccessTier::Trusted);
+    map.insert("member2".to_string(), AccessTier::Inner);
     ops.store_trust_map_for_domain(&domain, &map).await.unwrap();
 
     // Load it back
     let loaded = ops.load_trust_map_for_domain(&domain).await.unwrap();
-    assert_eq!(loaded.get("member1"), Some(&TrustTier::Trusted));
-    assert_eq!(loaded.get("member2"), Some(&TrustTier::Inner));
+    assert_eq!(loaded.get("member1"), Some(&AccessTier::Trusted));
+    assert_eq!(loaded.get("member2"), Some(&AccessTier::Inner));
 
     // Verify it shows up in domain list
     let domains = ops.list_trust_domains().await.unwrap();
@@ -310,7 +310,7 @@ async fn backwards_compatible_load_store_uses_personal() {
 
     // Use the backwards-compatible methods (no domain param)
     let mut map = ops.load_trust_map().await.unwrap();
-    map.insert("bob".to_string(), TrustTier::Trusted);
+    map.insert("bob".to_string(), AccessTier::Trusted);
     ops.store_trust_map(&map).await.unwrap();
 
     // Should be stored in "personal" domain
@@ -318,5 +318,5 @@ async fn backwards_compatible_load_store_uses_personal() {
         .load_trust_map_for_domain(DOMAIN_PERSONAL)
         .await
         .unwrap();
-    assert_eq!(personal.get("bob"), Some(&TrustTier::Trusted));
+    assert_eq!(personal.get("bob"), Some(&AccessTier::Trusted));
 }


### PR DESCRIPTION
## Summary

Slice 2 of the \`TrustTier → AccessTier\` rename started in [#551](https://github.com/EdgeVector/fold_db/pull/551). Migrates the 6 remaining in-crate call sites to use the new names directly, removing their reliance on the \`TrustTier = AccessTier\` type alias.

## What's in the diff

\`\`\`
src/access/audit.rs                       | 26 ++++----
src/access/mod.rs                         | 44 ++++++-------
src/schema/types/data_classification.rs   | 18 +++---
src/schema/types/declarative_schemas.rs   |  4 +-
tests/access_control_test.rs              | 108 ++++++++++++++++----------------
tests/trust_domains_test.rs               | 78 +++++++++++------------
\`\`\`

Pure mechanical find-and-replace of \`TrustTier → AccessTier\` and \`TrustMap → AccessMap\`. No semantic changes.

## What stays (intentionally)

- **\`TrustTier = AccessTier\` alias** in \`types.rs\` — fold_db_node and exemem-infra still reference \`TrustTier\` through it. Slices 3–4 migrate those; a final slice deletes the alias.
- **\`trust_tier\` field names** on schemas like \`Persona.trust_tier\` — on the *relationship* side of the access check ("Persona's trust tier in my access graph"), "trust" is the right word. Only the Rust enum name changes.
- **\`TrustInvite\` / future \`TrustGraph\` / future \`TrustDomain\`** — these describe relational state, not policy. A parallel PR on the workspace repo corrects the manifesto's rename table to reflect this clarification ([exemem-workspace/...](https://github.com/EdgeVector/exemem-workspace)).

## Test plan
- [x] \`cargo build\` → clean
- [x] \`cargo test --lib access\` → 41 passed, 0 failed
- [x] \`cargo test --test access_control_test --test trust_domains_test\` → 13 passed
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` → clean
- [x] \`cargo fmt --check\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)