### PR TITLE
feat(schema_service): accept Rust source, compile to WASM server-side

### DIFF
--- a/src/schema_service/external_persistence.rs
+++ b/src/schema_service/external_persistence.rs
@@ -85,4 +85,24 @@ pub trait ExternalSchemaPersistence: Send + Sync {
     /// Fetch WASM bytes for a single transform by hash. Returns `None`
     /// if the hash is unknown.
     async fn load_transform_wasm(&self, hash: &str) -> FoldDbResult<Option<Vec<u8>>>;
+
+    /// Persist the Rust source text for a transform, keyed by the WASM
+    /// hash. Called only when the transform was submitted as source
+    /// (not pre-compiled bytes).
+    ///
+    /// Default implementation is a no-op so existing backends stay
+    /// compatible; source will simply not be retrievable from those
+    /// backends. Override to enable server-side source storage.
+    async fn save_transform_source(&self, _hash: &str, _source: &str) -> FoldDbResult<()> {
+        Ok(())
+    }
+
+    /// Fetch the Rust source text for a transform by hash. Returns `None`
+    /// if the transform has no stored source (pre-compiled upload) or the
+    /// hash is unknown.
+    ///
+    /// Default implementation returns `None`.
+    async fn load_transform_source(&self, _hash: &str) -> FoldDbResult<Option<String>> {
+        Ok(None)
+    }
 }

--- a/src/schema_service/mod.rs
+++ b/src/schema_service/mod.rs
@@ -17,3 +17,4 @@ mod state_matching;
 mod state_transforms;
 pub mod transform_resolver;
 pub mod types;
+pub mod wasm_compiler;

--- a/src/schema_service/state_transforms.rs
+++ b/src/schema_service/state_transforms.rs
@@ -14,6 +14,7 @@ use super::types::{
     RegisterTransformRequest, SimilarTransformEntry, SimilarTransformsResponse,
     TransformAddOutcome, TransformListEntry, TransformRecord,
 };
+use super::wasm_compiler;
 
 /// NMI leakage threshold — above this, an output field carries meaningful
 /// information about the corresponding input field.
@@ -23,7 +24,7 @@ const NMI_LEAKAGE_THRESHOLD: f32 = 0.1;
 impl SchemaServiceState {
     // ============== Transform Storage ==============
 
-    /// Compute sha256 hex digest of WASM bytes.
+    /// Compute sha256 hex digest of arbitrary bytes (used for both WASM and source).
     pub fn compute_wasm_hash(wasm_bytes: &[u8]) -> String {
         let mut hasher = Sha256::new();
         hasher.update(wasm_bytes);
@@ -40,11 +41,6 @@ impl SchemaServiceState {
                 "Transform name must be non-empty".to_string(),
             ));
         }
-        if request.wasm_bytes.is_empty() {
-            return Err(FoldDbError::Config(
-                "Transform wasm_bytes must be non-empty".to_string(),
-            ));
-        }
         if request.version.trim().is_empty() {
             return Err(FoldDbError::Config(
                 "Transform version must be non-empty".to_string(),
@@ -56,7 +52,40 @@ impl SchemaServiceState {
             ));
         }
 
-        let hash = Self::compute_wasm_hash(&request.wasm_bytes);
+        let has_source = request
+            .rust_source
+            .as_ref()
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+        let has_bytes = !request.wasm_bytes.is_empty();
+
+        if has_source && has_bytes {
+            return Err(FoldDbError::Config(
+                "Transform request must provide either rust_source or wasm_bytes, not both"
+                    .to_string(),
+            ));
+        }
+        if !has_source && !has_bytes {
+            return Err(FoldDbError::Config(
+                "Transform request must provide either rust_source or wasm_bytes".to_string(),
+            ));
+        }
+
+        // Resolve the compiled bytes + (optional) source.
+        let (wasm_bytes, rust_source, source_hash) = if has_source {
+            let source = request
+                .rust_source
+                .clone()
+                .expect("rust_source presence already checked");
+            let bytes = wasm_compiler::compile_rust_to_wasm(&source)
+                .map_err(|e| FoldDbError::Config(format!("Rust→WASM compile failed: {}", e)))?;
+            let source_hash = Self::compute_wasm_hash(source.as_bytes());
+            (bytes, Some(source), Some(source_hash))
+        } else {
+            (request.wasm_bytes.clone(), None, None)
+        };
+
+        let hash = Self::compute_wasm_hash(&wasm_bytes);
 
         // Check if already registered (idempotent)
         if let Some(existing) = self.get_transform_by_hash(&hash)? {
@@ -70,7 +99,7 @@ impl SchemaServiceState {
         // Phase 2: NMI estimation (feature-gated)
         let (output_classification, nmi_matrix, classification_verified, sample_count) = self
             .estimate_output_classification(
-                &request.wasm_bytes,
+                &wasm_bytes,
                 &input_schema,
                 &request.output_fields,
                 input_ceiling.clone(),
@@ -93,6 +122,7 @@ impl SchemaServiceState {
             input_schema,
             output_schema: request.output_fields,
             source_url: request.source_url,
+            source_hash,
             registered_at: now,
             input_ceiling,
             output_classification,
@@ -102,10 +132,12 @@ impl SchemaServiceState {
             assigned_classification,
         };
 
-        // Persist metadata and WASM separately
+        // Persist metadata, WASM, and (when present) source.
         self.persist_transform_metadata(&record).await?;
-        self.persist_transform_wasm(&hash, &request.wasm_bytes)
-            .await?;
+        self.persist_transform_wasm(&hash, &wasm_bytes).await?;
+        if let Some(src) = &rust_source {
+            self.persist_transform_source(&hash, src).await?;
+        }
 
         // Insert into in-memory cache
         {
@@ -151,6 +183,34 @@ impl SchemaServiceState {
                 }
             }
             SchemaStorage::External(backend) => backend.load_transform_wasm(hash).await,
+        }
+    }
+
+    /// Get the Rust source for a transform by hash. Returns `None` if the
+    /// transform was registered from pre-compiled bytes (no source recorded)
+    /// or the hash is unknown.
+    pub async fn get_transform_source(&self, hash: &str) -> FoldDbResult<Option<String>> {
+        match &self.storage {
+            SchemaStorage::Sled { db, .. } => {
+                let src_tree = db.open_tree("transform_source").map_err(|e| {
+                    FoldDbError::Config(format!("Failed to open transform_source tree: {}", e))
+                })?;
+                match src_tree.get(hash.as_bytes()).map_err(|e| {
+                    FoldDbError::Config(format!("Failed to get transform source: {}", e))
+                })? {
+                    Some(bytes) => {
+                        let s = String::from_utf8(bytes.to_vec()).map_err(|e| {
+                            FoldDbError::Config(format!(
+                                "Stored transform source for '{}' is not valid UTF-8: {}",
+                                hash, e
+                            ))
+                        })?;
+                        Ok(Some(s))
+                    }
+                    None => Ok(None),
+                }
+            }
+            SchemaStorage::External(backend) => backend.load_transform_source(hash).await,
         }
     }
 
@@ -269,6 +329,30 @@ impl SchemaServiceState {
             }
             SchemaStorage::External(backend) => {
                 backend.save_transform_wasm(hash, wasm_bytes).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn persist_transform_source(&self, hash: &str, source: &str) -> FoldDbResult<()> {
+        match &self.storage {
+            SchemaStorage::Sled { db, .. } => {
+                let src_tree = db.open_tree("transform_source").map_err(|e| {
+                    FoldDbError::Config(format!("Failed to open transform_source tree: {}", e))
+                })?;
+                src_tree
+                    .insert(hash.as_bytes(), source.as_bytes())
+                    .map_err(|e| {
+                        FoldDbError::Config(format!(
+                            "Failed to insert transform source '{}': {}",
+                            hash, e
+                        ))
+                    })?;
+                db.flush()
+                    .map_err(|e| FoldDbError::Config(format!("Failed to flush sled: {}", e)))?;
+            }
+            SchemaStorage::External(backend) => {
+                backend.save_transform_source(hash, source).await?;
             }
         }
         Ok(())

--- a/src/schema_service/types.rs
+++ b/src/schema_service/types.rs
@@ -231,7 +231,7 @@ pub struct AvailableViewsResponse {
 // ============== Transform Types ==============
 
 /// A registered transform in the Global Transform Registry.
-/// Metadata record — does NOT include wasm_bytes (stored separately).
+/// Metadata record — does NOT include wasm_bytes or source (stored separately).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransformRecord {
     /// sha256(wasm_bytes) — the canonical identity
@@ -250,6 +250,14 @@ pub struct TransformRecord {
     /// URL to source code (GitHub, etc.) — for verifiability
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_url: Option<String>,
+    /// sha256 of the Rust source string. Present when the transform was
+    /// submitted as source and compiled server-side; `None` when only
+    /// pre-compiled bytes were uploaded. Separate from `hash` because the
+    /// same source deterministically produces the same bytes under a pinned
+    /// toolchain, so `source_hash` identifies author intent while `hash`
+    /// identifies the compiled artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_hash: Option<String>,
     /// When registered (Unix timestamp)
     pub registered_at: u64,
     /// Phase 1: max of all input field classifications
@@ -267,8 +275,16 @@ pub struct TransformRecord {
     pub assigned_classification: DataClassification,
 }
 
-/// Request to register a new transform
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Request to register a new transform.
+///
+/// Exactly one of `rust_source` or `wasm_bytes` must be provided:
+/// - `rust_source`: the service compiles the Rust to WASM server-side and
+///   stores both the source and the compiled bytes. Preferred for public
+///   auditability of what code a transform runs.
+/// - `wasm_bytes`: pre-compiled bytes, stored as-is. Retained for clients
+///   that cannot submit source, or for transforms produced by a different
+///   toolchain.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct RegisterTransformRequest {
     pub name: String,
     pub version: String,
@@ -280,7 +296,14 @@ pub struct RegisterTransformRequest {
     pub output_fields: HashMap<String, FieldValueType>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_url: Option<String>,
-    /// The compiled WASM bytes (base64-encoded in JSON)
+    /// Rust source for the `transform_impl` function. When set, the server
+    /// compiles this to WASM and stores both artifacts keyed by the compiled
+    /// hash. Mutually exclusive with `wasm_bytes` (at most one may be set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rust_source: Option<String>,
+    /// Pre-compiled WASM bytes (base64-encoded in JSON). Mutually exclusive
+    /// with `rust_source` (at most one may be set).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub wasm_bytes: Vec<u8>,
 }
 

--- a/src/schema_service/wasm_compiler.rs
+++ b/src/schema_service/wasm_compiler.rs
@@ -1,0 +1,200 @@
+//! Rust → WASM compiler for transform views.
+//!
+//! Takes a Rust function body (the `transform_impl` function), wraps it in
+//! a WASM scaffold with memory management and JSON serialization, compiles it
+//! to a `.wasm` module using `cargo build`, and returns the bytes.
+//!
+//! The schema service uses this at registration time so transforms can be
+//! submitted as source instead of pre-compiled bytes — the source is then
+//! stored in the registry alongside the bytes for public auditability.
+
+use std::path::Path;
+use std::process::Command;
+
+const SCAFFOLD_TEMPLATE: &str = r#"
+use serde_json::Value;
+
+// ---- Memory management ----
+static mut ARENA: Vec<u8> = Vec::new();
+
+#[no_mangle]
+pub extern "C" fn alloc(size: i32) -> i32 {
+    unsafe {
+        ARENA = vec![0u8; size as usize];
+        ARENA.as_ptr() as i32
+    }
+}
+
+// ---- Transform entry point ----
+#[no_mangle]
+pub extern "C" fn transform(ptr: *const u8, len: i32) -> i64 {
+    let input_bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+    let input: Value = match serde_json::from_slice(input_bytes) {
+        Ok(v) => v,
+        Err(_) => return 0,
+    };
+    let output = transform_impl(input);
+    let output_bytes = match serde_json::to_vec(&output) {
+        Ok(b) => b,
+        Err(_) => return 0,
+    };
+    let out_ptr = output_bytes.as_ptr() as i64;
+    let out_len = output_bytes.len() as i64;
+    std::mem::forget(output_bytes);
+    (out_ptr << 32) | out_len
+}
+
+// ---- Author-submitted transform ----
+TRANSFORM_BODY
+"#;
+
+const CARGO_TOML_TEMPLATE: &str = r#"[package]
+name = "wasm_transform"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+
+[profile.release]
+opt-level = "s"
+lto = true
+"#;
+
+/// Check that the `wasm32-unknown-unknown` rustup target is installed.
+pub fn check_wasm_toolchain() -> Result<(), String> {
+    let output = Command::new("rustup")
+        .args(["target", "list", "--installed"])
+        .output()
+        .map_err(|e| format!("Failed to run rustup: {e}. Is rustup installed?"))?;
+
+    let installed = String::from_utf8_lossy(&output.stdout);
+    if installed.contains("wasm32-unknown-unknown") {
+        Ok(())
+    } else {
+        Err(
+            "wasm32-unknown-unknown target not installed. Run: rustup target add wasm32-unknown-unknown"
+                .to_string(),
+        )
+    }
+}
+
+/// Compile a Rust transform function body to WASM bytes.
+///
+/// `rust_transform` should be the full `fn transform_impl(input: Value) -> Value { ... }`
+/// function definition. The compiler wraps it in a scaffold with alloc/transform exports.
+pub fn compile_rust_to_wasm(rust_transform: &str) -> Result<Vec<u8>, String> {
+    check_wasm_toolchain()?;
+
+    let tmp_dir =
+        tempfile::tempdir().map_err(|e| format!("Failed to create temp directory: {e}"))?;
+
+    let project_dir = tmp_dir.path().join("wasm_transform");
+    let src_dir = project_dir.join("src");
+    std::fs::create_dir_all(&src_dir)
+        .map_err(|e| format!("Failed to create project directory: {e}"))?;
+
+    std::fs::write(project_dir.join("Cargo.toml"), CARGO_TOML_TEMPLATE)
+        .map_err(|e| format!("Failed to write Cargo.toml: {e}"))?;
+
+    let lib_rs = SCAFFOLD_TEMPLATE.replace("TRANSFORM_BODY", rust_transform);
+    std::fs::write(src_dir.join("lib.rs"), &lib_rs)
+        .map_err(|e| format!("Failed to write lib.rs: {e}"))?;
+
+    log::info!(
+        "WASM compiler: building transform in {}",
+        project_dir.display()
+    );
+
+    // Pass `--target-dir` explicitly: a parent `CARGO_TARGET_DIR` env var
+    // (common in CI / workspace builds) would otherwise redirect output
+    // away from `project_dir/target/`.
+    let target_dir = project_dir.join("target");
+    let output = Command::new("cargo")
+        .args([
+            "build",
+            "--target",
+            "wasm32-unknown-unknown",
+            "--release",
+            "--manifest-path",
+        ])
+        .arg(project_dir.join("Cargo.toml"))
+        .arg("--target-dir")
+        .arg(&target_dir)
+        .output()
+        .map_err(|e| format!("Failed to run cargo build: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let errors: Vec<&str> = stderr.lines().filter(|l| l.contains("error")).collect();
+        let error_summary = if errors.is_empty() {
+            stderr.to_string()
+        } else {
+            errors.join("\n")
+        };
+        return Err(format!("Rust compilation failed:\n{error_summary}"));
+    }
+
+    let wasm_path = project_dir
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("release")
+        .join("wasm_transform.wasm");
+
+    read_wasm_file(&wasm_path)
+}
+
+fn read_wasm_file(path: &Path) -> Result<Vec<u8>, String> {
+    std::fs::read(path).map_err(|e| format!("Failed to read compiled WASM file: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaffold_template_wraps_body() {
+        let body = "fn transform_impl(input: Value) -> Value { input }";
+        let rendered = SCAFFOLD_TEMPLATE.replace("TRANSFORM_BODY", body);
+        assert!(rendered.contains("fn transform_impl"));
+        assert!(rendered.contains("pub extern \"C\" fn alloc"));
+        assert!(rendered.contains("pub extern \"C\" fn transform"));
+    }
+
+    #[test]
+    fn compile_simple_transform() {
+        if check_wasm_toolchain().is_err() {
+            eprintln!("Skipping: wasm32-unknown-unknown not installed");
+            return;
+        }
+
+        let rust_code = r#"
+fn transform_impl(input: Value) -> Value {
+    serde_json::json!({ "fields": { "result": input } })
+}
+"#;
+        let wasm_bytes = compile_rust_to_wasm(rust_code).expect("Compilation should succeed");
+        assert!(!wasm_bytes.is_empty(), "WASM output should not be empty");
+        assert_eq!(&wasm_bytes[..4], b"\0asm", "Should be a valid WASM module");
+    }
+
+    #[test]
+    fn compile_invalid_rust_fails() {
+        if check_wasm_toolchain().is_err() {
+            eprintln!("Skipping: wasm32-unknown-unknown not installed");
+            return;
+        }
+
+        let bad_code = r#"
+fn transform_impl(input: Value) -> Value {
+    this is not valid rust
+}
+"#;
+        let result = compile_rust_to_wasm(bad_code);
+        assert!(result.is_err(), "Invalid Rust should fail to compile");
+    }
+}

--- a/tests/transform_registry_test.rs
+++ b/tests/transform_registry_test.rs
@@ -108,6 +108,7 @@ fn make_register_request(
             .map(|(k, v)| (k.to_string(), v.clone()))
             .collect(),
         source_url: None,
+        rust_source: None,
         wasm_bytes: wasm_bytes.to_vec(),
     }
 }
@@ -471,6 +472,7 @@ async fn test_unknown_schema_in_query_fails_registration() {
         )],
         output_fields: HashMap::from([("out".to_string(), FieldValueType::String)]),
         source_url: None,
+        rust_source: None,
         wasm_bytes: b"some_wasm".to_vec(),
     };
 
@@ -496,6 +498,7 @@ async fn test_register_rejects_empty_name() {
         input_queries: vec![],
         output_fields: HashMap::from([("out".to_string(), FieldValueType::String)]),
         source_url: None,
+        rust_source: None,
         wasm_bytes: b"wasm".to_vec(),
     };
 
@@ -505,7 +508,7 @@ async fn test_register_rejects_empty_name() {
 }
 
 #[tokio::test]
-async fn test_register_rejects_empty_wasm() {
+async fn test_register_rejects_neither_source_nor_bytes() {
     let state = make_test_state();
     let request = RegisterTransformRequest {
         name: "test".to_string(),
@@ -514,12 +517,42 @@ async fn test_register_rejects_empty_wasm() {
         input_queries: vec![],
         output_fields: HashMap::from([("out".to_string(), FieldValueType::String)]),
         source_url: None,
+        rust_source: None,
         wasm_bytes: vec![],
     };
 
     let result = state.register_transform(request).await;
     assert!(result.is_err());
-    assert!(format!("{}", result.unwrap_err()).contains("non-empty"));
+    let err = format!("{}", result.unwrap_err());
+    assert!(
+        err.contains("rust_source or wasm_bytes"),
+        "Expected either/or error, got: {}",
+        err,
+    );
+}
+
+#[tokio::test]
+async fn test_register_rejects_both_source_and_bytes() {
+    let state = make_test_state();
+    let request = RegisterTransformRequest {
+        name: "test".to_string(),
+        version: "1.0.0".to_string(),
+        description: None,
+        input_queries: vec![],
+        output_fields: HashMap::from([("out".to_string(), FieldValueType::String)]),
+        source_url: None,
+        rust_source: Some("fn transform_impl(input: Value) -> Value { input }".to_string()),
+        wasm_bytes: b"wasm".to_vec(),
+    };
+
+    let result = state.register_transform(request).await;
+    assert!(result.is_err());
+    let err = format!("{}", result.unwrap_err());
+    assert!(
+        err.contains("not both"),
+        "Expected 'not both' error, got: {}",
+        err,
+    );
 }
 
 #[tokio::test]
@@ -532,6 +565,7 @@ async fn test_register_rejects_empty_version() {
         input_queries: vec![],
         output_fields: HashMap::from([("out".to_string(), FieldValueType::String)]),
         source_url: None,
+        rust_source: None,
         wasm_bytes: b"wasm".to_vec(),
     };
 
@@ -549,6 +583,7 @@ async fn test_register_rejects_empty_output_fields() {
         input_queries: vec![],
         output_fields: HashMap::new(),
         source_url: None,
+        rust_source: None,
         wasm_bytes: b"wasm".to_vec(),
     };
 
@@ -809,4 +844,196 @@ async fn add_view_rejects_empty_input_queries() {
         err.to_string().contains("at least one input query"),
         "unexpected error message: {err}"
     );
+}
+
+// ============== Rust source compilation ==============
+
+/// The tests below exercise the `cargo build --target wasm32-unknown-unknown`
+/// path. They're skipped on hosts without the wasm target installed so the
+/// main test job stays green on machines that only run library tests.
+fn wasm_toolchain_available() -> bool {
+    fold_db::schema_service::wasm_compiler::check_wasm_toolchain().is_ok()
+}
+
+fn minimal_transform_source() -> &'static str {
+    // Full `fn transform_impl(...)` definition that the scaffold wraps.
+    // Kept tiny to keep compile time bounded.
+    r#"
+fn transform_impl(input: Value) -> Value {
+    serde_json::json!({ "fields": { "summary": input } })
+}
+"#
+}
+
+#[tokio::test]
+async fn test_register_transform_accepts_rust_source_compiles_and_stores() {
+    if !wasm_toolchain_available() {
+        eprintln!("Skipping: wasm32-unknown-unknown not installed");
+        return;
+    }
+
+    let state = make_test_state();
+    let schema_name = add_test_schema(
+        &state,
+        "Notes",
+        &[("body", FieldValueType::String)],
+        &[("body", "word")],
+    )
+    .await;
+
+    let request = RegisterTransformRequest {
+        name: "summarize_notes".to_string(),
+        version: "1.0.0".to_string(),
+        description: Some("compile-from-source test".to_string()),
+        input_queries: vec![Query::new(schema_name.clone(), vec!["body".to_string()])],
+        output_fields: HashMap::from([("summary".to_string(), FieldValueType::String)]),
+        source_url: None,
+        rust_source: Some(minimal_transform_source().to_string()),
+        wasm_bytes: vec![],
+    };
+
+    let (record, outcome) = state
+        .register_transform(request)
+        .await
+        .expect("register_transform should succeed with rust_source");
+
+    assert!(matches!(outcome, TransformAddOutcome::Added));
+    assert!(!record.hash.is_empty(), "wasm hash must be populated");
+    let source_hash = record
+        .source_hash
+        .as_ref()
+        .expect("source_hash must be populated when rust_source is submitted");
+    assert_eq!(source_hash.len(), 64, "sha256 hex is 64 chars");
+    assert_ne!(
+        &record.hash, source_hash,
+        "wasm hash and source hash are distinct"
+    );
+
+    let wasm = state
+        .get_transform_wasm(&record.hash)
+        .await
+        .expect("wasm lookup should not error")
+        .expect("wasm bytes must be retrievable by hash");
+    assert_eq!(
+        &wasm[..4],
+        b"\0asm",
+        "stored artifact must be a valid WASM module"
+    );
+
+    let source = state
+        .get_transform_source(&record.hash)
+        .await
+        .expect("source lookup should not error")
+        .expect("source must be retrievable by hash");
+    assert_eq!(source, minimal_transform_source());
+}
+
+#[tokio::test]
+async fn test_register_transform_deterministic_compile_from_same_source() {
+    if !wasm_toolchain_available() {
+        eprintln!("Skipping: wasm32-unknown-unknown not installed");
+        return;
+    }
+
+    let state = make_test_state();
+    let schema_name = add_test_schema(
+        &state,
+        "Posts",
+        &[("text", FieldValueType::String)],
+        &[("text", "word")],
+    )
+    .await;
+
+    let build = |name: &str| RegisterTransformRequest {
+        name: name.to_string(),
+        version: "1.0.0".to_string(),
+        description: None,
+        input_queries: vec![Query::new(schema_name.clone(), vec!["text".to_string()])],
+        output_fields: HashMap::from([("summary".to_string(), FieldValueType::String)]),
+        source_url: None,
+        rust_source: Some(minimal_transform_source().to_string()),
+        wasm_bytes: vec![],
+    };
+
+    let (first, out1) = state
+        .register_transform(build("first"))
+        .await
+        .expect("first register should succeed");
+    let (second, out2) = state
+        .register_transform(build("second"))
+        .await
+        .expect("second register should succeed");
+
+    assert!(matches!(out1, TransformAddOutcome::Added));
+    assert!(
+        matches!(out2, TransformAddOutcome::AlreadyExists),
+        "same source should produce the same wasm hash and deduplicate"
+    );
+    assert_eq!(first.hash, second.hash);
+}
+
+#[tokio::test]
+async fn test_register_transform_rejects_invalid_rust_source() {
+    if !wasm_toolchain_available() {
+        eprintln!("Skipping: wasm32-unknown-unknown not installed");
+        return;
+    }
+
+    let state = make_test_state();
+    let request = RegisterTransformRequest {
+        name: "bad".to_string(),
+        version: "1.0.0".to_string(),
+        description: None,
+        input_queries: vec![],
+        output_fields: HashMap::from([("out".to_string(), FieldValueType::String)]),
+        source_url: None,
+        rust_source: Some(
+            "fn transform_impl(input: Value) -> Value { this is not valid rust }".to_string(),
+        ),
+        wasm_bytes: vec![],
+    };
+
+    let err = state
+        .register_transform(request)
+        .await
+        .expect_err("invalid rust must not compile");
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("compile") || msg.contains("error"),
+        "expected compile failure, got: {}",
+        msg,
+    );
+}
+
+#[tokio::test]
+async fn test_get_transform_source_returns_none_for_byte_upload() {
+    let state = make_test_state();
+    let schema_name = add_test_schema(
+        &state,
+        "Items",
+        &[("sku", FieldValueType::String)],
+        &[("sku", "word")],
+    )
+    .await;
+
+    let (record, _) = state
+        .register_transform(make_register_request(
+            "bytes_only",
+            &schema_name,
+            &["sku"],
+            &[("out", FieldValueType::String)],
+            b"pre_compiled_bytes",
+        ))
+        .await
+        .expect("register with pre-compiled bytes should succeed");
+
+    assert!(
+        record.source_hash.is_none(),
+        "no source_hash when only bytes uploaded"
+    );
+    let source = state
+        .get_transform_source(&record.hash)
+        .await
+        .expect("source lookup should not error");
+    assert!(source.is_none(), "no source stored for byte-only upload");
 }


### PR DESCRIPTION
## Summary

- Transform registration now takes `rust_source: Option<String>`; when provided the service compiles it server-side via `cargo build --target wasm32-unknown-unknown` and stores both the source and the compiled bytes in Sled. Exactly one of `rust_source` / `wasm_bytes` is required — rejects both-missing and both-present.
- `TransformRecord` gains `source_hash: Option<String>`, a sha256 of the submitted source. The compiled-bytes `hash` still identifies the artifact; `source_hash` identifies author intent.
- New `get_transform_source(hash)` on `SchemaServiceState` backs a future `GET /api/transform/{hash}/source` route (HTTP wrapping lives in fold_db_node).

## Why

Today the registry only sees compiled bytes — "what code does this transform run" has no answer beyond reverse-engineering WASM. Storing source makes transforms publicly auditable, and moving compilation to the service removes the `wasm32-unknown-unknown` toolchain requirement from every client (second devices, mobile, third-party tools).

## Shape of the change

- `wasm_compiler.rs` ported into `fold_db` (previously only in fold_db_node) so the schema service has no downstream dep.
- `ExternalSchemaPersistence` gains `save_transform_source` / `load_transform_source` with no-op default impls so existing remote backends (e.g. schema-infra Lambda) keep compiling.
- Byte-only uploads are still supported and unchanged; they store no source and `source_hash` stays `None`.

## Not in this PR

- **Deployment story**: the schema-infra Lambda needs cargo + `wasm32-unknown-unknown` in its build image. Lambda container size and cold-start impact are worth looking at; a Fargate task or dedicated build service may be more appropriate. Per directive, not enabling auto-merge until this is agreed.
- **Toolchain pinning**: determinism depends on a pinned toolchain on the build side — that belongs in the schema-infra repo rather than here.
- **HTTP route**: `GET /api/transform/{hash}/source` needs to be wired up in fold_db_node alongside the existing `/wasm` route.
- **fold_db_node memory consolidation**: switching `register_topic_clusters_view` to submit source instead of pre-compiled bytes is a downstream follow-up.
- **Task F of coherence project (drop inline bytes from StoredView)**: this PR enables it by making `wasm_bytes` always recoverable from `transform_hash`, but doesn't land it.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --test transform_registry_test` — all 31 tests pass, including:
  - `test_register_transform_accepts_rust_source_compiles_and_stores`
  - `test_register_transform_deterministic_compile_from_same_source`
  - `test_register_transform_rejects_invalid_rust_source`
  - `test_register_rejects_neither_source_nor_bytes`
  - `test_register_rejects_both_source_and_bytes`
  - `test_get_transform_source_returns_none_for_byte_upload`
- [x] `cargo test --lib` passes single-threaded (one unrelated pre-existing flake on `test_purge_org_data` when run in parallel — reproduces on pristine mainline; tracked separately)
- [ ] Toolchain-dependent tests auto-skip on hosts without `wasm32-unknown-unknown` installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)