### PR TITLE
feat(storage): local-only transform_cache namespace (MDT-B)

### DIFF
--- a/src/db_operations/core.rs
+++ b/src/db_operations/core.rs
@@ -22,7 +22,8 @@ pub struct DbOperations {
     schema_store: SchemaStore,
     /// Main namespace — atoms, molecules, mutation events, sync conflicts
     atom_store: AtomStore,
-    /// Transform view definitions, view states, field cache state
+    /// Transform view definitions, view states, and the local-only
+    /// `transform_cache` namespace (derived per-device, excluded from sync).
     view_store: ViewStore,
     /// Permissions + public keys
     permissions_store: PermissionsStore,
@@ -49,7 +50,10 @@ impl DbOperations {
         let superseded_by_kv = store.open_namespace("schema_superseded_by").await?;
         let views_kv = store.open_namespace("views").await?;
         let view_states_kv = store.open_namespace("view_states").await?;
-        let transform_field_states_kv = store.open_namespace("transform_field_states").await?;
+        // `transform_cache` holds the per-view ViewCacheState output. It is
+        // local-only — SyncingNamespacedStore explicitly excludes it from the
+        // sync log so derived cache state cannot leak between devices.
+        let transform_cache_kv = store.open_namespace("transform_cache").await?;
         let native_index_kv = store.open_namespace("native_index").await?;
 
         // Wrap KvStores in TypedKvStore adapters
@@ -64,14 +68,13 @@ impl DbOperations {
         let superseded_by_store = Arc::new(TypedKvStore::new(superseded_by_kv));
         let views_store = Arc::new(TypedKvStore::new(views_kv));
         let view_states_store = Arc::new(TypedKvStore::new(view_states_kv));
-        let transform_field_states_store = Arc::new(TypedKvStore::new(transform_field_states_kv));
+        let transform_cache_store = Arc::new(TypedKvStore::new(transform_cache_kv));
 
         // Domain stores
         let schema_store =
             SchemaStore::new(schemas_store, schema_states_store, superseded_by_store);
         let atom_store = AtomStore::new(main_store);
-        let view_store =
-            ViewStore::new(views_store, view_states_store, transform_field_states_store);
+        let view_store = ViewStore::new(views_store, view_states_store, transform_cache_store);
         let permissions_store = PermissionsStore::new(permissions_typed, public_keys_typed);
         let metadata_store =
             MetadataStore::new(metadata_typed, idempotency_typed, process_results_typed);

--- a/src/db_operations/org_operations.rs
+++ b/src/db_operations/org_operations.rs
@@ -31,7 +31,7 @@ impl DbOperations {
             self.schemas().raw_superseded_by(),
             self.views().raw_views(),
             self.views().raw_view_states(),
-            self.views().raw_transform_field_states(),
+            self.views().raw_transform_cache(),
             self.atoms().raw(),
         ];
 

--- a/src/db_operations/view_store.rs
+++ b/src/db_operations/view_store.rs
@@ -137,9 +137,7 @@ impl ViewStore {
 
     /// Clear cache state for a view (used when removing a view).
     pub async fn clear_view_cache_state(&self, view_name: &str) -> Result<(), SchemaError> {
-        self.transform_cache_store
-            .delete_item(view_name)
-            .await?;
+        self.transform_cache_store.delete_item(view_name).await?;
         self.transform_cache_store.inner().flush().await?;
         Ok(())
     }

--- a/src/db_operations/view_store.rs
+++ b/src/db_operations/view_store.rs
@@ -1,8 +1,14 @@
 //! Transform-view domain store.
 //!
 //! Owns the namespaces for transform view definitions, view states,
-//! and transform field cache state. External callers reach these via
+//! and the local-only transform cache. External callers reach these via
 //! `DbOperations::views()`.
+//!
+//! The `transform_cache` namespace is declared local-only in
+//! `SyncingNamespacedStore::LOCAL_ONLY_NAMESPACES` — writes to it never
+//! append to the sync log. Cached transform output is derived per-device
+//! and must not cross the wire (see `docs/design/multi_device_transforms.md`,
+//! "What Syncs vs. What Doesn't").
 
 use crate::schema::SchemaError;
 use crate::storage::traits::{KvStore, TypedStore};
@@ -17,19 +23,22 @@ use std::sync::Arc;
 pub struct ViewStore {
     views_store: Arc<TypedKvStore<dyn KvStore>>,
     view_states_store: Arc<TypedKvStore<dyn KvStore>>,
-    transform_field_states_store: Arc<TypedKvStore<dyn KvStore>>,
+    /// Local-only cache of computed `ViewCacheState` per view. Routed
+    /// through the `transform_cache` namespace, which `SyncingNamespacedStore`
+    /// excludes from the sync log.
+    transform_cache_store: Arc<TypedKvStore<dyn KvStore>>,
 }
 
 impl ViewStore {
     pub(crate) fn new(
         views_store: Arc<TypedKvStore<dyn KvStore>>,
         view_states_store: Arc<TypedKvStore<dyn KvStore>>,
-        transform_field_states_store: Arc<TypedKvStore<dyn KvStore>>,
+        transform_cache_store: Arc<TypedKvStore<dyn KvStore>>,
     ) -> Self {
         Self {
             views_store,
             view_states_store,
-            transform_field_states_store,
+            transform_cache_store,
         }
     }
 
@@ -42,8 +51,8 @@ impl ViewStore {
         &self.view_states_store
     }
 
-    pub(crate) fn raw_transform_field_states(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
-        &self.transform_field_states_store
+    pub(crate) fn raw_transform_cache(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+        &self.transform_cache_store
     }
 
     /// Store a transform view definition.
@@ -107,7 +116,7 @@ impl ViewStore {
         view_name: &str,
     ) -> Result<ViewCacheState, SchemaError> {
         Ok(self
-            .transform_field_states_store
+            .transform_cache_store
             .get_item::<ViewCacheState>(view_name)
             .await?
             .unwrap_or(ViewCacheState::Empty))
@@ -119,19 +128,19 @@ impl ViewStore {
         view_name: &str,
         state: &ViewCacheState,
     ) -> Result<(), SchemaError> {
-        self.transform_field_states_store
+        self.transform_cache_store
             .put_item(view_name, state)
             .await?;
-        self.transform_field_states_store.inner().flush().await?;
+        self.transform_cache_store.inner().flush().await?;
         Ok(())
     }
 
     /// Clear cache state for a view (used when removing a view).
     pub async fn clear_view_cache_state(&self, view_name: &str) -> Result<(), SchemaError> {
-        self.transform_field_states_store
+        self.transform_cache_store
             .delete_item(view_name)
             .await?;
-        self.transform_field_states_store.inner().flush().await?;
+        self.transform_cache_store.inner().flush().await?;
         Ok(())
     }
 }

--- a/src/storage/syncing_namespaced_store.rs
+++ b/src/storage/syncing_namespaced_store.rs
@@ -5,16 +5,29 @@ use crate::sync::SyncEngine;
 use async_trait::async_trait;
 use std::sync::Arc;
 
+/// Namespaces that must never append to the sync log.
+///
+/// These hold derived / per-device state that any node can recompute or
+/// regenerate locally. Routing them through `SyncingKvStore` would leak
+/// non-canonical state into the unified sync log and reintroduce the
+/// cache-coherence problem the multi-device transform design avoids
+/// (see `docs/design/multi_device_transforms.md`, "What Syncs vs. What Doesn't").
+const LOCAL_ONLY_NAMESPACES: &[&str] = &["transform_cache"];
+
 /// A NamespacedStore decorator that wraps each opened namespace with a SyncingKvStore.
 ///
 /// Every namespace opened through this store will automatically record
-/// write operations to the SyncEngine for S3 sync.
+/// write operations to the SyncEngine for S3 sync, **except** for names
+/// in [`LOCAL_ONLY_NAMESPACES`], which are returned unwrapped so their
+/// writes stay on-device.
 ///
 /// ```text
 /// SyncingNamespacedStore
-///   └── open_namespace("main")
-///         └── SyncingKvStore("main")  ← records ops
-///               └── inner KvStore     ← actual backend
+///   ├── open_namespace("main")
+///   │     └── SyncingKvStore("main")  ← records ops
+///   │           └── inner KvStore     ← actual backend
+///   └── open_namespace("transform_cache")
+///         └── inner KvStore           ← no wrapper, never syncs
 /// ```
 pub struct SyncingNamespacedStore {
     inner: Arc<dyn NamespacedStore>,
@@ -25,12 +38,20 @@ impl SyncingNamespacedStore {
     pub fn new(inner: Arc<dyn NamespacedStore>, sync_engine: Arc<SyncEngine>) -> Self {
         Self { inner, sync_engine }
     }
+
+    /// Returns true if writes to `name` must stay local and never append to the sync log.
+    pub fn is_local_only(name: &str) -> bool {
+        LOCAL_ONLY_NAMESPACES.contains(&name)
+    }
 }
 
 #[async_trait]
 impl NamespacedStore for SyncingNamespacedStore {
     async fn open_namespace(&self, name: &str) -> StorageResult<Arc<dyn KvStore>> {
         let inner_kv = self.inner.open_namespace(name).await?;
+        if Self::is_local_only(name) {
+            return Ok(inner_kv);
+        }
         let syncing = SyncingKvStore::new(inner_kv, self.sync_engine.clone(), name.to_string());
         Ok(Arc::new(syncing))
     }
@@ -104,5 +125,81 @@ mod tests {
         let names = store.list_namespaces().await.unwrap();
         assert!(names.contains(&"main".to_string()));
         assert!(names.contains(&"metadata".to_string()));
+    }
+
+    #[tokio::test]
+    async fn transform_cache_writes_are_not_recorded() {
+        let (store, engine) = test_setup().await;
+
+        let cache = store.open_namespace("transform_cache").await.unwrap();
+        assert_eq!(engine.pending_count().await, 0);
+
+        cache
+            .put(b"view:analytics", b"cached-output".to_vec())
+            .await
+            .unwrap();
+        cache
+            .put(b"view:other", b"another-output".to_vec())
+            .await
+            .unwrap();
+        cache.delete(b"view:other").await.unwrap();
+        cache
+            .batch_put(vec![
+                (b"view:a".to_vec(), b"va".to_vec()),
+                (b"view:b".to_vec(), b"vb".to_vec()),
+            ])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            engine.pending_count().await,
+            0,
+            "transform_cache namespace must never append to the sync log"
+        );
+        assert_eq!(
+            engine.state().await,
+            crate::sync::SyncState::Idle,
+            "sync engine state must stay Idle after transform_cache writes"
+        );
+    }
+
+    /// Positive control paired with `transform_cache_writes_are_not_recorded`:
+    /// writes to a synced namespace must record, writes to the local-only
+    /// namespace must not, under the same engine instance.
+    #[tokio::test]
+    async fn cache_writes_never_mix_with_synced_writes() {
+        let (store, engine) = test_setup().await;
+
+        let main = store.open_namespace("main").await.unwrap();
+        let cache = store.open_namespace("transform_cache").await.unwrap();
+
+        // Full cycle: compute → cache → read → recompute → cache again.
+        // None of this should enter the sync log.
+        for i in 0..5 {
+            let key = format!("view:v{}", i);
+            cache
+                .put(key.as_bytes(), format!("output-{}", i).into_bytes())
+                .await
+                .unwrap();
+            let got = cache.get(key.as_bytes()).await.unwrap();
+            assert!(got.is_some());
+            cache
+                .put(key.as_bytes(), format!("recomputed-{}", i).into_bytes())
+                .await
+                .unwrap();
+        }
+        assert_eq!(engine.pending_count().await, 0);
+
+        // A source-data write on the same engine must still record.
+        main.put(b"atom:1", b"source-data".to_vec()).await.unwrap();
+        assert_eq!(engine.pending_count().await, 1);
+    }
+
+    #[test]
+    fn is_local_only_classification() {
+        assert!(SyncingNamespacedStore::is_local_only("transform_cache"));
+        assert!(!SyncingNamespacedStore::is_local_only("main"));
+        assert!(!SyncingNamespacedStore::is_local_only("metadata"));
+        assert!(!SyncingNamespacedStore::is_local_only("schemas"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `transform_cache` as a local-only namespace in `SyncingNamespacedStore` — writes routed through it never append to the sync log.
- Renames `transform_field_states` → `transform_cache` so `ViewCacheState::Cached` writes (the existing per-view cache output) land in the excluded namespace.
- Closes open design item #2 from `docs/design/multi_device_transforms.md` ("What Syncs vs. What Doesn't" — `Cached` values must not sync).

## Why

The multi-device transform design treats cache as per-device derived state: any node can recompute it deterministically from synced source molecules + content-addressed WASM. Before this PR, the cache namespace (`transform_field_states`) was opened through `SyncingNamespacedStore` unqualified, which wrapped it with `SyncingKvStore` — meaning every cache write was appended to the unified sync log. That reintroduces the cache-coherence problem the design explicitly avoids.

## What changed

- `src/storage/syncing_namespaced_store.rs` — add `LOCAL_ONLY_NAMESPACES = &["transform_cache"]` constant + `is_local_only()` classifier; `open_namespace` returns the inner `KvStore` unwrapped for local-only namespaces.
- `src/db_operations/core.rs` — open `"transform_cache"` instead of `"transform_field_states"`.
- `src/db_operations/view_store.rs` — rename field + accessor (`raw_transform_cache`), updated module doc comments pointing at the design doc.
- `src/db_operations/org_operations.rs` — update the single `raw_transform_field_states()` → `raw_transform_cache()` call site in `purge_org_data`.

Cache population logic is untouched — this PR only changes the routing/namespace decision.

## Test plan

- [x] `cargo check --lib` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test --all-targets` — 660/660 passing.
- [x] New tests in `syncing_namespaced_store.rs`:
  - `transform_cache_writes_are_not_recorded` — put/delete/batch_put on the cache namespace ⇒ `pending_count == 0`, engine stays `Idle`.
  - `cache_writes_never_mix_with_synced_writes` — full compute→cache→read cycle produces zero sync-log entries; a subsequent `main` namespace write on the same engine records exactly one entry (positive control).
  - `is_local_only_classification` — sanity check on the exclusion set.

## Notes

- `view_states` and `views` namespaces remain synced — they contain the view *definitions* and registry-level state, not derived output. Only `Cached { entries }` content is per-device; design doc treats it separately.
- No data migration needed: cached state pre-this-PR lives under the old `transform_field_states` key-space and is simply stranded. Next query recomputes it into `transform_cache`. That's the correct behavior per the design ("cache is local memoization").

🤖 Generated with [Claude Code](https://claude.com/claude-code)