### PR TITLE
feat(schema_service): reject views whose output shape disagrees with linked transform

### DIFF
--- a/src/schema_service/state.rs
+++ b/src/schema_service/state.rs
@@ -1585,43 +1585,15 @@ impl SchemaServiceState {
             }
         }
 
-        // Build an output schema from the view's fields and run it through add_schema.
-        // Use descriptive_name as the initial schema name — add_schema replaces it with
-        // the identity hash, but having a meaningful name prevents infer_name_from_fields
-        // from falling back to the view name (which is not a collection name).
-        let mut output_schema = Schema::new(
-            request.descriptive_name.clone(),
-            crate::schema::types::schema::DeclarativeSchemaType::Single,
-            None,
-            Some(request.output_fields.clone()),
-            None,
-            None,
-        );
-        output_schema.descriptive_name = Some(request.descriptive_name.clone());
-        output_schema.field_descriptions = request.field_descriptions.clone();
-        output_schema.field_classifications = request.field_classifications.clone();
-        output_schema.field_data_classifications = request.field_data_classifications.clone();
-        output_schema.schema_type = request.schema_type.clone();
-
-        // Run through the full schema pipeline (similarity, canonicalization, dedup, expansion)
-        let schema_outcome = self.add_schema(output_schema, HashMap::new()).await?;
-
-        let (output_schema, _replaced_schema) = match &schema_outcome {
-            SchemaAddOutcome::Added(schema, _) => (schema.clone(), None),
-            SchemaAddOutcome::AlreadyExists(schema, _) => (schema.clone(), None),
-            SchemaAddOutcome::Expanded(old_name, schema, _) => {
-                (schema.clone(), Some(old_name.clone()))
-            }
-        };
-
-        // Resolve (wasm_bytes, transform_hash) per the AddViewRequest contract:
+        // Resolve (wasm_bytes, transform_hash) BEFORE building the output
+        // schema so the view's output shape can be cross-validated against
+        // the registered transform's output_schema. Failing here leaves no
+        // partially-persisted schema behind.
+        //
         //   (Some, None)  — derive hash from bytes (content-addressed link)
         //   (None, Some)  — look up registry, fetch bytes, reject if missing
         //   (Some, Some)  — verify sha256(bytes) == hash, reject on mismatch
         //   (None, None)  — identity view, no transform
-        // Supplied inline bytes are kept on the StoredView for
-        // `stored_view_to_transform_view`; registry-fetched bytes are cached
-        // the same way.
         let (resolved_wasm_bytes, resolved_transform_hash) = match (
             request.wasm_bytes,
             request.transform_hash,
@@ -1658,28 +1630,126 @@ impl SchemaServiceState {
             (None, None) => (None, None),
         };
 
-        // If the view links to a transform that's in the Global Transform
-        // Registry, the transform's Phase 1/2 classification was computed
-        // against its declared input_queries. Require the view's
-        // input_queries to name the same (schema_name, field) pairs so the
-        // stored classification stays coherent with what the transform sees
-        // at runtime. Self-attested (Some bytes, Some hash) bundles that
-        // aren't in the registry have no classification to protect and
-        // bypass this check.
-        if let Some(ref hash) = resolved_transform_hash {
-            if let Some(transform_record) = self.get_transform_by_hash(hash)? {
-                let transform_pairs = schema_field_pairs(&transform_record.input_queries);
-                let view_pairs = schema_field_pairs(&request.input_queries);
-                if transform_pairs != view_pairs {
-                    return Err(FoldDbError::Config(format!(
-                        "View input_queries do not match transform '{}': transform reads {{{}}} but view queries {{{}}}",
-                        hash,
-                        format_schema_field_pairs(&transform_pairs),
-                        format_schema_field_pairs(&view_pairs),
-                    )));
+        // Cross-validate the view against the transform it links to (if any).
+        // Self-attested (Some bytes, Some hash) bundles whose hash isn't in
+        // the registry have no classification or declared output to protect
+        // and bypass these checks.
+        let linked_transform = match &resolved_transform_hash {
+            Some(hash) => self.get_transform_by_hash(hash)?,
+            None => None,
+        };
+        if let Some(record) = &linked_transform {
+            // Input coherence: the transform's Phase 1/2 classification was
+            // computed against its declared input_queries. The view's
+            // input_queries must name the same (schema_name, field) pairs so
+            // the stored classification stays coherent with what the transform
+            // sees at runtime.
+            let transform_pairs = schema_field_pairs(&record.input_queries);
+            let view_pairs = schema_field_pairs(&request.input_queries);
+            if transform_pairs != view_pairs {
+                return Err(FoldDbError::Config(format!(
+                    "View input_queries do not match transform '{}': transform reads {{{}}} but view queries {{{}}}",
+                    record.hash,
+                    format_schema_field_pairs(&transform_pairs),
+                    format_schema_field_pairs(&view_pairs),
+                )));
+            }
+
+            // Output coherence: every declared output field must be emitted by
+            // the transform. Without this, the view's output schema looks up
+            // fields the WASM never produces — silent data loss at query time.
+            let mut missing: Vec<String> = request
+                .output_fields
+                .iter()
+                .filter(|f| !record.output_schema.contains_key(*f))
+                .cloned()
+                .collect();
+            if !missing.is_empty() {
+                missing.sort();
+                let emitted: Vec<String> = {
+                    let mut keys: Vec<String> = record.output_schema.keys().cloned().collect();
+                    keys.sort();
+                    keys
+                };
+                return Err(FoldDbError::Config(format!(
+                    "View output fields {:?} are not emitted by transform '{}' (hash {}); transform emits {:?}",
+                    missing, record.name, record.hash, emitted
+                )));
+            }
+
+            // Output type coherence: any declared field types must match the
+            // transform's declared output types.
+            let mut mismatches: Vec<String> = Vec::new();
+            for (field, declared) in &request.output_field_types {
+                let Some(expected) = record.output_schema.get(field) else {
+                    mismatches.push(format!(
+                        "'{}' (declared type {}, not emitted by transform)",
+                        field, declared
+                    ));
+                    continue;
+                };
+                if declared != expected {
+                    mismatches.push(format!(
+                        "'{}' (view declared {}, transform emits {})",
+                        field, declared, expected
+                    ));
+                }
+            }
+            if !mismatches.is_empty() {
+                mismatches.sort();
+                return Err(FoldDbError::Config(format!(
+                    "View output field types disagree with transform '{}' (hash {}): {}",
+                    record.name,
+                    record.hash,
+                    mismatches.join(", ")
+                )));
+            }
+        }
+
+        // Build an output schema from the view's fields and run it through add_schema.
+        // Use descriptive_name as the initial schema name — add_schema replaces it with
+        // the identity hash, but having a meaningful name prevents infer_name_from_fields
+        // from falling back to the view name (which is not a collection name).
+        let mut output_schema = Schema::new(
+            request.descriptive_name.clone(),
+            crate::schema::types::schema::DeclarativeSchemaType::Single,
+            None,
+            Some(request.output_fields.clone()),
+            None,
+            None,
+        );
+        output_schema.descriptive_name = Some(request.descriptive_name.clone());
+        output_schema.field_descriptions = request.field_descriptions.clone();
+        output_schema.field_classifications = request.field_classifications.clone();
+        output_schema.field_data_classifications = request.field_data_classifications.clone();
+        output_schema.schema_type = request.schema_type.clone();
+        // Seed field_types from the explicit request map, then fill gaps from
+        // the linked transform's output_schema so view-emitted fields carry
+        // concrete types downstream (validation, NMI, etc.) even when the
+        // caller didn't restate them.
+        for (field, ty) in &request.output_field_types {
+            output_schema.field_types.insert(field.clone(), ty.clone());
+        }
+        if let Some(record) = &linked_transform {
+            for field in &request.output_fields {
+                if !output_schema.field_types.contains_key(field) {
+                    if let Some(ty) = record.output_schema.get(field) {
+                        output_schema.field_types.insert(field.clone(), ty.clone());
+                    }
                 }
             }
         }
+
+        // Run through the full schema pipeline (similarity, canonicalization, dedup, expansion)
+        let schema_outcome = self.add_schema(output_schema, HashMap::new()).await?;
+
+        let (output_schema, _replaced_schema) = match &schema_outcome {
+            SchemaAddOutcome::Added(schema, _) => (schema.clone(), None),
+            SchemaAddOutcome::AlreadyExists(schema, _) => (schema.clone(), None),
+            SchemaAddOutcome::Expanded(old_name, schema, _) => {
+                (schema.clone(), Some(old_name.clone()))
+            }
+        };
 
         // Build the StoredView
         let view = StoredView {

--- a/src/schema_service/types.rs
+++ b/src/schema_service/types.rs
@@ -183,6 +183,13 @@ pub struct AddViewRequest {
     /// Data classifications for each output field (sensitivity + domain)
     #[serde(default)]
     pub field_data_classifications: HashMap<String, DataClassification>,
+    /// Optional value types for output fields. When the view is linked to a
+    /// registered transform, every declared type must match the transform's
+    /// output schema exactly — mismatches are rejected with the specific field
+    /// names. Fields omitted here are allowed and fall back to the transform's
+    /// types when linked, or to `Any`.
+    #[serde(default)]
+    pub output_field_types: HashMap<String, FieldValueType>,
     /// Optional WASM transform bytes
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wasm_bytes: Option<Vec<u8>>,

--- a/tests/transform_registry_test.rs
+++ b/tests/transform_registry_test.rs
@@ -797,6 +797,7 @@ async fn add_view_rejects_empty_input_queries() {
         field_descriptions: HashMap::from([("summary".to_string(), "summary field".to_string())]),
         field_classifications: HashMap::new(),
         field_data_classifications: HashMap::new(),
+        output_field_types: HashMap::new(),
         wasm_bytes: None,
         transform_hash: None,
         schema_type: fold_db::schema::types::schema::DeclarativeSchemaType::Single,
@@ -840,6 +841,7 @@ fn make_add_view_request(
         field_descriptions,
         field_classifications,
         field_data_classifications,
+        output_field_types: HashMap::new(),
         wasm_bytes,
         transform_hash,
         schema_type: fold_db::schema::types::schema::DeclarativeSchemaType::Single,
@@ -1128,6 +1130,7 @@ async fn add_view_accepts_matching_input_queries() {
         field_descriptions,
         field_classifications,
         field_data_classifications,
+        output_field_types: HashMap::new(),
         wasm_bytes: None,
         transform_hash: Some(record.hash.clone()),
         schema_type: fold_db::schema::types::schema::DeclarativeSchemaType::Single,
@@ -1141,4 +1144,176 @@ async fn add_view_accepts_matching_input_queries() {
     );
     assert_eq!(view.transform_hash.as_deref(), Some(record.hash.as_str()));
     assert_eq!(view.input_queries.len(), 2);
+}
+
+// ============== add_view ↔ transform output shape coherence ==============
+
+/// Register a transform emitting `{summary}` and try to add a view whose
+/// output is `{body}` — the view names a field the transform never produces,
+/// so add_view must reject it with a message naming the offending field.
+#[tokio::test]
+async fn add_view_rejects_output_field_missing_from_transform() {
+    let state = make_test_state();
+    let schema_name = add_test_schema(
+        &state,
+        "source_schema_shape_missing",
+        &[("body", FieldValueType::String)],
+        &[("body", "word")],
+    )
+    .await;
+
+    let wasm = b"summary_only_transform".to_vec();
+    let (record, _) = state
+        .register_transform(make_register_request(
+            "summary_only",
+            &schema_name,
+            &["body"],
+            &[("summary", FieldValueType::String)],
+            &wasm,
+        ))
+        .await
+        .expect("register_transform failed");
+
+    // View declares `body` as an output — not emitted by the transform,
+    // and its input_queries already match the transform's {schema_name.body}.
+    let request = make_add_view_request(
+        "ViewBadOutput",
+        &schema_name,
+        "body",
+        "body",
+        None,
+        Some(record.hash.clone()),
+    );
+
+    let err = state
+        .add_view(request)
+        .await
+        .expect_err("add_view must reject output fields not emitted by transform");
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("body") && msg.contains("not emitted"),
+        "expected missing-output-field error naming 'body', got: {}",
+        msg
+    );
+    assert!(
+        msg.contains(&record.hash),
+        "expected error to mention transform hash {}, got: {}",
+        record.hash,
+        msg
+    );
+}
+
+/// Register a transform that emits `summary: String` and try to add a view
+/// whose `output_field_types` declares `summary: Integer`. The type
+/// disagrees with the transform — add_view must reject with a message
+/// naming the field and both types.
+#[tokio::test]
+async fn add_view_rejects_output_field_type_mismatch() {
+    let state = make_test_state();
+    let schema_name = add_test_schema(
+        &state,
+        "source_schema_shape_type",
+        &[("body", FieldValueType::String)],
+        &[("body", "word")],
+    )
+    .await;
+
+    let wasm = b"string_summary_transform".to_vec();
+    let (record, _) = state
+        .register_transform(make_register_request(
+            "string_summary",
+            &schema_name,
+            &["body"],
+            &[("summary", FieldValueType::String)],
+            &wasm,
+        ))
+        .await
+        .expect("register_transform failed");
+
+    let mut request = make_add_view_request(
+        "ViewTypeMismatch",
+        &schema_name,
+        "body",
+        "summary",
+        None,
+        Some(record.hash.clone()),
+    );
+    request
+        .output_field_types
+        .insert("summary".to_string(), FieldValueType::Integer);
+
+    let err = state
+        .add_view(request)
+        .await
+        .expect_err("add_view must reject output field type disagreeing with transform");
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("summary"),
+        "expected error to name field 'summary', got: {}",
+        msg
+    );
+    assert!(
+        msg.contains("Integer") && msg.contains("String"),
+        "expected error to include both Integer and String, got: {}",
+        msg
+    );
+}
+
+/// Happy path: view declares the same output field + type the transform
+/// emits. add_view succeeds, and the resulting output schema carries the
+/// declared type on `field_types` so downstream validation sees it.
+#[tokio::test]
+async fn add_view_accepts_aligned_output_shape() {
+    let state = make_test_state();
+    let schema_name = add_test_schema(
+        &state,
+        "source_schema_shape_ok",
+        &[("body", FieldValueType::String)],
+        &[("body", "word")],
+    )
+    .await;
+
+    let wasm = b"aligned_transform".to_vec();
+    let (record, _) = state
+        .register_transform(make_register_request(
+            "aligned",
+            &schema_name,
+            &["body"],
+            &[("summary", FieldValueType::String)],
+            &wasm,
+        ))
+        .await
+        .expect("register_transform failed");
+
+    let mut request = make_add_view_request(
+        "ViewAligned",
+        &schema_name,
+        "body",
+        "summary",
+        None,
+        Some(record.hash.clone()),
+    );
+    request
+        .output_field_types
+        .insert("summary".to_string(), FieldValueType::String);
+
+    let outcome = state
+        .add_view(request)
+        .await
+        .expect("add_view must accept an aligned output shape");
+    let view = extract_stored_view(outcome);
+    assert_eq!(view.transform_hash.as_deref(), Some(record.hash.as_str()));
+
+    // Output schema should carry the declared type on summary so downstream
+    // consumers (validation, NMI) see the concrete shape.
+    let stored_schema = state
+        .get_schema_by_name(&view.output_schema_name)
+        .expect("schema lookup failed")
+        .expect("output schema must be registered");
+    assert_eq!(
+        stored_schema.field_types.get("summary"),
+        Some(&FieldValueType::String),
+        "view output schema missing field_types entry for 'summary': {:?}",
+        stored_schema.field_types
+    );
 }


### PR DESCRIPTION
## Summary

Part of the view+transform registry coherence project (task C in
`projects/schema-service-view-transform-coherence`). Builds on task B
(#577, `AddViewRequest.transform_hash`).

Before this change, `RegisterTransformRequest.output_fields` (typed map)
and `AddViewRequest.output_fields` (names only) were stored independently
with no cross-validation. A transform could be registered emitting
`{summary, confidence}` while a view linked to that transform declared
output fields `{body, derived_from}` — both `register_transform` and
`add_view` succeeded. At query time the WASM produced `summary/confidence`
but the view's output schema looked up `body/derived_from`, silently
dropping data.

### What `add_view` now does

When the view resolves to a registered transform (by `transform_hash` or
by inline `wasm_bytes` whose hash is in the registry):

1. Every entry in `output_fields` must be a key the transform emits.
   Otherwise the request is rejected with the offending field names and
   the set the transform actually emits.
2. Each entry in the new optional `AddViewRequest.output_field_types`
   map must match the transform's declared type for that field. On
   disagreement the error names each field, the declared type, and the
   transform's type.

Both error messages include the transform's name and hash so callers
don't have to guess which registry entry they collided with.

### Incidental ordering fix

Transform resolution (`(wasm_bytes, transform_hash)` match block) used
to run after `add_schema`. Now it runs before, so rejections don't leave
a partially-persisted output schema behind. The field-type map from the
request (and any gaps filled from the linked transform) is seeded onto
the output schema's `field_types` so downstream validation / NMI sees
the concrete shape.

## Tests

Three new tests in `tests/transform_registry_test.rs`:

- `add_view_rejects_output_field_missing_from_transform` — view declares
  an output field the transform doesn't emit → error naming the field
  and the transform hash.
- `add_view_rejects_output_field_type_mismatch` — view declares
  `summary: Integer`, transform declares `summary: String` → error
  naming both types.
- `add_view_accepts_aligned_output_shape` — happy path; also asserts
  the declared type appears on the output schema's `field_types`.

## Test plan

- [x] `cargo test -p fold_db --test transform_registry_test` — 33 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --workspace --all-targets` — one pre-existing flake
  (`db_operations::org_operations::tests::test_purge_org_data`) that
  reproduces on mainline without this change; all other tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)