### PR TITLE
feat(sync): SyncEngine::backup_snapshot() for on-demand snapshot uploads (B4)

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1595,8 +1595,7 @@ impl SyncEngine {
             self.device_id,
         );
 
-        let snapshot =
-            Snapshot::create(self.store.as_ref(), &self.device_id, current_seq).await?;
+        let snapshot = Snapshot::create(self.store.as_ref(), &self.device_id, current_seq).await?;
         let namespace_count = snapshot.namespaces.len();
         let sealed = snapshot.seal(&self.crypto).await?;
 

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1575,6 +1575,49 @@ impl SyncEngine {
     }
 
     // =========================================================================
+    // User-triggered snapshot backup
+    // =========================================================================
+
+    /// Create a snapshot of the current local store and upload it to the cloud.
+    ///
+    /// The snapshot is sealed with the personal crypto provider, uploaded under
+    /// both `snapshots/{seq}.enc` (point-in-time) and `snapshots/latest.enc`
+    /// (the key read by `bootstrap_target(0)` on new-device restore). Unlike
+    /// `compact`, this does NOT delete any log entries — it is an explicit
+    /// backup checkpoint users or the CLI can trigger on demand.
+    ///
+    /// Returns the sequence number of the uploaded snapshot.
+    pub async fn backup_snapshot(&self) -> SyncResult<u64> {
+        let current_seq = *self.seq.lock().await;
+        log::info!(
+            "backup_snapshot: creating snapshot at seq {} (device='{}')",
+            current_seq,
+            self.device_id,
+        );
+
+        let snapshot =
+            Snapshot::create(self.store.as_ref(), &self.device_id, current_seq).await?;
+        let namespace_count = snapshot.namespaces.len();
+        let sealed = snapshot.seal(&self.crypto).await?;
+
+        let seq_name = format!("{current_seq}.enc");
+        let seq_url = self.auth.presign_snapshot_upload(&seq_name).await?;
+        self.s3.upload(&seq_url, sealed.clone()).await?;
+
+        let latest_url = self.auth.presign_snapshot_upload("latest.enc").await?;
+        self.s3.upload(&latest_url, sealed).await?;
+
+        log::info!(
+            "backup_snapshot: uploaded {} namespaces at seq {} as 'latest.enc' and '{}' (device='{}')",
+            namespace_count,
+            current_seq,
+            seq_name,
+            self.device_id,
+        );
+        Ok(current_seq)
+    }
+
+    // =========================================================================
     // Lock management
     // =========================================================================
 


### PR DESCRIPTION
## Summary

- Adds `SyncEngine::backup_snapshot()` — creates a snapshot at the current seq, seals, and uploads to both `snapshots/{seq}.enc` and `snapshots/latest.enc`.
- Complements the existing `bootstrap_target(0)` (snapshot download+restore) — together these are the full B4 round-trip.
- Does NOT delete log entries (unlike `compact()`). This is an explicit user-triggered checkpoint, not a compaction.

## Context

Part of [alpha self-dogfood §3 item B4](https://github.com/EdgeVector/exemem-workspace/blob/master/docs/plans/alpha-self-dogfood.md). The snapshot primitive and the restore side already existed — only the upload orchestration was missing. The consumer-side HTTP handler and E2E test land in a follow-up fold_db_node PR.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` green — all 41 sync unit tests + 556 integration tests pass
- [ ] End-to-end backup→restore round-trip verified in the sibling fold_db_node PR (spins up a mock storage_service, exercises backup + bootstrap with real `SyncEngine`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)