### PR TITLE
feat(view): TransformFieldOverride molecule for Overridden state (MDT-D)

### DIFF
--- a/src/db_operations/core.rs
+++ b/src/db_operations/core.rs
@@ -54,6 +54,12 @@ impl DbOperations {
         // local-only — SyncingNamespacedStore explicitly excludes it from the
         // sync log so derived cache state cannot leak between devices.
         let transform_cache_kv = store.open_namespace("transform_cache").await?;
+        // `transform_field_overrides` holds per-(view, field, key) override
+        // molecules. Unlike transform_cache, overrides ARE user data, so this
+        // namespace participates in the unified sync log and converges across
+        // replicas via LWW on `written_at`.
+        let transform_field_overrides_kv =
+            store.open_namespace("transform_field_overrides").await?;
         let native_index_kv = store.open_namespace("native_index").await?;
 
         // Wrap KvStores in TypedKvStore adapters
@@ -69,12 +75,19 @@ impl DbOperations {
         let views_store = Arc::new(TypedKvStore::new(views_kv));
         let view_states_store = Arc::new(TypedKvStore::new(view_states_kv));
         let transform_cache_store = Arc::new(TypedKvStore::new(transform_cache_kv));
+        let transform_field_overrides_store =
+            Arc::new(TypedKvStore::new(transform_field_overrides_kv));
 
         // Domain stores
         let schema_store =
             SchemaStore::new(schemas_store, schema_states_store, superseded_by_store);
         let atom_store = AtomStore::new(main_store);
-        let view_store = ViewStore::new(views_store, view_states_store, transform_cache_store);
+        let view_store = ViewStore::new(
+            views_store,
+            view_states_store,
+            transform_cache_store,
+            transform_field_overrides_store,
+        );
         let permissions_store = PermissionsStore::new(permissions_typed, public_keys_typed);
         let metadata_store =
             MetadataStore::new(metadata_typed, idempotency_typed, process_results_typed);

--- a/src/db_operations/org_operations.rs
+++ b/src/db_operations/org_operations.rs
@@ -32,6 +32,7 @@ impl DbOperations {
             self.views().raw_views(),
             self.views().raw_view_states(),
             self.views().raw_transform_cache(),
+            self.views().raw_transform_field_overrides(),
             self.atoms().raw(),
         ];
 

--- a/src/db_operations/view_store.rs
+++ b/src/db_operations/view_store.rs
@@ -14,6 +14,7 @@ use crate::schema::SchemaError;
 use crate::storage::traits::{KvStore, TypedStore};
 use crate::storage::TypedKvStore;
 use crate::view::registry::ViewState;
+use crate::view::transform_field_override::TransformFieldOverride;
 use crate::view::types::{TransformView, ViewCacheState};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -27,6 +28,9 @@ pub struct ViewStore {
     /// through the `transform_cache` namespace, which `SyncingNamespacedStore`
     /// excludes from the sync log.
     transform_cache_store: Arc<TypedKvStore<dyn KvStore>>,
+    /// Per-(view, field, key) override molecules. Synced like any other
+    /// molecule write — converges across replicas via LWW on `written_at`.
+    transform_field_overrides_store: Arc<TypedKvStore<dyn KvStore>>,
 }
 
 impl ViewStore {
@@ -34,11 +38,13 @@ impl ViewStore {
         views_store: Arc<TypedKvStore<dyn KvStore>>,
         view_states_store: Arc<TypedKvStore<dyn KvStore>>,
         transform_cache_store: Arc<TypedKvStore<dyn KvStore>>,
+        transform_field_overrides_store: Arc<TypedKvStore<dyn KvStore>>,
     ) -> Self {
         Self {
             views_store,
             view_states_store,
             transform_cache_store,
+            transform_field_overrides_store,
         }
     }
 
@@ -140,5 +146,292 @@ impl ViewStore {
         self.transform_cache_store.delete_item(view_name).await?;
         self.transform_cache_store.inner().flush().await?;
         Ok(())
+    }
+
+    // ===== Transform field overrides =====
+    //
+    // Per-(view, field, key_value) override molecules. Stored in their own
+    // namespace so they participate in the unified sync log like any other
+    // molecule write — converging across replicas via LWW on `written_at`.
+
+    /// Build the storage key for an override entry. The view name and field
+    /// name come from registered schemas (already constrained to identifier
+    /// characters), so plain `|` separation is safe; key_str is opaque user
+    /// input but lives at the tail and never participates in prefix scans
+    /// past the field segment.
+    fn override_key(view_name: &str, field_name: &str, key_str: &str) -> String {
+        format!("{}|{}|{}", view_name, field_name, key_str)
+    }
+
+    /// Prefix that scans all overrides for a view.
+    fn override_view_prefix(view_name: &str) -> String {
+        format!("{}|", view_name)
+    }
+
+    /// Read an override for a single (view, field, key) tuple, if any.
+    pub async fn get_transform_field_override(
+        &self,
+        view_name: &str,
+        field_name: &str,
+        key_str: &str,
+    ) -> Result<Option<TransformFieldOverride>, SchemaError> {
+        let key = Self::override_key(view_name, field_name, key_str);
+        Ok(self
+            .transform_field_overrides_store
+            .get_item::<TransformFieldOverride>(&key)
+            .await?)
+    }
+
+    /// LWW-write an override. Returns whether the on-disk state changed.
+    /// If an existing entry is at least as new as `incoming`, the write is
+    /// dropped — this is what makes replay of older log entries idempotent.
+    pub async fn put_transform_field_override(
+        &self,
+        view_name: &str,
+        field_name: &str,
+        key_str: &str,
+        incoming: &TransformFieldOverride,
+    ) -> Result<bool, SchemaError> {
+        let key = Self::override_key(view_name, field_name, key_str);
+
+        if let Some(existing) = self
+            .transform_field_overrides_store
+            .get_item::<TransformFieldOverride>(&key)
+            .await?
+        {
+            if !TransformFieldOverride::should_replace(&existing, incoming) {
+                return Ok(false);
+            }
+        }
+
+        self.transform_field_overrides_store
+            .put_item(&key, incoming)
+            .await?;
+        self.transform_field_overrides_store.inner().flush().await?;
+        Ok(true)
+    }
+
+    /// Scan all overrides for a view. Returns (field_name, key_str, override)
+    /// tuples — caller groups by field as needed.
+    pub async fn scan_transform_field_overrides(
+        &self,
+        view_name: &str,
+    ) -> Result<Vec<(String, String, TransformFieldOverride)>, SchemaError> {
+        let prefix = Self::override_view_prefix(view_name);
+        let items: Vec<(String, TransformFieldOverride)> = self
+            .transform_field_overrides_store
+            .scan_items_with_prefix(&prefix)
+            .await?;
+
+        let mut out = Vec::with_capacity(items.len());
+        for (raw_key, value) in items {
+            // raw_key = "{view}|{field}|{key_str}". Splitting on the first
+            // two `|` separators gives back the components; the trailing
+            // `key_str` is preserved verbatim even if it contains `|`.
+            let after_view = raw_key.strip_prefix(&prefix).ok_or_else(|| {
+                SchemaError::InvalidData(format!(
+                    "override key '{}' missing prefix '{}'",
+                    raw_key, prefix
+                ))
+            })?;
+            let mut parts = after_view.splitn(2, '|');
+            let field = parts
+                .next()
+                .ok_or_else(|| {
+                    SchemaError::InvalidData(format!("override key '{}' missing field", raw_key))
+                })?
+                .to_string();
+            let key_str = parts.next().unwrap_or("").to_string();
+            out.push((field, key_str, value));
+        }
+        Ok(out)
+    }
+
+    /// Delete every override for a view (used when the view is removed).
+    pub async fn clear_transform_field_overrides(
+        &self,
+        view_name: &str,
+    ) -> Result<(), SchemaError> {
+        let prefix = Self::override_view_prefix(view_name);
+        let keys = self
+            .transform_field_overrides_store
+            .list_keys_with_prefix(&prefix)
+            .await?;
+        if keys.is_empty() {
+            return Ok(());
+        }
+        self.transform_field_overrides_store
+            .batch_delete_keys(keys)
+            .await?;
+        self.transform_field_overrides_store.inner().flush().await?;
+        Ok(())
+    }
+
+    pub(crate) fn raw_transform_field_overrides(&self) -> &Arc<TypedKvStore<dyn KvStore>> {
+        &self.transform_field_overrides_store
+    }
+}
+
+#[cfg(test)]
+mod override_tests {
+    use super::*;
+    use crate::db_operations::DbOperations;
+    use crate::storage::SledPool;
+    use serde_json::json;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    async fn fresh_store() -> (TempDir, ViewStore) {
+        let tmp = TempDir::new().unwrap();
+        let pool = Arc::new(SledPool::new(tmp.path().to_path_buf()));
+        let ops = DbOperations::from_sled(pool).await.unwrap();
+        (tmp, ops.views().clone())
+    }
+
+    #[tokio::test]
+    async fn put_get_round_trip() {
+        let (_tmp, store) = fresh_store().await;
+        let o = TransformFieldOverride::with_timestamp(json!("hello"), "pkA", 100);
+
+        let wrote = store
+            .put_transform_field_override("V", "f", "k1", &o)
+            .await
+            .unwrap();
+        assert!(wrote);
+
+        let got = store
+            .get_transform_field_override("V", "f", "k1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, o);
+    }
+
+    #[tokio::test]
+    async fn lww_newer_wins() {
+        let (_tmp, store) = fresh_store().await;
+        let older = TransformFieldOverride::with_timestamp(json!("a"), "pkA", 100);
+        let newer = TransformFieldOverride::with_timestamp(json!("b"), "pkB", 101);
+
+        // Order doesn't matter — older then newer:
+        assert!(store
+            .put_transform_field_override("V", "f", "k", &older)
+            .await
+            .unwrap());
+        assert!(store
+            .put_transform_field_override("V", "f", "k", &newer)
+            .await
+            .unwrap());
+        let got = store
+            .get_transform_field_override("V", "f", "k")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.value, json!("b"));
+        assert_eq!(got.written_at, 101);
+    }
+
+    #[tokio::test]
+    async fn lww_older_dropped() {
+        let (_tmp, store) = fresh_store().await;
+        let older = TransformFieldOverride::with_timestamp(json!("a"), "pkA", 100);
+        let newer = TransformFieldOverride::with_timestamp(json!("b"), "pkB", 101);
+
+        assert!(store
+            .put_transform_field_override("V", "f", "k", &newer)
+            .await
+            .unwrap());
+        // Replaying the older entry must not regress the value.
+        let wrote_old = store
+            .put_transform_field_override("V", "f", "k", &older)
+            .await
+            .unwrap();
+        assert!(!wrote_old, "older write should be no-op");
+        let got = store
+            .get_transform_field_override("V", "f", "k")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.value, json!("b"));
+    }
+
+    #[tokio::test]
+    async fn scan_returns_all_overrides_for_view() {
+        let (_tmp, store) = fresh_store().await;
+        let o1 = TransformFieldOverride::with_timestamp(json!(1), "pk", 1);
+        let o2 = TransformFieldOverride::with_timestamp(json!(2), "pk", 2);
+        let other = TransformFieldOverride::with_timestamp(json!(99), "pk", 1);
+        store
+            .put_transform_field_override("V", "f1", "k1", &o1)
+            .await
+            .unwrap();
+        store
+            .put_transform_field_override("V", "f2", "k2", &o2)
+            .await
+            .unwrap();
+        store
+            .put_transform_field_override("OtherView", "f1", "k1", &other)
+            .await
+            .unwrap();
+
+        let mut entries = store.scan_transform_field_overrides("V").await.unwrap();
+        entries.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, "f1");
+        assert_eq!(entries[0].1, "k1");
+        assert_eq!(entries[0].2.value, json!(1));
+        assert_eq!(entries[1].0, "f2");
+        assert_eq!(entries[1].1, "k2");
+    }
+
+    #[tokio::test]
+    async fn clear_removes_only_target_view() {
+        let (_tmp, store) = fresh_store().await;
+        let o = TransformFieldOverride::with_timestamp(json!(1), "pk", 1);
+        store
+            .put_transform_field_override("V", "f", "k", &o)
+            .await
+            .unwrap();
+        store
+            .put_transform_field_override("OtherView", "f", "k", &o)
+            .await
+            .unwrap();
+
+        store.clear_transform_field_overrides("V").await.unwrap();
+
+        assert!(store
+            .get_transform_field_override("V", "f", "k")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .get_transform_field_override("OtherView", "f", "k")
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn key_with_pipe_round_trips() {
+        // Real range keys can include `|` (e.g. composite IDs). The split
+        // on `|` for scan must preserve the trailing key verbatim.
+        let (_tmp, store) = fresh_store().await;
+        let o = TransformFieldOverride::with_timestamp(json!("v"), "pk", 1);
+        store
+            .put_transform_field_override("V", "f", "a|b|c", &o)
+            .await
+            .unwrap();
+
+        let got = store
+            .get_transform_field_override("V", "f", "a|b|c")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, o);
+
+        let scanned = store.scan_transform_field_overrides("V").await.unwrap();
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(scanned[0].0, "f");
+        assert_eq!(scanned[0].1, "a|b|c");
     }
 }

--- a/src/fold_db_core/query/query_executor.rs
+++ b/src/fold_db_core/query/query_executor.rs
@@ -233,9 +233,23 @@ impl QueryExecutor {
             ViewResolver::new(Arc::clone(self.view_resolver.wasm_engine())),
         );
 
+        // Load any per-(field, key) overrides — these take precedence over
+        // computed values on the read path, regardless of cache state.
+        let overrides = self
+            .db_ops
+            .views()
+            .scan_transform_field_overrides(&view.name)
+            .await?;
+
         let (results, new_cache) = self
             .view_resolver
-            .resolve(&view, &query.fields, &cache_state, &source_query)
+            .resolve_with_overrides(
+                &view,
+                &query.fields,
+                &cache_state,
+                &source_query,
+                &overrides,
+            )
             .await?;
 
         // Persist terminal state transitions so a follow-up query doesn't

--- a/src/fold_db_core/query/source_query.rs
+++ b/src/fold_db_core/query/source_query.rs
@@ -153,9 +153,24 @@ impl StandardSourceQuery {
             mode: self.mode,
         };
 
+        // Recursive resolution must also consult overrides — a view used as
+        // a source for another view must serve overridden values, not the
+        // computed-from-source values it would produce otherwise.
+        let overrides = self
+            .db_ops
+            .views()
+            .scan_transform_field_overrides(&view.name)
+            .await?;
+
         let (results, new_cache) = self
             .view_resolver
-            .resolve(&view, &query.fields, &effective_cache, &nested_source)
+            .resolve_with_overrides(
+                &view,
+                &query.fields,
+                &effective_cache,
+                &nested_source,
+                &overrides,
+            )
             .await?;
 
         // Persist terminal transitions from Empty. Cached makes the next

--- a/src/fold_db_core/view_orchestrator.rs
+++ b/src/fold_db_core/view_orchestrator.rs
@@ -16,6 +16,7 @@ use crate::db_operations::DbOperations;
 use crate::schema::types::Mutation;
 use crate::schema::{SchemaCore, SchemaError};
 use crate::view::resolver::ViewResolver;
+use crate::view::transform_field_override::TransformFieldOverride;
 use crate::view::types::ViewCacheState;
 
 use super::query::StandardSourceQuery;
@@ -36,8 +37,20 @@ impl ViewOrchestrator {
         }
     }
 
-    /// Redirect mutations targeting identity views to their source schemas.
-    /// WASM views are not writable (would require inverse transforms).
+    /// Route mutations targeting transform views.
+    ///
+    /// Identity views: writes go through to the source schema (the inverse
+    /// of identity is itself).
+    ///
+    /// WASM views (no inverse): writes are persisted as
+    /// `TransformFieldOverride` molecules per `transform_views_design.md` —
+    /// the field flips into the `Overridden` state and the source link is
+    /// marked stale. The override is stored in its own namespace so it
+    /// participates in the unified sync log and converges across replicas
+    /// via LWW on `written_at`. These mutations do NOT propagate further
+    /// down the pipeline (they are not source-schema mutations); the
+    /// returned vector contains only the rewritten source mutations and any
+    /// non-view mutations that pass through unchanged.
     pub async fn redirect_mutation(
         &self,
         mutations: Vec<Mutation>,
@@ -58,49 +71,86 @@ impl ViewOrchestrator {
                 continue;
             };
 
-            // Get source field map (only works for identity views)
-            let field_map = view.source_field_map().ok_or_else(|| {
-                SchemaError::InvalidData(format!(
-                    "Cannot write to WASM view '{}'. Write-back through WASM views is not yet supported.",
-                    view.name
-                ))
-            })?;
+            if let Some(field_map) = view.source_field_map() {
+                // Identity view — rewrite to source mutations.
+                let mut redirected: HashMap<String, HashMap<String, serde_json::Value>> =
+                    HashMap::new();
 
-            // Group mutation fields by target source schema
-            let mut redirected: HashMap<String, HashMap<String, serde_json::Value>> =
-                HashMap::new();
+                for (field_name, value) in &mutation.fields_and_values {
+                    let (source_schema, source_field) =
+                        field_map.get(field_name).ok_or_else(|| {
+                            SchemaError::InvalidField(format!(
+                                "Field '{}' not found in view '{}'",
+                                field_name, view.name
+                            ))
+                        })?;
 
-            for (field_name, value) in &mutation.fields_and_values {
-                let (source_schema, source_field) = field_map.get(field_name).ok_or_else(|| {
-                    SchemaError::InvalidField(format!(
-                        "Field '{}' not found in view '{}'",
-                        field_name, view.name
-                    ))
-                })?;
+                    redirected
+                        .entry(source_schema.clone())
+                        .or_default()
+                        .insert(source_field.clone(), value.clone());
+                }
 
-                redirected
-                    .entry(source_schema.clone())
-                    .or_default()
-                    .insert(source_field.clone(), value.clone());
-            }
-
-            // Create one redirected mutation per source schema
-            for (target_schema, fields_and_values) in redirected {
-                result.push(Mutation {
-                    uuid: uuid::Uuid::new_v4().to_string(),
-                    schema_name: target_schema,
-                    fields_and_values,
-                    key_value: mutation.key_value.clone(),
-                    pub_key: mutation.pub_key.clone(),
-                    mutation_type: mutation.mutation_type.clone(),
-                    synchronous: mutation.synchronous,
-                    source_file_name: mutation.source_file_name.clone(),
-                    metadata: mutation.metadata.clone(),
-                });
+                for (target_schema, fields_and_values) in redirected {
+                    result.push(Mutation {
+                        uuid: uuid::Uuid::new_v4().to_string(),
+                        schema_name: target_schema,
+                        fields_and_values,
+                        key_value: mutation.key_value.clone(),
+                        pub_key: mutation.pub_key.clone(),
+                        mutation_type: mutation.mutation_type.clone(),
+                        synchronous: mutation.synchronous,
+                        source_file_name: mutation.source_file_name.clone(),
+                        metadata: mutation.metadata.clone(),
+                    });
+                }
+            } else {
+                // Irreversible (WASM) view — persist each field as an override.
+                self.persist_overrides_for_mutation(&view.name, &mutation)
+                    .await?;
             }
         }
 
         Ok(result)
+    }
+
+    /// Persist a `TransformFieldOverride` for every (field, key) in the
+    /// mutation. The mutation's `pub_key` becomes the override's writer
+    /// pubkey; its `key_value` becomes the per-key handle. Each call stamps
+    /// `written_at = now`, so concurrent writes on different replicas resolve
+    /// via LWW once they meet through the sync log.
+    async fn persist_overrides_for_mutation(
+        &self,
+        view_name: &str,
+        mutation: &Mutation,
+    ) -> Result<(), SchemaError> {
+        // The view must be registered for us to honor the write — otherwise we
+        // would silently drop user data. The caller has already established
+        // the view exists, so this is just a defensive lookup against schema
+        // mutations between the registry read and now.
+        let view_exists = {
+            let registry = self.schema_manager.view_registry().lock().map_err(|_| {
+                SchemaError::InvalidData("Failed to acquire view_registry lock".to_string())
+            })?;
+            registry.get_view(view_name).is_some()
+        };
+        if !view_exists {
+            return Err(SchemaError::NotFound(format!(
+                "View '{}' disappeared mid-mutation",
+                view_name
+            )));
+        }
+
+        let key_str = mutation.key_value.to_string();
+        let view_store = self.db_ops.views();
+
+        for (field_name, value) in &mutation.fields_and_values {
+            let override_mol = TransformFieldOverride::new(value.clone(), mutation.pub_key.clone());
+            view_store
+                .put_transform_field_override(view_name, field_name, &key_str, &override_mol)
+                .await?;
+        }
+        Ok(())
     }
 
     /// Invalidate a single named view (and its cascade), then spawn a
@@ -352,8 +402,22 @@ impl ViewOrchestrator {
             );
 
             let resolver = ViewResolver::new(Arc::clone(&wasm_engine));
+            // Precompute also has to honor overrides — otherwise the
+            // background pass would write a `Cached` state that ignores the
+            // user's pin, and the next read would briefly serve the wrong
+            // value before being corrected by `resolve_with_overrides`.
+            let overrides = db_ops
+                .views()
+                .scan_transform_field_overrides(view_name)
+                .await?;
             match resolver
-                .resolve(&view, &[], &ViewCacheState::Empty, &source_query)
+                .resolve_with_overrides(
+                    &view,
+                    &[],
+                    &ViewCacheState::Empty,
+                    &source_query,
+                    &overrides,
+                )
                 .await
             {
                 Ok((_, new_cache)) => {

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -1,12 +1,14 @@
 pub mod dependency_tracker;
 pub mod registry;
 pub mod resolver;
+pub mod transform_field_override;
 pub mod types;
 pub mod wasm_engine;
 
 pub use dependency_tracker::DependencyTracker;
 pub use registry::ViewRegistry;
 pub use resolver::ViewResolver;
+pub use transform_field_override::TransformFieldOverride;
 pub use types::{TransformView, UnavailableReason, ViewCacheState};
 pub use wasm_engine::WasmTransformEngine;
 pub mod invertibility;

--- a/src/view/resolver.rs
+++ b/src/view/resolver.rs
@@ -2,6 +2,7 @@ use crate::schema::types::errors::SchemaError;
 use crate::schema::types::field::FieldValue;
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::operations::Query;
+use crate::view::transform_field_override::TransformFieldOverride;
 use crate::view::types::{TransformView, UnavailableReason, ViewCacheState};
 use crate::view::wasm_engine::WasmTransformEngine;
 use async_trait::async_trait;
@@ -82,6 +83,30 @@ impl ViewResolver {
         ),
         SchemaError,
     > {
+        self.resolve_with_overrides(view, requested_fields, cache_state, source_query, &[])
+            .await
+    }
+
+    /// Same as `resolve`, but applies any per-(field, key) overrides on top
+    /// of the computed output. Overrides are looked up from the override
+    /// store by the caller and passed in. When an override exists for a
+    /// `(field, key)` it supersedes whatever the WASM/identity path produced
+    /// — and the override survives even if the source link is stale, which
+    /// is what makes `Overridden` sticky against subsequent source mutations.
+    pub async fn resolve_with_overrides(
+        &self,
+        view: &TransformView,
+        requested_fields: &[String],
+        cache_state: &ViewCacheState,
+        source_query: &dyn SourceQueryFn,
+        overrides: &[(String, String, TransformFieldOverride)],
+    ) -> Result<
+        (
+            HashMap<String, HashMap<KeyValue, FieldValue>>,
+            ViewCacheState,
+        ),
+        SchemaError,
+    > {
         // Determine which fields to return
         let fields_to_return: Vec<String> = if requested_fields.is_empty() {
             view.output_fields.keys().cloned().collect()
@@ -105,6 +130,9 @@ impl ViewResolver {
                 let field_entries = entries.get(field_name).cloned().unwrap_or_default();
                 result.insert(field_name.clone(), field_entries.into_iter().collect());
             }
+            // Cached path still consults overrides — overrides are sticky and
+            // must beat anything in the per-view cache too.
+            self.apply_overrides(&mut result, overrides);
             return Ok((result, cache_state.clone()));
         }
 
@@ -136,7 +164,7 @@ impl ViewResolver {
         // rather than a hard error: they are per-input compute failures,
         // so the caller should persist the state (no retry) but callers
         // above the resolver are free to surface it to the user.
-        let output = if let Some(wasm_bytes) = &view.wasm_transform {
+        let mut output = if let Some(wasm_bytes) = &view.wasm_transform {
             match self.execute_wasm_transform(wasm_bytes, &all_query_results) {
                 Ok(output) => output,
                 Err(e) => {
@@ -147,6 +175,12 @@ impl ViewResolver {
         } else {
             self.identity_pass_through(&all_query_results, view)?
         };
+
+        // Apply overrides BEFORE type validation so the user-supplied value
+        // is what we validate. Overrides also extend the output to fields
+        // that the source path produced no entries for (overrides are
+        // sticky regardless of source state).
+        Self::apply_overrides_to_field_map(&mut output, view, overrides);
 
         // Validate output against declared types. A mismatch is a per-input
         // failure of the transform (the WASM produced a wrongly-shaped value
@@ -192,6 +226,49 @@ impl ViewResolver {
         }
 
         Ok((result, new_cache))
+    }
+
+    /// Substitute override values into an already-shaped result map.
+    /// Used by the cached short-circuit where we don't have the full
+    /// `output_fields` typing context and only care about the requested
+    /// subset.
+    fn apply_overrides(
+        &self,
+        result: &mut HashMap<String, HashMap<KeyValue, FieldValue>>,
+        overrides: &[(String, String, TransformFieldOverride)],
+    ) {
+        for (field_name, key_str, override_mol) in overrides {
+            if let Some(field_entries) = result.get_mut(field_name) {
+                let key = parse_key_str(key_str);
+                let fv = override_field_value(override_mol);
+                field_entries.insert(key, fv);
+            }
+        }
+    }
+
+    /// Substitute overrides into the freshly-computed output map. Unlike
+    /// `apply_overrides`, this version honors the view's declared
+    /// `output_fields` — overrides for fields not declared on the view are
+    /// ignored (defensive: a stale override left over from a removed field
+    /// shouldn't materialize). Overrides for declared fields are inserted
+    /// even if the source produced no entries, so the override survives a
+    /// stale source link.
+    fn apply_overrides_to_field_map(
+        output: &mut HashMap<String, HashMap<KeyValue, FieldValue>>,
+        view: &TransformView,
+        overrides: &[(String, String, TransformFieldOverride)],
+    ) {
+        for (field_name, key_str, override_mol) in overrides {
+            if !view.output_fields.contains_key(field_name) {
+                continue;
+            }
+            let key = parse_key_str(key_str);
+            let fv = override_field_value(override_mol);
+            output
+                .entry(field_name.clone())
+                .or_default()
+                .insert(key, fv);
+        }
     }
 
     /// Identity pass-through: collect all query results and map to output fields.
@@ -290,6 +367,43 @@ impl ViewResolver {
 
     pub fn wasm_engine(&self) -> &Arc<WasmTransformEngine> {
         &self.wasm_engine
+    }
+}
+
+/// Reverse of `KeyValue::Display`: `"hash:range"` → hash+range,
+/// `"hash"` → hash-only, `""` → both `None`. Range-only encoding (the
+/// default for view output) is the common case here.
+fn parse_key_str(s: &str) -> KeyValue {
+    if s.is_empty() {
+        KeyValue::new(None, None)
+    } else if let Some((hash, range)) = s.split_once(':') {
+        KeyValue::new(Some(hash.to_string()), Some(range.to_string()))
+    } else {
+        // Single-segment keys are ambiguous between hash-only and range-only;
+        // view output is keyed by range, and override writes are stored using
+        // `KeyValue::Display` which omits the colon when only `range` is set.
+        // So a bare segment here came from a range-only key.
+        KeyValue::new(None, Some(s.to_string()))
+    }
+}
+
+/// Convert an override molecule into a `FieldValue` suitable for view output.
+/// Override molecules don't have an underlying atom so atom-level provenance
+/// fields stay empty; the override's `writer_pubkey` is preserved so callers
+/// can attribute the value.
+fn override_field_value(o: &TransformFieldOverride) -> FieldValue {
+    FieldValue {
+        value: o.value.clone(),
+        atom_uuid: String::new(),
+        source_file_name: None,
+        metadata: None,
+        molecule_uuid: None,
+        molecule_version: None,
+        writer_pubkey: if o.writer_pubkey.is_empty() {
+            None
+        } else {
+            Some(o.writer_pubkey.clone())
+        },
     }
 }
 

--- a/src/view/transform_field_override.rs
+++ b/src/view/transform_field_override.rs
@@ -1,0 +1,183 @@
+//! Override molecule for transform fields.
+//!
+//! When a user directly writes a value to an irreversible transform field
+//! (a transform whose WASM has no inverse), the write cannot be reduced to
+//! a source mutation. Instead it is recorded as a `TransformFieldOverride`
+//! molecule. The override carries the supplied value, marks the source link
+//! stale, and records writer provenance for last-writer-wins reconciliation
+//! across replicas.
+//!
+//! The on-disk shape is a normal serde-serializable struct so the override
+//! syncs through the same encrypted log path as any other molecule.
+//!
+//! # State machine
+//!
+//! Per `transform_views_design.md` a transform field has three states:
+//! `Empty`, `Cached`, `Overridden`. This module owns the data shape for the
+//! `Overridden` state. Cache lifecycle (`Empty`, `Cached`) is handled by
+//! `ViewCacheState` and is intentionally untouched here.
+//!
+//! # LWW
+//!
+//! Two replicas that override the same `(view, field, key)` tuple settle by
+//! `written_at`. The newer wins. Source mutations against the *source* field
+//! never beat an override — the override is sticky by virtue of being checked
+//! first on the read path.
+
+use serde::{Deserialize, Serialize};
+
+/// Direct write to an irreversible transform field.
+///
+/// Stored per-(view, field, key). Participates in LWW like any other
+/// molecule. `source_link_stale` is `true` for the lifetime of the override:
+/// once a user has pinned a value here, future source mutations no longer
+/// invalidate the field (per the 3-state machine in
+/// `transform_views_design.md`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TransformFieldOverride {
+    /// User-supplied override value.
+    pub value: serde_json::Value,
+    /// Once `true`, source mutations stop driving this field. Always `true`
+    /// for newly-created overrides; the field exists so callers can reason
+    /// about the flag explicitly rather than implying it from presence.
+    pub source_link_stale: bool,
+    /// Nanos since Unix epoch. Sole input to LWW comparison.
+    pub written_at: u64,
+    /// Base64-encoded public key of the writer.
+    pub writer_pubkey: String,
+    /// Base64-encoded signature over canonical bytes. Optional today —
+    /// signing-key plumbing arrives with the broader provenance work; the
+    /// shape is reserved so callers downstream can verify once it's wired.
+    #[serde(default)]
+    pub signature: String,
+    /// Signature scheme version (`0` = unsigned, `1+` = future schemes).
+    #[serde(default)]
+    pub signature_version: u8,
+}
+
+impl TransformFieldOverride {
+    /// Build a fresh override stamped with the current wall clock.
+    pub fn new(value: serde_json::Value, writer_pubkey: impl Into<String>) -> Self {
+        Self {
+            value,
+            source_link_stale: true,
+            written_at: now_nanos(),
+            writer_pubkey: writer_pubkey.into(),
+            signature: String::new(),
+            signature_version: 0,
+        }
+    }
+
+    /// Build an override with an explicit timestamp. Tests use this to drive
+    /// LWW deterministically; callers in production paths should prefer
+    /// `new()` so the write reflects real wall-clock order.
+    pub fn with_timestamp(
+        value: serde_json::Value,
+        writer_pubkey: impl Into<String>,
+        written_at: u64,
+    ) -> Self {
+        Self {
+            value,
+            source_link_stale: true,
+            written_at,
+            writer_pubkey: writer_pubkey.into(),
+            signature: String::new(),
+            signature_version: 0,
+        }
+    }
+
+    /// LWW: should `incoming` overwrite `existing`?
+    ///
+    /// Strictly newer `written_at` wins. Ties break on `writer_pubkey` to
+    /// keep the result deterministic across replicas — without that, two
+    /// nodes seeing the same pair in different orders could disagree on
+    /// which they kept locally.
+    pub fn should_replace(existing: &Self, incoming: &Self) -> bool {
+        match incoming.written_at.cmp(&existing.written_at) {
+            std::cmp::Ordering::Greater => true,
+            std::cmp::Ordering::Less => false,
+            std::cmp::Ordering::Equal => incoming.writer_pubkey > existing.writer_pubkey,
+        }
+    }
+}
+
+fn now_nanos() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn new_sets_stale_and_pubkey() {
+        let o = TransformFieldOverride::new(json!("v"), "pkA");
+        assert!(o.source_link_stale);
+        assert_eq!(o.value, json!("v"));
+        assert_eq!(o.writer_pubkey, "pkA");
+        assert_eq!(o.signature_version, 0);
+        assert!(o.written_at > 0);
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_all_fields() {
+        let original = TransformFieldOverride {
+            value: json!({"nested": [1, 2, 3]}),
+            source_link_stale: true,
+            written_at: 1_700_000_000_000_000_000,
+            writer_pubkey: "base64key==".to_string(),
+            signature: "sig".to_string(),
+            signature_version: 1,
+        };
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let decoded: TransformFieldOverride = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn serde_back_compat_defaults_signature_fields() {
+        // An override persisted before signature plumbing existed should
+        // still deserialize. signature/signature_version default.
+        let json_str = r#"{
+            "value": "hello",
+            "source_link_stale": true,
+            "written_at": 42,
+            "writer_pubkey": "pk"
+        }"#;
+        let decoded: TransformFieldOverride = serde_json::from_str(json_str).unwrap();
+        assert_eq!(decoded.signature, "");
+        assert_eq!(decoded.signature_version, 0);
+        assert_eq!(decoded.written_at, 42);
+    }
+
+    #[test]
+    fn lww_newer_replaces_older() {
+        let older = TransformFieldOverride::with_timestamp(json!("a"), "pkA", 100);
+        let newer = TransformFieldOverride::with_timestamp(json!("b"), "pkB", 101);
+        assert!(TransformFieldOverride::should_replace(&older, &newer));
+        assert!(!TransformFieldOverride::should_replace(&newer, &older));
+    }
+
+    #[test]
+    fn lww_equal_timestamp_breaks_on_pubkey() {
+        // Same wall clock on two replicas — pick the lexicographically
+        // larger pubkey so both replicas converge.
+        let a = TransformFieldOverride::with_timestamp(json!("a"), "pkA", 100);
+        let b = TransformFieldOverride::with_timestamp(json!("b"), "pkB", 100);
+        assert!(TransformFieldOverride::should_replace(&a, &b));
+        assert!(!TransformFieldOverride::should_replace(&b, &a));
+    }
+
+    #[test]
+    fn lww_identical_writer_does_not_replace() {
+        // Same writer, same timestamp → no churn. Idempotent re-delivery
+        // of the same override should not bump anything.
+        let a = TransformFieldOverride::with_timestamp(json!("a"), "pk", 100);
+        let b = TransformFieldOverride::with_timestamp(json!("a"), "pk", 100);
+        assert!(!TransformFieldOverride::should_replace(&a, &b));
+    }
+}

--- a/tests/view_query_test.rs
+++ b/tests/view_query_test.rs
@@ -272,8 +272,13 @@ async fn identity_view_write_invalidates_view_cache() {
     );
 }
 
+/// WASM (irreversible) views accept direct writes by persisting a
+/// `TransformFieldOverride` instead of redirecting to source — the field
+/// transitions to the `Overridden` state per `transform_views_design.md`.
+/// The mutation succeeds, no source data is touched, and the override is
+/// available through `views().get_transform_field_override`.
 #[tokio::test]
-async fn wasm_view_write_is_rejected() {
+async fn wasm_view_write_persists_override_in_view_query_test() {
     let db = setup_db().await;
 
     db.load_schema_from_json(&blogpost_schema_json())
@@ -284,7 +289,6 @@ async fn wasm_view_write_is_rejected() {
         .await
         .unwrap();
 
-    // Register a WASM view (not identity)
     let view = TransformView::new(
         "WasmView",
         SchemaType::Single,
@@ -293,28 +297,34 @@ async fn wasm_view_write_is_rejected() {
             "BlogPost".to_string(),
             vec!["content".to_string()],
         )],
-        Some(vec![0, 1, 2]), // Placeholder WASM — won't be executed
+        Some(vec![0, 1, 2]), // Placeholder WASM — never executed on the write path.
         HashMap::from([("out".to_string(), FieldValueType::String)]),
     );
     db.schema_manager().register_view(view).await.unwrap();
 
-    // Try to mutate the WASM view — should be rejected
+    let key = KeyValue::new(None, Some("2026-01-01".to_string()));
     let mut mutation_fields = HashMap::new();
-    mutation_fields.insert("out".to_string(), json!("should fail"));
+    mutation_fields.insert("out".to_string(), json!("user pinned"));
     let mutation = Mutation::new(
         "WasmView".to_string(),
         mutation_fields,
-        KeyValue::new(None, Some("2026-01-01".to_string())),
-        "pk".to_string(),
+        key.clone(),
+        "writer-pk".to_string(),
         MutationType::Create,
     );
-    let result = db
-        .mutation_manager()
+
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
-        .await;
-    assert!(result.is_err());
-    assert!(
-        result.unwrap_err().to_string().contains("WASM view"),
-        "Should mention WASM view write-back not supported"
-    );
+        .await
+        .expect("WASM view writes now persist as overrides");
+
+    let stored = db
+        .db_ops()
+        .views()
+        .get_transform_field_override("WasmView", "out", &key.to_string())
+        .await
+        .unwrap()
+        .expect("override molecule should exist");
+    assert_eq!(stored.value, json!("user pinned"));
+    assert!(stored.source_link_stale);
 }

--- a/tests/view_write_test.rs
+++ b/tests/view_write_test.rs
@@ -6,6 +6,7 @@ use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
 use fold_db::test_helpers::TestSchemaBuilder;
+use fold_db::view::transform_field_override::TransformFieldOverride;
 use fold_db::view::types::{TransformView, ViewCacheState};
 use serde_json::json;
 use std::collections::HashMap;
@@ -98,10 +99,13 @@ async fn identity_write_redirects_to_source() {
     );
 }
 
-/// WASM views do not support write-back — source_field_map returns None,
-/// and attempting a mutation is rejected.
+/// WASM (irreversible) views can't redirect to source — direct writes
+/// instead persist a `TransformFieldOverride` molecule per
+/// `transform_views_design.md` (Overridden state). The mutation succeeds,
+/// no source data is touched, and the override is stored under the view's
+/// own override namespace ready to be replayed across replicas.
 #[tokio::test]
-async fn wasm_view_write_is_rejected() {
+async fn wasm_view_write_persists_override() {
     let db = setup_db().await;
 
     db.load_schema_from_json(&blogpost_schema_json())
@@ -112,7 +116,6 @@ async fn wasm_view_write_is_rejected() {
         .await
         .unwrap();
 
-    // Register a WASM view (not identity)
     let view = TransformView::new(
         "WasmView",
         SchemaType::Single,
@@ -121,38 +124,233 @@ async fn wasm_view_write_is_rejected() {
             "BlogPost".to_string(),
             vec!["content".to_string()],
         )],
-        Some(vec![0, 1, 2]), // Placeholder WASM — won't be executed
+        Some(vec![0, 1, 2]), // Placeholder WASM — never executed on the write path.
         HashMap::from([("out".to_string(), FieldValueType::String)]),
     );
     db.schema_manager().register_view(view).await.unwrap();
 
-    // WASM view should not expose a source_field_map (no inverse)
     let stored = db.schema_manager().get_view("WasmView").unwrap().unwrap();
     assert!(!stored.is_identity());
-    assert!(
-        stored.source_field_map().is_none(),
-        "WASM view should not have a source_field_map"
-    );
+    assert!(stored.source_field_map().is_none());
 
-    // Try to mutate the WASM view — should be rejected
     let mut mutation_fields = HashMap::new();
-    mutation_fields.insert("out".to_string(), json!("should fail"));
+    mutation_fields.insert("out".to_string(), json!("manual override"));
+    let key = KeyValue::new(None, Some("2026-01-01".to_string()));
     let mutation = Mutation::new(
         "WasmView".to_string(),
         mutation_fields,
-        KeyValue::new(None, Some("2026-01-01".to_string())),
-        "pk".to_string(),
+        key.clone(),
+        "writer-pk".to_string(),
         MutationType::Create,
     );
-    let result = db
-        .mutation_manager()
+    db.mutation_manager()
         .write_mutations_batch_async(vec![mutation])
-        .await;
-    assert!(result.is_err());
-    assert!(
-        result.unwrap_err().to_string().contains("WASM view"),
-        "Should mention WASM view write-back not supported"
+        .await
+        .expect("WASM view writes should now persist as overrides");
+
+    let stored_override = db
+        .db_ops()
+        .views()
+        .get_transform_field_override("WasmView", "out", &key.to_string())
+        .await
+        .unwrap()
+        .expect("override molecule must be stored");
+    assert_eq!(stored_override.value, json!("manual override"));
+    assert!(stored_override.source_link_stale);
+    assert_eq!(stored_override.writer_pubkey, "writer-pk");
+}
+
+/// Override molecule wins over identity-view source data on the read path.
+/// Once the override exists, subsequent source mutations do NOT recover the
+/// source value — the `Overridden` state is sticky per the 3-state machine.
+///
+/// This is the MDT-D "source-vs-override" scenario, expressed against an
+/// identity view so the read path doesn't depend on the optional
+/// `transform-wasm` feature for execution. The override consultation logic
+/// in `ViewResolver::resolve_with_overrides` is the same code that runs for
+/// WASM views; the source-stickiness behavior is identical.
+#[tokio::test]
+async fn override_supersedes_source_and_sticks_across_source_mutations() {
+    let db = setup_db().await;
+
+    db.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager()
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    // Identity view over BlogPost.content keyed by publish_date.
+    let view = identity_view("OverrideStickyView", "BlogPost", "content");
+    db.schema_manager().register_view(view).await.unwrap();
+
+    let key = KeyValue::new(None, Some("2026-04-23".to_string()));
+
+    // Source write at "earlier" — this lands in BlogPost.content.
+    let mut source_fields = HashMap::new();
+    source_fields.insert("content".to_string(), json!("from source"));
+    source_fields.insert("publish_date".to_string(), json!("2026-04-23"));
+    db.mutation_manager()
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            source_fields,
+            key.clone(),
+            "device_a".to_string(),
+            MutationType::Create,
+        )])
+        .await
+        .unwrap();
+
+    // Override at "later" — emulating a deliberate user pin from device B
+    // that wins LWW. We persist directly through the store rather than via
+    // a mutation so identity write-redirection doesn't bypass the override.
+    let override_mol = TransformFieldOverride::with_timestamp(
+        json!("from override"),
+        "device_b",
+        2_000_000_000_000_000_000,
     );
+    db.db_ops()
+        .views()
+        .put_transform_field_override(
+            "OverrideStickyView",
+            "content",
+            &key.to_string(),
+            &override_mol,
+        )
+        .await
+        .unwrap();
+
+    // Read should return the override, not the source value.
+    let query = Query::new(
+        "OverrideStickyView".to_string(),
+        vec!["content".to_string()],
+    );
+    let results = db.query_executor().query(query.clone()).await.unwrap();
+    let values: Vec<_> = results["content"]
+        .values()
+        .map(|fv| fv.value.clone())
+        .collect();
+    assert!(
+        values.contains(&json!("from override")),
+        "Override must beat source on read; got {:?}",
+        values
+    );
+    assert!(
+        !values.contains(&json!("from source")),
+        "Source value must not appear once the override is in place; got {:?}",
+        values
+    );
+
+    // A subsequent source mutation arriving "after" the override must not
+    // unstick it — the override stays.
+    let mut updated_source = HashMap::new();
+    updated_source.insert("content".to_string(), json!("source updated again"));
+    updated_source.insert("publish_date".to_string(), json!("2026-04-23"));
+    db.mutation_manager()
+        .write_mutations_batch_async(vec![Mutation::new(
+            "BlogPost".to_string(),
+            updated_source,
+            key.clone(),
+            "device_a".to_string(),
+            MutationType::Update,
+        )])
+        .await
+        .unwrap();
+
+    let results = db.query_executor().query(query).await.unwrap();
+    let values: Vec<_> = results["content"]
+        .values()
+        .map(|fv| fv.value.clone())
+        .collect();
+    assert!(
+        values.contains(&json!("from override")),
+        "Override must remain after source mutation (sticky); got {:?}",
+        values
+    );
+    assert!(
+        !values.contains(&json!("source updated again")),
+        "Refreshed source must not appear; got {:?}",
+        values
+    );
+}
+
+/// Two-device concurrent override scenario from the design doc:
+/// device A writes override at t=100, device B writes override at t=101 —
+/// both devices converge on B's value once the log replays. Order of
+/// `write_mutations_batch_async` calls must not affect the outcome; we run
+/// the same scenario both ways to prove convergence.
+#[tokio::test]
+async fn concurrent_overrides_converge_via_lww() {
+    let db = setup_db().await;
+
+    db.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager()
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let view = TransformView::new(
+        "ConcurrentView",
+        SchemaType::Single,
+        None,
+        vec![Query::new(
+            "BlogPost".to_string(),
+            vec!["content".to_string()],
+        )],
+        Some(vec![0, 1, 2]),
+        HashMap::from([("out".to_string(), FieldValueType::String)]),
+    );
+    db.schema_manager().register_view(view).await.unwrap();
+
+    let key = KeyValue::new(None, Some("k".to_string()));
+    let key_str = key.to_string();
+    let store = db.db_ops().views();
+
+    // Device A at t=100 (older). Device B at t=101 (newer).
+    let device_a = TransformFieldOverride::with_timestamp(json!("A"), "pk_a", 100);
+    let device_b = TransformFieldOverride::with_timestamp(json!("B"), "pk_b", 101);
+
+    // Order 1: A then B → B wins.
+    store
+        .put_transform_field_override("ConcurrentView", "out", &key_str, &device_a)
+        .await
+        .unwrap();
+    store
+        .put_transform_field_override("ConcurrentView", "out", &key_str, &device_b)
+        .await
+        .unwrap();
+    let got = store
+        .get_transform_field_override("ConcurrentView", "out", &key_str)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.value, json!("B"));
+
+    // Order 2: clear, then B then A → still B (replaying older log entry
+    // is a no-op).
+    store
+        .clear_transform_field_overrides("ConcurrentView")
+        .await
+        .unwrap();
+    store
+        .put_transform_field_override("ConcurrentView", "out", &key_str, &device_b)
+        .await
+        .unwrap();
+    store
+        .put_transform_field_override("ConcurrentView", "out", &key_str, &device_a)
+        .await
+        .unwrap();
+    let got = store
+        .get_transform_field_override("ConcurrentView", "out", &key_str)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.value, json!("B"));
+    assert_eq!(got.writer_pubkey, "pk_b");
+    assert_eq!(got.written_at, 101);
 }
 
 /// Writing through a view should invalidate that view's cache so


### PR DESCRIPTION
## Summary

Closes the first open design item in `docs/design/multi_device_transforms.md` (exemem-workspace PR #137): a concrete molecule shape for the `Overridden` field state from `transform_views_design.md`. Direct writes to irreversible (WASM) transform views now persist as `TransformFieldOverride` molecules that converge across replicas via LWW on `written_at`, instead of being rejected.

## What's new

- **`src/view/transform_field_override.rs`** — `TransformFieldOverride { value, source_link_stale, written_at, writer_pubkey, signature, signature_version }` with serde + LWW (`should_replace`) + back-compat default for unsigned overrides.
- **`src/db_operations/view_store.rs`** — new `transform_field_overrides` namespace (rides the unified sync log like any other molecule write) with `put_transform_field_override` (LWW-enforcing — older writes are dropped), `get_*`, `scan_*`, `clear_*`. Org-purge now scrubs override entries for purged orgs.
- **`src/fold_db_core/view_orchestrator.rs`** — `redirect_mutation` no longer rejects WASM-view writes. For each `(field, key)` pair we persist a `TransformFieldOverride` stamped with the mutation's `pub_key`. Identity-view redirection is unchanged.
- **`src/view/resolver.rs`** — new `resolve_with_overrides` consults the override store and substitutes overridden values per `(field, key)` even when the cached path short-circuits, so `Overridden` stays sticky across source mutations and across cache lifecycle. Wired into `query_executor` + `source_query` (recursive view-as-source) + `view_orchestrator` (precompute) so all three read paths honor overrides.

## Design choices made (per ship policy)

- **Storage shape:** flat `value + source_link_stale + written_at + writer_pubkey + signature[_version]` mirroring `AtomEntry`/`Molecule`. Reserved signature fields default to unsigned (`signature_version = 0`); the field is plumbed for the broader provenance rollout but isn't generated yet — same as the current `Atom`/`Molecule` story.
- **Key encoding:** `view_name|field_name|key_str`, where `key_str` is `KeyValue::Display`. Range keys with embedded `|` round-trip correctly; the test `key_with_pipe_round_trips` proves this.
- **LWW tiebreak:** equal `written_at` resolves on `writer_pubkey` lexicographic order so two replicas observing the pair in different orders converge.
- **Sync hookup:** the override namespace participates in `SyncingNamespacedStore`'s default partitioning — overrides DO sync. (Item #2 in the multi-device design — keeping the per-device cache out of sync — is unrelated; that's about the `transform_field_states` cache, not overrides.)
- **Source-vs-override stickiness:** implemented via "always consult overrides on the read path", not via mutating cache state. This keeps the existing Cached/Empty machine untouched (per anti-scope).

## Anti-scope

- `Cached` / `Empty` state lifecycle untouched.
- `Unavailable { reason }` / gas-exceeded state out of scope (MDT-A).
- Reversible (inverse-WASM) write path untouched.
- Override molecules carry signature *fields* but are not yet signed — same posture as today's molecules.

## Tests

- `view::transform_field_override::tests` (6) — `new()` defaults, serde round-trip, serde back-compat (defaults `signature*`), LWW `newer_replaces_older`, equal-timestamp tiebreak, idempotent re-delivery.
- `db_operations::view_store::override_tests` (6) — store-level put/get round-trip, LWW newer wins, LWW older dropped (idempotent replay), scan-by-view, clear-only-target-view, key-with-`|`-round-trips.
- `tests/view_write_test.rs` (3 new) covering the MDT-D required scenarios:
  - `wasm_view_write_persists_override` — write to WASM view succeeds + override appears in store.
  - `concurrent_overrides_converge_via_lww` — design doc "Concurrency Cases" case 1: two-device override at t=100 vs t=101, both orderings converge to t=101.
  - `override_supersedes_source_and_sticks_across_source_mutations` — design doc "Concurrency Cases" case 2: source-vs-override; once override exists, subsequent source mutations don't recover the source value.
- Old `wasm_view_write_is_rejected` mirror in `view_query_test.rs` updated to assert the new behavior.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --features transform-wasm -- -D warnings`
- [x] `cargo test --workspace --all-targets -- --test-threads=1` (parallel surfaces a pre-existing flake in `db_operations::org_operations::tests::test_purge_org_data` unrelated to this change — env-var sensitive `temp_env::with_var` race; serial run is clean)
- [x] `cargo test --features transform-wasm --test view_wasm_integration_test`
- [x] Rebased on latest `origin/mainline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)