### PR TITLE
fix(face-detection): multi-scale inference so close-up faces are detected

### DIFF
--- a/src/db_operations/native_index/face/detector.rs
+++ b/src/db_operations/native_index/face/detector.rs
@@ -15,7 +15,20 @@ pub struct FaceDetection {
 
 pub struct ScrfdDetector {
     session: Session,
-    input_size: (u32, u32), // (640, 640)
+    /// Input sizes to evaluate per image. SCRFD det_500m exported from
+    /// buffalo_sc v0.7 is trained with anchors that miss faces occupying
+    /// most of the frame at 640×640 — a close-up portrait (e.g. the
+    /// `test-framework/fixtures/face-*.jpg` selfies) scores max ~0.2 and
+    /// falls below the 0.5 threshold, so no detection is emitted. At
+    /// 320×320 the same face scores ~0.83. To cover both close-ups and
+    /// smaller faces in wider photos we run inference at each listed
+    /// size and merge via NMS.
+    ///
+    /// Reference: InsightFace's own FaceAnalysis with `det_size=(640,640)`
+    /// misses these same fixtures; switching to `det_size=(320,320)`
+    /// detects them. See `fold_db/docs/...` or the face-detection PR
+    /// description for the investigation.
+    input_sizes: Vec<(u32, u32)>,
     conf_threshold: f32,
     nms_threshold: f32,
 }
@@ -31,15 +44,29 @@ impl ScrfdDetector {
 
         Ok(Self {
             session,
-            input_size: (640, 640),
+            input_sizes: vec![(320, 320), (640, 640)],
             conf_threshold: 0.5,
             nms_threshold: 0.4,
         })
     }
 
     pub fn detect(&self, image: &DynamicImage) -> Result<Vec<FaceDetection>, SchemaError> {
+        let mut all = Vec::new();
+        for &size in &self.input_sizes {
+            let dets = self.detect_at_size(image, size)?;
+            all.extend(dets);
+        }
+        self.nms(&mut all);
+        Ok(all)
+    }
+
+    fn detect_at_size(
+        &self,
+        image: &DynamicImage,
+        input_size: (u32, u32),
+    ) -> Result<Vec<FaceDetection>, SchemaError> {
         let (orig_w, orig_h) = image.dimensions();
-        let (input_w, input_h) = self.input_size;
+        let (input_w, input_h) = input_size;
 
         let resized = image.resize_exact(input_w, input_h, FilterType::Lanczos3);
 


### PR DESCRIPTION
## Summary

Fixes the `face-discovery-self.yaml` E2E timeout. Root cause is **not** a hang and not a preprocessing bug — it's that SCRFD `det_500m.onnx` at 640×640 input scores a close-up frontal face at max ~0.20, below the 0.5 threshold, so `index_faces` returns `Ok(0)` and the harness times out waiting on the empty face list.

Verified upstream: InsightFace's own Python \`FaceAnalysis(name='buffalo_sc').prepare(det_size=(640,640))\` returns **0 detections** on the same fixture. Same model at \`det_size=(320,320)\` detects 1 face at 0.83.

## Fix

Run inference at both 320×320 and 640×640, merge raw detections, then NMS. The 320×320 pass catches close-up selfies (our E2E fixtures + typical dogfood selfies); the 640×640 pass keeps sensitivity for smaller faces in wider framings.

Cost: one extra forward pass per image at a ~2.5MB model — ~250ms added on CPU, well inside the 90s harness budget.

## Test plan

- [x] \`cargo check --features face-detection\`
- [x] \`cargo clippy --features face-detection --all-targets -- -D warnings\`
- [x] \`cargo fmt --all --check\`
- [x] Local \`FACE_TEST_IMAGE=... cargo test test_face_detection_real_image\` on all three fixtures:
  - \`face-a.jpg\` → 1 face, conf 0.835 (was 0)
  - \`face-b.jpg\` → 1 face, conf 0.864 (was 0)
  - \`face-c.jpg\` → 1 face, conf 0.841 (was 0)
- [ ] Follow-up: bump \`fold_db\` pointer in \`fold_db_node\`, run \`e2e-cloud.yml\` with \`face-discovery-self.yaml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)