### PR TITLE
test(schema): regression guard for trust_domain across restart (903af)

### DIFF
--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -1190,4 +1190,83 @@ mod tests {
             "runtime_fields should contain 'content'"
         );
     }
+
+    #[tokio::test]
+    async fn trust_domain_persists_across_schema_core_restart() {
+        // Regression test for alpha papercut 903af: after `set-org-hash`, both
+        // `org_hash` and `trust_domain` must survive a node restart. Before the
+        // fix, `org_hash` persisted but `trust_domain` did not — the node would
+        // boot with a tagged-but-untrusted schema, breaking access checks that
+        // rely on `trust_domain = "org:<hash>"`.
+        let tmp = tempfile::TempDir::new().expect("tmpdir");
+        let db_path = tmp.path().to_path_buf();
+        let org_hash = "a".repeat(64);
+
+        {
+            let pool = std::sync::Arc::new(crate::storage::SledPool::new(db_path.clone()));
+            let db_ops = std::sync::Arc::new(
+                crate::db_operations::DbOperations::from_sled(pool)
+                    .await
+                    .expect("db_ops"),
+            );
+            let message_bus = Arc::new(AsyncMessageBus::new());
+            let core = SchemaCore::new(Arc::clone(&db_ops), Arc::clone(&message_bus))
+                .await
+                .expect("init core");
+
+            let json = r#"{
+                "name": "TaggedNotes",
+                "key": { "range_field": "created_at" },
+                "fields": { "body": {}, "created_at": {} }
+            }"#;
+            let declarative: crate::schema::types::DeclarativeSchemaDefinition =
+                serde_json::from_str(json).expect("parse");
+            let mut schema =
+                crate::schema::SchemaInterpreter::interpret(declarative).expect("interpret");
+            schema.org_hash = Some(org_hash.clone());
+            schema.trust_domain = Some(format!("org:{}", org_hash));
+            core.update_schema(&schema).await.expect("tag + store");
+
+            let before = core
+                .get_schema_metadata("TaggedNotes")
+                .expect("read")
+                .expect("present");
+            assert_eq!(before.org_hash.as_deref(), Some(org_hash.as_str()));
+            assert_eq!(
+                before.trust_domain.as_deref(),
+                Some(format!("org:{}", org_hash).as_str()),
+                "trust_domain must be set after tagging",
+            );
+
+            db_ops.flush().await.expect("flush");
+        }
+
+        // Fresh SchemaCore pointed at the same Sled directory — simulates
+        // process restart. Both fields must round-trip.
+        let pool = std::sync::Arc::new(crate::storage::SledPool::new(db_path));
+        let db_ops = std::sync::Arc::new(
+            crate::db_operations::DbOperations::from_sled(pool)
+                .await
+                .expect("db_ops reopen"),
+        );
+        let message_bus = Arc::new(AsyncMessageBus::new());
+        let core = SchemaCore::new(Arc::clone(&db_ops), Arc::clone(&message_bus))
+            .await
+            .expect("reopen core");
+
+        let after = core
+            .get_schema_metadata("TaggedNotes")
+            .expect("read")
+            .expect("present after restart");
+        assert_eq!(
+            after.org_hash.as_deref(),
+            Some(org_hash.as_str()),
+            "org_hash must persist across restart",
+        );
+        assert_eq!(
+            after.trust_domain.as_deref(),
+            Some(format!("org:{}", org_hash).as_str()),
+            "trust_domain must persist across restart — regression 903af",
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Alpha papercut **903af** (found in E2E dogfood **Run-6 Flow-3**) reported
that after `POST /api/schema/<name>/set-org-hash`, `schema.org_hash`
survived a node restart but `schema.trust_domain` came back as `null` —
leaving a tagged-but-untrusted schema behind which breaks any access
check that reads `trust_domain = \"org:<hash>\"`.

The underlying fix landed in **d2f07 (#567)**: the `DeclarativeSchemaDefinition`
custom `Deserialize` helper was missing `trust_domain`, and on-disk
replay didn't refresh the cache. Both are now handled.

This PR **does not add a code fix** — it adds the missing
SchemaCore-level regression test that directly exercises the persistence
boundary 903af points at: store a schema tagged with `org_hash` +
`trust_domain`, drop the `SchemaCore` / `DbOperations` / `SledPool`,
re-open fresh on the same data dir, and assert both fields round-trip.

Without this test, a future regression in the `DeclarativeSchemaDefinition`
deserializer (or any mid-layer that drops `trust_domain`) would slip
past CI the way d2f07 did — because the existing tests only check
in-memory serialize/deserialize or the sync-replay reload path, not a
full close-and-reopen against Sled.

## Test plan

- [x] `cargo test --lib schema::core::tests` — 17/17 pass including the new `trust_domain_persists_across_schema_core_restart`
- [x] `cargo test --lib` — 578/578 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)