### PR TITLE
feat(sync): server-allocated seqs for org uploads (M1)

### DIFF
--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -53,6 +53,10 @@ pub struct PresignedResponse {
     pub ok: bool,
     #[serde(default)]
     pub urls: Vec<PresignedUrl>,
+    /// Sequence numbers assigned by the server (only populated for
+    /// server-allocated org uploads). Ordered alongside `urls`.
+    #[serde(default)]
+    pub seq_numbers: Vec<u64>,
     #[serde(default)]
     pub error: Option<String>,
 }
@@ -317,6 +321,13 @@ impl AuthClient {
 
     /// Post to the presign endpoint and parse the response, returning all URLs.
     async fn presign_urls(&self, body: serde_json::Value) -> SyncResult<Vec<PresignedUrl>> {
+        self.presign_response(body).await.map(|r| r.urls)
+    }
+
+    /// Post to the presign endpoint and return the full parsed response —
+    /// including any server-assigned `seq_numbers` (for server-allocated org
+    /// uploads).
+    async fn presign_response(&self, body: serde_json::Value) -> SyncResult<PresignedResponse> {
         let action = body
             .get("action")
             .and_then(|v| v.as_str())
@@ -329,7 +340,7 @@ impl AuthClient {
                 parsed.error.unwrap_or_else(|| format!("{action} failed")),
             ));
         }
-        Ok(parsed.urls)
+        Ok(parsed)
     }
 
     /// Presign multiple URLs for a log action (upload or download) on a sync target.
@@ -357,6 +368,50 @@ impl AuthClient {
     ) -> SyncResult<Vec<PresignedUrl>> {
         self.presign_log_urls("presign_log_upload", target, seq_numbers)
             .await
+    }
+
+    /// Ask the server to atomically allocate `count` sequence numbers for an
+    /// org upload and presign matching URLs in the same request. Returns the
+    /// server-assigned seqs paired with their presigned URLs, sorted in
+    /// ascending seq order.
+    ///
+    /// Only valid for org targets (non-empty prefix) — personal uploads
+    /// must keep client-assigned nanosecond seqs because they use the
+    /// single-writer device lock for ordering.
+    pub async fn presign_upload_alloc(
+        &self,
+        target: &super::org_sync::SyncTarget,
+        count: u32,
+    ) -> SyncResult<Vec<(u64, PresignedUrl)>> {
+        if target.prefix.is_empty() {
+            return Err(SyncError::Auth(
+                "presign_upload_alloc requires an org target (empty prefix)".to_string(),
+            ));
+        }
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+        let body = serde_json::json!({
+            "action": "presign_log_upload",
+            "org_hash": target.prefix,
+            "count": count,
+        });
+        let resp = self.presign_response(body).await?;
+        if resp.seq_numbers.len() != resp.urls.len() {
+            return Err(SyncError::Auth(format!(
+                "presign_upload_alloc: seq_numbers ({}) and urls ({}) length mismatch",
+                resp.seq_numbers.len(),
+                resp.urls.len(),
+            )));
+        }
+        if resp.seq_numbers.len() != count as usize {
+            return Err(SyncError::Auth(format!(
+                "presign_upload_alloc: expected {} seqs, got {}",
+                count,
+                resp.seq_numbers.len(),
+            )));
+        }
+        Ok(resp.seq_numbers.into_iter().zip(resp.urls).collect())
     }
 
     /// Presign URLs for downloading log entries from a sync target.
@@ -571,5 +626,86 @@ mod tests {
         let result = cb().await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "network down");
+    }
+
+    #[tokio::test]
+    async fn presign_upload_alloc_rejects_personal_target() {
+        use crate::crypto::CryptoProvider;
+        use crate::sync::org_sync::SyncTarget;
+
+        let http = Arc::new(Client::new());
+        let client = AuthClient::new(
+            http,
+            "http://localhost:9999".to_string(),
+            SyncAuth::ApiKey("test".into()),
+        );
+
+        // Personal target (empty prefix) must be rejected — server-allocated
+        // seqs are only valid for orgs.
+        let target = SyncTarget {
+            label: "personal".to_string(),
+            prefix: String::new(),
+            crypto: Arc::new(crate::crypto::NoOpCryptoProvider) as Arc<dyn CryptoProvider>,
+        };
+        let result = client.presign_upload_alloc(&target, 3).await;
+        assert!(result.is_err(), "personal target should be rejected");
+        let msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            msg.contains("org target"),
+            "error message should mention org target requirement: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn presign_upload_alloc_count_zero_returns_empty() {
+        use crate::crypto::CryptoProvider;
+        use crate::sync::org_sync::SyncTarget;
+
+        let http = Arc::new(Client::new());
+        let client = AuthClient::new(
+            http,
+            "http://localhost:9999".to_string(),
+            SyncAuth::ApiKey("test".into()),
+        );
+
+        let target = SyncTarget {
+            label: "test-org".to_string(),
+            prefix: "0".repeat(64),
+            crypto: Arc::new(crate::crypto::NoOpCryptoProvider) as Arc<dyn CryptoProvider>,
+        };
+        // count = 0 returns immediately with an empty vec and does not hit
+        // the network (so the localhost:9999 non-server does not matter).
+        let result = client.presign_upload_alloc(&target, 0).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn presigned_response_parses_server_assigned_seq_numbers() {
+        // When the server allocates seqs for an org upload, it returns them
+        // alongside the URLs. Old servers (personal upload path) return only
+        // `urls` and the default empty `seq_numbers` must deserialize cleanly.
+        let json_with_seqs = serde_json::json!({
+            "ok": true,
+            "urls": [
+                {"url": "https://s3.example/put-42", "method": "PUT", "expires_in_secs": 900},
+                {"url": "https://s3.example/put-43", "method": "PUT", "expires_in_secs": 900},
+            ],
+            "seq_numbers": [42, 43],
+        });
+        let parsed: PresignedResponse = serde_json::from_value(json_with_seqs).unwrap();
+        assert!(parsed.ok);
+        assert_eq!(parsed.urls.len(), 2);
+        assert_eq!(parsed.seq_numbers, vec![42, 43]);
+
+        let json_without_seqs = serde_json::json!({
+            "ok": true,
+            "urls": [
+                {"url": "https://s3.example/put-1", "method": "PUT", "expires_in_secs": 900},
+            ],
+        });
+        let parsed: PresignedResponse = serde_json::from_value(json_without_seqs).unwrap();
+        assert!(parsed.ok);
+        assert_eq!(parsed.urls.len(), 1);
+        assert!(parsed.seq_numbers.is_empty());
     }
 }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -825,28 +825,64 @@ impl SyncEngine {
     }
 
     /// Upload entries to a single sync target.
+    ///
+    /// Personal targets (empty prefix) upload under each entry's own
+    /// client-assigned nanosecond `entry.seq`. Org targets let the server
+    /// atomically allocate a contiguous block of seqs via
+    /// `presign_upload_alloc`; each entry's `seq` is rewritten to its
+    /// server-assigned value before sealing so the S3 key, the sealed
+    /// payload, and the downloader's parsed seq all agree.
     async fn upload_entries(&self, target: &SyncTarget, entries: &[LogEntry]) -> SyncResult<usize> {
         if entries.is_empty() {
             return Ok(0);
         }
 
-        let mut sealed = Vec::with_capacity(entries.len());
-        for entry in entries {
-            let s = entry.seal(&target.crypto).await?;
-            sealed.push((entry.seq, s));
-        }
+        let is_org = !target.prefix.is_empty();
 
-        let seq_numbers: Vec<u64> = sealed.iter().map(|(seq, _)| *seq).collect();
-        let urls = self.auth.presign_upload(target, &seq_numbers).await?;
-
-        if urls.len() != sealed.len() {
-            return Err(SyncError::Auth(format!(
-                "expected {} presigned URLs for '{}', got {}",
-                sealed.len(),
-                target.label,
-                urls.len()
-            )));
-        }
+        let (sealed, urls): (
+            Vec<(u64, super::log::SealedLogEntry)>,
+            Vec<super::s3::PresignedUrl>,
+        ) = if is_org {
+            let pairs = self
+                .auth
+                .presign_upload_alloc(target, entries.len() as u32)
+                .await?;
+            if pairs.len() != entries.len() {
+                return Err(SyncError::Auth(format!(
+                    "expected {} server-assigned seqs for '{}', got {}",
+                    entries.len(),
+                    target.label,
+                    pairs.len(),
+                )));
+            }
+            let mut sealed = Vec::with_capacity(entries.len());
+            let mut urls = Vec::with_capacity(entries.len());
+            for (entry, (server_seq, url)) in entries.iter().zip(pairs) {
+                let mut rewritten = entry.clone();
+                rewritten.seq = server_seq;
+                let s = rewritten.seal(&target.crypto).await?;
+                sealed.push((server_seq, s));
+                urls.push(url);
+            }
+            (sealed, urls)
+        } else {
+            let mut sealed = Vec::with_capacity(entries.len());
+            for entry in entries {
+                let s = entry.seal(&target.crypto).await?;
+                sealed.push((entry.seq, s));
+            }
+            let seq_numbers: Vec<u64> = sealed.iter().map(|(seq, _)| *seq).collect();
+            let urls = self.auth.presign_upload(target, &seq_numbers).await?;
+            if urls.len() != sealed.len() {
+                return Err(SyncError::Auth(format!(
+                    "expected {} presigned URLs for '{}', got {}",
+                    sealed.len(),
+                    target.label,
+                    urls.len()
+                )));
+            }
+            (sealed, urls)
+        };
 
         let mut uploaded_count = 0;
         for ((seq, s), url) in sealed.into_iter().zip(urls.iter()) {


### PR DESCRIPTION
## Summary

- `AuthClient::presign_upload_alloc(target, count)` asks storage_service to atomically allocate N seqs and presign N upload URLs in one RPC.
- `SyncEngine::upload_entries` branches on `target.prefix`:
  - **Personal** (empty prefix): unchanged — client-assigned nanosecond seqs, single-writer under device lock.
  - **Org** (non-empty prefix): rewrite each `entry.seq` to the server-assigned value before sealing, so the S3 key, the sealed payload, and the downloader's parsed seq all agree.
- `PresignedResponse` now carries an optional `seq_numbers` populated only for server-allocated responses.

## Why

Two-way org sync (alpha plan M1) needs a collision-free seq space when multiple members upload to the same `{org_hash}/log/` prefix. Depends on exemem-infra PR #123 which adds `count`-based allocation to the `presign_log_upload` endpoint.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --all-targets` clean (new tests: `presign_upload_alloc_rejects_personal_target`, `presign_upload_alloc_count_zero_returns_empty`, `presigned_response_parses_server_assigned_seq_numbers`).
- [ ] After exemem-infra #123 deploys to dev: end-to-end two-node dogfood via `/qa-folddb --dogfood` org-sync leg — Tom and Fei each write 10 org-scoped molecules and observe each other's writes within two sync cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)