### PR TITLE
fix(org): preserve trust_domain + auto-approve org schemas on sync (d2f07)

### DIFF
--- a/src/db_operations/schema_store.rs
+++ b/src/db_operations/schema_store.rs
@@ -75,6 +75,12 @@ impl SchemaStore {
     /// org sync log. Without the dual-write, the partitioner only ever sees
     /// the bare key and the schema never reaches org peers, leaving them with
     /// orphaned molecules (alpha BLOCKER af4ba).
+    ///
+    /// The current schema_state (if any) is mirrored to the org-prefixed key
+    /// too, so peers receive approval status together with the schema body.
+    /// Without this, tagging an already-approved schema via `set-org-hash`
+    /// would propagate the schema but leave peers stuck at `Available`
+    /// (alpha papercut d2f07).
     pub async fn store_schema(
         &self,
         schema_name: &str,
@@ -84,6 +90,15 @@ impl SchemaStore {
         if let Some(org_hash) = schema.org_hash.as_deref() {
             let org_key = format!("{org_hash}:{schema_name}");
             self.schemas_store.put_item(&org_key, schema).await?;
+
+            if let Some(state) = self
+                .schema_states_store
+                .get_item::<SchemaState>(schema_name)
+                .await?
+            {
+                self.schema_states_store.put_item(&org_key, &state).await?;
+                self.schema_states_store.inner().flush().await?;
+            }
         }
         self.schemas_store.inner().flush().await?;
         Ok(())
@@ -336,6 +351,60 @@ mod tests {
         let states = store.get_all_schema_states().await.unwrap();
         assert_eq!(states.len(), 1);
         assert_eq!(states.get("org_notes"), Some(&SchemaState::Approved));
+    }
+
+    #[tokio::test]
+    async fn store_schema_mirrors_existing_state_to_org_prefixed_key() {
+        // Ordering: approve the schema first (bare-only state write), then
+        // tag it with org_hash. The subsequent store_schema must carry the
+        // pre-existing state onto the org-prefixed key so peers receive
+        // approval alongside the tagged schema body (papercut d2f07).
+        let store = build_store().await;
+        let org_hash = "f".repeat(64);
+
+        let personal = build_schema("later_tagged", None);
+        store.store_schema("later_tagged", &personal).await.unwrap();
+        store
+            .store_schema_state("later_tagged", &SchemaState::Approved)
+            .await
+            .unwrap();
+
+        // At this point the state lives under the bare key only.
+        let org_key = format!("{}:later_tagged", org_hash);
+        let pre_tag_prefixed: Option<SchemaState> =
+            store.schema_states_store.get_item(&org_key).await.unwrap();
+        assert!(pre_tag_prefixed.is_none());
+
+        // Tagging: store the same schema with org_hash set.
+        let tagged = build_schema("later_tagged", Some(&org_hash));
+        store.store_schema("later_tagged", &tagged).await.unwrap();
+
+        let mirrored: Option<SchemaState> =
+            store.schema_states_store.get_item(&org_key).await.unwrap();
+        assert_eq!(
+            mirrored,
+            Some(SchemaState::Approved),
+            "store_schema must mirror the pre-existing state to the org-prefixed key so the org log carries approval",
+        );
+    }
+
+    #[tokio::test]
+    async fn store_schema_without_prior_state_does_not_mirror_state() {
+        // If no state has been recorded yet, store_schema should not
+        // fabricate one on the org-prefixed key — state propagates later
+        // when the caller explicitly sets it via store_schema_state.
+        let store = build_store().await;
+        let org_hash = "9".repeat(64);
+        let schema = build_schema("fresh_org", Some(&org_hash));
+        store.store_schema("fresh_org", &schema).await.unwrap();
+
+        let org_key = format!("{}:fresh_org", org_hash);
+        let prefixed: Option<SchemaState> =
+            store.schema_states_store.get_item(&org_key).await.unwrap();
+        assert!(
+            prefixed.is_none(),
+            "no state should be written when none exists",
+        );
     }
 
     #[tokio::test]

--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -83,36 +83,81 @@ impl SchemaCore {
         Ok(schema_core)
     }
 
-    /// Reload schemas from the persistent store, merging any newly-discovered
-    /// schemas into the in-memory cache. Existing entries are NOT overwritten
-    /// (additive merge only). Returns the count of newly added schemas.
+    /// Reload schemas from the persistent store.
+    ///
+    /// Refreshes the in-memory cache from disk for both new and changed
+    /// schemas — needed because sync replay writes directly to the
+    /// persistent store and the cache must follow. Existing entries are
+    /// overwritten only when the disk copy differs from the cached copy.
+    ///
+    /// After refresh, any schema carrying an `org_hash` is auto-approved
+    /// if its current state is `Available` (or unset): membership in the
+    /// org implies trust in the schema, so peers shouldn't have to
+    /// manually approve org-shared schemas (alpha papercut d2f07).
+    /// `Blocked` state is preserved.
+    ///
+    /// Returns the number of schemas that were added or refreshed.
     pub async fn reload_from_store(&self) -> Result<usize, SchemaError> {
         let stored_schemas = self.db_ops.get_all_schemas().await?;
         let stored_states = self.db_ops.get_all_schema_states().await?;
 
-        let mut schemas = lock_map(&self.schemas, "schemas")?;
-        let mut states = lock_map(&self.schema_states, "schema_states")?;
+        let mut auto_approve: Vec<String> = Vec::new();
+        let mut changed = 0usize;
 
-        let mut added = 0usize;
-        for (name, mut schema) in stored_schemas {
-            if !schemas.contains_key(&name) {
+        {
+            let mut schemas = lock_map(&self.schemas, "schemas")?;
+            let mut states = lock_map(&self.schema_states, "schema_states")?;
+
+            for (name, mut schema) in stored_schemas {
                 // Ensure runtime_fields are populated — schemas coming from
                 // sync replay won't have them (runtime_fields is #[serde(skip)]).
                 if schema.runtime_fields.is_empty() {
                     schema.populate_runtime_fields()?;
                 }
-                schemas.insert(name.clone(), schema);
-                let state = stored_states.get(&name).copied().unwrap_or_default();
-                states.insert(name, state);
-                added += 1;
+
+                let schema_changed = schemas.get(&name) != Some(&schema);
+                if schema_changed {
+                    schemas.insert(name.clone(), schema);
+                    changed += 1;
+                }
+
+                if let Some(disk_state) = stored_states.get(&name).copied() {
+                    states.insert(name.clone(), disk_state);
+                } else {
+                    states.entry(name.clone()).or_default();
+                }
+            }
+
+            for (name, schema) in schemas.iter() {
+                if schema.org_hash.is_some()
+                    && matches!(
+                        states.get(name).copied().unwrap_or_default(),
+                        SchemaState::Available
+                    )
+                {
+                    auto_approve.push(name.clone());
+                }
+            }
+
+            for name in &auto_approve {
+                states.insert(name.clone(), SchemaState::Approved);
             }
         }
 
-        if added > 0 {
-            log::info!("reload_from_store: added {} new schema(s) to cache", added);
+        for name in auto_approve {
+            self.db_ops
+                .store_schema_state(&name, &SchemaState::Approved)
+                .await?;
         }
 
-        Ok(added)
+        if changed > 0 {
+            log::info!(
+                "reload_from_store: refreshed {} schema(s) in cache",
+                changed
+            );
+        }
+
+        Ok(changed)
     }
 
     pub fn get_schemas(&self) -> Result<HashMap<String, Schema>, SchemaError> {
@@ -916,8 +961,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reload_from_store_preserves_existing() {
-        // Verify that reload_from_store does NOT overwrite schemas already in cache.
+    async fn reload_from_store_is_noop_when_disk_matches_cache() {
+        // Verify that reload_from_store does not report changes when the
+        // persistent store matches the in-memory cache.
         let tmp = tempfile::TempDir::new().expect("tmpdir");
         let pool = std::sync::Arc::new(crate::storage::SledPool::new(tmp.path().to_path_buf()));
         let db_ops = std::sync::Arc::new(
@@ -930,17 +976,172 @@ mod tests {
             .await
             .expect("init core");
 
-        // Load a schema normally (into both cache and Sled)
+        // Load a schema normally (into both cache and Sled).
         core.load_schema_from_json(&blogpost_schema_json())
             .await
             .expect("load");
 
-        // Reload should add 0 new schemas (BlogPost is already in cache)
-        let added = core.reload_from_store().await.expect("reload");
-        assert_eq!(added, 0);
+        // Reload sees no difference — disk == cache.
+        let changed = core.reload_from_store().await.expect("reload");
+        assert_eq!(changed, 0);
 
-        // Still exactly one schema
+        // Still exactly one schema.
         assert_eq!(core.get_schemas().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn reload_from_store_refreshes_changed_schemas() {
+        // A schema written directly to Sled (simulating sync replay) that
+        // differs from the cached copy must refresh the cache.
+        let tmp = tempfile::TempDir::new().expect("tmpdir");
+        let pool = std::sync::Arc::new(crate::storage::SledPool::new(tmp.path().to_path_buf()));
+        let db_ops = std::sync::Arc::new(
+            crate::db_operations::DbOperations::from_sled(pool)
+                .await
+                .expect("db_ops"),
+        );
+        let message_bus = Arc::new(AsyncMessageBus::new());
+        let core = SchemaCore::new(Arc::clone(&db_ops), Arc::clone(&message_bus))
+            .await
+            .expect("init core");
+
+        // Seed cache + Sled with a pre-tag version of a schema.
+        let json = r#"{
+            "name": "SharedNotes",
+            "key": { "range_field": "created_at" },
+            "fields": { "body": {}, "created_at": {} }
+        }"#;
+        let declarative: crate::schema::types::DeclarativeSchemaDefinition =
+            serde_json::from_str(json).expect("parse");
+        let pre_tag = crate::schema::SchemaInterpreter::interpret(declarative).expect("interpret");
+        core.update_schema(&pre_tag).await.expect("seed");
+
+        // Simulate sync replay overwriting the on-disk entry with an
+        // org-tagged version — peer node sees a tagged schema arrive.
+        let mut tagged = pre_tag.clone();
+        tagged.org_hash = Some("a".repeat(64));
+        tagged.trust_domain = Some(format!("org:{}", "a".repeat(64)));
+        db_ops
+            .store_schema("SharedNotes", &tagged)
+            .await
+            .expect("replay put");
+
+        let changed = core.reload_from_store().await.expect("reload");
+        assert_eq!(
+            changed, 1,
+            "reload must refresh the cached copy when disk differs"
+        );
+
+        let refreshed = core
+            .get_schema_metadata("SharedNotes")
+            .expect("read")
+            .expect("present");
+        assert_eq!(refreshed.org_hash.as_deref(), Some("a".repeat(64).as_str()));
+        assert!(
+            refreshed
+                .trust_domain
+                .as_deref()
+                .is_some_and(|d| d.starts_with("org:")),
+            "trust_domain must survive replay",
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_from_store_auto_approves_org_tagged_schemas() {
+        // Org schemas arriving via sync replay should be auto-approved on
+        // the receiving node — membership in the org implies trust.
+        let tmp = tempfile::TempDir::new().expect("tmpdir");
+        let pool = std::sync::Arc::new(crate::storage::SledPool::new(tmp.path().to_path_buf()));
+        let db_ops = std::sync::Arc::new(
+            crate::db_operations::DbOperations::from_sled(pool)
+                .await
+                .expect("db_ops"),
+        );
+        let message_bus = Arc::new(AsyncMessageBus::new());
+        let core = SchemaCore::new(Arc::clone(&db_ops), Arc::clone(&message_bus))
+            .await
+            .expect("init core");
+
+        let json = r#"{
+            "name": "OrgShared",
+            "key": { "range_field": "created_at" },
+            "fields": { "body": {}, "created_at": {} }
+        }"#;
+        let declarative: crate::schema::types::DeclarativeSchemaDefinition =
+            serde_json::from_str(json).expect("parse");
+        let mut schema =
+            crate::schema::SchemaInterpreter::interpret(declarative).expect("interpret");
+        schema.org_hash = Some("b".repeat(64));
+        schema.trust_domain = Some(format!("org:{}", "b".repeat(64)));
+
+        // Simulate replay: schema on disk, no state entry, cache empty.
+        db_ops
+            .store_schema("OrgShared", &schema)
+            .await
+            .expect("store");
+
+        let _ = core.reload_from_store().await.expect("reload");
+
+        let state = core
+            .get_schema_states()
+            .expect("states")
+            .get("OrgShared")
+            .copied();
+        assert_eq!(
+            state,
+            Some(SchemaState::Approved),
+            "org-tagged schema arriving via sync must be auto-approved",
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_from_store_preserves_blocked_state_for_org_schemas() {
+        // Blocked schemas must NOT get auto-promoted to Approved even when
+        // they carry an org_hash — Blocked means the user explicitly rejected.
+        let tmp = tempfile::TempDir::new().expect("tmpdir");
+        let pool = std::sync::Arc::new(crate::storage::SledPool::new(tmp.path().to_path_buf()));
+        let db_ops = std::sync::Arc::new(
+            crate::db_operations::DbOperations::from_sled(pool)
+                .await
+                .expect("db_ops"),
+        );
+        let message_bus = Arc::new(AsyncMessageBus::new());
+        let core = SchemaCore::new(Arc::clone(&db_ops), Arc::clone(&message_bus))
+            .await
+            .expect("init core");
+
+        let json = r#"{
+            "name": "BlockedOrg",
+            "key": { "range_field": "created_at" },
+            "fields": { "body": {}, "created_at": {} }
+        }"#;
+        let declarative: crate::schema::types::DeclarativeSchemaDefinition =
+            serde_json::from_str(json).expect("parse");
+        let mut schema =
+            crate::schema::SchemaInterpreter::interpret(declarative).expect("interpret");
+        schema.org_hash = Some("c".repeat(64));
+
+        db_ops
+            .store_schema("BlockedOrg", &schema)
+            .await
+            .expect("store");
+        db_ops
+            .store_schema_state("BlockedOrg", &SchemaState::Blocked)
+            .await
+            .expect("block");
+
+        let _ = core.reload_from_store().await.expect("reload");
+
+        let state = core
+            .get_schema_states()
+            .expect("states")
+            .get("BlockedOrg")
+            .copied();
+        assert_eq!(
+            state,
+            Some(SchemaState::Blocked),
+            "Blocked must be preserved"
+        );
     }
 
     #[tokio::test]

--- a/src/schema/types/declarative_schemas.rs
+++ b/src/schema/types/declarative_schemas.rs
@@ -136,6 +136,8 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
             identity_hash: Option<String>,
             #[serde(skip_serializing_if = "Option::is_none", default)]
             org_hash: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none", default)]
+            trust_domain: Option<String>,
             #[serde(default)]
             field_access_policies: HashMap<String, crate::access::types::FieldAccessPolicy>,
         }
@@ -221,6 +223,7 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
         schema.field_types = helper.field_types;
         schema.identity_hash = helper.identity_hash;
         schema.org_hash = helper.org_hash;
+        schema.trust_domain = helper.trust_domain;
         schema.field_access_policies = helper.field_access_policies;
 
         Ok(schema)
@@ -829,6 +832,40 @@ mod tests {
         assert_eq!(
             deserialized.name, "UserProfile",
             "Schema name should be preserved"
+        );
+    }
+
+    #[test]
+    fn test_trust_domain_round_trip() {
+        // The custom Deserialize impl previously dropped `trust_domain`,
+        // so tagging a schema with `set-org-hash` sent `trust_domain=None`
+        // to peers even though the serialized form carried it. Regression
+        // guard for alpha papercut d2f07.
+        use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
+
+        let mut schema = DeclarativeSchemaDefinition::new(
+            "OrgNotes".to_string(),
+            SchemaType::Single,
+            None,
+            Some(vec!["body".to_string()]),
+            None,
+            None,
+        );
+        schema.org_hash = Some("a".repeat(64));
+        schema.trust_domain = Some(format!("org:{}", "a".repeat(64)));
+
+        let serialized = serde_json::to_string(&schema).expect("serialize");
+        assert!(
+            serialized.contains("trust_domain"),
+            "serialized form must contain trust_domain when set"
+        );
+
+        let deserialized: DeclarativeSchemaDefinition =
+            serde_json::from_str(&serialized).expect("deserialize");
+        assert_eq!(
+            deserialized.trust_domain,
+            Some(format!("org:{}", "a".repeat(64))),
+            "trust_domain must survive JSON round-trip"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes alpha papercut **d2f07** (filed during Alpha E2E Dogfood Run 5, Flow 3). When Bob received Alice's org-tagged schema via cross-node sync, it arrived with `trust_domain=None` and `state=Available` — so it looked like an untagged, unapproved schema on the peer.

Three coupled fixes:

1. **`DeclarativeSchemaDefinition` deserializer silently dropped `trust_domain`.** The helper struct used in the custom `Deserialize` impl was missing the field, so every disk→memory round-trip returned `None` regardless of what was serialized. This is the root cause of the peer seeing `trust_domain=None`.

2. **`SchemaStore::store_schema` mirrors the current schema state to the org-prefixed key** when dual-writing an org-tagged schema. Previously, tagging an already-approved schema via `set-org-hash` propagated the schema body to the org log but left the state entry under the bare key only, so peers got the schema without the approval state.

3. **`SchemaCore::reload_from_store` refreshes existing entries when the disk copy differs from the cached copy** (not just adds new ones), and **auto-approves any schema carrying an `org_hash` that is still `Available`** — membership in the org implies trust, so peers shouldn't have to manually approve org-shared schemas. `Blocked` state is preserved (explicit user rejection).

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --workspace --all-targets` — all pass (577+ unit, 100+ integration)
- [x] New unit tests:
  - `test_trust_domain_round_trip` — guards the deserializer regression
  - `store_schema_mirrors_existing_state_to_org_prefixed_key` — approve-then-tag lifecycle
  - `store_schema_without_prior_state_does_not_mirror_state` — no fabricated state
  - `reload_from_store_refreshes_changed_schemas` — cache follows disk
  - `reload_from_store_auto_approves_org_tagged_schemas` — membership → trust
  - `reload_from_store_preserves_blocked_state_for_org_schemas` — no Blocked override
  - `reload_from_store_is_noop_when_disk_matches_cache` — stable when unchanged

## Follow-up

- Workspace submodule pointer bump after merge.