### PR TITLE
feat(native_index): add pure detect_faces method

### DIFF
--- a/src/db_operations/native_index/mod.rs
+++ b/src/db_operations/native_index/mod.rs
@@ -12,9 +12,9 @@ mod tests;
 pub use embedding_index::cosine_similarity;
 pub use embedding_index::FaceListEntry;
 pub use embedding_model::{Embedder, FastEmbedModel};
-pub use face::FaceEmbedding;
 #[cfg(any(test, feature = "test-utils"))]
 pub use embedding_model::{MockEmbeddingModel, ScriptedEmbeddingModel};
+pub use face::FaceEmbedding;
 pub use types::IndexResult;
 
 use crate::schema::types::key_value::KeyValue;
@@ -190,10 +190,7 @@ impl NativeIndexManager {
 
     /// Detect faces and return embeddings without mutating the index. Callers that also want the index updated should use `index_faces`.
     #[cfg(feature = "face-detection")]
-    pub fn detect_faces(
-        &self,
-        image_bytes: &[u8],
-    ) -> Result<Vec<FaceEmbedding>, SchemaError> {
+    pub fn detect_faces(&self, image_bytes: &[u8]) -> Result<Vec<FaceEmbedding>, SchemaError> {
         let processor = self
             .face_processor
             .get()

--- a/src/db_operations/native_index/mod.rs
+++ b/src/db_operations/native_index/mod.rs
@@ -12,6 +12,7 @@ mod tests;
 pub use embedding_index::cosine_similarity;
 pub use embedding_index::FaceListEntry;
 pub use embedding_model::{Embedder, FastEmbedModel};
+pub use face::FaceEmbedding;
 #[cfg(any(test, feature = "test-utils"))]
 pub use embedding_model::{MockEmbeddingModel, ScriptedEmbeddingModel};
 pub use types::IndexResult;
@@ -185,6 +186,19 @@ impl NativeIndexManager {
     #[cfg(feature = "face-detection")]
     pub fn set_face_processor(&self, processor: Arc<dyn FaceProcessor>) {
         let _ = self.face_processor.set(processor);
+    }
+
+    /// Detect faces and return embeddings without mutating the index. Callers that also want the index updated should use `index_faces`.
+    #[cfg(feature = "face-detection")]
+    pub fn detect_faces(
+        &self,
+        image_bytes: &[u8],
+    ) -> Result<Vec<FaceEmbedding>, SchemaError> {
+        let processor = self
+            .face_processor
+            .get()
+            .ok_or_else(|| SchemaError::InvalidData("No face processor configured".to_string()))?;
+        processor.detect_and_embed(image_bytes)
     }
 
     /// Detect faces in an image, embed each face, and store the embeddings.

--- a/src/db_operations/native_index/tests.rs
+++ b/src/db_operations/native_index/tests.rs
@@ -215,3 +215,17 @@ async fn test_null_field_skipped() {
     assert_eq!(entries.len(), 1, "Null field should be skipped");
     assert_eq!(entries[0].field_name, "content");
 }
+
+#[cfg(feature = "face-detection")]
+#[tokio::test]
+async fn test_detect_faces_errors_without_processor() {
+    let mgr = make_manager().await;
+    let result = mgr.detect_faces(b"not-an-image");
+    assert!(result.is_err(), "expected error when no face processor configured");
+    let msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        msg.contains("No face processor configured"),
+        "unexpected error: {}",
+        msg
+    );
+}

--- a/src/db_operations/native_index/tests.rs
+++ b/src/db_operations/native_index/tests.rs
@@ -221,7 +221,10 @@ async fn test_null_field_skipped() {
 async fn test_detect_faces_errors_without_processor() {
     let mgr = make_manager().await;
     let result = mgr.detect_faces(b"not-an-image");
-    assert!(result.is_err(), "expected error when no face processor configured");
+    assert!(
+        result.is_err(),
+        "expected error when no face processor configured"
+    );
     let msg = format!("{:?}", result.unwrap_err());
     assert!(
         msg.contains("No face processor configured"),


### PR DESCRIPTION
## Summary

Adds `NativeIndexManager::detect_faces(image_bytes) -> Result<Vec<FaceEmbedding>, SchemaError>` — a pure-compute variant of the existing `index_faces` that returns face embeddings without mutating the embedding index.

The existing `index_faces` detects faces, embeds them, AND persists them. This new method exposes the detection-only path so callers that just want to score/match faces (without storing) can use it.

Also re-exports `FaceEmbedding` at the `db_operations::native_index` module level for downstream use.

## Why

The fold_db_node detect-faces-endpoint project (`projects/detect-faces-endpoint`) needs a pure detection endpoint for self-identity face capture. fold_db_node can't compose this from the existing API because the `face_processor` field on `NativeIndexManager` is private.

## Test plan

- [x] Unit test: `detect_faces` returns an error when no face processor is configured
- [x] `cargo clippy --all-targets -- -D warnings` (default features)
- [x] `cargo clippy --all-targets --features face-detection -- -D warnings`
- [x] `cargo test --all-targets`
- [x] `cargo test --features face-detection --lib db_operations::native_index::tests::test_detect_faces`