### PR TITLE
feat(factory): inject SledPool into create_fold_db_with_auth_refresh

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -29,6 +29,25 @@ pub async fn create_fold_db_with_auth_refresh(
     e2e_keys: &E2eKeys,
     auth_refresh: Option<crate::sync::AuthRefreshCallback>,
 ) -> FoldDbResult<Arc<FoldDB>> {
+    create_fold_db_with_pool_and_auth_refresh(config, e2e_keys, auth_refresh, None).await
+}
+
+/// Like [`create_fold_db_with_auth_refresh`], but accepts an optional pre-existing
+/// [`SledPool`] to reuse across FoldDB lifetimes.
+///
+/// Why reuse matters: each `SledPool` holds an exclusive OS file lock on the Sled
+/// database directory. Two pools pointing at the same path cannot both be open at
+/// the same time. When a caller (e.g. NodeManager) invalidates and recreates the
+/// FoldDB for the same path — for instance, after `/api/auth/register` activates
+/// cloud sync — handing the same pool into the new instance avoids a
+/// `WouldBlock` race where the old pool's Sled handle is still closing while the
+/// new instance tries to open the same path.
+pub async fn create_fold_db_with_pool_and_auth_refresh(
+    config: &DatabaseConfig,
+    e2e_keys: &E2eKeys,
+    auth_refresh: Option<crate::sync::AuthRefreshCallback>,
+    pool: Option<Arc<SledPool>>,
+) -> FoldDbResult<Arc<FoldDB>> {
     let sync_setup = if let Some(cloud) = &config.cloud_sync {
         let path = std::env::var("FOLD_STORAGE_PATH").unwrap_or_else(|_| "data".to_string());
         let mut setup = SyncSetup::from_exemem(&cloud.api_url, &cloud.api_key, &path);
@@ -38,7 +57,7 @@ pub async fn create_fold_db_with_auth_refresh(
         None
     };
 
-    let db = create_local_fold_db(&config.path, e2e_keys, sync_setup).await?;
+    let db = create_local_fold_db(&config.path, e2e_keys, sync_setup, pool).await?;
 
     // If cloud sync is configured, persist ONLY api_url and user_hash to Sled.
     // API keys and session tokens are per-device secrets stored in credentials.json
@@ -76,13 +95,20 @@ async fn create_local_fold_db(
     path: &std::path::Path,
     e2e_keys: &E2eKeys,
     sync_setup: Option<SyncSetup>,
+    injected_pool: Option<Arc<SledPool>>,
 ) -> FoldDbResult<Arc<FoldDB>> {
     let path_str = path
         .to_str()
         .ok_or_else(|| FoldDbError::Config("Invalid storage path".to_string()))?;
 
-    let pool = Arc::new(SledPool::new(path.to_path_buf()));
-    pool.start_idle_reaper(std::time::Duration::from_secs(30));
+    let pool = match injected_pool {
+        Some(pool) => pool,
+        None => {
+            let pool = Arc::new(SledPool::new(path.to_path_buf()));
+            pool.start_idle_reaper(std::time::Duration::from_secs(30));
+            pool
+        }
+    };
 
     // Create the config store for runtime node configuration.
     // Pass the E2E encryption key so sensitive fields (node identity


### PR DESCRIPTION
## Summary
- Add `create_fold_db_with_pool_and_auth_refresh` — takes an optional pre-existing `Arc<SledPool>` and reuses it instead of always creating a fresh one.
- Existing `create_fold_db` / `create_fold_db_with_auth_refresh` delegate with `None`, so behavior is unchanged for current callers.

## Why

Two `SledPool` instances pointing at the same path cannot both hold Sled's OS file lock at once. When fold_db_node's `NodeManager` invalidates its cached node (e.g. after `/api/auth/register` activates cloud sync) and a follow-up request triggers `create_node` while a background bootstrap task still holds the old pool, today's factory would always call `Arc::new(SledPool::new(...))` and hit `sled::open` -> `WouldBlock`.

That surfaces as HTTP 500 `NODE_CREATION_FAILED` on `/api/sync/status` when called within the first ~500ms after register — see [alpha-e2e-dogfood-run-2-2026-04-19.md](https://github.com/EdgeVector/exemem-workspace/blob/master/docs/dogfood/alpha-e2e-dogfood-run-2-2026-04-19.md) "Sled lock transient error on first post-register `/api/sync/status` call".

This commit is the library-side enabler — the fix on the NodeManager side (reusing one pool across invalidations) ships in the companion fold_db_node PR.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --lib` — 559 passed
- [x] Verified existing `create_fold_db_with_auth_refresh` callers are behavior-preserving (delegates with `None`, factory falls back to the old `SledPool::new(...) + start_idle_reaper` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)