### PR TITLE
docs(llm_registry): clarify Anthropic constant usage

### DIFF
--- a/src/llm_registry/models.rs
+++ b/src/llm_registry/models.rs
@@ -5,12 +5,15 @@
 
 // ---- Anthropic Models ----
 
-/// Fast, cheap model for structured classification tasks.
-/// Used by: schema service field classification (`fold_db`).
+/// Fast, cheap model for structured classification tasks. Default for ingestion.
+/// Used by: schema service field classification (`fold_db`),
+/// `fold_db_node` ingestion schema analysis (matches Sonnet quality at ~67%
+/// the cost and ~2.5x the speed — see `autoresearch-ingestion/evaluate_anthropic.py`).
 pub const ANTHROPIC_HAIKU: &str = "claude-haiku-4-5-20251001";
 
-/// Default model for complex reasoning tasks (ingestion, query analysis, agents).
-/// Used by: `fold_db_node` ingestion + LLM query service.
+/// Higher-reasoning model for natural-language query analysis and agents.
+/// Used by: `fold_db_node` LLM query service (override on top of the
+/// ingestion default in `IngestionConfig::default()`).
 pub const ANTHROPIC_SONNET: &str = "claude-sonnet-4-20250514";
 
 /// OpenRouter-style model path for Sonnet.


### PR DESCRIPTION
## Summary

Doc-comment only update on the two Anthropic model constants to reflect that Haiku 4.5 is now the default for fold_db_node ingestion (see companion PR EdgeVector/fold_db_node#543). No functional change.

- `ANTHROPIC_HAIKU`: now also the ingestion default; note it matches Sonnet quality on the eval.
- `ANTHROPIC_SONNET`: now only used for the LLM query path via the explicit override in `IngestionConfig::default()`.

Eval evidence: 8-case rubric in `autoresearch-ingestion/evaluate_anthropic.py` (workspace PR `feat/autoresearch-anthropic-evaluator`) — both models score 0.900 avg, Haiku is 2.5x faster and ~67% cheaper.

## Test plan

- [x] Comment-only change; `cargo test` in this crate unaffected.
- [x] Companion change in fold_db_node pins defaults accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)