### PR TITLE
refactor(triggers): extract simulate helpers into shared module

### DIFF
--- a/src/fold_db_core/trigger_runner.rs
+++ b/src/fold_db_core/trigger_runner.rs
@@ -49,6 +49,7 @@ use crate::schema::types::{KeyValue, Mutation};
 use crate::schema::{SchemaCore, SchemaError};
 use crate::storage::SledPool;
 use crate::triggers::clock::Clock;
+use crate::triggers::simulate::{next_fire_from_cron, should_coalesce_fire};
 use crate::triggers::types::Trigger;
 use crate::triggers::{fields, status, TRIGGER_FIRING_SCHEMA_NAME};
 
@@ -206,27 +207,6 @@ struct PersistedViewState {
     fail_streak: u32,
     last_fire_ms: i64,
     quarantined: bool,
-}
-
-/// Shared fire predicate for `OnWriteCoalesced` triggers. Fires when we
-/// have a full batch past the debounce window, OR when max_wait has
-/// elapsed since the first pending event. Returns `false` on an empty
-/// batch — both the mutation-notified and scheduler-tick paths rely on
-/// this gate to avoid dispatching with nothing pending.
-fn should_coalesce_fire(
-    state: &PersistedViewState,
-    now_ms: i64,
-    min_batch: u32,
-    debounce_ms: u64,
-    max_wait_ms: u64,
-) -> bool {
-    if state.pending_count == 0 {
-        return false;
-    }
-    let batch_ok = state.pending_count >= min_batch;
-    let debounce_ok = (now_ms - state.last_event_ms) >= debounce_ms as i64 && batch_ok;
-    let max_wait_ok = (now_ms - state.first_event_ms) >= max_wait_ms as i64;
-    (batch_ok && debounce_ok) || max_wait_ok
 }
 
 /// In-memory runtime for one view. An atomic `dispatch_in_flight` flag
@@ -435,7 +415,9 @@ impl<C: Clock> TriggerRunner<C> {
                             st.last_event_ms = now;
 
                             let fire = should_coalesce_fire(
-                                &st,
+                                st.pending_count,
+                                st.first_event_ms,
+                                st.last_event_ms,
                                 now,
                                 *min_batch,
                                 *debounce_ms,
@@ -903,7 +885,15 @@ impl<C: Clock> TriggerRunner<C> {
                 // Coalesce scheduler tick: fire if the debounce window has
                 // elapsed AND we have a batch, OR if max_wait is hit.
                 let st = rt.persisted.lock().await;
-                should_coalesce_fire(&st, now_ms, *min_batch, *debounce_ms, *max_wait_ms)
+                should_coalesce_fire(
+                    st.pending_count,
+                    st.first_event_ms,
+                    st.last_event_ms,
+                    now_ms,
+                    *min_batch,
+                    *debounce_ms,
+                    *max_wait_ms,
+                )
             }
             _ => false,
         };
@@ -1098,23 +1088,6 @@ impl FiringWriter for MutationManagerFiringWriter {
         mm.write_mutations_batch_async(vec![mutation]).await?;
         Ok(())
     }
-}
-
-/// Compute the next cron occurrence strictly after `now_ms` in the given
-/// IANA timezone. Returns the fire time as Unix epoch milliseconds (UTC),
-/// or `None` if the cron expression or timezone fail to parse.
-///
-/// DST handling follows croner: `find_next_occurrence(…, false)` advances
-/// to the first valid tick after a spring-forward gap, and fires once per
-/// local clock-time even during a fall-back overlap (croner walks UTC
-/// under the hood, so the ambiguous hour doesn't double-fire).
-fn next_fire_from_cron(cron_expr: &str, tz_str: &str, now_ms: i64) -> Option<i64> {
-    let cron = croner::Cron::new(cron_expr).parse().ok()?;
-    let tz: chrono_tz::Tz = tz_str.parse().ok()?;
-    let now_utc = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(now_ms)?;
-    let now_in_tz = now_utc.with_timezone(&tz);
-    let next = cron.find_next_occurrence(&now_in_tz, false).ok()?;
-    Some(next.with_timezone(&chrono::Utc).timestamp_millis())
 }
 
 fn exp_backoff_ms(fail_streak: u32) -> u64 {
@@ -1902,75 +1875,6 @@ mod tests {
         assert_eq!(exp_backoff_ms(6), 32_000);
         assert_eq!(exp_backoff_ms(7), BACKOFF_MAX_MS);
         assert_eq!(exp_backoff_ms(100), BACKOFF_MAX_MS);
-    }
-
-    #[test]
-    fn should_coalesce_fire_predicate() {
-        let min_batch: u32 = 3;
-        let debounce_ms: u64 = 100;
-        let max_wait_ms: u64 = 10_000;
-
-        // Batch met, debounce window NOT elapsed, max_wait NOT elapsed — no fire.
-        let st = PersistedViewState {
-            pending_count: 3,
-            first_event_ms: 1_000,
-            last_event_ms: 1_050,
-            ..Default::default()
-        };
-        assert!(!should_coalesce_fire(
-            &st,
-            1_100,
-            min_batch,
-            debounce_ms,
-            max_wait_ms
-        ));
-
-        // Batch met AND debounce window elapsed — fire.
-        let st = PersistedViewState {
-            pending_count: 3,
-            first_event_ms: 1_000,
-            last_event_ms: 1_050,
-            ..Default::default()
-        };
-        assert!(should_coalesce_fire(
-            &st,
-            1_200,
-            min_batch,
-            debounce_ms,
-            max_wait_ms
-        ));
-
-        // Batch NOT met but max_wait elapsed — fire.
-        let st = PersistedViewState {
-            pending_count: 1,
-            first_event_ms: 1_000,
-            last_event_ms: 1_050,
-            ..Default::default()
-        };
-        assert!(should_coalesce_fire(
-            &st,
-            12_000,
-            min_batch,
-            debounce_ms,
-            max_wait_ms
-        ));
-
-        // Nothing pending — never fire, even if max_wait would otherwise trip.
-        // This is the guard that was only at the scheduler-tick callsite
-        // before the extraction; the helper now enforces it globally.
-        let st = PersistedViewState {
-            pending_count: 0,
-            first_event_ms: 1_000,
-            last_event_ms: 1_000,
-            ..Default::default()
-        };
-        assert!(!should_coalesce_fire(
-            &st,
-            12_000,
-            min_batch,
-            debounce_ms,
-            max_wait_ms
-        ));
     }
 
     // Helper: wait up to `max_ticks * 2ms` real wall time for `predicate`

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -9,9 +9,11 @@
 //! refreshes the in-memory cache without clobbering on-disk state.
 
 pub mod clock;
+pub mod simulate;
 pub mod types;
 
 pub use clock::{Clock, MockClock, SystemClock};
+pub use simulate::{next_fire_from_cron, should_coalesce_fire};
 pub use types::Trigger;
 
 use std::sync::Arc;

--- a/src/triggers/simulate.rs
+++ b/src/triggers/simulate.rs
@@ -1,0 +1,120 @@
+//! Pure helpers shared between the live `TriggerRunner` and dry-run
+//! simulators that preview trigger behavior (e.g. schema_service's
+//! `POST /v1/triggers/simulate`).
+//!
+//! These are deliberately stateless functions with primitive-only
+//! signatures so downstream crates can reuse them without taking a
+//! dependency on fold_db's internal `PersistedViewState` type.
+
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
+
+/// Compute the next cron occurrence strictly after `now_ms` in the given
+/// IANA timezone. Returns the fire time as Unix epoch milliseconds (UTC),
+/// or `None` if the cron expression or timezone fail to parse.
+///
+/// DST handling follows croner: `find_next_occurrence(…, false)` advances
+/// to the first valid tick after a spring-forward gap, and fires once per
+/// local clock-time even during a fall-back overlap (croner walks UTC
+/// under the hood, so the ambiguous hour doesn't double-fire).
+pub fn next_fire_from_cron(cron_expr: &str, tz_str: &str, now_ms: i64) -> Option<i64> {
+    let cron = croner::Cron::new(cron_expr).parse().ok()?;
+    let tz: Tz = tz_str.parse().ok()?;
+    let now_utc = DateTime::<Utc>::from_timestamp_millis(now_ms)?;
+    let now_in_tz = now_utc.with_timezone(&tz);
+    let next = cron.find_next_occurrence(&now_in_tz, false).ok()?;
+    Some(next.with_timezone(&Utc).timestamp_millis())
+}
+
+/// Shared fire predicate for `OnWriteCoalesced` triggers.
+///
+/// Fires when we have a full batch past the debounce window, OR when
+/// `max_wait_ms` has elapsed since the first pending event. Returns
+/// `false` on an empty batch — both the mutation-notified and
+/// scheduler-tick paths rely on this gate to avoid dispatching with
+/// nothing pending.
+///
+/// Parameterized on raw values (not `&PersistedViewState`) so dry-run
+/// simulators outside fold_db can call it directly.
+pub fn should_coalesce_fire(
+    pending: u32,
+    first_event_ms: i64,
+    last_event_ms: i64,
+    now_ms: i64,
+    min_batch: u32,
+    debounce_ms: u64,
+    max_wait_ms: u64,
+) -> bool {
+    if pending == 0 {
+        return false;
+    }
+    let batch_ok = pending >= min_batch;
+    let debounce_ok = (now_ms - last_event_ms) >= debounce_ms as i64 && batch_ok;
+    let max_wait_ok = (now_ms - first_event_ms) >= max_wait_ms as i64;
+    (batch_ok && debounce_ok) || max_wait_ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_fire_from_cron_parses_and_steps_forward() {
+        // 1970-01-01 00:00:00 UTC → next "0 2 * * *" is 1970-01-01 02:00 UTC.
+        let next = next_fire_from_cron("0 2 * * *", "UTC", 0).expect("cron parse");
+        assert_eq!(next, 2 * 3_600 * 1_000);
+    }
+
+    #[test]
+    fn next_fire_from_cron_returns_none_on_invalid_cron() {
+        assert!(next_fire_from_cron("not a cron", "UTC", 0).is_none());
+    }
+
+    #[test]
+    fn next_fire_from_cron_returns_none_on_invalid_tz() {
+        assert!(next_fire_from_cron("0 2 * * *", "Not/AZone", 0).is_none());
+    }
+
+    #[test]
+    fn should_coalesce_fire_empty_batch_never_fires() {
+        // The empty-batch guard is global — even with max_wait elapsed,
+        // pending==0 must return false or the runtime would dispatch on
+        // a batch that has nothing to coalesce.
+        assert!(!should_coalesce_fire(
+            0, 1_000, 1_000, 99_999, 3, 100, 10_000
+        ));
+    }
+
+    #[test]
+    fn should_coalesce_fire_batch_met_but_no_debounce() {
+        // 3 events (min_batch=3), last event at 1_050, now at 1_100:
+        // only 50ms of quiet — debounce window of 100ms not satisfied.
+        assert!(!should_coalesce_fire(
+            3, 1_000, 1_050, 1_100, 3, 100, 10_000
+        ));
+    }
+
+    #[test]
+    fn should_coalesce_fire_batch_and_debounce() {
+        // Same batch, now at 1_200: 150ms of quiet past min_batch → fire.
+        assert!(should_coalesce_fire(3, 1_000, 1_050, 1_200, 3, 100, 10_000));
+    }
+
+    #[test]
+    fn should_coalesce_fire_max_wait_alone() {
+        // 1 event, min_batch=3 (not met), but max_wait (10s) elapsed from
+        // the first event → fire anyway to bound latency.
+        assert!(should_coalesce_fire(
+            1, 1_000, 1_050, 12_000, 3, 100, 10_000
+        ));
+    }
+
+    #[test]
+    fn should_coalesce_fire_pending_below_min_batch_inside_max_wait() {
+        // 1 event at 1_000, now at 5_000 (<max_wait of 10s, <debounce from
+        // last_event of 100ms with batch not met): neither predicate trips.
+        assert!(!should_coalesce_fire(
+            1, 1_000, 1_000, 5_000, 3, 100, 10_000
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Factor two pure helpers out of `fold_db_core::trigger_runner` into a new `fold_db::triggers::simulate` module so downstream dry-run simulators (specifically `schema_service`'s `POST /v1/triggers/simulate` handler) can share the same fire semantics the live runner uses:

- `next_fire_from_cron(cron, tz, now_ms) -> Option<i64>`
- `should_coalesce_fire(pending, first_event_ms, last_event_ms, now_ms, min_batch, debounce_ms, max_wait_ms) -> bool`

`should_coalesce_fire` is re-parameterized from `&PersistedViewState` to raw values so external crates can reuse it without depending on fold_db internals. Runner callsites inside this crate pass the raw fields from the persisted-state lock they already hold.

This is part 1 of a two-PR chain for the D1 DRY cleanup flagged in the trigger-feature round-1 audit (kanban task `0e397`). Part 2 in `schema_service` will bump the `fold_db` git-dep pin to this commit and delete the duplicated local logic noted at `schema_service/crates/core/src/trigger_simulate.rs:9-13`.

## Changes

- **new**: `src/triggers/simulate.rs` — the two helpers + 8 unit tests pinning the contract (cron happy-path, invalid cron/tz returning `None`, coalesce predicate over the batch / debounce / max_wait / empty-batch axes).
- **modified**: `src/triggers/mod.rs` — declares and re-exports the new module.
- **modified**: `src/fold_db_core/trigger_runner.rs` — deletes the two local `fn` definitions, imports the helpers, updates the three callsites. No behavior change. The duplicated `should_coalesce_fire_predicate` unit test in this module is deleted (it's superseded by the coverage in `simulate.rs::tests`); the DST / leap-year / tz-alias `next_fire_from_cron_*` tests stay put since they're integration-shaped and continue to pin the public helper's contract at the runner-module layer.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --all-targets` — all green
- [x] `cargo test --lib triggers::simulate` — 8/8 pass (new)
- [x] `cargo test --lib fold_db_core::trigger_runner` — 17/17 pass (0 regressions: 4 `next_fire_from_cron_*` DST/leap/alias tests + 13 runtime tests all continue to pass against the now-imported helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)