### PR TITLE
feat(schema_service): require view input_queries to match linked transform

### DIFF
--- a/src/schema_service/state.rs
+++ b/src/schema_service/state.rs
@@ -5,6 +5,7 @@ use crate::db_operations::native_index::{cosine_similarity, Embedder, FastEmbedM
 use crate::error::{FoldDbError, FoldDbResult};
 use crate::log_feature;
 use crate::logging::features::LogFeature;
+use crate::schema::types::operations::Query;
 use crate::schema::types::Schema;
 
 use super::external_persistence::ExternalSchemaPersistence;
@@ -1657,6 +1658,29 @@ impl SchemaServiceState {
             (None, None) => (None, None),
         };
 
+        // If the view links to a transform that's in the Global Transform
+        // Registry, the transform's Phase 1/2 classification was computed
+        // against its declared input_queries. Require the view's
+        // input_queries to name the same (schema_name, field) pairs so the
+        // stored classification stays coherent with what the transform sees
+        // at runtime. Self-attested (Some bytes, Some hash) bundles that
+        // aren't in the registry have no classification to protect and
+        // bypass this check.
+        if let Some(ref hash) = resolved_transform_hash {
+            if let Some(transform_record) = self.get_transform_by_hash(hash)? {
+                let transform_pairs = schema_field_pairs(&transform_record.input_queries);
+                let view_pairs = schema_field_pairs(&request.input_queries);
+                if transform_pairs != view_pairs {
+                    return Err(FoldDbError::Config(format!(
+                        "View input_queries do not match transform '{}': transform reads {{{}}} but view queries {{{}}}",
+                        hash,
+                        format_schema_field_pairs(&transform_pairs),
+                        format_schema_field_pairs(&view_pairs),
+                    )));
+                }
+            }
+        }
+
         // Build the StoredView
         let view = StoredView {
             name: request.name.clone(),
@@ -1834,6 +1858,29 @@ impl SchemaServiceState {
         }
         Ok(())
     }
+}
+
+/// Flatten a list of queries into the set of (schema_name, field) pairs they
+/// read. Non-selection query fields (filter, as_of, sort_order) are ignored —
+/// this set is about which data the queries expose, not how they execute.
+fn schema_field_pairs(queries: &[Query]) -> HashSet<(String, String)> {
+    let mut pairs = HashSet::new();
+    for query in queries {
+        for field in &query.fields {
+            pairs.insert((query.schema_name.clone(), field.clone()));
+        }
+    }
+    pairs
+}
+
+/// Render a (schema, field) set as a stable, comma-separated `Schema.field` list.
+fn format_schema_field_pairs(pairs: &HashSet<(String, String)>) -> String {
+    let mut as_vec: Vec<String> = pairs
+        .iter()
+        .map(|(schema, field)| format!("{}.{}", schema, field))
+        .collect();
+    as_vec.sort();
+    as_vec.join(", ")
 }
 
 #[cfg(test)]

--- a/src/schema_service/state_transforms.rs
+++ b/src/schema_service/state_transforms.rs
@@ -90,6 +90,7 @@ impl SchemaServiceState {
             name: request.name,
             version: request.version,
             description: request.description,
+            input_queries: request.input_queries,
             input_schema,
             output_schema: request.output_fields,
             source_url: request.source_url,

--- a/src/schema_service/types.rs
+++ b/src/schema_service/types.rs
@@ -249,6 +249,12 @@ pub struct TransformRecord {
     /// Optional description
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// The input queries the transform was registered against. Views linked
+    /// to this transform must query the same (schema_name, field) pairs so
+    /// the Phase 1/2 classification stays coherent with what the transform
+    /// actually sees at runtime.
+    #[serde(default)]
+    pub input_queries: Vec<Query>,
     /// Input field types expected by the transform (resolved from input_queries)
     pub input_schema: HashMap<String, FieldValueType>,
     /// Output field types produced by the transform

--- a/tests/transform_registry_test.rs
+++ b/tests/transform_registry_test.rs
@@ -997,3 +997,148 @@ async fn add_view_accepts_matching_bytes_and_hash() {
     assert_eq!(view.transform_hash.as_deref(), Some(hash.as_str()));
     assert_eq!(view.wasm_bytes.as_deref(), Some(bytes.as_slice()));
 }
+
+// ============== add_view input_queries coherence with transform ==============
+
+/// A view that links to a registered transform must query the same
+/// (schema_name, field) pairs the transform was classified against. If the
+/// view reads a different set, the stored classification is stale against
+/// what the transform actually sees at runtime — reject with a diff message.
+#[tokio::test]
+async fn add_view_rejects_input_queries_different_from_transform() {
+    let state = make_test_state();
+    let schema_a = add_test_schema(
+        &state,
+        "coherence_schema_a",
+        &[("x", FieldValueType::String)],
+        &[("x", "word")],
+    )
+    .await;
+    let schema_b = add_test_schema(
+        &state,
+        "coherence_schema_b",
+        &[("y", FieldValueType::String)],
+        &[("y", "word")],
+    )
+    .await;
+
+    // Transform declares {A.x, B.y}
+    let (record, _) = state
+        .register_transform(RegisterTransformRequest {
+            name: "cross_schema_xform".to_string(),
+            version: "1.0.0".to_string(),
+            description: None,
+            input_queries: vec![
+                Query::new(schema_a.clone(), vec!["x".to_string()]),
+                Query::new(schema_b.clone(), vec!["y".to_string()]),
+            ],
+            output_fields: HashMap::from([("out".to_string(), FieldValueType::String)]),
+            source_url: None,
+            wasm_bytes: b"cross_schema_wasm".to_vec(),
+        })
+        .await
+        .expect("register_transform failed");
+
+    // View queries only {A.x} — missing B.y
+    let request = make_add_view_request(
+        "MismatchedInputs",
+        &schema_a,
+        "x",
+        "out",
+        None,
+        Some(record.hash.clone()),
+    );
+
+    let err = state
+        .add_view(request)
+        .await
+        .expect_err("add_view must reject view input_queries that differ from transform's");
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("do not match") && msg.contains(&record.hash),
+        "expected mismatch error referencing transform '{}', got: {}",
+        record.hash,
+        msg
+    );
+    assert!(
+        msg.contains(&format!("{}.x", schema_a)),
+        "expected transform-side pair {}.x in error, got: {}",
+        schema_a,
+        msg
+    );
+    assert!(
+        msg.contains(&format!("{}.y", schema_b)),
+        "expected transform-side pair {}.y in error, got: {}",
+        schema_b,
+        msg
+    );
+}
+
+/// Happy path: the view's (schema, field) set equals the transform's, so
+/// the stored classification is coherent with what the transform reads.
+#[tokio::test]
+async fn add_view_accepts_matching_input_queries() {
+    let state = make_test_state();
+    let schema_a = add_test_schema(
+        &state,
+        "match_schema_a",
+        &[("x", FieldValueType::String)],
+        &[("x", "word")],
+    )
+    .await;
+    let schema_b = add_test_schema(
+        &state,
+        "match_schema_b",
+        &[("y", FieldValueType::String)],
+        &[("y", "word")],
+    )
+    .await;
+
+    let (record, _) = state
+        .register_transform(RegisterTransformRequest {
+            name: "matching_xform".to_string(),
+            version: "1.0.0".to_string(),
+            description: None,
+            input_queries: vec![
+                Query::new(schema_a.clone(), vec!["x".to_string()]),
+                Query::new(schema_b.clone(), vec!["y".to_string()]),
+            ],
+            output_fields: HashMap::from([("out".to_string(), FieldValueType::String)]),
+            source_url: None,
+            wasm_bytes: b"matching_wasm".to_vec(),
+        })
+        .await
+        .expect("register_transform failed");
+
+    let mut field_descriptions = HashMap::new();
+    field_descriptions.insert("out".to_string(), "view output".to_string());
+    let mut field_classifications = HashMap::new();
+    field_classifications.insert("out".to_string(), vec!["low".to_string()]);
+    let mut field_data_classifications = HashMap::new();
+    field_data_classifications.insert("out".to_string(), DataClassification::low());
+
+    let request = AddViewRequest {
+        name: "MatchingView".to_string(),
+        descriptive_name: "Matching View".to_string(),
+        input_queries: vec![
+            Query::new(schema_a.clone(), vec!["x".to_string()]),
+            Query::new(schema_b.clone(), vec!["y".to_string()]),
+        ],
+        output_fields: vec!["out".to_string()],
+        field_descriptions,
+        field_classifications,
+        field_data_classifications,
+        wasm_bytes: None,
+        transform_hash: Some(record.hash.clone()),
+        schema_type: fold_db::schema::types::schema::DeclarativeSchemaType::Single,
+    };
+
+    let view = extract_stored_view(
+        state
+            .add_view(request)
+            .await
+            .expect("add_view must accept matching input_queries"),
+    );
+    assert_eq!(view.transform_hash.as_deref(), Some(record.hash.as_str()));
+    assert_eq!(view.input_queries.len(), 2);
+}


### PR DESCRIPTION
## Summary

- `SchemaServiceState::add_view` now requires a view linked to a **registered** transform (via `transform_hash`) to query the same `(schema_name, field)` pairs the transform was classified against. On mismatch the request is rejected with a diff message listing both sides.
- `TransformRecord` now carries the original `input_queries` it was registered with (`#[serde(default)]` for any persisted records that predate this change).
- Self-attested `(Some wasm_bytes, Some transform_hash)` bundles that aren't in the registry have no classification to protect and bypass the check — consistent with task B's resolution branch.

## Why

Transforms are classified (Phase 1/2) against their declared `input_queries`. A view can reference a transform but use an entirely different input set, so the stored classification becomes stale against what the transform actually sees at runtime.

Part of the view + transform registry coherence work — task C, depends on task B (#577).

## Test plan

- [x] `cargo test -p fold_db --test transform_registry_test` — 32/32 pass, including:
  - `add_view_rejects_input_queries_different_from_transform` — transform declares `{A.x, B.y}`, view queries `{A.x}`, rejects with diff message.
  - `add_view_accepts_matching_input_queries` — happy path for matched pairs.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace --all-targets` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)