### PR TITLE
docs(triggers): document should_skip_catch_up defense-in-depth contract (R2-G2)

### DIFF
--- a/src/triggers/simulate.rs
+++ b/src/triggers/simulate.rs
@@ -70,6 +70,16 @@ pub fn parse_max_catch_up_age_ms(s: &str) -> Option<i64> {
 /// * `lag_ms <= 0` (fire arrived on time or early) → always returns
 ///   `false` regardless of budget.
 ///
+/// Contract: malformed budget strings ARE rejected upstream by
+/// `schema_service::state::validate_max_catch_up_age` at `PUT /v1/views`
+/// register time. The `Some(budget_str) → parse → None → false` branch
+/// here is defense in depth for non-HTTP code paths (direct in-process
+/// callers, pre-existing sled rows from older schema revisions, and
+/// loopback tests that bypass the HTTP validator) — production fires
+/// should never exercise it, and the schema_service validator's
+/// accept-set is kept a strict subset of `parse_max_catch_up_age_ms`'s
+/// `Some` set so a green registration is always a parseable budget here.
+///
 /// Purpose: bound fire storms after process downtime (laptop sleep, crash
 /// restart) when the cron scheduler would otherwise back-fill every missed
 /// tick between `last_fire_ms` and `now`.


### PR DESCRIPTION
## Summary

Docs-only follow-up to the R2-G2 audit (see schema_service PR [#23](https://github.com/EdgeVector/schema_service/pull/23)). Expands the comment on `should_skip_catch_up` to spell out the defense-in-depth contract:

- `schema_service::state::validate_max_catch_up_age` rejects every string the runtime would fail to parse (post-#23).
- The runtime's \`Some(budget_str) → parse → None → false\` branch stays as defense in depth for non-HTTP code paths (direct in-process callers, pre-existing sled rows from older schema revisions, and loopback tests that bypass the HTTP validator).
- The validator's accept-set is kept a strict subset of `parse_max_catch_up_age_ms`'s `Some` set, so a green registration is always a parseable budget here.

This is the minimum change needed on the fold_db side — all behavior changes live in schema_service PR #23.

## Test plan

- [x] `cargo test --package fold_db triggers` → 32 trigger tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)