### PR TITLE
feat(face-detection): bundle ONNX models at build time (fix E2E 90s timeout)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,17 @@ zip = { version = "2", optional = true, default-features = false, features = ["d
 
 ed25519-compact = "2.2.0"
 
+# Build-time dependencies used by build.rs to download + extract the
+# InsightFace face-detection model pack into OUT_DIR when the
+# `face-detection` cargo feature is enabled. Keeping them as
+# build-dependencies (not normal `dependencies`) means the compiled
+# binary carries no extra runtime code — the model bytes are pulled
+# in via `include_bytes!` and the download machinery exists only at
+# build time.
+[build-dependencies]
+ureq = "2"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "full"] }
 reqwest = { version = "0.11", features = ["json"] }

--- a/build.rs
+++ b/build.rs
@@ -1,32 +1,110 @@
+//! Build script for `fold_db`.
+//!
+//! When the `face-detection` feature is on, this script fetches the
+//! InsightFace `buffalo_sc` model pack at build time, extracts the two
+//! ONNX files the runtime uses (SCRFD detector + ArcFace embedder),
+//! and drops them in `OUT_DIR` so the face-detection module embeds
+//! them via `include_bytes!`. Prior to this, the runtime code pulled
+//! the same zip from GitHub on first use — which broke the E2E harness
+//! (90-second budget vs download + extract + detect) and penalized
+//! every fresh deploy and every ephemeral test environment.
+//!
+//! Files land in `OUT_DIR` so they never enter the source tree or the
+//! git repo. Cargo caches `OUT_DIR` between incremental builds, so
+//! repeat builds don't re-download. `cargo:rerun-if-env-changed` lets
+//! callers pin a different URL (e.g. a local mirror) via
+//! `FOLDDB_FACE_MODEL_PACK_URL` without editing this file.
+
 fn main() {
-    // Ensure the static-react/dist directory exists so that RustEmbed doesn't panic
-    // Only generate placeholder assets if we are NOT packaging (cargo publish)
-    // Cargo publish verification fails if build.rs modifies the source directory.
-    // We detect packaging by checking if the manifest dir is read-only or if we are in a special mode.
-    // A simpler heuristic: usage of TARGET or CARGO_MANIFEST_DIR often implies build.
-
-    // Better yet: only create if they don't exist AND we are not in a packaged build context?
-    // Actually, simply relying on .gitignore is not enough for cargo publish verify.
-    // We should output to OUT_DIR instead, but that requires changing the RustEmbed path.
-    // For now, let's just create them if they are completely missing, but handle errors gracefully
-    // and potentially skip if the directory seems to be the package source during verify.
-
-    // BUT, the user asked to "remove it as part of the publishing step" if it's not working.
-    // Since we determined `src/server/static-react/dist` seems UNUSED by Rust code (grep failed),
-    // maybe we can just remove this block entirely or comment it out?
-
-    // Let's comment closely.
-    // However, if I remove it, and something DOES use it (maybe I missed it), build might fail.
-    // But grep "react" in src/fold_node yielded nothing.
-    // Let's try pointing it to the RIGHT place if `src/server/static-react/dist` is what matters.
-
-    // Wait, the user said "If the frontend part isn't working, remove it as part of the publishing step".
-    // I will modify build.rs to ONLY print rerun-if-changed and NOT create files.
-
-    // Ensure the static-react/dist directory exists so that RustEmbed doesn't panic
-    // let path = std::path::Path::new("src/server/static-react/dist");
-    // ... all commented out ...
     println!("cargo:rerun-if-changed=build.rs");
 
-    println!("cargo:rerun-if-changed=build.rs");
+    #[cfg(feature = "face-detection")]
+    face_detection::fetch_and_extract_models();
+}
+
+#[cfg(feature = "face-detection")]
+mod face_detection {
+    use std::io::Read;
+    use std::path::PathBuf;
+
+    const DEFAULT_MODEL_PACK_URL: &str =
+        "https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_sc.zip";
+
+    // Names inside the InsightFace buffalo_sc zip.
+    const SCRFD_ZIP_NAME: &str = "det_500m.onnx";
+    const ARCFACE_ZIP_NAME: &str = "w600k_mbf.onnx";
+
+    // Output file names the runtime `ModelManager` reads via `include_bytes!`.
+    // Kept aligned with the filenames the pre-bundling runtime wrote to disk
+    // so log lines and external docs stay accurate.
+    const SCRFD_OUT_NAME: &str = "scrfd_2.5g_bnkps.onnx";
+    const ARCFACE_OUT_NAME: &str = "arcface_r100.onnx";
+
+    pub fn fetch_and_extract_models() {
+        println!("cargo:rerun-if-env-changed=FOLDDB_FACE_MODEL_PACK_URL");
+
+        let out_dir =
+            PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR set by cargo in build.rs"));
+        let scrfd_out = out_dir.join(SCRFD_OUT_NAME);
+        let arcface_out = out_dir.join(ARCFACE_OUT_NAME);
+
+        // Cache: if both files are already in OUT_DIR from a previous build,
+        // skip the download entirely. That's what keeps incremental rebuilds
+        // fast even with `face-detection` on.
+        if scrfd_out.exists() && arcface_out.exists() {
+            return;
+        }
+
+        let url = std::env::var("FOLDDB_FACE_MODEL_PACK_URL")
+            .unwrap_or_else(|_| DEFAULT_MODEL_PACK_URL.to_string());
+        println!(
+            "cargo:warning=fold_db build.rs: fetching face-detection models from {url} (~15MB)"
+        );
+
+        let response = ureq::get(&url)
+            .call()
+            .unwrap_or_else(|e| panic!("fold_db build.rs: failed to GET {url}: {e}"));
+        let mut zip_bytes = Vec::new();
+        response
+            .into_reader()
+            .read_to_end(&mut zip_bytes)
+            .expect("fold_db build.rs: failed to read zip body");
+
+        let cursor = std::io::Cursor::new(zip_bytes);
+        let mut archive =
+            zip::ZipArchive::new(cursor).expect("fold_db build.rs: failed to parse buffalo_sc.zip");
+
+        let mut wrote_scrfd = false;
+        let mut wrote_arcface = false;
+        for i in 0..archive.len() {
+            let mut entry = archive
+                .by_index(i)
+                .expect("fold_db build.rs: failed to read zip entry");
+            let name = entry.name().to_string();
+            let dest = if name.contains(SCRFD_ZIP_NAME) || name.ends_with(SCRFD_ZIP_NAME) {
+                wrote_scrfd = true;
+                &scrfd_out
+            } else if name.contains(ARCFACE_ZIP_NAME) || name.ends_with(ARCFACE_ZIP_NAME) {
+                wrote_arcface = true;
+                &arcface_out
+            } else {
+                continue;
+            };
+            let mut contents = Vec::new();
+            entry
+                .read_to_end(&mut contents)
+                .expect("fold_db build.rs: failed to extract entry");
+            std::fs::write(dest, &contents)
+                .unwrap_or_else(|e| panic!("fold_db build.rs: failed to write {dest:?}: {e}"));
+        }
+
+        assert!(
+            wrote_scrfd,
+            "fold_db build.rs: {SCRFD_ZIP_NAME} not found in {url}"
+        );
+        assert!(
+            wrote_arcface,
+            "fold_db build.rs: {ARCFACE_ZIP_NAME} not found in {url}"
+        );
+    }
 }

--- a/src/db_operations/native_index/face/model.rs
+++ b/src/db_operations/native_index/face/model.rs
@@ -1,21 +1,35 @@
-use std::io::{Cursor, Read};
+//! Model manager for the face-detection pipeline.
+//!
+//! Exposes paths to two ONNX models — SCRFD (detector) and ArcFace
+//! (embedder). The bytes are embedded in the binary at compile time
+//! (see `build.rs`, which downloads the InsightFace `buffalo_sc` pack
+//! and drops the extracted files in `OUT_DIR`). At runtime we materialize
+//! them to a per-`FOLDDB_HOME` directory the first time they're
+//! requested, because `ort` (ONNX Runtime) takes a filesystem path, not
+//! a byte slice.
+//!
+//! Why bundle instead of download-on-first-use:
+//! - The previous implementation pulled the pack from GitHub on demand,
+//!   which broke the E2E harness (90-second timeout vs. network fetch +
+//!   extract + model load) and penalized every ephemeral environment.
+//! - The E2E symptom: `ERROR: ingestion wrote 1 records but face
+//!   detection produced 0 faces after 90s`. See CI run 24618304745.
+//! - The bundled bytes add ~15MB to the binary, which is immaterial
+//!   against the `folddb_server` debug binary size.
+
 use std::path::{Path, PathBuf};
 
 use crate::schema::SchemaError;
 
 const MODELS_DIR: &str = "models";
 
-/// Model pack URL (InsightFace buffalo_sc — smallest pack, ~15MB)
-/// Contains det_500m.onnx (SCRFD, 2.5MB) and w600k_mbf.onnx (MobileFaceNet, 13MB)
-const MODEL_PACK_URL: &str =
-    "https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_sc.zip";
-
 const SCRFD_FILENAME: &str = "scrfd_2.5g_bnkps.onnx";
 const ARCFACE_FILENAME: &str = "arcface_r100.onnx";
 
-// Names inside the zip
-const SCRFD_ZIP_NAME: &str = "det_500m.onnx";
-const ARCFACE_ZIP_NAME: &str = "w600k_mbf.onnx";
+/// SCRFD detector, embedded at compile time by `build.rs`.
+const SCRFD_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/scrfd_2.5g_bnkps.onnx"));
+/// ArcFace embedder, embedded at compile time by `build.rs`.
+const ARCFACE_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/arcface_r100.onnx"));
 
 pub struct ModelManager {
     models_dir: PathBuf,
@@ -28,92 +42,97 @@ impl ModelManager {
         }
     }
 
+    /// Path to the SCRFD detector ONNX file. Materializes the embedded
+    /// bytes to `<folddb_home>/models/scrfd_2.5g_bnkps.onnx` on first
+    /// call and returns that path on subsequent calls.
     pub fn scrfd_path(&self) -> Result<PathBuf, SchemaError> {
-        let path = self.models_dir.join(SCRFD_FILENAME);
-        if path.exists() {
-            return Ok(path);
-        }
-        self.download_model_pack()?;
-        if path.exists() {
-            Ok(path)
-        } else {
-            Err(SchemaError::InvalidData(
-                "SCRFD model not found after download".to_string(),
-            ))
-        }
+        self.ensure_extracted(SCRFD_FILENAME, SCRFD_BYTES)
     }
 
+    /// Path to the ArcFace embedder ONNX file. Same materialization
+    /// contract as [`scrfd_path`].
     pub fn arcface_path(&self) -> Result<PathBuf, SchemaError> {
-        let path = self.models_dir.join(ARCFACE_FILENAME);
-        if path.exists() {
-            return Ok(path);
-        }
-        self.download_model_pack()?;
-        if path.exists() {
-            Ok(path)
-        } else {
-            Err(SchemaError::InvalidData(
-                "ArcFace model not found after download".to_string(),
-            ))
-        }
+        self.ensure_extracted(ARCFACE_FILENAME, ARCFACE_BYTES)
     }
 
-    fn download_model_pack(&self) -> Result<(), SchemaError> {
+    /// Ensure the given model file exists on disk, writing the embedded
+    /// bytes if it's missing. Idempotent.
+    fn ensure_extracted(&self, filename: &str, bytes: &[u8]) -> Result<PathBuf, SchemaError> {
+        let dest = self.models_dir.join(filename);
+        if dest.exists() {
+            return Ok(dest);
+        }
+
         std::fs::create_dir_all(&self.models_dir).map_err(|e| {
-            SchemaError::InvalidData(format!("Failed to create models directory: {e}"))
+            SchemaError::InvalidData(format!(
+                "Failed to create models directory {:?}: {e}",
+                self.models_dir
+            ))
         })?;
 
-        log::info!("Downloading face models from {} ...", MODEL_PACK_URL);
+        // Write atomically so a concurrent reader can't observe a
+        // half-written ONNX file. Rust's `std::fs::write` is not
+        // atomic, but a rename from a sibling temp file is on the same
+        // filesystem.
+        let tmp = self.models_dir.join(format!(".{filename}.tmp"));
+        std::fs::write(&tmp, bytes)
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to write {tmp:?}: {e}")))?;
+        std::fs::rename(&tmp, &dest).map_err(|e| {
+            SchemaError::InvalidData(format!("Failed to rename {tmp:?} -> {dest:?}: {e}"))
+        })?;
+        log::info!(
+            "Extracted bundled face model {} ({} bytes)",
+            dest.display(),
+            bytes.len()
+        );
+        Ok(dest)
+    }
+}
 
-        // Use ureq (not reqwest::blocking) because reqwest::blocking panics
-        // when called inside a tokio async runtime.
-        let response = ureq::get(MODEL_PACK_URL)
-            .call()
-            .map_err(|e| SchemaError::InvalidData(format!("Failed to download models: {e}")))?;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        let mut bytes = Vec::new();
-        response
-            .into_reader()
-            .read_to_end(&mut bytes)
-            .map_err(|e| SchemaError::InvalidData(format!("Failed to read model bytes: {e}")))?;
+    #[test]
+    fn bundled_bytes_are_nonempty_and_match_expected_sizes() {
+        // buffalo_sc v0.7: det_500m.onnx ≈ 2.5MB, w600k_mbf.onnx ≈ 13MB.
+        // Exact sizes can shift if InsightFace re-publishes the release,
+        // so we only sanity-check orders of magnitude.
+        assert!(
+            SCRFD_BYTES.len() > 1_000_000,
+            "SCRFD bytes suspiciously small: {}",
+            SCRFD_BYTES.len()
+        );
+        assert!(
+            ARCFACE_BYTES.len() > 5_000_000,
+            "ArcFace bytes suspiciously small: {}",
+            ARCFACE_BYTES.len()
+        );
+    }
 
-        log::info!("Downloaded {} bytes", bytes.len());
+    #[test]
+    fn ensure_extracted_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = ModelManager::new(tmp.path());
+        let p1 = mgr.scrfd_path().unwrap();
+        let p2 = mgr.scrfd_path().unwrap();
+        assert_eq!(p1, p2);
+        assert!(p1.exists());
+        assert_eq!(
+            std::fs::metadata(&p1).unwrap().len() as usize,
+            SCRFD_BYTES.len()
+        );
+    }
 
-        // Extract ONNX files from the zip
-        let cursor = Cursor::new(&bytes);
-        let mut archive = zip::ZipArchive::new(cursor)
-            .map_err(|e| SchemaError::InvalidData(format!("Failed to open model zip: {e}")))?;
-
-        for i in 0..archive.len() {
-            let mut file = archive
-                .by_index(i)
-                .map_err(|e| SchemaError::InvalidData(format!("Failed to read zip entry: {e}")))?;
-
-            let name = file.name().to_string();
-            if !name.ends_with(".onnx") {
-                continue;
-            }
-
-            // Map zip filenames to our canonical names
-            let dest_name = if name.contains(SCRFD_ZIP_NAME) || name.ends_with(SCRFD_ZIP_NAME) {
-                SCRFD_FILENAME
-            } else if name.contains(ARCFACE_ZIP_NAME) || name.ends_with(ARCFACE_ZIP_NAME) {
-                ARCFACE_FILENAME
-            } else {
-                continue;
-            };
-
-            let dest = self.models_dir.join(dest_name);
-            let mut contents = Vec::new();
-            file.read_to_end(&mut contents).map_err(|e| {
-                SchemaError::InvalidData(format!("Failed to extract {}: {e}", name))
-            })?;
-            std::fs::write(&dest, &contents).map_err(|e| {
-                SchemaError::InvalidData(format!("Failed to write {}: {e}", dest.display()))
-            })?;
-            log::info!("Extracted {} ({} bytes)", dest.display(), contents.len());
-        }
-
-        Ok(())
+    #[test]
+    fn both_model_files_extracted_to_expected_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = ModelManager::new(tmp.path());
+        let scrfd = mgr.scrfd_path().unwrap();
+        let arcface = mgr.arcface_path().unwrap();
+        assert!(scrfd.ends_with("models/scrfd_2.5g_bnkps.onnx"));
+        assert!(arcface.ends_with("models/arcface_r100.onnx"));
+        assert!(scrfd.exists());
+        assert!(arcface.exists());
     }
 }


### PR DESCRIPTION
## Summary

Replaces the runtime \`download-buffalo_sc.zip-from-GitHub-on-first-use\` flow with a compile-time fetch. The two ONNX files (SCRFD detector + ArcFace embedder, ~15MB total) are downloaded by \`build.rs\` into \`OUT_DIR\` and embedded via \`include_bytes!\`. The runtime \`ModelManager\` materializes them from memory to \`\$FOLDDB_HOME/models/\` the first time ORT asks for a path.

## Motivation

E2E run 24618304745 — the one where everything else was green (Anthropic vision backend, schema service cold-start fix) — still hit this:

\`\`\`
INFO  Downloading face models from https://github.com/.../buffalo_sc.zip ...
INFO  Downloaded 14969382 bytes
INFO  Extracted scrfd_2.5g_bnkps.onnx ... arcface_r100.onnx ...
INFO  SIGTERM received
[step] ERROR: ingestion wrote 1 records but face detection produced 0 faces after 90s.
\`\`\`

The 90-second harness budget isn't enough for a cold download + extract + ORT session load + actual detection. Every ephemeral environment (E2E CI, dev installs, transient Lambda containers) pays this cost.

## Changes

- \`build.rs\`: when the \`face-detection\` feature is on, downloads \`buffalo_sc.zip\`, extracts \`det_500m.onnx\` and \`w600k_mbf.onnx\` into \`OUT_DIR\`. Cached between incremental builds. \`FOLDDB_FACE_MODEL_PACK_URL\` env var lets callers pin a different URL (local mirror / internal hosting).
- \`Cargo.toml\`: adds \`[build-dependencies]\` \`ureq = "2"\` + \`zip = "2"\`. The runtime no longer fetches models.
- \`src/db_operations/native_index/face/model.rs\`: embedded \`SCRFD_BYTES\` / \`ARCFACE_BYTES\` via \`include_bytes!\`; runtime \`ensure_extracted\` writes to disk atomically (temp-file + rename) on first use. Drops the \`ureq\` + \`zip\` runtime imports from this file.

Binary size impact: ~+15MB. The \`folddb_server\` debug binary is already ~80MB; the model is a negligible fraction of dogfood artifacts.

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --features face-detection --all-targets -- -D warnings\` clean
- [x] 3 new unit tests passing (bundled bytes non-empty, idempotent extraction, both files at expected paths)
- [ ] After merge + fold_db_node rebuild, next E2E run on \`face-discovery-self.yaml\` should clear the 90s face-detection timeout and produce fingerprint records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)