### PR TITLE
refactor(triggers): canonical Trigger shape in fold_db (Consolidation Task A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "croner"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c344b0690c1ad1c7176fe18eb173e0c927008fdaaa256e40dfd43ddd149c0843"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -1190,9 +1221,11 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "chrono",
+ "chrono-tz",
  "clap",
  "clap_complete",
  "colored",
+ "croner",
  "ed25519-compact",
  "ed25519-dalek",
  "fastembed",
@@ -2636,6 +2669,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,6 +2694,44 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -3543,6 +3623,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ sled = "0.34"
 # Core utilities
 uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.9"
+croner = "2"
 regex = "1"
 rand = "0.8"
 tempfile = "3.8"

--- a/src/fold_db_core/trigger_runner.rs
+++ b/src/fold_db_core/trigger_runner.rs
@@ -346,6 +346,9 @@ impl<C: Clock> TriggerRunner<C> {
     /// from the live registry — no separate mutation_schema_index cache
     /// because the registry lock is already cheap and AddView races are
     /// impossible with a rebuild-per-call.
+    ///
+    /// Each Trigger carries its own `schemas` subscription list; only
+    /// triggers whose list includes `schema_name` are returned.
     fn views_triggered_by(
         &self,
         schema_name: &str,
@@ -358,13 +361,12 @@ impl<C: Clock> TriggerRunner<C> {
 
         let mut out = Vec::new();
         for view in registry.list_views() {
-            if !view.source_schemas().iter().any(|s| s == schema_name) {
-                continue;
-            }
             let triggers: Vec<Trigger> = view
                 .effective_triggers()
                 .into_iter()
-                .filter(Trigger::is_write_triggered)
+                .filter(|t| {
+                    t.is_write_triggered() && t.schemas().iter().any(|s| s == schema_name)
+                })
                 .collect();
             if !triggers.is_empty() {
                 out.push((view.name.clone(), triggers));
@@ -396,13 +398,14 @@ impl<C: Clock> TriggerRunner<C> {
 
             for (idx, trig) in triggers.iter().enumerate() {
                 match trig {
-                    Trigger::OnWrite => {
+                    Trigger::OnWrite { .. } => {
                         self.dispatch_inline_once(&view_name, idx, &rt).await;
                     }
                     Trigger::OnWriteCoalesced {
                         min_batch,
                         debounce_ms,
                         max_wait_ms,
+                        ..
                     } => {
                         let should_fire = {
                             let mut st = rt.persisted.lock().await;
@@ -797,18 +800,21 @@ impl<C: Clock> TriggerRunner<C> {
             if existing.contains(&(view_name.clone(), idx)) {
                 continue;
             }
-            let rt = self.runtime_for(&view_name).await;
-            let interval_ms = match trig {
-                Trigger::Scheduled { interval_ms } | Trigger::ScheduledIfDirty { interval_ms } => {
-                    interval_ms
+            let (cron_expr, tz_str) = match &trig {
+                Trigger::Scheduled {
+                    cron, timezone, ..
                 }
+                | Trigger::ScheduledIfDirty {
+                    cron, timezone, ..
+                } => (cron.as_str(), timezone.as_str()),
                 _ => continue,
             };
-            let last = rt.persisted.lock().await.last_fire_ms;
-            let next_at = if last == 0 {
-                now_ms + interval_ms as i64
-            } else {
-                last + interval_ms as i64
+            let Some(next_at) = next_fire_from_cron(cron_expr, tz_str, now_ms) else {
+                warn!(
+                    "trigger '{}:{}': failed to compute next fire from cron='{}' tz='{}'",
+                    view_name, idx, cron_expr, tz_str
+                );
+                continue;
             };
             let mut heap = self.scheduler.lock().await;
             heap.push(Reverse(ScheduledFire {
@@ -857,7 +863,14 @@ impl<C: Clock> TriggerRunner<C> {
         let rt = self.runtime_for(&fire.view_name).await;
 
         let should_fire = match &trigger {
-            Trigger::Scheduled { .. } => true,
+            Trigger::Scheduled { skip_if_idle, .. } => {
+                if *skip_if_idle {
+                    let st = rt.persisted.lock().await;
+                    st.dirty
+                } else {
+                    true
+                }
+            }
             Trigger::ScheduledIfDirty { .. } => {
                 let st = rt.persisted.lock().await;
                 st.dirty
@@ -866,6 +879,7 @@ impl<C: Clock> TriggerRunner<C> {
                 min_batch,
                 debounce_ms,
                 max_wait_ms,
+                ..
             } => {
                 // Coalesce scheduler tick: fire if the debounce window has
                 // elapsed AND we have a batch, OR if max_wait is hit.
@@ -883,17 +897,29 @@ impl<C: Clock> TriggerRunner<C> {
             _ => false,
         };
 
+        let reschedule_cron = match &trigger {
+            Trigger::Scheduled {
+                cron, timezone, ..
+            }
+            | Trigger::ScheduledIfDirty {
+                cron, timezone, ..
+            } => Some((cron.clone(), timezone.clone())),
+            _ => None,
+        };
+
         if !should_fire {
-            // Re-enqueue for the next interval if it was a scheduled one.
-            if let Trigger::Scheduled { interval_ms } | Trigger::ScheduledIfDirty { interval_ms } =
-                trigger
-            {
-                let mut heap = self.scheduler.lock().await;
-                heap.push(Reverse(ScheduledFire {
-                    fire_at_ms: now_ms + interval_ms as i64,
-                    view_name: fire.view_name,
-                    trigger_index: fire.trigger_index,
-                }));
+            // Re-enqueue the next cron occurrence for scheduled triggers —
+            // skip_if_idle / dirty-check skipped this tick but the next
+            // cron tick should still be tracked.
+            if let Some((cron, tz)) = reschedule_cron {
+                if let Some(next_at) = next_fire_from_cron(&cron, &tz, now_ms) {
+                    let mut heap = self.scheduler.lock().await;
+                    heap.push(Reverse(ScheduledFire {
+                        fire_at_ms: next_at,
+                        view_name: fire.view_name,
+                        trigger_index: fire.trigger_index,
+                    }));
+                }
             }
             return;
         }
@@ -901,16 +927,16 @@ impl<C: Clock> TriggerRunner<C> {
         self.dispatch_nonblocking(&fire.view_name, fire.trigger_index, &rt)
             .await;
 
-        // For interval-based triggers, re-arm for the next cycle.
-        if let Trigger::Scheduled { interval_ms } | Trigger::ScheduledIfDirty { interval_ms } =
-            trigger
-        {
-            let mut heap = self.scheduler.lock().await;
-            heap.push(Reverse(ScheduledFire {
-                fire_at_ms: now_ms + interval_ms as i64,
-                view_name: fire.view_name,
-                trigger_index: fire.trigger_index,
-            }));
+        // Re-arm the next cron occurrence.
+        if let Some((cron, tz)) = reschedule_cron {
+            if let Some(next_at) = next_fire_from_cron(&cron, &tz, now_ms) {
+                let mut heap = self.scheduler.lock().await;
+                heap.push(Reverse(ScheduledFire {
+                    fire_at_ms: next_at,
+                    view_name: fire.view_name,
+                    trigger_index: fire.trigger_index,
+                }));
+            }
         }
     }
 
@@ -1063,6 +1089,23 @@ impl FiringWriter for MutationManagerFiringWriter {
         mm.write_mutations_batch_async(vec![mutation]).await?;
         Ok(())
     }
+}
+
+/// Compute the next cron occurrence strictly after `now_ms` in the given
+/// IANA timezone. Returns the fire time as Unix epoch milliseconds (UTC),
+/// or `None` if the cron expression or timezone fail to parse.
+///
+/// DST handling follows croner: `find_next_occurrence(…, false)` advances
+/// to the first valid tick after a spring-forward gap, and fires once per
+/// local clock-time even during a fall-back overlap (croner walks UTC
+/// under the hood, so the ambiguous hour doesn't double-fire).
+fn next_fire_from_cron(cron_expr: &str, tz_str: &str, now_ms: i64) -> Option<i64> {
+    let cron = croner::Cron::new(cron_expr).parse().ok()?;
+    let tz: chrono_tz::Tz = tz_str.parse().ok()?;
+    let now_utc = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(now_ms)?;
+    let now_in_tz = now_utc.with_timezone(&tz);
+    let next = cron.find_next_occurrence(&now_in_tz, false).ok()?;
+    Some(next.with_timezone(&chrono::Utc).timestamp_millis())
 }
 
 fn exp_backoff_ms(fail_streak: u32) -> u64 {
@@ -1237,7 +1280,14 @@ mod tests {
     #[tokio::test]
     async fn on_write_single_mutation_fires_once() {
         let sm = make_schema_manager().await;
-        register_view(&sm, "V1", "S1", vec![Trigger::OnWrite]);
+        register_view(
+            &sm,
+            "V1",
+            "S1",
+            vec![Trigger::OnWrite {
+                schemas: vec!["S1".into()],
+            }],
+        );
         let clock = Arc::new(MockClock::new(1_000));
         let fire = RecordingFireHandler::all_success();
         let writer = CountingFiringWriter::new();
@@ -1276,6 +1326,7 @@ mod tests {
             "V1",
             "S1",
             vec![Trigger::OnWriteCoalesced {
+                schemas: vec!["S1".into()],
                 min_batch: 3,
                 debounce_ms: 0,
                 max_wait_ms: 10_000,
@@ -1313,6 +1364,7 @@ mod tests {
             "V1",
             "S1",
             vec![Trigger::OnWriteCoalesced {
+                schemas: vec!["S1".into()],
                 min_batch: 100,
                 debounce_ms: 10_000,
                 max_wait_ms: 500,
@@ -1350,6 +1402,7 @@ mod tests {
             "V1",
             "S1",
             vec![Trigger::OnWriteCoalesced {
+                schemas: vec!["S1".into()],
                 min_batch: 2,
                 debounce_ms: 100,
                 max_wait_ms: 100_000,
@@ -1386,12 +1439,20 @@ mod tests {
 
     #[tokio::test]
     async fn scheduled_if_dirty_only_fires_when_dirty() {
+        // Cron "* * * * *" fires every minute on the 0-second boundary.
+        // MockClock starts at epoch 0 (1970-01-01 00:00:00 UTC); next fire
+        // from t=0 is 00:01:00 = 60_000 ms.
         let sm = make_schema_manager().await;
         register_view(
             &sm,
             "V1",
             "S1",
-            vec![Trigger::ScheduledIfDirty { interval_ms: 1_000 }],
+            vec![Trigger::ScheduledIfDirty {
+                cron: "* * * * *".into(),
+                timezone: "UTC".into(),
+                window: None,
+                schemas: vec!["S1".into()],
+            }],
         );
         let clock = Arc::new(MockClock::new(0));
         let fire = RecordingFireHandler::all_success();
@@ -1405,14 +1466,14 @@ mod tests {
 
         // First tick populates scheduler; not dirty yet.
         runner.tick_once().await;
-        clock.advance(1_000);
+        clock.advance(60_000);
         runner.tick_once().await;
         tokio::task::yield_now().await;
         assert_eq!(fire.call_count.load(Ordering::SeqCst), 0);
 
-        // Mark dirty via mutation; next interval should fire.
+        // Mark dirty via mutation; next cron tick should fire.
         runner.on_mutation_notified("S1").await.unwrap();
-        clock.advance(1_000);
+        clock.advance(60_000);
         runner.tick_once().await;
         for _ in 0..30 {
             if fire.call_count.load(Ordering::SeqCst) > 0 {
@@ -1424,13 +1485,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn scheduled_fires_at_interval() {
+    async fn scheduled_fires_on_cron_tick() {
+        // "0 2 * * *" = 02:00 UTC daily. MockClock at epoch 0 → next fire
+        // is 1970-01-01 02:00:00 UTC = 2 * 3600 * 1000 = 7_200_000 ms.
         let sm = make_schema_manager().await;
         register_view(
             &sm,
             "V1",
             "S1",
-            vec![Trigger::Scheduled { interval_ms: 500 }],
+            vec![Trigger::Scheduled {
+                cron: "0 2 * * *".into(),
+                timezone: "UTC".into(),
+                window: None,
+                skip_if_idle: false,
+                schemas: vec!["S1".into()],
+            }],
         );
         let clock = Arc::new(MockClock::new(0));
         let fire = RecordingFireHandler::all_success();
@@ -1443,14 +1512,14 @@ mod tests {
         );
 
         runner.tick_once().await;
-        // Before interval elapses, no fire.
-        clock.advance(100);
+        // Before cron fires, no-op.
+        clock.advance(3_600_000); // 1h: not yet 02:00
         runner.tick_once().await;
         tokio::task::yield_now().await;
         assert_eq!(fire.call_count.load(Ordering::SeqCst), 0);
 
-        // After interval, one fire.
-        clock.advance(500);
+        // Past 02:00 → should fire.
+        clock.advance(24 * 3_600_000); // +24h, well past next 02:00
         runner.tick_once().await;
         for _ in 0..30 {
             if fire.call_count.load(Ordering::SeqCst) >= 1 {
@@ -1462,9 +1531,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn scheduled_skip_if_idle_suppresses_fire_when_clean() {
+        // `skip_if_idle` makes plain `Scheduled` behave like
+        // `ScheduledIfDirty` — no fire when no mutation has landed.
+        let sm = make_schema_manager().await;
+        register_view(
+            &sm,
+            "V1",
+            "S1",
+            vec![Trigger::Scheduled {
+                cron: "* * * * *".into(),
+                timezone: "UTC".into(),
+                window: None,
+                skip_if_idle: true,
+                schemas: vec!["S1".into()],
+            }],
+        );
+        let clock = Arc::new(MockClock::new(0));
+        let fire = RecordingFireHandler::all_success();
+        let writer = CountingFiringWriter::new();
+        let runner = make_runner(
+            Arc::clone(&sm),
+            Arc::clone(&clock),
+            Arc::clone(&fire) as Arc<dyn FireHandler>,
+            Arc::clone(&writer) as Arc<dyn FiringWriter>,
+        );
+
+        runner.tick_once().await;
+        // Clean, no mutations: even past the cron tick, no fire.
+        clock.advance(60_000);
+        runner.tick_once().await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            fire.call_count.load(Ordering::SeqCst),
+            0,
+            "skip_if_idle must suppress fire when dirty bit is clean"
+        );
+    }
+
+    #[test]
+    fn next_fire_from_cron_parses_and_steps_forward() {
+        // 1970-01-01 00:00:00 UTC → next "0 2 * * *" is 1970-01-01 02:00 UTC.
+        let next = next_fire_from_cron("0 2 * * *", "UTC", 0).expect("cron parse");
+        assert_eq!(next, 2 * 3_600 * 1_000);
+
+        // Invalid cron → None.
+        assert!(next_fire_from_cron("not a cron", "UTC", 0).is_none());
+        // Invalid tz → None.
+        assert!(next_fire_from_cron("0 2 * * *", "Not/AZone", 0).is_none());
+    }
+
+    #[tokio::test]
     async fn fail_streak_triggers_quarantine_after_three_errors() {
         let sm = make_schema_manager().await;
-        register_view(&sm, "V1", "S1", vec![Trigger::OnWrite]);
+        register_view(
+            &sm,
+            "V1",
+            "S1",
+            vec![Trigger::OnWrite {
+                schemas: vec!["S1".into()],
+            }],
+        );
         let clock = Arc::new(MockClock::new(0));
         let fire = RecordingFireHandler::all_error();
         let writer = CountingFiringWriter::new();
@@ -1543,7 +1670,14 @@ mod tests {
         }
 
         let sm = make_schema_manager().await;
-        register_view(&sm, "V1", "S1", vec![Trigger::OnWrite]);
+        register_view(
+            &sm,
+            "V1",
+            "S1",
+            vec![Trigger::OnWrite {
+                schemas: vec!["S1".into()],
+            }],
+        );
         let clock = Arc::new(MockClock::new(0));
         let handler = Arc::new(GatedHandler {
             release: Arc::new(AtomicBool::new(false)),
@@ -1632,7 +1766,14 @@ mod tests {
         // triggers to compute the next fire. Advancing it on a failed
         // audit write would lose one firing from the TriggerFiring log.
         let sm = make_schema_manager().await;
-        register_view(&sm, "V1", "S1", vec![Trigger::OnWrite]);
+        register_view(
+            &sm,
+            "V1",
+            "S1",
+            vec![Trigger::OnWrite {
+                schemas: vec!["S1".into()],
+            }],
+        );
         let clock = Arc::new(MockClock::new(1_000));
         let fire = RecordingFireHandler::all_success();
         let writer = CountingFiringWriter::new();
@@ -1744,7 +1885,14 @@ mod tests {
         // mutations and advance the clock past each 1s backoff. The
         // 3rd mutation's spawned retry sees a healthy writer.
         let sm = make_schema_manager().await;
-        register_view(&sm, "V1", "S1", vec![Trigger::OnWrite]);
+        register_view(
+            &sm,
+            "V1",
+            "S1",
+            vec![Trigger::OnWrite {
+                schemas: vec!["S1".into()],
+            }],
+        );
         let clock = Arc::new(MockClock::new(1_000));
         let fire = RecordingFireHandler::all_success();
         let writer = CountingFiringWriter::new();

--- a/src/fold_db_core/trigger_runner.rs
+++ b/src/fold_db_core/trigger_runner.rs
@@ -364,9 +364,7 @@ impl<C: Clock> TriggerRunner<C> {
             let triggers: Vec<Trigger> = view
                 .effective_triggers()
                 .into_iter()
-                .filter(|t| {
-                    t.is_write_triggered() && t.schemas().iter().any(|s| s == schema_name)
-                })
+                .filter(|t| t.is_write_triggered() && t.schemas().iter().any(|s| s == schema_name))
                 .collect();
             if !triggers.is_empty() {
                 out.push((view.name.clone(), triggers));
@@ -801,12 +799,10 @@ impl<C: Clock> TriggerRunner<C> {
                 continue;
             }
             let (cron_expr, tz_str) = match &trig {
-                Trigger::Scheduled {
-                    cron, timezone, ..
+                Trigger::Scheduled { cron, timezone, .. }
+                | Trigger::ScheduledIfDirty { cron, timezone, .. } => {
+                    (cron.as_str(), timezone.as_str())
                 }
-                | Trigger::ScheduledIfDirty {
-                    cron, timezone, ..
-                } => (cron.as_str(), timezone.as_str()),
                 _ => continue,
             };
             let Some(next_at) = next_fire_from_cron(cron_expr, tz_str, now_ms) else {
@@ -898,12 +894,10 @@ impl<C: Clock> TriggerRunner<C> {
         };
 
         let reschedule_cron = match &trigger {
-            Trigger::Scheduled {
-                cron, timezone, ..
+            Trigger::Scheduled { cron, timezone, .. }
+            | Trigger::ScheduledIfDirty { cron, timezone, .. } => {
+                Some((cron.clone(), timezone.clone()))
             }
-            | Trigger::ScheduledIfDirty {
-                cron, timezone, ..
-            } => Some((cron.clone(), timezone.clone())),
             _ => None,
         };
 

--- a/src/triggers/types.rs
+++ b/src/triggers/types.rs
@@ -188,7 +188,10 @@ mod tests {
             schemas: vec!["S".into()],
         };
         let json = serde_json::to_string(&t_no_window).unwrap();
-        assert!(!json.contains("window"), "None window must be omitted: {json}");
+        assert!(
+            !json.contains("window"),
+            "None window must be omitted: {json}"
+        );
     }
 
     #[test]

--- a/src/triggers/types.rs
+++ b/src/triggers/types.rs
@@ -1,59 +1,94 @@
 //! Trigger configuration attached to a view.
 //!
+//! fold_db is the single source of truth for this type. The schema_service
+//! validator (Phase 0) imports it and validates the same shape; the
+//! fold_db_node adapter that used to translate canonical→exec is gone once
+//! consolidation Tasks B + C land.
+//!
 //! A view declares zero or more triggers. `TriggerRunner` consults these to
-//! decide when to fire the view's materialization. Phase 1 supports:
+//! decide when to fire the view's materialization.
 //!
-//! - `OnWrite`: fire immediately on any mutation against a source schema.
-//! - `OnWriteCoalesced { min_batch, debounce_ms, max_wait_ms }`: batch
-//!   mutations; fire once thresholds are crossed.
-//! - `Scheduled { interval_ms }`: fire every `interval_ms`, regardless of
-//!   mutation activity.
-//! - `ScheduledIfDirty { interval_ms }`: at each interval tick, fire only
-//!   if a source mutation has set the dirty flag since the last fire.
-//! - `Manual`: only fires via the explicit run endpoint (Phase 2+).
+//! - `OnWrite { schemas }`: fire immediately on any mutation against one of
+//!   the named source schemas.
+//! - `OnWriteCoalesced { schemas, min_batch, debounce_ms, max_wait_ms }`:
+//!   batch mutations; fire once thresholds are crossed.
+//! - `Scheduled { cron, timezone, window, skip_if_idle, schemas }`: fire on
+//!   a cron schedule in the given IANA timezone. When `window` is set, it
+//!   auto-injects a time filter into input queries at fire time (e.g.
+//!   `"24h"`, `"7d"`). `skip_if_idle` suppresses the tick when no source
+//!   mutations have landed since the last fire.
+//! - `ScheduledIfDirty { cron, timezone, window, schemas }`: like
+//!   `Scheduled` but only fires when the per-view dirty bit is set.
+//! - `Manual`: only fires via explicit run (future endpoint).
 //!
-//! If a view is registered with an empty `triggers` vec, it is treated as
-//! `[Trigger::OnWrite]` (backwards-compatible default — every pre-trigger
-//! view will continue to invalidate on mutation).
+//! If a view is registered with an empty `triggers` vec, `effective_triggers`
+//! returns `[OnWrite { schemas: <view's source schemas> }]` so every
+//! pre-trigger view continues to invalidate on mutation.
 
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind")]
 pub enum Trigger {
-    OnWrite,
+    OnWrite {
+        schemas: Vec<String>,
+    },
     OnWriteCoalesced {
+        schemas: Vec<String>,
         min_batch: u32,
         debounce_ms: u64,
         max_wait_ms: u64,
     },
     Scheduled {
-        interval_ms: u64,
+        cron: String,
+        timezone: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        window: Option<String>,
+        skip_if_idle: bool,
+        schemas: Vec<String>,
     },
     ScheduledIfDirty {
-        interval_ms: u64,
+        cron: String,
+        timezone: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        window: Option<String>,
+        schemas: Vec<String>,
     },
     Manual,
 }
 
 impl Trigger {
     /// True when a mutation against a source schema should route to this
-    /// trigger's runtime path (OnWrite + OnWriteCoalesced). Scheduled and
-    /// ScheduledIfDirty only consume mutation notifications to flip the
-    /// dirty flag — the scheduler tick does the actual firing.
+    /// trigger's runtime path (OnWrite + OnWriteCoalesced). ScheduledIfDirty
+    /// consumes mutation notifications to flip the dirty flag — the
+    /// scheduler tick does the actual firing.
     pub fn is_write_triggered(&self) -> bool {
         matches!(
             self,
-            Trigger::OnWrite | Trigger::OnWriteCoalesced { .. } | Trigger::ScheduledIfDirty { .. }
+            Trigger::OnWrite { .. }
+                | Trigger::OnWriteCoalesced { .. }
+                | Trigger::ScheduledIfDirty { .. }
         )
     }
 
-    /// True when the scheduler tracks this trigger in its min-heap.
+    /// True when the scheduler tracks this trigger.
     pub fn is_scheduled(&self) -> bool {
         matches!(
             self,
             Trigger::Scheduled { .. } | Trigger::ScheduledIfDirty { .. }
         )
+    }
+
+    /// Source schemas this trigger subscribes to. `Manual` returns an empty
+    /// slice — it has no mutation subscription.
+    pub fn schemas(&self) -> &[String] {
+        match self {
+            Trigger::OnWrite { schemas }
+            | Trigger::OnWriteCoalesced { schemas, .. }
+            | Trigger::Scheduled { schemas, .. }
+            | Trigger::ScheduledIfDirty { schemas, .. } => schemas.as_slice(),
+            Trigger::Manual => &[],
+        }
     }
 }
 
@@ -63,21 +98,34 @@ mod tests {
 
     #[test]
     fn on_write_is_write_triggered_not_scheduled() {
-        let t = Trigger::OnWrite;
+        let t = Trigger::OnWrite {
+            schemas: vec!["S".into()],
+        };
         assert!(t.is_write_triggered());
         assert!(!t.is_scheduled());
     }
 
     #[test]
     fn scheduled_if_dirty_is_both() {
-        let t = Trigger::ScheduledIfDirty { interval_ms: 1000 };
+        let t = Trigger::ScheduledIfDirty {
+            cron: "0 * * * *".into(),
+            timezone: "UTC".into(),
+            window: None,
+            schemas: vec!["S".into()],
+        };
         assert!(t.is_write_triggered());
         assert!(t.is_scheduled());
     }
 
     #[test]
     fn scheduled_only_scheduled() {
-        let t = Trigger::Scheduled { interval_ms: 5000 };
+        let t = Trigger::Scheduled {
+            cron: "0 * * * *".into(),
+            timezone: "UTC".into(),
+            window: None,
+            skip_if_idle: false,
+            schemas: vec!["S".into()],
+        };
         assert!(!t.is_write_triggered());
         assert!(t.is_scheduled());
     }
@@ -90,15 +138,62 @@ mod tests {
     }
 
     #[test]
-    fn serializes_with_kind_tag() {
+    fn schemas_accessor_returns_vec() {
+        let t = Trigger::OnWrite {
+            schemas: vec!["A".into(), "B".into()],
+        };
+        assert_eq!(t.schemas(), &["A".to_string(), "B".to_string()]);
+        let m = Trigger::Manual;
+        assert!(m.schemas().is_empty());
+    }
+
+    #[test]
+    fn serializes_with_kind_tag_camel_case() {
         let t = Trigger::OnWriteCoalesced {
+            schemas: vec!["S1".into()],
             min_batch: 10,
             debounce_ms: 500,
             max_wait_ms: 5000,
         };
         let json = serde_json::to_string(&t).unwrap();
-        assert!(json.contains(r#""kind":"on_write_coalesced""#));
+        assert!(
+            json.contains(r#""kind":"OnWriteCoalesced""#),
+            "canonical JSON uses CamelCase tag values: {json}"
+        );
         let round: Trigger = serde_json::from_str(&json).unwrap();
         assert_eq!(round, t);
+    }
+
+    #[test]
+    fn scheduled_roundtrips_with_optional_window() {
+        let t = Trigger::Scheduled {
+            cron: "0 2 * * *".into(),
+            timezone: "America/New_York".into(),
+            window: Some("24h".into()),
+            skip_if_idle: true,
+            schemas: vec!["Source".into()],
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        assert!(json.contains(r#""kind":"Scheduled""#));
+        assert!(json.contains(r#""window":"24h""#));
+        let round: Trigger = serde_json::from_str(&json).unwrap();
+        assert_eq!(round, t);
+
+        // Window omitted on serialize when None.
+        let t_no_window = Trigger::Scheduled {
+            cron: "0 2 * * *".into(),
+            timezone: "UTC".into(),
+            window: None,
+            skip_if_idle: false,
+            schemas: vec!["S".into()],
+        };
+        let json = serde_json::to_string(&t_no_window).unwrap();
+        assert!(!json.contains("window"), "None window must be omitted: {json}");
+    }
+
+    #[test]
+    fn manual_serializes_bare() {
+        let json = serde_json::to_string(&Trigger::Manual).unwrap();
+        assert_eq!(json, r#"{"kind":"Manual"}"#);
     }
 }

--- a/src/view/types.rs
+++ b/src/view/types.rs
@@ -96,11 +96,14 @@ impl TransformView {
     }
 
     /// Effective trigger list. Empty `triggers` defaults to
-    /// `[Trigger::OnWrite]` so every view fires on mutation unless the
-    /// caller explicitly opted into a different trigger policy.
+    /// `[Trigger::OnWrite { schemas: source_schemas }]` so every view fires
+    /// on mutation unless the caller explicitly opted into a different
+    /// trigger policy.
     pub fn effective_triggers(&self) -> Vec<Trigger> {
         if self.triggers.is_empty() {
-            vec![Trigger::OnWrite]
+            vec![Trigger::OnWrite {
+                schemas: self.source_schemas(),
+            }]
         } else {
             self.triggers.clone()
         }

--- a/tests/trigger_runner_integration_test.rs
+++ b/tests/trigger_runner_integration_test.rs
@@ -110,7 +110,9 @@ async fn on_write_trigger_writes_trigger_firing_row() {
             "BP_Content",
             "BlogPost",
             "content",
-            vec![Trigger::OnWrite],
+            vec![Trigger::OnWrite {
+                schemas: vec!["BlogPost".to_string()],
+            }],
         ))
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

First of three consolidation tasks that make **fold_db the single source of truth for the Trigger type** (schema_service_core currently has a canonical copy, fold_db_node maintains a lossy adapter).

- Enriches fold_db's local `Trigger` enum to the full canonical shape — per-trigger \`schemas\`, \`cron\`+\`timezone\` for Scheduled variants, \`window\`, \`skip_if_idle\`. JSON tag matches canonical (\`\"kind\":\"OnWrite\"\`).
- Wires \`croner\` + \`chrono-tz\` into \`TriggerRunner\`'s scheduler so next-fire is computed from cron in the requested IANA zone (DST via croner: spring-forward-skip, fall-back-single-fire).
- \`skip_if_idle\` on Scheduled now suppresses the tick when the per-view dirty bit is clean.

Follow-ups, already scoped in gbrain:
- **Task B** — schema_service_core drops its local \`Trigger\`; imports from fold_db.
- **Task C** — fold_db_node deletes \`trigger_adapter.rs\` and consumes canonical directly; plumb \`window\` into query filtering at fire time.

Supersedes gbrain \`projects/fold-db-native-cron-support\`.

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace --all-targets\` — all integration suites green; existing runner tests translated to the new shape
- [x] New unit tests:
  - \`scheduled_fires_on_cron_tick\` — MockClock + \`\"0 2 * * *\"\` UTC, advance 24h, assert one fire
  - \`scheduled_skip_if_idle_suppresses_fire_when_clean\` — Scheduled+skip_if_idle is clean → no fire
  - \`next_fire_from_cron_parses_and_steps_forward\` — parser + error paths
  - \`scheduled_roundtrips_with_optional_window\` — serde shape
- [x] \`test_purge_org_data\` failure in the --lib run is pre-existing on mainline (env-var race on \`FOLD_DISABLE_NATIVE_INDEX\`), unrelated to this change; passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)