### PR TITLE
fix(schema_service): reject identity views whose output fields have no matching source

### DIFF
--- a/src/schema_service/state.rs
+++ b/src/schema_service/state.rs
@@ -1584,6 +1584,26 @@ impl SchemaServiceState {
             }
         }
 
+        // Identity views (no wasm_bytes, no transform_hash) use pass-through semantics
+        // (see view::resolver::identity_pass_through): each output field maps from a
+        // source field with the same name. Reject at registration if any output field
+        // has no matching source — otherwise mismatches surface only at first query.
+        if request.wasm_bytes.is_none() {
+            let source_fields: HashSet<&str> = request
+                .input_queries
+                .iter()
+                .flat_map(|q| q.fields.iter().map(String::as_str))
+                .collect();
+            for output_field in &request.output_fields {
+                if !source_fields.contains(output_field.as_str()) {
+                    return Err(FoldDbError::Config(format!(
+                        "Identity view '{}' output field '{}' has no matching source field in any input query",
+                        request.name, output_field
+                    )));
+                }
+            }
+        }
+
         // Build an output schema from the view's fields and run it through add_schema.
         // Use descriptive_name as the initial schema name — add_schema replaces it with
         // the identity hash, but having a meaningful name prevents infer_name_from_fields

--- a/tests/transform_registry_test.rs
+++ b/tests/transform_registry_test.rs
@@ -810,3 +810,95 @@ async fn add_view_rejects_empty_input_queries() {
         "unexpected error message: {err}"
     );
 }
+
+// ============== Identity view output validation ==============
+
+fn make_identity_view_request(
+    name: &str,
+    descriptive_name: &str,
+    schema_name: &str,
+    input_fields: &[&str],
+    output_fields: &[&str],
+) -> AddViewRequest {
+    let mut field_descriptions = HashMap::new();
+    for f in output_fields {
+        field_descriptions.insert(f.to_string(), format!("{} description", f));
+    }
+    AddViewRequest {
+        name: name.to_string(),
+        descriptive_name: descriptive_name.to_string(),
+        input_queries: vec![Query::new(
+            schema_name.to_string(),
+            input_fields.iter().map(|f| f.to_string()).collect(),
+        )],
+        output_fields: output_fields.iter().map(|f| f.to_string()).collect(),
+        field_descriptions,
+        field_classifications: HashMap::new(),
+        field_data_classifications: HashMap::new(),
+        wasm_bytes: None,
+        schema_type: fold_db::schema::types::schema::DeclarativeSchemaType::Single,
+    }
+}
+
+#[tokio::test]
+async fn add_view_identity_rejects_output_field_not_in_sources() {
+    let state = make_test_state();
+    let schema_name = add_test_schema(
+        &state,
+        "Identity Source",
+        &[
+            ("title", FieldValueType::String),
+            ("body", FieldValueType::String),
+        ],
+        &[("title", "word"), ("body", "word")],
+    )
+    .await;
+
+    // Output field "summary" is not in the input query's fields ["title", "body"]
+    let request = make_identity_view_request(
+        "BadIdentityView",
+        "Bad Identity View Output",
+        &schema_name,
+        &["title", "body"],
+        &["title", "summary"],
+    );
+
+    let err = state
+        .add_view(request)
+        .await
+        .expect_err("expected identity view registration to fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("summary") && msg.contains("BadIdentityView"),
+        "expected error to mention missing source 'summary' and view name, got: {}",
+        msg
+    );
+}
+
+#[tokio::test]
+async fn add_view_identity_accepts_matching_output_fields() {
+    let state = make_test_state();
+    let schema_name = add_test_schema(
+        &state,
+        "Identity Source Happy",
+        &[
+            ("title", FieldValueType::String),
+            ("body", FieldValueType::String),
+        ],
+        &[("title", "word"), ("body", "word")],
+    )
+    .await;
+
+    let request = make_identity_view_request(
+        "GoodIdentityView",
+        "Good Identity View Output",
+        &schema_name,
+        &["title", "body"],
+        &["title", "body"],
+    );
+
+    state
+        .add_view(request)
+        .await
+        .expect("identity view with matching output fields should register");
+}


### PR DESCRIPTION
## Summary

- Identity views (no `wasm_bytes`, no `transform_hash`) use pass-through semantics in `view::resolver::identity_pass_through` — every output field name must exist as a source field in some input query.
- `SchemaServiceState::add_view` previously did not validate this, so mismatches surfaced only at first query time.
- Now reject at registration with `FoldDbError::Config` naming the missing source field and view.

Part of the view+transform registry coherence project (gbrain task D).

## Test plan
- [x] `cargo test -p fold_db --test transform_registry_test` (27 tests pass, includes 2 new)
  - `add_view_identity_rejects_output_field_not_in_sources`
  - `add_view_identity_accepts_matching_output_fields`
- [x] `cargo test --workspace --all-targets` (all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)