### PR TITLE
fix(schema_service): reject views with no input queries

### DIFF
--- a/src/schema_service/state.rs
+++ b/src/schema_service/state.rs
@@ -1530,6 +1530,14 @@ impl SchemaServiceState {
             ));
         }
 
+        // Validate input queries exist (a view must fetch source data for the transform)
+        if request.input_queries.is_empty() {
+            return Err(FoldDbError::Config(
+                "View must have at least one input query (fetches source data for the transform)"
+                    .to_string(),
+            ));
+        }
+
         // Validate input queries have explicit field lists
         for (i, query) in request.input_queries.iter().enumerate() {
             if query.fields.is_empty() {

--- a/tests/transform_registry_test.rs
+++ b/tests/transform_registry_test.rs
@@ -7,7 +7,9 @@ use fold_db::schema::types::field_value_type::FieldValueType;
 use fold_db::schema::types::operations::Query;
 use fold_db::schema::types::Schema;
 use fold_db::schema_service::state::SchemaServiceState;
-use fold_db::schema_service::types::{RegisterTransformRequest, TransformAddOutcome};
+use fold_db::schema_service::types::{
+    AddViewRequest, RegisterTransformRequest, TransformAddOutcome,
+};
 use tempfile::tempdir;
 
 /// Create a test state with a temp directory.
@@ -781,4 +783,30 @@ async fn test_stored_view_without_transform_hash() {
 
     let view: StoredView = serde_json::from_str(json).expect("deserialize failed");
     assert!(view.transform_hash.is_none());
+}
+
+#[tokio::test]
+async fn add_view_rejects_empty_input_queries() {
+    let state = make_test_state();
+
+    let request = AddViewRequest {
+        name: "NoSourceView".to_string(),
+        descriptive_name: "No Source View".to_string(),
+        input_queries: vec![],
+        output_fields: vec!["summary".to_string()],
+        field_descriptions: HashMap::from([("summary".to_string(), "summary field".to_string())]),
+        field_classifications: HashMap::new(),
+        field_data_classifications: HashMap::new(),
+        wasm_bytes: None,
+        schema_type: fold_db::schema::types::schema::DeclarativeSchemaType::Single,
+    };
+
+    let err = state
+        .add_view(request)
+        .await
+        .expect_err("expected add_view to reject empty input_queries");
+    assert!(
+        err.to_string().contains("at least one input query"),
+        "unexpected error message: {err}"
+    );
 }


### PR DESCRIPTION
## Summary
- A view must have at least one input query to fetch source data for its transform. `add_view` previously validated each input query's fields individually but never checked whether `input_queries` itself was non-empty, so a view with zero sources would register cleanly.
- Add an explicit `input_queries.is_empty()` check in `SchemaServiceState::add_view` that returns `FoldDbError::Config` with a message explaining the invariant, placed before the existing per-query field-list validation.
- Add `add_view_rejects_empty_input_queries` to `tests/transform_registry_test.rs` covering the new check.

Part of the view+transform registry coherence project (gbrain `projects/schema-service-view-transform-coherence` task A).

## Test plan
- [x] `cargo test -p fold_db --test transform_registry_test` — 27 passed (new test + 26 existing).
- [x] `cargo test --workspace --all-targets` — all suites pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)