### PR TITLE
fix(schema_service): populate StoredView.transform_hash from wasm_bytes

### DIFF
--- a/src/schema_service/state.rs
+++ b/src/schema_service/state.rs
@@ -1605,11 +1605,26 @@ impl SchemaServiceState {
             }
         };
 
+        // Compute the transform hash from the inline WASM bytes (if any)
+        // so the StoredView is always linked to a content-addressed
+        // identifier. Without this, `transform_hash` was perpetually None
+        // and a view registered with WASM had no audit trail back to the
+        // Global Transform Registry. The hash matches whatever
+        // `register_transform` would compute for the same bytes, so a
+        // transform registered separately will have the same hash here.
+        //
+        // The bytes themselves still live on the StoredView for backwards
+        // compatibility with `stored_view_to_transform_view`, which reads
+        // them directly. A future platform improvement: drop inline bytes
+        // and have the view-load path fetch from the transform registry
+        // by hash.
+        let transform_hash = request.wasm_bytes.as_deref().map(Self::compute_wasm_hash);
+
         // Build the StoredView
         let view = StoredView {
             name: request.name.clone(),
             input_queries: request.input_queries,
-            transform_hash: None,
+            transform_hash,
             wasm_bytes: request.wasm_bytes,
             output_schema_name: output_schema.name.clone(),
             schema_type: request.schema_type,

--- a/tests/transform_registry_test.rs
+++ b/tests/transform_registry_test.rs
@@ -782,3 +782,151 @@ async fn test_stored_view_without_transform_hash() {
     let view: StoredView = serde_json::from_str(json).expect("deserialize failed");
     assert!(view.transform_hash.is_none());
 }
+
+/// Verify that `SchemaServiceState::add_view` populates `StoredView.transform_hash`
+/// with the sha256 of the supplied `wasm_bytes`. This is the linkage between a
+/// view and its transform in the Global Transform Registry — without it, views
+/// with inline bytes had no audit trail back to the registry entry, and the
+/// invariant "every view references its transform" was only nominally enforced.
+///
+/// This test was added when Tom caught during Phase 1a review that
+/// `StoredView.transform_hash` was always `None` in the prior implementation.
+#[tokio::test]
+async fn add_view_populates_transform_hash_from_wasm_bytes() {
+    use fold_db::schema_service::types::AddViewRequest;
+
+    let state = make_test_state();
+
+    // Seed a source schema the view will read from.
+    add_test_schema(
+        &state,
+        "source_schema",
+        &[
+            ("id", FieldValueType::String),
+            ("body", FieldValueType::String),
+        ],
+        &[("id", "low"), ("body", "low")],
+    )
+    .await;
+
+    // Minimal valid WASM header — the bytes aren't executed here; we're just
+    // checking that they get hashed and stored correctly on the StoredView.
+    let wasm_bytes = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+    let expected_hash = SchemaServiceState::compute_wasm_hash(&wasm_bytes);
+
+    let mut output_field_types = HashMap::new();
+    output_field_types.insert("summary".to_string(), FieldValueType::String);
+
+    let mut field_descriptions = HashMap::new();
+    field_descriptions.insert("summary".to_string(), "cluster summary".to_string());
+    // Provide classifications up-front so add_schema doesn't fall back to
+    // an Ollama classify call (fails in test environments without Ollama).
+    let mut field_classifications = HashMap::new();
+    field_classifications.insert("summary".to_string(), vec!["low".to_string()]);
+    let mut field_data_classifications = HashMap::new();
+    field_data_classifications.insert(
+        "summary".to_string(),
+        DataClassification::new(0, "general").unwrap(),
+    );
+
+    let add_view_request = AddViewRequest {
+        name: "TestView".to_string(),
+        descriptive_name: "TestView".to_string(),
+        input_queries: vec![Query::new(
+            "source_schema".to_string(),
+            vec!["body".to_string()],
+        )],
+        output_fields: vec!["summary".to_string()],
+        field_descriptions,
+        field_classifications,
+        field_data_classifications,
+        wasm_bytes: Some(wasm_bytes.clone()),
+        schema_type: fold_db::schema::types::schema::DeclarativeSchemaType::Range,
+    };
+
+    let outcome = state
+        .add_view(add_view_request)
+        .await
+        .expect("add_view must succeed");
+
+    // Extract the StoredView from the outcome.
+    use fold_db::schema_service::types::ViewAddOutcome;
+    let stored_view = match outcome {
+        ViewAddOutcome::Added(v, _)
+        | ViewAddOutcome::AddedWithExistingSchema(v, _)
+        | ViewAddOutcome::Expanded(v, _, _) => v,
+    };
+
+    // THE CORE INVARIANT: transform_hash is populated, not None.
+    assert!(
+        stored_view.transform_hash.is_some(),
+        "add_view must populate transform_hash when wasm_bytes is provided; got None"
+    );
+
+    // And it matches the sha256 of the provided bytes — same hash that
+    // `register_transform` would compute for the same bytes.
+    assert_eq!(
+        stored_view.transform_hash.as_deref(),
+        Some(expected_hash.as_str()),
+        "StoredView.transform_hash must be sha256(wasm_bytes)"
+    );
+
+    // The bytes are still present for backward compatibility with the
+    // view-load path that reads them directly.
+    assert_eq!(
+        stored_view.wasm_bytes.as_deref(),
+        Some(wasm_bytes.as_slice())
+    );
+}
+
+/// Complement: when no wasm_bytes are provided (identity view), transform_hash
+/// stays None. Identity views don't need a transform.
+#[tokio::test]
+async fn add_view_identity_leaves_transform_hash_none() {
+    use fold_db::schema_service::types::AddViewRequest;
+
+    let state = make_test_state();
+
+    add_test_schema(
+        &state,
+        "source_schema",
+        &[("body", FieldValueType::String)],
+        &[("body", "low")],
+    )
+    .await;
+
+    let mut field_descriptions = HashMap::new();
+    field_descriptions.insert("body".to_string(), "passthrough body".to_string());
+
+    let add_view_request = AddViewRequest {
+        name: "IdentityTestView".to_string(),
+        descriptive_name: "IdentityTestView".to_string(),
+        input_queries: vec![Query::new(
+            "source_schema".to_string(),
+            vec!["body".to_string()],
+        )],
+        output_fields: vec!["body".to_string()],
+        field_descriptions,
+        field_classifications: HashMap::new(),
+        field_data_classifications: HashMap::new(),
+        wasm_bytes: None,
+        schema_type: fold_db::schema::types::schema::DeclarativeSchemaType::Single,
+    };
+
+    let outcome = state
+        .add_view(add_view_request)
+        .await
+        .expect("add_view must succeed for identity view");
+    use fold_db::schema_service::types::ViewAddOutcome;
+    let stored_view = match outcome {
+        ViewAddOutcome::Added(v, _)
+        | ViewAddOutcome::AddedWithExistingSchema(v, _)
+        | ViewAddOutcome::Expanded(v, _, _) => v,
+    };
+
+    assert!(
+        stored_view.transform_hash.is_none(),
+        "identity view (no wasm_bytes) must have transform_hash = None"
+    );
+    assert!(stored_view.wasm_bytes.is_none());
+}


### PR DESCRIPTION
## Summary

Caught while reviewing fold_db_node's memory consolidation work
(EdgeVector/fold_db_node#618): \`SchemaServiceState::add_view\` had
\`transform_hash: None\` hardcoded. Every view registered with inline WASM
bytes had no link to its transform entry in the Global Transform
Registry. The invariant \"every view references its transform by content
hash\" was only nominally enforced — the field existed but nothing
populated it, anywhere in the codebase.

## Fix

\`add_view\` now computes sha256 of \`wasm_bytes\` when provided and stores
the hex digest as \`StoredView.transform_hash\`. Matches whatever
\`register_transform\` would compute for the same bytes, so a view and a
separately-registered transform with identical WASM converge on the same
hash.

Inline bytes are still stored for backward compatibility with
\`stored_view_to_transform_view\`. Future platform improvement: drop
inline bytes, fetch from the registry by hash on demand.

## Tests

- \`add_view_populates_transform_hash_from_wasm_bytes\` — asserts hash
  equals \`compute_wasm_hash(&wasm_bytes)\` after \`add_view\`
- \`add_view_identity_leaves_transform_hash_none\` — identity views
  correctly leave hash None

Both pass. Full \`transform_registry_test\` (27 tests) and
\`view_registration_test\` (11 tests) still green. Clippy clean.

## Test plan

- [x] New assertions pass
- [x] Existing transform/view tests still pass
- [x] \`cargo clippy -p fold_db --lib -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)