### PR TITLE
refactor(access): delete TrustTier/TrustMap aliases (rename slice 4, final)

### DIFF
--- a/src/access/types.rs
+++ b/src/access/types.rs
@@ -69,20 +69,6 @@ impl fmt::Display for AccessTier {
 /// Flat access-graph map: public key → tier. One map per domain, stored in Sled.
 pub type AccessMap = HashMap<String, AccessTier>;
 
-// ─── Backward-compat aliases (manifesto proposal #4: TrustX → AccessX) ────
-//
-// These exist so the rename rolls out across repos incrementally without a
-// big-bang migration. Consumers in fold_db_node, exemem-infra, tests, and
-// the rest of this crate continue to compile unchanged. Remove once every
-// call site in the workspace has migrated to `AccessTier` / `AccessMap`.
-// See `docs/designs/platform_manifesto.md`.
-
-/// Deprecated alias — use [`AccessTier`] instead.
-pub type TrustTier = AccessTier;
-
-/// Deprecated alias — use [`AccessMap`] instead.
-pub type TrustMap = AccessMap;
-
 /// Well-known trust domain names.
 pub const DOMAIN_PERSONAL: &str = "personal";
 pub const DOMAIN_FAMILY: &str = "family";

--- a/src/db_operations/permissions_store.rs
+++ b/src/db_operations/permissions_store.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::access::types::{TrustMap, DOMAIN_PERSONAL};
+use crate::access::types::{AccessMap, DOMAIN_PERSONAL};
 use crate::access::{AuditEvent, AuditLog};
 use crate::constants::SINGLE_PUBLIC_KEY_ID;
 use crate::schema::SchemaError;
@@ -92,15 +92,15 @@ impl PermissionsStore {
     /// On first call for `personal`, migrates the legacy `trust_graph` key to
     /// `trust_graph:personal`. If deserialization of old format fails, returns
     /// an empty map (graceful migration).
-    pub async fn load_trust_map_for_domain(&self, domain: &str) -> Result<TrustMap, SchemaError> {
+    pub async fn load_trust_map_for_domain(&self, domain: &str) -> Result<AccessMap, SchemaError> {
         let key = Self::trust_graph_key(domain);
-        match self.permissions_store.get_item::<TrustMap>(&key).await {
+        match self.permissions_store.get_item::<AccessMap>(&key).await {
             Ok(Some(map)) => Ok(map),
             Ok(None) => {
                 if domain == DOMAIN_PERSONAL {
                     if let Ok(Some(legacy)) = self
                         .permissions_store
-                        .get_item::<TrustMap>(LEGACY_TRUST_GRAPH_KEY)
+                        .get_item::<AccessMap>(LEGACY_TRUST_GRAPH_KEY)
                         .await
                     {
                         let _ = self.permissions_store.put_item(&key, &legacy).await;
@@ -118,7 +118,7 @@ impl PermissionsStore {
     }
 
     /// Load the trust map (default "personal" domain).
-    pub async fn load_trust_map(&self) -> Result<TrustMap, SchemaError> {
+    pub async fn load_trust_map(&self) -> Result<AccessMap, SchemaError> {
         self.load_trust_map_for_domain(DOMAIN_PERSONAL).await
     }
 
@@ -126,7 +126,7 @@ impl PermissionsStore {
     pub async fn store_trust_map_for_domain(
         &self,
         domain: &str,
-        map: &TrustMap,
+        map: &AccessMap,
     ) -> Result<(), SchemaError> {
         let key = Self::trust_graph_key(domain);
         self.permissions_store
@@ -141,7 +141,7 @@ impl PermissionsStore {
     }
 
     /// Persist the trust map (default "personal" domain).
-    pub async fn store_trust_map(&self, map: &TrustMap) -> Result<(), SchemaError> {
+    pub async fn store_trust_map(&self, map: &AccessMap) -> Result<(), SchemaError> {
         self.store_trust_map_for_domain(DOMAIN_PERSONAL, map).await
     }
 

--- a/src/db_operations/trust_operations.rs
+++ b/src/db_operations/trust_operations.rs
@@ -2,7 +2,7 @@
 //! persistence. Real implementations live on
 //! [`super::permissions_store::PermissionsStore`].
 
-use crate::access::types::TrustMap;
+use crate::access::types::AccessMap;
 use crate::access::{AuditEvent, AuditLog};
 use crate::schema::SchemaError;
 
@@ -10,12 +10,12 @@ use super::DbOperations;
 
 impl DbOperations {
     /// Load the trust map for a specific domain.
-    pub async fn load_trust_map_for_domain(&self, domain: &str) -> Result<TrustMap, SchemaError> {
+    pub async fn load_trust_map_for_domain(&self, domain: &str) -> Result<AccessMap, SchemaError> {
         self.permissions().load_trust_map_for_domain(domain).await
     }
 
     /// Load the trust map (default "personal" domain).
-    pub async fn load_trust_map(&self) -> Result<TrustMap, SchemaError> {
+    pub async fn load_trust_map(&self) -> Result<AccessMap, SchemaError> {
         self.permissions().load_trust_map().await
     }
 
@@ -23,7 +23,7 @@ impl DbOperations {
     pub async fn store_trust_map_for_domain(
         &self,
         domain: &str,
-        map: &TrustMap,
+        map: &AccessMap,
     ) -> Result<(), SchemaError> {
         self.permissions()
             .store_trust_map_for_domain(domain, map)
@@ -31,7 +31,7 @@ impl DbOperations {
     }
 
     /// Persist the trust map (default "personal" domain).
-    pub async fn store_trust_map(&self, map: &TrustMap) -> Result<(), SchemaError> {
+    pub async fn store_trust_map(&self, map: &AccessMap) -> Result<(), SchemaError> {
         self.permissions().store_trust_map(map).await
     }
 


### PR DESCRIPTION
## Summary

Final slice of the \`TrustTier → AccessTier\` rename. With fold_db's own call sites migrated ([#552](https://github.com/EdgeVector/fold_db/pull/552)) and fold_db_node migrated ([fold_db_node #514](https://github.com/EdgeVector/fold_db_node/pull/514)), the \`pub type TrustTier = AccessTier\` and \`pub type TrustMap = AccessMap\` aliases in \`src/access/types.rs\` have no remaining consumers. Removed.

Also cleans up 2 stragglers in \`db_operations/\` that slice 2 missed.

## Diff

\`\`\`
src/access/types.rs                    | 14 --------------
src/db_operations/permissions_store.rs | 14 +++++++-------
src/db_operations/trust_operations.rs  | 10 +++++-----
\`\`\`

## Scope note

exemem-infra has \`min_trust_tier: Option<i32>\` and a Postgres column \`min_trust_tier INT\` but never imports the Rust enum. No Rust rename needed there. The DB column rename is a separate concern (requires migration) and out of scope for this pass.

## Final workspace vocabulary (matches corrected manifesto)

- \`AccessTier\` — the 0-4 enum
- \`min_read_tier\` / \`min_write_tier\` — policy side (already correct)
- \`trust_tier\` — kept as field/variable name on relationship-side structures (Persona, sharing audit) because "trust" is the right natural word on the subject side
- \`TrustInvite\` / (future) \`TrustGraph\` / (future) \`TrustDomain\` — kept named after trust because they describe relational state

## Test plan

- [x] \`cargo build\` → clean
- [x] \`cargo test --lib\` → 574 passed
- [x] \`cargo test --workspace --all-targets --no-run\` → all crates compile
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` → clean
- [x] \`cargo fmt --check\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)