### PR TITLE
feat(triggers): register TriggerFiring schema at FoldDB startup (Phase 1 T1)

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -391,6 +391,14 @@ impl FoldDB {
                 .map_err(|e| StorageError::IoError(std::io::Error::other(e.to_string())))?,
         );
 
+        // Register internal TriggerFiring schema so the TriggerRunner
+        // (Phase 1 task 3) has somewhere to log every view firing. The
+        // call is idempotent — subsequent boots refresh the cache and
+        // re-approve a no-op.
+        crate::triggers::register_trigger_firing_schema(&schema_manager)
+            .await
+            .map_err(|e| StorageError::IoError(std::io::Error::other(e.to_string())))?;
+
         // Create and start EventMonitor for system-wide observability
         let event_monitor = Arc::new(EventMonitor::new(Arc::clone(&message_bus)).await);
         info!("Started EventMonitor for system-wide event tracking");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod testing_utils;
 /// Always compiled (zero runtime cost when unused). Downstream crates
 /// can also access this via the `test-utils` feature.
 pub mod test_helpers;
+pub mod triggers;
 pub mod view;
 
 // Re-export main types for convenience

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -1,0 +1,225 @@
+//! TriggerFiring schema — internal log of every view trigger firing.
+//!
+//! TriggerRunner (Phase 1 task 3) writes one row here per attempt, win or
+//! lose. Rows are keyed by (trigger_id, fired_at) so callers can list a
+//! trigger's history in time order without scanning the whole log.
+//!
+//! Registered at FoldDB startup via [`register_trigger_firing_schema`].
+//! Idempotent: if the schema already exists in the store, load_schema
+//! refreshes the in-memory cache without clobbering on-disk state.
+
+use std::sync::Arc;
+
+use crate::schema::types::data_classification::{DataClassification, INTERNAL};
+use crate::schema::types::field_value_type::FieldValueType;
+use crate::schema::types::key_config::KeyConfig;
+use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
+use crate::schema::types::Schema;
+use crate::schema::{SchemaCore, SchemaError, SchemaState};
+
+pub const TRIGGER_FIRING_SCHEMA_NAME: &str = "TriggerFiring";
+
+/// Field names on the TriggerFiring schema. Exposed so the runner can
+/// reference them by identifier instead of stringly-typed literals.
+pub mod fields {
+    pub const TRIGGER_ID: &str = "trigger_id";
+    pub const VIEW_NAME: &str = "view_name";
+    pub const FIRED_AT: &str = "fired_at";
+    pub const DURATION_MS: &str = "duration_ms";
+    pub const STATUS: &str = "status";
+    pub const INPUT_ROW_COUNT: &str = "input_row_count";
+    pub const OUTPUT_ROW_COUNT: &str = "output_row_count";
+    pub const ERROR_MESSAGE: &str = "error_message";
+}
+
+/// Status values written to the `status` field.
+pub mod status {
+    pub const SUCCESS: &str = "success";
+    pub const ERROR: &str = "error";
+    pub const QUARANTINED: &str = "quarantined";
+}
+
+/// Build the TriggerFiring schema definition.
+///
+/// Shape: HashRange keyed by (trigger_id, fired_at) so a trigger's
+/// firing history is naturally clustered and range-scannable.
+pub fn trigger_firing_schema() -> Schema {
+    let all_fields = [
+        (
+            fields::TRIGGER_ID,
+            FieldValueType::String,
+            "Stable id derived from the trigger config (e.g. `{view_id}:{index}`)",
+        ),
+        (
+            fields::VIEW_NAME,
+            FieldValueType::String,
+            "Name of the view that fired",
+        ),
+        (
+            fields::FIRED_AT,
+            FieldValueType::Integer,
+            "Milliseconds since Unix epoch when the firing began",
+        ),
+        (
+            fields::DURATION_MS,
+            FieldValueType::Integer,
+            "How long the firing took, in milliseconds",
+        ),
+        (
+            fields::STATUS,
+            FieldValueType::String,
+            "Outcome: \"success\" | \"error\" | \"quarantined\"",
+        ),
+        (
+            fields::INPUT_ROW_COUNT,
+            FieldValueType::Integer,
+            "Rows read from source schemas",
+        ),
+        (
+            fields::OUTPUT_ROW_COUNT,
+            FieldValueType::Integer,
+            "Rows written to the output schema",
+        ),
+        (
+            fields::ERROR_MESSAGE,
+            FieldValueType::OneOf(vec![FieldValueType::String, FieldValueType::Null]),
+            "Error detail when status != \"success\"",
+        ),
+    ];
+
+    let field_names: Vec<String> = all_fields.iter().map(|(n, _, _)| n.to_string()).collect();
+
+    let mut schema = Schema::new(
+        TRIGGER_FIRING_SCHEMA_NAME.to_string(),
+        SchemaType::HashRange,
+        Some(KeyConfig::new(
+            Some(fields::TRIGGER_ID.to_string()),
+            Some(fields::FIRED_AT.to_string()),
+        )),
+        Some(field_names),
+        None,
+        None,
+    );
+
+    schema.descriptive_name = Some(TRIGGER_FIRING_SCHEMA_NAME.to_string());
+
+    for (name, ty, description) in all_fields {
+        schema.field_types.insert(name.to_string(), ty);
+        schema
+            .field_descriptions
+            .insert(name.to_string(), description.to_string());
+        schema.field_data_classifications.insert(
+            name.to_string(),
+            DataClassification {
+                sensitivity_level: INTERNAL,
+                data_domain: "general".to_string(),
+            },
+        );
+        schema
+            .field_classifications
+            .insert(name.to_string(), vec!["word".to_string()]);
+    }
+
+    schema.compute_identity_hash();
+    schema
+}
+
+/// Register the TriggerFiring schema with the local SchemaCore and
+/// auto-approve it so the runner can write rows immediately.
+///
+/// Idempotent — safe to call on every boot. If the schema is already
+/// present in persistent storage, `load_schema_internal` refreshes the
+/// in-memory cache and `set_schema_state(Approved)` is a no-op.
+pub async fn register_trigger_firing_schema(
+    schema_manager: &Arc<SchemaCore>,
+) -> Result<(), SchemaError> {
+    schema_manager
+        .load_schema_internal(trigger_firing_schema())
+        .await?;
+    schema_manager
+        .set_schema_state(TRIGGER_FIRING_SCHEMA_NAME, SchemaState::Approved)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_has_expected_fields_and_shape() {
+        let schema = trigger_firing_schema();
+
+        assert_eq!(schema.name, TRIGGER_FIRING_SCHEMA_NAME);
+        assert_eq!(schema.schema_type, SchemaType::HashRange);
+
+        let key = schema.key.as_ref().expect("HashRange schema needs a key");
+        assert_eq!(key.hash_field.as_deref(), Some(fields::TRIGGER_ID));
+        assert_eq!(key.range_field.as_deref(), Some(fields::FIRED_AT));
+
+        let mut declared: Vec<&str> = schema
+            .fields
+            .as_ref()
+            .expect("fields should be populated")
+            .iter()
+            .map(String::as_str)
+            .collect();
+        declared.sort();
+        let mut expected = vec![
+            fields::TRIGGER_ID,
+            fields::VIEW_NAME,
+            fields::FIRED_AT,
+            fields::DURATION_MS,
+            fields::STATUS,
+            fields::INPUT_ROW_COUNT,
+            fields::OUTPUT_ROW_COUNT,
+            fields::ERROR_MESSAGE,
+        ];
+        expected.sort();
+        assert_eq!(declared, expected);
+    }
+
+    #[test]
+    fn error_message_is_nullable_string() {
+        let schema = trigger_firing_schema();
+        let ty = schema.field_types.get(fields::ERROR_MESSAGE).unwrap();
+        match ty {
+            FieldValueType::OneOf(variants) => {
+                assert!(variants.contains(&FieldValueType::String));
+                assert!(variants.contains(&FieldValueType::Null));
+            }
+            other => panic!("expected OneOf(String, Null), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn count_and_time_fields_are_integer() {
+        let schema = trigger_firing_schema();
+        for name in [
+            fields::FIRED_AT,
+            fields::DURATION_MS,
+            fields::INPUT_ROW_COUNT,
+            fields::OUTPUT_ROW_COUNT,
+        ] {
+            assert_eq!(
+                schema.field_types.get(name),
+                Some(&FieldValueType::Integer),
+                "{} should be Integer",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn every_field_has_classification() {
+        let schema = trigger_firing_schema();
+        for name in schema.fields.as_ref().unwrap() {
+            let cls = schema
+                .field_data_classifications
+                .get(name)
+                .unwrap_or_else(|| panic!("{} missing DataClassification", name));
+            assert_eq!(cls.sensitivity_level, INTERNAL);
+            assert_eq!(cls.data_domain, "general");
+        }
+    }
+}

--- a/tests/trigger_firing_schema_test.rs
+++ b/tests/trigger_firing_schema_test.rs
@@ -1,0 +1,125 @@
+//! Round-trip coverage for the TriggerFiring schema registered at
+//! FoldDB startup. Exercises the actual boot path — no direct calls
+//! into `register_trigger_firing_schema`.
+
+use fold_db::fold_db_core::fold_db::FoldDB;
+use fold_db::schema::types::field_value_type::FieldValueType;
+use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
+use fold_db::schema::SchemaState;
+use fold_db::triggers::{fields, TRIGGER_FIRING_SCHEMA_NAME};
+
+async fn boot_fresh_db() -> (tempfile::TempDir, FoldDB) {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let path = temp_dir.path().to_str().expect("utf8 path").to_string();
+    let db = FoldDB::new(&path).await.expect("FoldDB::new");
+    (temp_dir, db)
+}
+
+#[tokio::test]
+async fn trigger_firing_schema_is_registered_at_startup() {
+    let (_tmp, db) = boot_fresh_db().await;
+
+    let schema = db
+        .schema_manager()
+        .get_schema(TRIGGER_FIRING_SCHEMA_NAME)
+        .await
+        .expect("get_schema")
+        .expect("TriggerFiring schema should be present after FoldDB::new");
+
+    assert_eq!(schema.name, TRIGGER_FIRING_SCHEMA_NAME);
+    assert_eq!(schema.schema_type, SchemaType::HashRange);
+
+    let key = schema.key.as_ref().expect("HashRange key");
+    assert_eq!(key.hash_field.as_deref(), Some(fields::TRIGGER_ID));
+    assert_eq!(key.range_field.as_deref(), Some(fields::FIRED_AT));
+
+    let mut declared: Vec<&str> = schema
+        .fields
+        .as_ref()
+        .expect("fields present")
+        .iter()
+        .map(String::as_str)
+        .collect();
+    declared.sort();
+    let mut expected = vec![
+        fields::TRIGGER_ID,
+        fields::VIEW_NAME,
+        fields::FIRED_AT,
+        fields::DURATION_MS,
+        fields::STATUS,
+        fields::INPUT_ROW_COUNT,
+        fields::OUTPUT_ROW_COUNT,
+        fields::ERROR_MESSAGE,
+    ];
+    expected.sort();
+    assert_eq!(declared, expected);
+
+    for numeric in [
+        fields::FIRED_AT,
+        fields::DURATION_MS,
+        fields::INPUT_ROW_COUNT,
+        fields::OUTPUT_ROW_COUNT,
+    ] {
+        assert_eq!(
+            schema.field_types.get(numeric),
+            Some(&FieldValueType::Integer),
+            "{numeric} should be Integer"
+        );
+    }
+    for string_field in [fields::TRIGGER_ID, fields::VIEW_NAME, fields::STATUS] {
+        assert_eq!(
+            schema.field_types.get(string_field),
+            Some(&FieldValueType::String),
+            "{string_field} should be String"
+        );
+    }
+    match schema.field_types.get(fields::ERROR_MESSAGE) {
+        Some(FieldValueType::OneOf(variants)) => {
+            assert!(variants.contains(&FieldValueType::String));
+            assert!(variants.contains(&FieldValueType::Null));
+        }
+        other => panic!("expected OneOf(String, Null) for error_message, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn trigger_firing_schema_is_approved_at_startup() {
+    let (_tmp, db) = boot_fresh_db().await;
+
+    let states = db.schema_manager().get_schema_states().expect("states");
+    assert_eq!(
+        states.get(TRIGGER_FIRING_SCHEMA_NAME),
+        Some(&SchemaState::Approved),
+        "TriggerFiring must be Approved so the runner can write without a manual approval step",
+    );
+}
+
+#[tokio::test]
+async fn registration_is_idempotent_on_repeated_calls() {
+    let (_tmp, db) = boot_fresh_db().await;
+
+    // The first registration ran inside FoldDB::new. Re-running it
+    // against the same SchemaCore is what the idempotency contract
+    // guards — it must not error and must not clobber state.
+    let schema_manager = db.schema_manager();
+    fold_db::triggers::register_trigger_firing_schema(&schema_manager)
+        .await
+        .expect("second registration");
+    fold_db::triggers::register_trigger_firing_schema(&schema_manager)
+        .await
+        .expect("third registration");
+
+    let schema = schema_manager
+        .get_schema(TRIGGER_FIRING_SCHEMA_NAME)
+        .await
+        .expect("get_schema")
+        .expect("schema should still be present");
+    assert_eq!(schema.name, TRIGGER_FIRING_SCHEMA_NAME);
+    assert_eq!(
+        schema_manager
+            .get_schema_states()
+            .expect("states")
+            .get(TRIGGER_FIRING_SCHEMA_NAME),
+        Some(&SchemaState::Approved),
+    );
+}


### PR DESCRIPTION
## Summary

Phase 1 task 1 of `projects/trigger-feature`. Defines the `TriggerFiring` log schema and wires it into the `FoldDB` boot path so the Phase 1 TriggerRunner (task 3) has somewhere to write without a manual approval step.

- **New module** `src/triggers/` — `trigger_firing_schema()` builder + idempotent `register_trigger_firing_schema()`.
- **Boot wiring** — called in `FoldDB::initialize_from_db_ops_with_sled` right after `SchemaCore::new`, so every boot path (`new`, `new_with_components`, factory) registers it.
- **Shape**: HashRange keyed by `(trigger_id, fired_at)` — a trigger's firing history is naturally clustered and range-scannable in time order.
- **Fields**: `trigger_id`/`view_name`/`status` (String), `fired_at`/`duration_ms`/`input_row_count`/`output_row_count` (Integer), `error_message` (`OneOf<String, Null>`). All classified Internal / `"general"` — system telemetry, not user data.
- **Idempotent**: `load_schema_internal` refreshes cache without clobbering persisted state; `set_schema_state(Approved)` is a no-op on an already-Approved schema.

## Out of scope (sibling Phase 1 tasks)

- TriggerRunner module + mutation hookup — task 3.
- fold_db_node cascade (bump schema_service pin + add `triggers` to every AddViewRequest construction site) — task 2.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test --lib triggers` — 4 unit tests (field set, HashRange key, Integer counts, nullable `error_message`, classifications).
- [x] `cargo test --test trigger_firing_schema_test` — 3 integration tests through the real boot path: schema present after `FoldDB::new`, state is `Approved`, re-registration idempotent.
- [x] `cargo test --workspace --all-targets` — entire suite green, no regressions (464 lib + all integration suites pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)