### PR TITLE
docs(readme): homebrew primary, fix 404 curl URL, update daemon hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,30 +9,37 @@ Drop in files, JSON, or social media exports — FoldDB detects schemas, extract
 **Try it now** — install with one command and have a working database in under a minute:
 
 ```bash
-brew tap EdgeVector/fold_db && brew install folddb
-folddb_server --port 9001
-# Open http://localhost:9001 — drag in a JSON file, ask a question
+brew install edgevector/folddb/folddb
+folddb daemon start
+# Open http://localhost:9101 — drag in a JSON file, ask a question
 ```
 
 ## Quick Start
 
 ### Option A: Desktop App (macOS)
 
-Download the latest `.dmg` from [GitHub Releases](https://github.com/EdgeVector/fold_db/releases), open it, and drag **FoldDB.app** to Applications. Double-click to launch — no terminal needed.
+Download the latest `.dmg` from [GitHub Releases](https://github.com/EdgeVector/fold_db_node/releases), open it, and drag **FoldDB.app** to Applications. Double-click to launch — no terminal needed.
 
-> **First launch:** macOS will block the unsigned app. Right-click the app → **Open** → click **Open** in the dialog, or go to **System Settings → Privacy & Security → Open Anyway**.
-
-### Option B: Install via Homebrew
+### Option B: Install via Homebrew (macOS + Linux x86_64)
 
 ```bash
-brew tap EdgeVector/fold_db
-brew install folddb
+brew install edgevector/folddb/folddb
 ```
+
+Ships `folddb` (CLI), `folddb_server` (daemon), and `schema_service` (local schema registry). Handles upgrades via `brew upgrade folddb`.
 
 ### Option C: Install from Source
 
+Fallback for platforms not covered by the tap (Linux arm64, air-gapped). Downloads the latest release tarball from the `EdgeVector/fold_db` mirror and verifies its sha256:
+
 ```bash
-curl -fsSL https://raw.githubusercontent.com/EdgeVector/fold_db/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/EdgeVector/fold_db_node/main/install.sh | sh
+```
+
+Or build from source:
+
+```bash
+cargo install --git https://github.com/EdgeVector/fold_db_node folddb folddb_server schema_service
 ```
 
 ### Run


### PR DESCRIPTION
## Summary

- Tap invocation `brew tap EdgeVector/fold_db && brew install folddb` was never valid — the real tap is `edgevector/folddb` (lowercase org path, formula at [`EdgeVector/homebrew-folddb`](https://github.com/EdgeVector/homebrew-folddb)). Replaced with `brew install edgevector/folddb/folddb`.
- The curl one-liner pointed at `https://raw.githubusercontent.com/EdgeVector/fold_db/master/install.sh`, which is a **404** — `install.sh` moved to `fold_db_node/main/install.sh` during the fold_db/fold_db_node split. Fixed.
- Removed the "macOS will block the unsigned app" warning on the DMG — `tauri-release.yml` has been codesigning + notarizing DMGs since 2026-03.
- Updated the quick-start daemon command to `folddb daemon start` (current CLI) and the dashboard port to `9101` (brew-installed default).
- Clarified Option C as the source/fallback path: rewritten curl installer for Linux arm64 / air-gapped, or `cargo install --git ...` direct.

Ships alongside [`fold_db_node#604`](https://github.com/EdgeVector/fold_db_node/pull/604) (auto-bump homebrew-folddb on release + rewrite install.sh) and [`homebrew-folddb#1`](https://github.com/EdgeVector/homebrew-folddb/pull/1) (formula v0.3.1 bump).

## Test plan

- [ ] `brew install edgevector/folddb/folddb` resolves and installs the three binaries
- [ ] `curl -fsSL https://raw.githubusercontent.com/EdgeVector/fold_db_node/main/install.sh | sh` resolves after fold_db_node#604 merges
- [ ] README renders cleanly on github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)