### PR TITLE
refactor(triggers): rename window → max_catch_up_age + implement staleness-budget skip (adde8)

### DIFF
--- a/src/fold_db_core/trigger_runner.rs
+++ b/src/fold_db_core/trigger_runner.rs
@@ -49,7 +49,7 @@ use crate::schema::types::{KeyValue, Mutation};
 use crate::schema::{SchemaCore, SchemaError};
 use crate::storage::SledPool;
 use crate::triggers::clock::Clock;
-use crate::triggers::simulate::{next_fire_from_cron, should_coalesce_fire};
+use crate::triggers::simulate::{next_fire_from_cron, should_coalesce_fire, should_skip_catch_up};
 use crate::triggers::types::Trigger;
 use crate::triggers::{fields, status, TRIGGER_FIRING_SCHEMA_NAME};
 
@@ -923,6 +923,42 @@ impl<C: Clock> TriggerRunner<C> {
             return;
         }
 
+        // Staleness budget: if this scheduled catch-up has slipped
+        // further behind the ideal fire time than the trigger's
+        // `max_catch_up_age` allows, skip dispatching and advance the
+        // cursor to the next cron tick. Bounds fire storms after process
+        // downtime (laptop sleep, crash restart) when the scheduler
+        // would otherwise back-fill every missed tick. Only applies to
+        // Scheduled / ScheduledIfDirty (OnWriteCoalesced entries on the
+        // heap don't carry a budget).
+        let max_age = match &trigger {
+            Trigger::Scheduled {
+                max_catch_up_age, ..
+            }
+            | Trigger::ScheduledIfDirty {
+                max_catch_up_age, ..
+            } => max_catch_up_age.as_deref(),
+            _ => None,
+        };
+        let lag_ms = now_ms - fire.fire_at_ms;
+        if should_skip_catch_up(max_age, lag_ms) {
+            warn!(
+                "trigger '{}:{}': skipping catch-up tick — lag {}ms exceeds max_catch_up_age={:?}",
+                fire.view_name, fire.trigger_index, lag_ms, max_age
+            );
+            if let Some((cron, tz)) = reschedule_cron {
+                if let Some(next_at) = next_fire_from_cron(&cron, &tz, now_ms) {
+                    let mut heap = self.scheduler.lock().await;
+                    heap.push(Reverse(ScheduledFire {
+                        fire_at_ms: next_at,
+                        view_name: fire.view_name,
+                        trigger_index: fire.trigger_index,
+                    }));
+                }
+            }
+            return;
+        }
+
         self.dispatch_nonblocking(&fire.view_name, fire.trigger_index, &rt)
             .await;
 
@@ -1432,7 +1468,7 @@ mod tests {
             vec![Trigger::ScheduledIfDirty {
                 cron: "* * * * *".into(),
                 timezone: "UTC".into(),
-                window: None,
+                max_catch_up_age: None,
                 schemas: vec!["S1".into()],
             }],
         );
@@ -1478,7 +1514,7 @@ mod tests {
             vec![Trigger::Scheduled {
                 cron: "0 2 * * *".into(),
                 timezone: "UTC".into(),
-                window: None,
+                max_catch_up_age: None,
                 skip_if_idle: false,
                 schemas: vec!["S1".into()],
             }],
@@ -1524,7 +1560,7 @@ mod tests {
             vec![Trigger::Scheduled {
                 cron: "* * * * *".into(),
                 timezone: "UTC".into(),
-                window: None,
+                max_catch_up_age: None,
                 skip_if_idle: true,
                 schemas: vec!["S1".into()],
             }],
@@ -2156,7 +2192,7 @@ mod tests {
             vec![Trigger::Scheduled {
                 cron: "not-a-cron".into(),
                 timezone: "UTC".into(),
-                window: None,
+                max_catch_up_age: None,
                 skip_if_idle: false,
                 schemas: vec!["S1".into()],
             }],
@@ -2205,6 +2241,173 @@ mod tests {
             !runner.test_is_quarantined("V1").await,
             "malformed cron is a parse/warn-skip condition, NOT a fire \
              failure — must not burn the 3-strikes quarantine budget"
+        );
+    }
+
+    // --- max_catch_up_age (staleness budget) regression tests ---------------
+    //
+    // These tests exercise `process_scheduled_fire`'s catch-up skip gate
+    // through the public `tick_once` entry. The registered `Scheduled`
+    // trigger uses cron "0 * * * *" (hourly on the 0-minute boundary); the
+    // first tick from epoch 0 pushes a heap entry at 01:00 UTC
+    // (= 3_600_000 ms), which is then aged with `MockClock::advance` to
+    // simulate process downtime before the second tick.
+
+    #[tokio::test]
+    async fn scheduled_unbounded_catch_up_fires_after_long_downtime() {
+        // `max_catch_up_age: None` preserves legacy unbounded catch-up —
+        // a 3h lag past the nominal fire must still dispatch on resume.
+        let sm = make_schema_manager().await;
+        register_view(
+            &sm,
+            "V1",
+            "S1",
+            vec![Trigger::Scheduled {
+                cron: "0 * * * *".into(),
+                timezone: "UTC".into(),
+                max_catch_up_age: None,
+                skip_if_idle: false,
+                schemas: vec!["S1".into()],
+            }],
+        );
+        let clock = Arc::new(MockClock::new(0));
+        let fire = RecordingFireHandler::all_success();
+        let writer = CountingFiringWriter::new();
+        let runner = make_runner(
+            Arc::clone(&sm),
+            Arc::clone(&clock),
+            Arc::clone(&fire) as Arc<dyn FireHandler>,
+            Arc::clone(&writer) as Arc<dyn FiringWriter>,
+        );
+
+        // First tick populates the heap with the 01:00 UTC fire_at.
+        runner.tick_once().await;
+
+        // Advance to 04:00 UTC — now 3h past the nominal 01:00 fire.
+        clock.advance(4 * 3_600_000);
+        runner.tick_once().await;
+
+        for _ in 0..30 {
+            if fire.call_count.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            fire.call_count.load(Ordering::SeqCst),
+            1,
+            "unbounded catch-up (max_catch_up_age=None) must fire on resume \
+             after downtime regardless of lag"
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduled_catch_up_budget_skips_stale_fire_but_later_tick_runs() {
+        // `max_catch_up_age: Some("1h")`: a 3h+ lag past the nominal fire
+        // exceeds budget → skip that catch-up dispatch, advance the cursor,
+        // and fire on the next in-budget tick.
+        let sm = make_schema_manager().await;
+        register_view(
+            &sm,
+            "V1",
+            "S1",
+            vec![Trigger::Scheduled {
+                cron: "0 * * * *".into(),
+                timezone: "UTC".into(),
+                max_catch_up_age: Some("1h".into()),
+                skip_if_idle: false,
+                schemas: vec!["S1".into()],
+            }],
+        );
+        let clock = Arc::new(MockClock::new(0));
+        let fire = RecordingFireHandler::all_success();
+        let writer = CountingFiringWriter::new();
+        let runner = make_runner(
+            Arc::clone(&sm),
+            Arc::clone(&clock),
+            Arc::clone(&fire) as Arc<dyn FireHandler>,
+            Arc::clone(&writer) as Arc<dyn FiringWriter>,
+        );
+
+        // Populate heap with first fire at 01:00 UTC (= 3_600_000 ms).
+        runner.tick_once().await;
+
+        // Simulate downtime: advance to 04:05 UTC. The 01:00 fire is now
+        // 3h05m behind, which exceeds the 1h budget → runner must skip.
+        clock.advance(4 * 3_600_000 + 5 * 60_000);
+        runner.tick_once().await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            fire.call_count.load(Ordering::SeqCst),
+            0,
+            "fire slipped 3h past a 1h budget must be skipped, not dispatched"
+        );
+        assert!(
+            writer.rows.lock().await.is_empty(),
+            "skipped catch-up must not emit a TriggerFiring audit row"
+        );
+
+        // Skip path re-enqueued the NEXT cron occurrence: 05:00 UTC.
+        // Advance there; the in-budget fire must dispatch.
+        clock.advance(55 * 60_000);
+        runner.tick_once().await;
+        for _ in 0..30 {
+            if fire.call_count.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            fire.call_count.load(Ordering::SeqCst),
+            1,
+            "next in-budget cron tick after the skip must fire normally"
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduled_catch_up_within_budget_fires_normally() {
+        // `max_catch_up_age: Some("24h")` with a 30m lag → well within
+        // budget; fire normally (regression guard against an overeager
+        // skip that treats any lag as stale).
+        let sm = make_schema_manager().await;
+        register_view(
+            &sm,
+            "V1",
+            "S1",
+            vec![Trigger::Scheduled {
+                cron: "0 * * * *".into(),
+                timezone: "UTC".into(),
+                max_catch_up_age: Some("24h".into()),
+                skip_if_idle: false,
+                schemas: vec!["S1".into()],
+            }],
+        );
+        let clock = Arc::new(MockClock::new(0));
+        let fire = RecordingFireHandler::all_success();
+        let writer = CountingFiringWriter::new();
+        let runner = make_runner(
+            Arc::clone(&sm),
+            Arc::clone(&clock),
+            Arc::clone(&fire) as Arc<dyn FireHandler>,
+            Arc::clone(&writer) as Arc<dyn FiringWriter>,
+        );
+
+        runner.tick_once().await; // populates with 01:00 UTC fire.
+                                  // Advance to 01:30 UTC — 30m lag, far below the 24h budget.
+        clock.advance(3_600_000 + 30 * 60_000);
+        runner.tick_once().await;
+        for _ in 0..30 {
+            if fire.call_count.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            fire.call_count.load(Ordering::SeqCst),
+            1,
+            "30m lag under a 24h budget must fire normally"
         );
     }
 

--- a/src/triggers/simulate.rs
+++ b/src/triggers/simulate.rs
@@ -26,6 +26,63 @@ pub fn next_fire_from_cron(cron_expr: &str, tz_str: &str, now_ms: i64) -> Option
     Some(next.with_timezone(&Utc).timestamp_millis())
 }
 
+/// Parse a `max_catch_up_age` duration string (e.g. `"30m"`, `"1h"`,
+/// `"7d"`, `"2w"`) into a millisecond count. Accepted format is
+/// `<positive-int><unit>` with unit in m/h/d/w. Returns `None` if the
+/// string doesn't match — input validation is owned by schema_service's
+/// `validate_max_catch_up_age` register-time hook; this consumer parses
+/// safely (treating an unparseable or zero value as unbounded, via
+/// `should_skip_catch_up`) rather than panicking at fire time.
+pub fn parse_max_catch_up_age_ms(s: &str) -> Option<i64> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (num_part, unit) = trimmed
+        .char_indices()
+        .rfind(|(_, c)| c.is_ascii_digit())
+        .map(|(last_digit_idx, _)| trimmed.split_at(last_digit_idx + 1))?;
+    let n: i64 = num_part.parse().ok()?;
+    if n <= 0 {
+        return None;
+    }
+    let ms_per_unit: i64 = match unit {
+        "m" => 60_000,
+        "h" => 3_600_000,
+        "d" => 86_400_000,
+        "w" => 7 * 86_400_000,
+        _ => return None,
+    };
+    n.checked_mul(ms_per_unit)
+}
+
+/// Staleness-budget predicate for `Scheduled` / `ScheduledIfDirty` catch-up
+/// fires. Given the trigger's optional `max_catch_up_age` and the
+/// wall-clock lag between `now` and the ideal cron fire time, decide
+/// whether to skip this tick (and wait for the next cron occurrence).
+///
+/// * `None` budget → always returns `false` (unbounded catch-up; legacy
+///   behavior).
+/// * `Some(budget)` → returns `true` when `lag_ms > budget`. A
+///   malformed budget string parses to `None` and returns `false` — it's a
+///   warn condition at the caller, not a skip condition, so we err on the
+///   side of firing.
+/// * `lag_ms <= 0` (fire arrived on time or early) → always returns
+///   `false` regardless of budget.
+///
+/// Purpose: bound fire storms after process downtime (laptop sleep, crash
+/// restart) when the cron scheduler would otherwise back-fill every missed
+/// tick between `last_fire_ms` and `now`.
+pub fn should_skip_catch_up(max_catch_up_age: Option<&str>, lag_ms: i64) -> bool {
+    let Some(budget_str) = max_catch_up_age else {
+        return false;
+    };
+    let Some(budget_ms) = parse_max_catch_up_age_ms(budget_str) else {
+        return false;
+    };
+    lag_ms > budget_ms
+}
+
 /// Shared fire predicate for `OnWriteCoalesced` triggers.
 ///
 /// Fires when we have a full batch past the debounce window, OR when
@@ -116,5 +173,74 @@ mod tests {
         assert!(!should_coalesce_fire(
             1, 1_000, 1_000, 5_000, 3, 100, 10_000
         ));
+    }
+
+    #[test]
+    fn parse_max_catch_up_age_ms_accepts_all_units() {
+        assert_eq!(parse_max_catch_up_age_ms("30m"), Some(30 * 60_000));
+        assert_eq!(parse_max_catch_up_age_ms("1h"), Some(3_600_000));
+        assert_eq!(parse_max_catch_up_age_ms("24h"), Some(24 * 3_600_000));
+        assert_eq!(parse_max_catch_up_age_ms("7d"), Some(7 * 86_400_000));
+        assert_eq!(parse_max_catch_up_age_ms("2w"), Some(14 * 86_400_000));
+    }
+
+    #[test]
+    fn parse_max_catch_up_age_ms_rejects_malformed() {
+        // Empty / whitespace.
+        assert!(parse_max_catch_up_age_ms("").is_none());
+        assert!(parse_max_catch_up_age_ms("   ").is_none());
+        // Missing unit.
+        assert!(parse_max_catch_up_age_ms("24").is_none());
+        // Unknown unit (seconds intentionally not supported — catch-up
+        // budget is a coarse-grained knob).
+        assert!(parse_max_catch_up_age_ms("5s").is_none());
+        assert!(parse_max_catch_up_age_ms("3y").is_none());
+        // Non-numeric prefix.
+        assert!(parse_max_catch_up_age_ms("abc").is_none());
+        assert!(parse_max_catch_up_age_ms("h").is_none());
+        // Zero / negative are rejected to avoid a zero-budget degenerate.
+        assert!(parse_max_catch_up_age_ms("0h").is_none());
+        assert!(parse_max_catch_up_age_ms("-1h").is_none());
+    }
+
+    #[test]
+    fn should_skip_catch_up_none_never_skips() {
+        // Unbounded catch-up: never skip regardless of lag magnitude.
+        assert!(!should_skip_catch_up(None, 0));
+        assert!(!should_skip_catch_up(None, 1_000_000_000));
+    }
+
+    #[test]
+    fn should_skip_catch_up_within_budget_does_not_skip() {
+        // 24h budget, 30m lag → well under the budget; fire normally.
+        assert!(!should_skip_catch_up(Some("24h"), 30 * 60_000));
+        // 1h budget, exactly at the budget → boundary is inclusive of
+        // firing (strict `>`), so lag == budget does not skip.
+        assert!(!should_skip_catch_up(Some("1h"), 3_600_000));
+    }
+
+    #[test]
+    fn should_skip_catch_up_over_budget_skips() {
+        // 1h budget, 3h lag → skip this catch-up tick.
+        assert!(should_skip_catch_up(Some("1h"), 3 * 3_600_000));
+        // 1h budget, 1h + 1ms lag → just over; skip.
+        assert!(should_skip_catch_up(Some("1h"), 3_600_001));
+    }
+
+    #[test]
+    fn should_skip_catch_up_malformed_budget_falls_back_to_fire() {
+        // Malformed budget → treat as unbounded (return false, don't skip).
+        // Input validation lives in schema_service; this consumer must
+        // never panic or silently drop a fire on garbage input.
+        assert!(!should_skip_catch_up(Some("abc"), 10 * 3_600_000));
+        assert!(!should_skip_catch_up(Some(""), 10 * 3_600_000));
+        assert!(!should_skip_catch_up(Some("0h"), 10 * 3_600_000));
+    }
+
+    #[test]
+    fn should_skip_catch_up_non_positive_lag_never_skips() {
+        // Fire arrived early or on time: never a catch-up situation.
+        assert!(!should_skip_catch_up(Some("1h"), 0));
+        assert!(!should_skip_catch_up(Some("1h"), -5_000));
     }
 }

--- a/src/triggers/types.rs
+++ b/src/triggers/types.rs
@@ -12,12 +12,17 @@
 //!   the named source schemas.
 //! - `OnWriteCoalesced { schemas, min_batch, debounce_ms, max_wait_ms }`:
 //!   batch mutations; fire once thresholds are crossed.
-//! - `Scheduled { cron, timezone, window, skip_if_idle, schemas }`: fire on
-//!   a cron schedule in the given IANA timezone. When `window` is set, it
-//!   auto-injects a time filter into input queries at fire time (e.g.
-//!   `"24h"`, `"7d"`). `skip_if_idle` suppresses the tick when no source
-//!   mutations have landed since the last fire.
-//! - `ScheduledIfDirty { cron, timezone, window, schemas }`: like
+//! - `Scheduled { cron, timezone, max_catch_up_age, skip_if_idle, schemas }`:
+//!   fire on a cron schedule in the given IANA timezone.
+//!   `max_catch_up_age` is an optional staleness budget — if the current
+//!   fire is more than `max_catch_up_age` behind the ideal fire time, the
+//!   runner skips this catch-up tick and advances to the next cron
+//!   occurrence. Bounds fire storms after process downtime (laptop sleep,
+//!   crash restart). Format: `<int><unit>` with unit in m/h/d/w
+//!   (e.g. `"30m"`, `"24h"`, `"7d"`). `None` means unbounded catch-up.
+//!   `skip_if_idle` suppresses the tick when no source mutations have
+//!   landed since the last fire.
+//! - `ScheduledIfDirty { cron, timezone, max_catch_up_age, schemas }`: like
 //!   `Scheduled` but only fires when the per-view dirty bit is set.
 //! - `Manual`: only fires via explicit run (future endpoint).
 //!
@@ -43,7 +48,7 @@ pub enum Trigger {
         cron: String,
         timezone: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        window: Option<String>,
+        max_catch_up_age: Option<String>,
         skip_if_idle: bool,
         schemas: Vec<String>,
     },
@@ -51,7 +56,7 @@ pub enum Trigger {
         cron: String,
         timezone: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        window: Option<String>,
+        max_catch_up_age: Option<String>,
         schemas: Vec<String>,
     },
     Manual,
@@ -110,7 +115,7 @@ mod tests {
         let t = Trigger::ScheduledIfDirty {
             cron: "0 * * * *".into(),
             timezone: "UTC".into(),
-            window: None,
+            max_catch_up_age: None,
             schemas: vec!["S".into()],
         };
         assert!(t.is_write_triggered());
@@ -122,7 +127,7 @@ mod tests {
         let t = Trigger::Scheduled {
             cron: "0 * * * *".into(),
             timezone: "UTC".into(),
-            window: None,
+            max_catch_up_age: None,
             skip_if_idle: false,
             schemas: vec!["S".into()],
         };
@@ -165,32 +170,59 @@ mod tests {
     }
 
     #[test]
-    fn scheduled_roundtrips_with_optional_window() {
+    fn scheduled_roundtrips_with_optional_max_catch_up_age() {
         let t = Trigger::Scheduled {
             cron: "0 2 * * *".into(),
             timezone: "America/New_York".into(),
-            window: Some("24h".into()),
+            max_catch_up_age: Some("24h".into()),
             skip_if_idle: true,
             schemas: vec!["Source".into()],
         };
         let json = serde_json::to_string(&t).unwrap();
         assert!(json.contains(r#""kind":"Scheduled""#));
-        assert!(json.contains(r#""window":"24h""#));
+        assert!(json.contains(r#""max_catch_up_age":"24h""#));
         let round: Trigger = serde_json::from_str(&json).unwrap();
         assert_eq!(round, t);
 
-        // Window omitted on serialize when None.
-        let t_no_window = Trigger::Scheduled {
+        // max_catch_up_age omitted on serialize when None.
+        let t_no_budget = Trigger::Scheduled {
             cron: "0 2 * * *".into(),
             timezone: "UTC".into(),
-            window: None,
+            max_catch_up_age: None,
             skip_if_idle: false,
             schemas: vec!["S".into()],
         };
-        let json = serde_json::to_string(&t_no_window).unwrap();
+        let json = serde_json::to_string(&t_no_budget).unwrap();
         assert!(
-            !json.contains("window"),
-            "None window must be omitted: {json}"
+            !json.contains("max_catch_up_age"),
+            "None max_catch_up_age must be omitted: {json}"
+        );
+    }
+
+    #[test]
+    fn scheduled_if_dirty_roundtrips_with_optional_max_catch_up_age() {
+        let t = Trigger::ScheduledIfDirty {
+            cron: "*/5 * * * *".into(),
+            timezone: "UTC".into(),
+            max_catch_up_age: Some("1h".into()),
+            schemas: vec!["Source".into()],
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        assert!(json.contains(r#""kind":"ScheduledIfDirty""#));
+        assert!(json.contains(r#""max_catch_up_age":"1h""#));
+        let round: Trigger = serde_json::from_str(&json).unwrap();
+        assert_eq!(round, t);
+
+        let t_no_budget = Trigger::ScheduledIfDirty {
+            cron: "*/5 * * * *".into(),
+            timezone: "UTC".into(),
+            max_catch_up_age: None,
+            schemas: vec!["S".into()],
+        };
+        let json = serde_json::to_string(&t_no_budget).unwrap();
+        assert!(
+            !json.contains("max_catch_up_age"),
+            "None max_catch_up_age must be omitted on ScheduledIfDirty: {json}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Audit round 1 §F1 resolution: `window: Option<String>` was declared, validated, persisted, and documented — but never consumed at runtime. Two conflicting semantics collided (A: inject time filter into input queries; B: staleness budget). Tom picked B with a rename; A is deleted scope.
- **Rename** `window` → `max_catch_up_age` on `Trigger::Scheduled` + `Trigger::ScheduledIfDirty`. No alias preserved — the old field never worked, clean break is safe.
- **Implement** the staleness-budget semantic: `TriggerRunner::process_scheduled_fire` now checks `lag_ms > budget`; when true it warns, advances the cursor to the next cron occurrence, and skips dispatch. Bounds fire storms after laptop sleep / crash restart. `None` preserves current unbounded catch-up behavior.
- **Pure helpers** in `triggers/simulate.rs`: `parse_max_catch_up_age_ms` (parses `<int><m|h|d|w>`) and `should_skip_catch_up(max_catch_up_age, lag_ms)`. Malformed input falls back to unbounded-catch-up rather than panicking — input validation is owned by schema_service.

## Cascade (auto-started, linked kanban)
- `schema_service` needs the equivalent rename (`validate_window` → `validate_max_catch_up_age`) — kicked off on merge.
- `fold_db_node` is a pass-through consumer; only a Cargo.lock bump is required.

## Test plan
- [x] `cargo test -p fold_db --lib triggers::` — 31 passed (6 new on helpers + 1 new serde round-trip for ScheduledIfDirty).
- [x] `cargo test -p fold_db --lib fold_db_core::trigger_runner` — 22 passed (3 new MockClock regression tests: unbounded, skip, within-budget).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace --all-targets` — only the known pre-existing flake (`db_operations::org_operations::tests::test_purge_org_data`, tracked as `7f3e7`) fails under parallel load; passes in isolation. Unrelated to this change (same failure reproduces on unmodified origin/mainline).
- [x] Doc examples in `docs/designs/triggers.md` (workspace PR) updated to match new field name + semantic B description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)