### PR TITLE
docs: drop schema_service references from install + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,8 @@ log_feature!(LogFeature::HttpServer, info, "Server started on {}", addr);
 
 ## Schema Service Environments
 
-- **Prod**: `https://axo709qs11.execute-api.us-east-1.amazonaws.com` (default)
-- **Dev**: `https://y0q3m6vk75.execute-api.us-west-2.amazonaws.com` (use `--dev` flag)
-- **Local**: `http://127.0.0.1:9002` (use `--local-schema` flag)
+The schema service is a separate cloud service deployed at `schema.folddb.com`. Source code lives in [EdgeVector/schema_service](https://github.com/EdgeVector/schema_service); deploy spec in [EdgeVector/schema-infra](https://github.com/EdgeVector/schema-infra). fold_db consumes it as a client.
+
+- **Prod**: `https://axo709qs11.execute-api.us-east-1.amazonaws.com/v1/*` (default)
+- **Dev**: `https://y0q3m6vk75.execute-api.us-west-2.amazonaws.com/v1/*` (use `--dev` flag)
+- **Local**: `http://127.0.0.1:9102` (use `--local-schema` flag; runs the actix dev binary from the `schema_service` submodule)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Download the latest `.dmg` from [GitHub Releases](https://github.com/EdgeVector/
 brew install edgevector/folddb/folddb
 ```
 
-Ships `folddb` (CLI), `folddb_server` (daemon), and `schema_service` (local schema registry). Handles upgrades via `brew upgrade folddb`.
+Ships `folddb` (CLI) and `folddb_server` (daemon). Handles upgrades via `brew upgrade folddb`. The schema service runs in the cloud at `schema.folddb.com` — no local binary is installed.
 
 ### Option C: Install from Source
 
@@ -39,7 +39,7 @@ curl -fsSL https://raw.githubusercontent.com/EdgeVector/fold_db_node/main/instal
 Or build from source:
 
 ```bash
-cargo install --git https://github.com/EdgeVector/fold_db_node folddb folddb_server schema_service
+cargo install --git https://github.com/EdgeVector/fold_db_node folddb folddb_server
 ```
 
 ### Run


### PR DESCRIPTION
## Summary

- README install options: brew and `cargo install` no longer ship a `schema_service` binary (extraction complete in Phase 0 T5 + Phase 2 T4). Readers are pointed at `schema.folddb.com` for the cloud service instead.
- CLAUDE.md Schema Service Environments section: add cross-repo pointers, fix the stale local port (`9002` → `9102`), and spell out the `/v1/*` prefix on all three environments.

Context: workspace gbrain `projects/schema-service-extraction-complete`.

## Test plan
- [x] Markdown renders correctly.
- [x] No stale `schema_service` binary references remain.
- [x] Stale port `9002` replaced with `9102`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)