### PR TITLE
fix(sync): propagate org-tagged schemas to peers via org log (af4ba)

### DIFF
--- a/src/db_operations/schema_store.rs
+++ b/src/db_operations/schema_store.rs
@@ -7,6 +7,7 @@
 use crate::schema::{Schema, SchemaError, SchemaState};
 use crate::storage::traits::{KvStore, TypedStore};
 use crate::storage::TypedKvStore;
+use crate::sync::org_sync::strip_org_prefix;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -68,17 +69,31 @@ impl SchemaStore {
     }
 
     /// Store a schema.
+    ///
+    /// When the schema carries an `org_hash`, the entry is ALSO written under
+    /// `{org_hash}:{schema_name}` so `SyncPartitioner` routes that copy to the
+    /// org sync log. Without the dual-write, the partitioner only ever sees
+    /// the bare key and the schema never reaches org peers, leaving them with
+    /// orphaned molecules (alpha BLOCKER af4ba).
     pub async fn store_schema(
         &self,
         schema_name: &str,
         schema: &Schema,
     ) -> Result<(), SchemaError> {
         self.schemas_store.put_item(schema_name, schema).await?;
+        if let Some(org_hash) = schema.org_hash.as_deref() {
+            let org_key = format!("{org_hash}:{schema_name}");
+            self.schemas_store.put_item(&org_key, schema).await?;
+        }
         self.schemas_store.inner().flush().await?;
         Ok(())
     }
 
-    /// Store schema state
+    /// Store schema state.
+    ///
+    /// Mirrors `store_schema`'s dual-write when the schema carries an
+    /// `org_hash` so peers receive the approval state alongside the schema
+    /// body. The `org_hash` is resolved from the stored schema.
     pub async fn store_schema_state(
         &self,
         schema_name: &str,
@@ -87,16 +102,29 @@ impl SchemaStore {
         self.schema_states_store
             .put_item(schema_name, state)
             .await?;
+        if let Some(schema) = self.schemas_store.get_item::<Schema>(schema_name).await? {
+            if let Some(org_hash) = schema.org_hash.as_deref() {
+                let org_key = format!("{org_hash}:{schema_name}");
+                self.schema_states_store.put_item(&org_key, state).await?;
+            }
+        }
         self.schema_states_store.inner().flush().await?;
         Ok(())
     }
 
-    /// Get all schemas
+    /// Get all schemas.
+    ///
+    /// Org-prefixed keys (`{org_hash}:{name}`) are sync routing duplicates of
+    /// the bare-key entry and are filtered out so callers see each schema
+    /// exactly once, under its real name.
     pub async fn get_all_schemas(&self) -> Result<HashMap<String, Schema>, SchemaError> {
         let items: Vec<(String, Schema)> = self.schemas_store.scan_items_with_prefix("").await?;
 
         let mut schemas = HashMap::with_capacity(items.len());
         for (key, mut schema) in items {
+            if strip_org_prefix(&key).is_some() {
+                continue;
+            }
             schema.populate_runtime_fields()?;
             schemas.insert(key, schema);
         }
@@ -124,22 +152,210 @@ impl SchemaStore {
         Ok(items.into_iter().collect())
     }
 
-    /// Get all schema states
+    /// Get all schema states.
+    ///
+    /// Org-prefixed keys are filtered out for the same reason as
+    /// `get_all_schemas`.
     pub async fn get_all_schema_states(&self) -> Result<HashMap<String, SchemaState>, SchemaError> {
         let items: Vec<(String, SchemaState)> =
             self.schema_states_store.scan_items_with_prefix("").await?;
-        Ok(items.into_iter().collect())
+        Ok(items
+            .into_iter()
+            .filter(|(k, _)| strip_org_prefix(k).is_none())
+            .collect())
     }
 
     /// Delete a schema entry (name only) from the schemas namespace.
+    ///
+    /// Resolves `org_hash` from the stored schema and also deletes the
+    /// org-prefixed companion entry so the sync routing copy does not linger.
     pub async fn delete_schema(&self, schema_name: &str) -> Result<(), SchemaError> {
+        let org_hash = self
+            .schemas_store
+            .get_item::<Schema>(schema_name)
+            .await?
+            .and_then(|s| s.org_hash);
         self.schemas_store.delete_item(schema_name).await?;
+        if let Some(org_hash) = org_hash {
+            let org_key = format!("{org_hash}:{schema_name}");
+            self.schemas_store.delete_item(&org_key).await?;
+        }
         Ok(())
     }
 
     /// Delete a schema state entry.
+    ///
+    /// Resolves `org_hash` from the stored schema when it still exists, so
+    /// the companion org-prefixed state entry is also removed. Callers that
+    /// have already deleted the schema first must invoke `delete_schema`
+    /// (which handles both namespaces transitively) instead.
     pub async fn delete_schema_state(&self, schema_name: &str) -> Result<(), SchemaError> {
+        let org_hash = self
+            .schemas_store
+            .get_item::<Schema>(schema_name)
+            .await?
+            .and_then(|s| s.org_hash);
         self.schema_states_store.delete_item(schema_name).await?;
+        if let Some(org_hash) = org_hash {
+            let org_key = format!("{org_hash}:{schema_name}");
+            self.schema_states_store.delete_item(&org_key).await?;
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::Schema;
+    use crate::schema::SchemaState;
+    use crate::storage::inmemory_backend::InMemoryNamespacedStore;
+    use crate::storage::traits::NamespacedStore;
+
+    async fn build_store() -> SchemaStore {
+        let backend = Arc::new(InMemoryNamespacedStore::new()) as Arc<dyn NamespacedStore>;
+        let schemas = Arc::new(TypedKvStore::new(
+            backend.open_namespace("schemas").await.unwrap(),
+        ));
+        let states = Arc::new(TypedKvStore::new(
+            backend.open_namespace("schema_states").await.unwrap(),
+        ));
+        let superseded = Arc::new(TypedKvStore::new(
+            backend.open_namespace("superseded_by").await.unwrap(),
+        ));
+        SchemaStore::new(schemas, states, superseded)
+    }
+
+    fn build_schema(name: &str, org_hash: Option<&str>) -> Schema {
+        let mut v = serde_json::json!({
+            "name": name,
+            "schema_type": "Single",
+            "fields": ["pk"],
+            "field_data_classifications": {
+                "pk": { "sensitivity_level": 0, "data_domain": "general" }
+            }
+        });
+        if let Some(h) = org_hash {
+            v["org_hash"] = serde_json::json!(h);
+            v["trust_domain"] = serde_json::json!(format!("org:{h}"));
+        }
+        serde_json::from_value(v).expect("test schema must deserialize")
+    }
+
+    #[tokio::test]
+    async fn store_schema_dual_writes_when_org_hash_set() {
+        let store = build_store().await;
+        let org_hash = "a".repeat(64);
+        let schema = build_schema("org_notes", Some(&org_hash));
+        store.store_schema("org_notes", &schema).await.unwrap();
+
+        let bare: Option<Schema> = store.schemas_store.get_item("org_notes").await.unwrap();
+        assert!(bare.is_some(), "bare key must be written");
+
+        let org_key = format!("{}:org_notes", org_hash);
+        let prefixed: Option<Schema> = store.schemas_store.get_item(&org_key).await.unwrap();
+        assert!(
+            prefixed.is_some(),
+            "org-prefixed key must be written when org_hash is set so SyncPartitioner routes the copy to the org log"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_schema_personal_writes_only_bare_key() {
+        let store = build_store().await;
+        let schema = build_schema("personal_notes", None);
+        store.store_schema("personal_notes", &schema).await.unwrap();
+
+        let items: Vec<(String, Schema)> = store
+            .schemas_store
+            .scan_items_with_prefix("")
+            .await
+            .unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].0, "personal_notes");
+    }
+
+    #[tokio::test]
+    async fn get_all_schemas_filters_out_org_prefixed_duplicates() {
+        let store = build_store().await;
+        let org_hash = "b".repeat(64);
+        let schema = build_schema("shared_notes", Some(&org_hash));
+        store.store_schema("shared_notes", &schema).await.unwrap();
+
+        let all = store.get_all_schemas().await.unwrap();
+        assert_eq!(
+            all.len(),
+            1,
+            "org-prefixed companion must not surface as a second schema"
+        );
+        assert!(
+            all.contains_key("shared_notes"),
+            "bare name must be the only visible key"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_schema_state_dual_writes_for_org_tagged_schema() {
+        let store = build_store().await;
+        let org_hash = "c".repeat(64);
+        let schema = build_schema("org_notes", Some(&org_hash));
+        store.store_schema("org_notes", &schema).await.unwrap();
+
+        store
+            .store_schema_state("org_notes", &SchemaState::Approved)
+            .await
+            .unwrap();
+
+        let org_key = format!("{}:org_notes", org_hash);
+        let bare: Option<SchemaState> = store
+            .schema_states_store
+            .get_item("org_notes")
+            .await
+            .unwrap();
+        let prefixed: Option<SchemaState> =
+            store.schema_states_store.get_item(&org_key).await.unwrap();
+        assert_eq!(bare, Some(SchemaState::Approved));
+        assert_eq!(
+            prefixed,
+            Some(SchemaState::Approved),
+            "org-prefixed state companion must be written so peers receive approval"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_all_schema_states_filters_out_org_prefixed_duplicates() {
+        let store = build_store().await;
+        let org_hash = "d".repeat(64);
+        let schema = build_schema("org_notes", Some(&org_hash));
+        store.store_schema("org_notes", &schema).await.unwrap();
+        store
+            .store_schema_state("org_notes", &SchemaState::Approved)
+            .await
+            .unwrap();
+
+        let states = store.get_all_schema_states().await.unwrap();
+        assert_eq!(states.len(), 1);
+        assert_eq!(states.get("org_notes"), Some(&SchemaState::Approved));
+    }
+
+    #[tokio::test]
+    async fn delete_schema_removes_both_bare_and_org_prefixed_entries() {
+        let store = build_store().await;
+        let org_hash = "e".repeat(64);
+        let schema = build_schema("org_notes", Some(&org_hash));
+        store.store_schema("org_notes", &schema).await.unwrap();
+
+        store.delete_schema("org_notes").await.unwrap();
+
+        let items: Vec<(String, Schema)> = store
+            .schemas_store
+            .scan_items_with_prefix("")
+            .await
+            .unwrap();
+        assert!(
+            items.is_empty(),
+            "both bare and org-prefixed keys must be removed, got {:?}",
+            items
+        );
     }
 }

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1389,7 +1389,7 @@ impl SyncEngine {
                 key,
                 value,
             } => {
-                let final_key = Self::rewrite_key_if_needed(key, target)?;
+                let final_key = Self::rewrite_key_if_needed(namespace, key, target)?;
                 self.replay_put(
                     namespace,
                     &LogOp::encode_bytes(&final_key),
@@ -1401,12 +1401,12 @@ impl SyncEngine {
             }
             LogOp::Delete { namespace, key } => {
                 let kv = self.store.open_namespace(namespace).await?;
-                let final_key = Self::rewrite_key_if_needed(key, target)?;
+                let final_key = Self::rewrite_key_if_needed(namespace, key, target)?;
                 kv.delete(&final_key).await?;
             }
             LogOp::BatchPut { namespace, items } => {
                 for (key, value) in items {
-                    let final_key = Self::rewrite_key_if_needed(key, target)?;
+                    let final_key = Self::rewrite_key_if_needed(namespace, key, target)?;
                     self.replay_put(
                         namespace,
                         &LogOp::encode_bytes(&final_key),
@@ -1421,7 +1421,7 @@ impl SyncEngine {
                 let kv = self.store.open_namespace(namespace).await?;
                 let decoded: Vec<Vec<u8>> = keys
                     .iter()
-                    .map(|k| Self::rewrite_key_if_needed(k, target))
+                    .map(|k| Self::rewrite_key_if_needed(namespace, k, target))
                     .collect::<SyncResult<Vec<_>>>()?;
                 kv.batch_delete(decoded).await?;
             }
@@ -1429,8 +1429,26 @@ impl SyncEngine {
         Ok(())
     }
 
-    /// Rewrites log entry keys based on namespace isolation rules for ShareSubscriptions.
-    fn rewrite_key_if_needed(key_b64: &str, target: Option<&SyncTarget>) -> SyncResult<Vec<u8>> {
+    /// Rewrites log entry keys based on namespace isolation rules.
+    ///
+    /// Two rewrites apply:
+    ///
+    /// 1. **Share subscriptions** — `{share_prefix}:…` keys replayed from an
+    ///    inbound share become `from:{sender_hash}:…` locally, so the
+    ///    receiver reads shared data through a distinct namespace.
+    /// 2. **Org schemas** — `{org_hash}:{schema_name}` entries replayed into
+    ///    the `schemas` or `schema_states` namespaces from an org target are
+    ///    stripped back to the bare `{schema_name}`. Schemas are addressed
+    ///    by name locally; the org prefix exists only to drive sync routing
+    ///    on the writer side. Without this rewrite, peers would store the
+    ///    schema under a name like `{org_hash}:sync_notes` and name-based
+    ///    lookups (`/api/schemas`, `get_schema`) would miss it — orphaning
+    ///    every org-prefixed molecule (alpha BLOCKER af4ba).
+    fn rewrite_key_if_needed(
+        namespace: &str,
+        key_b64: &str,
+        target: Option<&SyncTarget>,
+    ) -> SyncResult<Vec<u8>> {
         let key_bytes = LogOp::decode_bytes(key_b64)?;
 
         if let Some(t) = target {
@@ -1453,6 +1471,14 @@ impl SyncEngine {
 
                         return Ok(final_key);
                     }
+                }
+            } else if !t.prefix.is_empty()
+                && (namespace == "schemas" || namespace == "schema_states")
+            {
+                let prefix_str = format!("{}:", t.prefix);
+                let prefix_bytes = prefix_str.as_bytes();
+                if key_bytes.starts_with(prefix_bytes) {
+                    return Ok(key_bytes[prefix_bytes.len()..].to_vec());
                 }
             }
         }
@@ -2064,19 +2090,19 @@ mod tests {
     fn test_rewrite_key_share_prefix_to_from_prefix() {
         let target = share_target("share:alice:me");
         let key_b64 = LogOp::encode_bytes(b"share:alice:me:atom:uuid-1");
-        let result = SyncEngine::rewrite_key_if_needed(&key_b64, Some(&target)).unwrap();
+        let result = SyncEngine::rewrite_key_if_needed("main", &key_b64, Some(&target)).unwrap();
         assert_eq!(result, b"from:alice:atom:uuid-1");
     }
 
     #[test]
     fn test_rewrite_key_no_target_passes_through() {
         let key_b64 = LogOp::encode_bytes(b"atom:uuid-1");
-        let result = SyncEngine::rewrite_key_if_needed(&key_b64, None).unwrap();
+        let result = SyncEngine::rewrite_key_if_needed("main", &key_b64, None).unwrap();
         assert_eq!(result, b"atom:uuid-1");
     }
 
     #[test]
-    fn test_rewrite_key_non_share_target_passes_through() {
+    fn test_rewrite_key_org_target_main_namespace_passes_through() {
         use crate::crypto::provider::LocalCryptoProvider;
         let target = SyncTarget {
             label: "org".to_string(),
@@ -2084,9 +2110,50 @@ mod tests {
             crypto: Arc::new(LocalCryptoProvider::from_key([0x10u8; 32])),
         };
         let key_b64 = LogOp::encode_bytes(b"org_hash_abc:atom:uuid-1");
-        let result = SyncEngine::rewrite_key_if_needed(&key_b64, Some(&target)).unwrap();
-        // Non-share target: no rewriting
+        let result = SyncEngine::rewrite_key_if_needed("main", &key_b64, Some(&target)).unwrap();
+        // Non-schema namespace: org prefix stays, because atom/ref keys are
+        // stored org-prefixed locally on every peer.
         assert_eq!(result, b"org_hash_abc:atom:uuid-1");
+    }
+
+    #[test]
+    fn test_rewrite_key_org_target_schemas_namespace_strips_prefix() {
+        use crate::crypto::provider::LocalCryptoProvider;
+        let target = SyncTarget {
+            label: "org".to_string(),
+            prefix: "org_hash_abc".to_string(),
+            crypto: Arc::new(LocalCryptoProvider::from_key([0x10u8; 32])),
+        };
+        let key_b64 = LogOp::encode_bytes(b"org_hash_abc:sync_notes");
+        let result = SyncEngine::rewrite_key_if_needed("schemas", &key_b64, Some(&target)).unwrap();
+        assert_eq!(result, b"sync_notes");
+    }
+
+    #[test]
+    fn test_rewrite_key_org_target_schema_states_namespace_strips_prefix() {
+        use crate::crypto::provider::LocalCryptoProvider;
+        let target = SyncTarget {
+            label: "org".to_string(),
+            prefix: "org_hash_abc".to_string(),
+            crypto: Arc::new(LocalCryptoProvider::from_key([0x10u8; 32])),
+        };
+        let key_b64 = LogOp::encode_bytes(b"org_hash_abc:sync_notes");
+        let result =
+            SyncEngine::rewrite_key_if_needed("schema_states", &key_b64, Some(&target)).unwrap();
+        assert_eq!(result, b"sync_notes");
+    }
+
+    #[test]
+    fn test_rewrite_key_personal_target_schemas_namespace_passes_through() {
+        use crate::crypto::provider::LocalCryptoProvider;
+        let target = SyncTarget {
+            label: "personal".to_string(),
+            prefix: String::new(),
+            crypto: Arc::new(LocalCryptoProvider::from_key([0x10u8; 32])),
+        };
+        let key_b64 = LogOp::encode_bytes(b"sync_notes");
+        let result = SyncEngine::rewrite_key_if_needed("schemas", &key_b64, Some(&target)).unwrap();
+        assert_eq!(result, b"sync_notes");
     }
 
     #[test]
@@ -2094,7 +2161,7 @@ mod tests {
         let target = share_target("share:alice:me");
         // Key has a different prefix than the target
         let key_b64 = LogOp::encode_bytes(b"atom:uuid-1");
-        let result = SyncEngine::rewrite_key_if_needed(&key_b64, Some(&target)).unwrap();
+        let result = SyncEngine::rewrite_key_if_needed("main", &key_b64, Some(&target)).unwrap();
         assert_eq!(result, b"atom:uuid-1");
     }
 

--- a/tests/org_sync_e2e_test.rs
+++ b/tests/org_sync_e2e_test.rs
@@ -444,3 +444,150 @@ async fn test_org_sync_does_not_leak_personal_data() {
         "Personal schema should not exist on node2"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Test: org schema propagates to peer via org-prefixed sync routing
+//
+// Regression cover for alpha BLOCKER af4ba: before the `SchemaStore`
+// dual-write + `SyncEngine::rewrite_key_if_needed` org-prefix strip,
+// org-tagged schemas were only stored under the bare key. The
+// SyncPartitioner then routed them to the writer's personal log, so
+// peers downloading from the org log never received the schema and any
+// molecules they did receive were orphaned.
+//
+// This test simulates the full sync path without the manual
+// `load_schema_internal` shortcut used by earlier tests:
+//
+// 1. Node 1 registers a schema with `org_hash` set — the dual-write puts
+//    both `sync_notes` and `{org_hash}:sync_notes` into the schemas
+//    namespace.
+// 2. The org-log sync is simulated by copying ONLY `{org_hash}:`-prefixed
+//    keys across the `schemas`, `schema_states`, and `main` namespaces to
+//    node 2, then applying the replay-side rewrite (strip org prefix for
+//    the schemas and schema_states namespaces) so node 2's store matches
+//    what `SyncEngine::replay_entry` would produce.
+// 3. Node 2 refreshes its SchemaCore via `reload_from_store` (the same
+//    callback the sync engine fires on schema replay) and must surface
+//    the schema under its bare name and return all 3 molecules.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_org_schema_propagates_via_org_prefixed_sync() {
+    let tmp1 = tempfile::tempdir().unwrap();
+    let tmp2 = tempfile::tempdir().unwrap();
+    let node1 = make_folddb(&tmp1).await;
+    let node2 = make_folddb(&tmp2).await;
+
+    let pool1 = node1.sled_pool().cloned().unwrap();
+    let membership =
+        org_ops::create_org(&pool1, "Propagation Corp", "pubkey_alice", "Alice").unwrap();
+    let org_hash = membership.org_hash.clone();
+
+    register_schema(&node1, "propagation_notes", Some(&org_hash)).await;
+    for i in 1..=3 {
+        write_mutation(
+            &node1,
+            "propagation_notes",
+            &format!("note-{i}"),
+            &format!("2026-04-{i:02}"),
+            &format!("body from node1 #{i}"),
+        )
+        .await;
+    }
+
+    // The dual-write must leave the schema in node 1's Sled under both the
+    // bare name (so local lookup works) and the org-prefixed name (so
+    // partitioning routes the sync copy to the org log).
+    let pool1 = node1.sled_pool().unwrap();
+    let pool2 = node2.sled_pool().unwrap();
+    let guard1 = pool1.acquire_arc().unwrap();
+    let guard2 = pool2.acquire_arc().unwrap();
+    let sled1 = guard1.db();
+    let sled2 = guard2.db();
+
+    let org_prefix = format!("{}:", org_hash);
+    let schemas1 = sled1.open_tree("schemas").unwrap();
+    let states1 = sled1.open_tree("schema_states").unwrap();
+    let main1 = sled1.open_tree("main").unwrap();
+
+    assert!(
+        schemas1
+            .get("propagation_notes".as_bytes())
+            .unwrap()
+            .is_some(),
+        "bare schema key must exist on node 1 for local lookup"
+    );
+    assert!(
+        schemas1
+            .get(format!("{}propagation_notes", org_prefix).as_bytes())
+            .unwrap()
+            .is_some(),
+        "org-prefixed schema key must exist on node 1 so SyncPartitioner routes it to the org log"
+    );
+
+    // Simulate the org-log replay: only `{org_hash}:`-prefixed entries
+    // reach node 2. For schemas and schema_states, the replay rewrite
+    // strips the org prefix before writing, so the schema lands under its
+    // bare name. For the main namespace (atoms, refs), the org prefix is
+    // preserved — peers store org molecules under the same key Alice did.
+    let schemas2 = sled2.open_tree("schemas").unwrap();
+    let states2 = sled2.open_tree("schema_states").unwrap();
+    let main2 = sled2.open_tree("main").unwrap();
+
+    let org_schema_key = format!("{}propagation_notes", org_prefix);
+    let schema_bytes = schemas1
+        .get(org_schema_key.as_bytes())
+        .unwrap()
+        .expect("org-prefixed schema must exist on node 1");
+    schemas2
+        .insert("propagation_notes".as_bytes(), schema_bytes)
+        .unwrap();
+
+    let org_state_key = format!("{}propagation_notes", org_prefix);
+    if let Some(state_bytes) = states1.get(org_state_key.as_bytes()).unwrap() {
+        states2
+            .insert("propagation_notes".as_bytes(), state_bytes)
+            .unwrap();
+    }
+
+    let synced_main = copy_prefixed_keys(&main1, &main2, &org_prefix);
+    assert!(
+        synced_main > 0,
+        "expected org-prefixed atom/ref entries to sync"
+    );
+
+    // The schema reloader callback is what `SyncEngine` fires after a
+    // successful schema replay. Exercise the same entrypoint.
+    node2.schema_manager().reload_from_store().await.unwrap();
+
+    // Node 2 must now see the schema under its bare name — not under the
+    // org-prefixed name, not both. get_all_schemas filters the companion
+    // on the writer side, and the replay strip ensures the peer only has
+    // the bare entry to begin with.
+    let visible: Vec<String> = node2
+        .schema_manager()
+        .get_schemas()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect();
+    assert!(
+        visible.contains(&"propagation_notes".to_string()),
+        "node 2 schemas must include propagation_notes by its bare name — got {:?}",
+        visible
+    );
+    assert!(
+        visible.iter().all(|k| !k.starts_with(&org_prefix)),
+        "node 2 must not surface org-prefixed schema names, got {:?}",
+        visible
+    );
+
+    // Molecules must resolve against the replayed schema — the alpha
+    // thesis in one assertion.
+    let node2_bodies = query_field_values(&node2, "propagation_notes", "body").await;
+    assert_eq!(
+        node2_bodies.len(),
+        3,
+        "node 2 must query all 3 org molecules through the propagated schema"
+    );
+}


### PR DESCRIPTION
## Summary

Alpha BLOCKER **af4ba** — the alpha-thesis gate. `set-org-hash` (and any schema created with `org_hash`) wrote the schema under the bare `{schema_name}` key only. The `SyncPartitioner` partitions by key prefix, so the schema entry routed to the writer's personal log. Peers polling the org log received the molecules but never the schema — orphaning every synced molecule in the two-founder dogfood flow.

## Fix

- `SchemaStore::store_schema` and `store_schema_state` dual-write to `{name}` and `{org_hash}:{name}` when `org_hash` is set, so the partitioner routes the companion copy to the org log.
- `SyncEngine::rewrite_key_if_needed` strips the org prefix back to the bare name on replay into the `schemas` / `schema_states` namespaces, so peers see the schema under its real name.
- `reload_from_store` (already fired by the schema reloader callback) surfaces it via the normal cache path.
- `get_all_schemas` / `get_all_schema_states` filter out the org-prefixed companion so UIs see each schema exactly once.
- `delete_schema` resolves `org_hash` and cleans the companion entry.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean (ts-rs parse warnings only)
- [x] `cargo test --workspace --all-targets` — all pass
- [x] New unit tests on `SchemaStore` for dual-write, filter, and dual-delete (6 tests)
- [x] New unit tests on `SyncEngine::rewrite_key_if_needed` covering schemas, schema_states, main, share, and personal target combinations (4 new tests)
- [x] New integration `test_org_schema_propagates_via_org_prefixed_sync` exercising the end-to-end flow without the `load_schema_internal` shortcut earlier tests used to hide the gap

## Related

- Alpha E2E Dogfood Run 4: https://github.com/EdgeVector/exemem-workspace (see `projects/alpha-e2e-dogfood-run-4` gbrain slug)
- Kanban: af4ba
- Sibling BLOCKER `3e063` (pre-tag molecule dual-read) is in a separate branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)