### PR TITLE
feat(view): enforce system-wide max_gas via wasmtime fuel (MDT-E)

### DIFF
--- a/src/schema/types/errors.rs
+++ b/src/schema/types/errors.rs
@@ -9,6 +9,15 @@ pub enum SchemaError {
     InvalidTransform(String),
     InvalidData(String),
     PermissionDenied(String),
+    /// Transform exceeded its fuel budget (MDT-E). Carried separately from
+    /// `InvalidTransform` so the view resolver can classify it as
+    /// `UnavailableReason::GasExceeded` without stringly-typed sniffing —
+    /// `max_gas` must fail identically on every device, so mis-classifying
+    /// a fuel trap as a generic execution error would let the state
+    /// machine loop retrying on the same input.
+    TransformGasExceeded {
+        input_size: u64,
+    },
 }
 
 impl fmt::Display for SchemaError {
@@ -20,6 +29,9 @@ impl fmt::Display for SchemaError {
             Self::InvalidTransform(msg) => write!(f, "Invalid transform: {msg}"),
             Self::InvalidData(msg) => write!(f, "Invalid data: {msg}"),
             Self::PermissionDenied(msg) => write!(f, "Permission denied: {msg}"),
+            Self::TransformGasExceeded { input_size } => {
+                write!(f, "Transform gas exceeded (input_size={input_size})")
+            }
         }
     }
 }

--- a/src/view/invertibility.rs
+++ b/src/view/invertibility.rs
@@ -11,12 +11,13 @@ pub fn verify_roundtrip(
     engine: &WasmTransformEngine,
     forward: &[u8],
     inverse: &[u8],
+    max_gas: u64,
 ) -> Result<bool, SchemaError> {
     let test_inputs = generate_test_inputs();
 
     for input in &test_inputs {
-        let forward_result = engine.execute(forward, input)?;
-        let inverse_result = engine.execute(inverse, &forward_result)?;
+        let forward_result = engine.execute(forward, input, max_gas)?;
+        let inverse_result = engine.execute(inverse, &forward_result, max_gas)?;
 
         if !values_equal(input, &inverse_result) {
             return Ok(false);

--- a/src/view/registry.rs
+++ b/src/view/registry.rs
@@ -238,6 +238,7 @@ mod tests {
     use crate::schema::types::field_value_type::FieldValueType;
     use crate::schema::types::operations::Query;
     use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
+    use crate::view::types::WasmTransformSpec;
 
     fn make_registry() -> ViewRegistry {
         let engine = Arc::new(WasmTransformEngine::new().unwrap());
@@ -467,7 +468,10 @@ mod tests {
             SchemaType::Hash,
             None,
             vec![Query::new("S1".to_string(), vec!["f1".to_string()])],
-            Some(vec![0, 1, 2]),
+            Some(WasmTransformSpec {
+                bytes: vec![0, 1, 2],
+                max_gas: 1_000_000,
+            }),
             HashMap::from([("out".to_string(), FieldValueType::Any)]),
         );
         let result = registry.register_view(view, |_| true);
@@ -483,7 +487,10 @@ mod tests {
             SchemaType::Single,
             None,
             vec![Query::new("S1".to_string(), vec!["f1".to_string()])],
-            Some(vec![0, 1, 2]),
+            Some(WasmTransformSpec {
+                bytes: vec![0, 1, 2],
+                max_gas: 1_000_000,
+            }),
             HashMap::from([("out".to_string(), FieldValueType::Any)]),
         );
         assert!(registry.register_view(single_view, |_| true).is_ok());
@@ -493,7 +500,10 @@ mod tests {
             SchemaType::Range,
             None,
             vec![Query::new("S2".to_string(), vec!["f2".to_string()])],
-            Some(vec![0, 1, 2]),
+            Some(WasmTransformSpec {
+                bytes: vec![0, 1, 2],
+                max_gas: 1_000_000,
+            }),
             HashMap::from([("out".to_string(), FieldValueType::Any)]),
         );
         assert!(registry.register_view(range_view, |_| true).is_ok());
@@ -560,7 +570,10 @@ mod tests {
                 ),
                 Query::new("Author".to_string(), vec!["name".to_string()]),
             ],
-            Some(vec![0, 1, 2]), // Placeholder WASM
+            Some(WasmTransformSpec {
+                bytes: vec![0, 1, 2],
+                max_gas: 1_000_000,
+            }), // Placeholder WASM
             HashMap::from([
                 ("enriched_title".to_string(), FieldValueType::String),
                 ("word_count".to_string(), FieldValueType::Integer),

--- a/src/view/resolver.rs
+++ b/src/view/resolver.rs
@@ -11,16 +11,19 @@ use std::sync::Arc;
 
 /// Classify a `SchemaError` produced during WASM transform execution into
 /// the corresponding [`UnavailableReason`]. Compile-time errors surface as
-/// `CompileError`; everything else from the WASM path is `ExecutionError`
-/// (including output parse failures and type-validation mismatches, which
-/// are downstream of the transform's runtime behavior).
+/// `CompileError`; fuel exhaustion (MDT-E) surfaces as `GasExceeded` with
+/// the recorded `input_size`; everything else from the WASM path is
+/// `ExecutionError` (including output parse failures and type-validation
+/// mismatches, which are downstream of the transform's runtime behavior).
 ///
-/// Gas classification (`GasExceeded`) and registry-fetch classification
-/// (`TransformBytesUnavailable`) are wired in by MDT-E and the transform
-/// resolver work respectively; they aren't reachable from today's code
-/// path but the variants exist so the state machine is complete.
+/// Registry-fetch classification (`TransformBytesUnavailable`) is wired in
+/// by the transform resolver work; that variant exists so the state
+/// machine is complete but isn't reachable from today's code path.
 fn classify_wasm_failure(err: &SchemaError) -> UnavailableReason {
     match err {
+        SchemaError::TransformGasExceeded { input_size } => UnavailableReason::GasExceeded {
+            input_size: *input_size,
+        },
         SchemaError::InvalidTransform(msg) => {
             if msg.starts_with("Failed to compile WASM module") {
                 UnavailableReason::CompileError {
@@ -164,8 +167,8 @@ impl ViewResolver {
         // rather than a hard error: they are per-input compute failures,
         // so the caller should persist the state (no retry) but callers
         // above the resolver are free to surface it to the user.
-        let mut output = if let Some(wasm_bytes) = &view.wasm_transform {
-            match self.execute_wasm_transform(wasm_bytes, &all_query_results) {
+        let mut output = if let Some(spec) = &view.wasm_transform {
+            match self.execute_wasm_transform(&spec.bytes, spec.max_gas, &all_query_results) {
                 Ok(output) => output,
                 Err(e) => {
                     let reason = classify_wasm_failure(&e);
@@ -300,9 +303,17 @@ impl ViewResolver {
     }
 
     /// Execute the WASM transform with assembled input from all queries.
+    ///
+    /// `max_gas` is the system-wide per-invocation fuel ceiling (MDT-E):
+    /// the engine seeds the `Store`'s fuel counter to exactly this value
+    /// before entering the guest, and fuel exhaustion surfaces as
+    /// [`SchemaError::TransformGasExceeded`] which the caller maps to
+    /// [`UnavailableReason::GasExceeded`] via
+    /// [`classify_wasm_failure`].
     fn execute_wasm_transform(
         &self,
         wasm_bytes: &[u8],
+        max_gas: u64,
         query_results: &HashMap<String, HashMap<String, HashMap<KeyValue, FieldValue>>>,
     ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
         // Assemble input JSON: { "inputs": { schema_name: { field: { key: value } } } }
@@ -324,7 +335,7 @@ impl ViewResolver {
         }
 
         let input_json = serde_json::json!({ "inputs": inputs });
-        let output_json = self.wasm_engine.execute(wasm_bytes, &input_json)?;
+        let output_json = self.wasm_engine.execute(wasm_bytes, &input_json, max_gas)?;
 
         // Parse output JSON: { "fields": { field_name: { key: value } } }
         let fields_obj = output_json

--- a/src/view/types.rs
+++ b/src/view/types.rs
@@ -108,6 +108,25 @@ impl ViewCacheState {
     }
 }
 
+/// A WASM transform attached to a view: compiled bytes + the per-invocation
+/// fuel ceiling enforced on every device that executes it.
+///
+/// `max_gas` is required — the whole point of MDT-E is that a given
+/// `(transform, input)` pair must either succeed on every device or fail
+/// with [`UnavailableReason::GasExceeded`] on every device. Allowing a
+/// missing budget would let one device silently skip fuel metering and
+/// produce state that other devices can't reproduce. The schema service
+/// enforces `0 < max_gas <= 10^18` at registration (see
+/// `schema_service_core::state_transforms::MAX_GAS_CEILING`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WasmTransformSpec {
+    /// Compiled WASM module bytes.
+    pub bytes: Vec<u8>,
+    /// Per-invocation fuel ceiling. Wasmtime fuel is set to exactly this
+    /// value on every `Store` before `transform` is called.
+    pub max_gas: u64,
+}
+
 /// The view definition — a multi-query typed view.
 /// Declares input queries (potentially across multiple schemas),
 /// an optional WASM transform, and a typed output schema.
@@ -121,9 +140,12 @@ pub struct TransformView {
     pub key_config: Option<KeyConfig>,
     /// Queries to execute against source schemas.
     pub input_queries: Vec<Query>,
-    /// WASM module bytes. None = identity pass-through.
+    /// WASM transform (compiled bytes + system-wide `max_gas`). `None`
+    /// means identity pass-through — the view materializes source
+    /// fields directly without running any code, so no fuel ceiling is
+    /// required. When `Some`, fuel metering is mandatory (MDT-E).
     #[serde(default)]
-    pub wasm_transform: Option<Vec<u8>>,
+    pub wasm_transform: Option<WasmTransformSpec>,
     /// Typed output schema: field_name → type.
     pub output_fields: HashMap<String, FieldValueType>,
     /// Trigger configuration that controls when the view is fired.
@@ -140,7 +162,7 @@ impl TransformView {
         schema_type: SchemaType,
         key_config: Option<KeyConfig>,
         input_queries: Vec<Query>,
-        wasm_transform: Option<Vec<u8>>,
+        wasm_transform: Option<WasmTransformSpec>,
         output_fields: HashMap<String, FieldValueType>,
     ) -> Self {
         Self {
@@ -367,7 +389,10 @@ mod tests {
             SchemaType::Single,
             None,
             vec![],
-            Some(vec![0, 1, 2]),
+            Some(WasmTransformSpec {
+                bytes: vec![0, 1, 2],
+                max_gas: 1_000_000,
+            }),
             HashMap::new(),
         );
         assert!(!wasm_view.is_identity());

--- a/src/view/wasm_engine.rs
+++ b/src/view/wasm_engine.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 #[cfg(feature = "transform-wasm")]
 use std::sync::Mutex;
 #[cfg(feature = "transform-wasm")]
-use wasmtime::{Config, Engine, Linker, Module, Store};
+use wasmtime::{Config, Engine, Linker, Module, Store, Trap};
 
 /// Sandboxed WASM execution engine with compiled module caching.
 pub struct WasmTransformEngine {
@@ -23,16 +23,27 @@ impl WasmTransformEngine {
     pub fn new() -> Result<Self, SchemaError> {
         #[cfg(feature = "transform-wasm")]
         {
-            // Enable Cranelift's NaN canonicalization pass so every
-            // architecture produces the same IEEE 754 bit pattern for a
-            // quiet NaN. Without this, aarch64 and x86_64 Cranelift
-            // back-ends choose different sign bits for `0.0 / 0.0` and
-            // `sqrt(-1)` (x86 returns FFF8…, ARM returns 7FF8…), which is
-            // the exact cross-device divergence called out as Invariant #1
-            // in docs/design/multi_device_transforms.md (exemem-workspace
-            // PR #137). The `wasm-determinism` CI job enforces this.
+            // Cross-device determinism stacks two engine-level configs:
+            //
+            //   * `cranelift_nan_canonicalization(true)` (MDT-C) — so
+            //     every architecture produces the same IEEE 754 bit
+            //     pattern for a quiet NaN. Without this, aarch64 and
+            //     x86_64 Cranelift back-ends pick different sign bits
+            //     for `0.0 / 0.0` and `sqrt(-1)` (x86 → FFF8…, ARM →
+            //     7FF8…), the cross-device divergence called out as
+            //     Invariant #1 in `docs/design/multi_device_transforms.md`
+            //     (exemem-workspace PR #137). The `wasm-determinism` CI
+            //     job enforces it.
+            //
+            //   * `consume_fuel(true)` (MDT-E) — the per-invocation
+            //     `max_gas` budget is set on the Store before each
+            //     `transform` call so identical inputs trap at
+            //     identical fuel counts on every device. Without this
+            //     the `Store::set_fuel` call inside `execute_wasm`
+            //     would itself error.
             let mut config = Config::new();
             config.cranelift_nan_canonicalization(true);
+            config.consume_fuel(true);
             let engine = Engine::new(&config)
                 .map_err(|e| SchemaError::InvalidTransform(format!("wasmtime engine init: {e}")))?;
             Ok(Self {
@@ -46,21 +57,34 @@ impl WasmTransformEngine {
         }
     }
 
-    /// Execute a WASM transform on the given input value.
+    /// Execute a WASM transform on the given input value with an explicit
+    /// per-invocation fuel ceiling.
+    ///
+    /// `max_gas` is the wasmtime fuel budget consumed before the guest is
+    /// trapped. It is set on the `Store` to exactly this value — callers
+    /// do not get to relax or tighten it per-device — so a given
+    /// `(transform, input)` pair either succeeds on every device or fails
+    /// with [`SchemaError::TransformGasExceeded`] on every device (MDT-E).
     ///
     /// The WASM module must export:
     /// - `alloc(size: i32) -> i32` — allocate memory for input
     /// - `transform(ptr: i32, len: i32) -> i64` — execute transform, returns (ptr << 32 | len)
     /// - `memory` — linear memory export
-    pub fn execute(&self, wasm_bytes: &[u8], input: &Value) -> Result<Value, SchemaError> {
+    pub fn execute(
+        &self,
+        wasm_bytes: &[u8],
+        input: &Value,
+        max_gas: u64,
+    ) -> Result<Value, SchemaError> {
         #[cfg(feature = "transform-wasm")]
         {
-            self.execute_wasm(wasm_bytes, input)
+            self.execute_wasm(wasm_bytes, input, max_gas)
         }
         #[cfg(not(feature = "transform-wasm"))]
         {
             let _ = wasm_bytes;
             let _ = input;
+            let _ = max_gas;
             Err(SchemaError::InvalidTransform(
                 "WASM transforms require the 'transform-wasm' feature flag".to_string(),
             ))
@@ -68,10 +92,26 @@ impl WasmTransformEngine {
     }
 
     #[cfg(feature = "transform-wasm")]
-    fn execute_wasm(&self, wasm_bytes: &[u8], input: &Value) -> Result<Value, SchemaError> {
+    fn execute_wasm(
+        &self,
+        wasm_bytes: &[u8],
+        input: &Value,
+        max_gas: u64,
+    ) -> Result<Value, SchemaError> {
         let module = self.get_or_compile(wasm_bytes)?;
         let linker = Linker::new(&self.engine);
         let mut store = Store::new(&self.engine, ());
+
+        // Seed the per-invocation fuel budget. With `consume_fuel(true)`
+        // on the engine, wasmtime traps with `Trap::OutOfFuel` when this
+        // counter reaches zero — exactly the enforcement contract MDT-E
+        // requires. `set_fuel` itself fails only if fuel metering was
+        // not enabled on the engine, which is a programmer error.
+        store.set_fuel(max_gas).map_err(|e| {
+            SchemaError::InvalidTransform(format!(
+                "WASM fuel metering misconfigured (set_fuel failed): {e}"
+            ))
+        })?;
 
         let instance = linker.instantiate(&mut store, &module).map_err(|e| {
             SchemaError::InvalidTransform(format!("WASM instantiation failed: {e}"))
@@ -93,14 +133,18 @@ impl WasmTransformEngine {
                 SchemaError::InvalidTransform(format!("WASM module must export 'transform': {e}"))
             })?;
 
-        // Write input JSON to WASM memory
+        // Write input JSON to WASM memory. `input_bytes.len()` is the
+        // deterministic "primary input dimension" fed to
+        // `SchemaError::TransformGasExceeded` so the classifier at the
+        // resolver boundary can surface a size-aware reason.
         let input_bytes = serde_json::to_vec(input).map_err(|e| {
             SchemaError::InvalidData(format!("Failed to serialize transform input: {e}"))
         })?;
+        let input_size = input_bytes.len() as u64;
 
         let input_ptr = alloc_fn
             .call(&mut store, input_bytes.len() as i32)
-            .map_err(|e| SchemaError::InvalidTransform(format!("WASM alloc failed: {e}")))?;
+            .map_err(|e| classify_call_error(e, input_size, "WASM alloc"))?;
 
         memory.data_mut(&mut store)[input_ptr as usize..input_ptr as usize + input_bytes.len()]
             .copy_from_slice(&input_bytes);
@@ -108,9 +152,7 @@ impl WasmTransformEngine {
         // Call transform
         let result_packed = transform_fn
             .call(&mut store, (input_ptr, input_bytes.len() as i32))
-            .map_err(|e| {
-                SchemaError::InvalidTransform(format!("WASM transform execution failed: {e}"))
-            })?;
+            .map_err(|e| classify_call_error(e, input_size, "WASM transform execution"))?;
 
         // Unpack result pointer and length from i64
         let result_ptr = (result_packed >> 32) as usize;
@@ -147,6 +189,21 @@ impl WasmTransformEngine {
     }
 }
 
+/// Classify a `wasmtime::Error` returned from a guest `call`. Fuel
+/// exhaustion surfaces as [`SchemaError::TransformGasExceeded`] so the
+/// resolver can produce a `GasExceeded` reason without stringly-typed
+/// sniffing; everything else stays as `InvalidTransform` for
+/// classification as `ExecutionError` downstream.
+#[cfg(feature = "transform-wasm")]
+fn classify_call_error(err: wasmtime::Error, input_size: u64, context: &str) -> SchemaError {
+    if let Some(trap) = err.downcast_ref::<Trap>() {
+        if *trap == Trap::OutOfFuel {
+            return SchemaError::TransformGasExceeded { input_size };
+        }
+    }
+    SchemaError::InvalidTransform(format!("{context} failed: {err}"))
+}
+
 impl std::fmt::Debug for WasmTransformEngine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WasmTransformEngine").finish()
@@ -168,7 +225,7 @@ mod tests {
     #[cfg(not(feature = "transform-wasm"))]
     fn test_execute_without_feature_flag_errors() {
         let engine = WasmTransformEngine::new().unwrap();
-        let result = engine.execute(&[0, 1, 2], &serde_json::json!(42));
+        let result = engine.execute(&[0, 1, 2], &serde_json::json!(42), 1_000_000);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(

--- a/tests/view_query_test.rs
+++ b/tests/view_query_test.rs
@@ -6,7 +6,7 @@ use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
 use fold_db::test_helpers::TestSchemaBuilder;
-use fold_db::view::types::TransformView;
+use fold_db::view::types::{TransformView, WasmTransformSpec};
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -297,7 +297,10 @@ async fn wasm_view_write_persists_override_in_view_query_test() {
             "BlogPost".to_string(),
             vec!["content".to_string()],
         )],
-        Some(vec![0, 1, 2]), // Placeholder WASM — never executed on the write path.
+        Some(WasmTransformSpec {
+            bytes: vec![0, 1, 2],
+            max_gas: 1_000_000,
+        }), // Placeholder WASM — never executed on the write path.
         HashMap::from([("out".to_string(), FieldValueType::String)]),
     );
     db.schema_manager().register_view(view).await.unwrap();

--- a/tests/view_registration_test.rs
+++ b/tests/view_registration_test.rs
@@ -4,7 +4,7 @@ use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::SchemaCore;
 use fold_db::test_helpers::TestSchemaBuilder;
 use fold_db::view::registry::ViewState;
-use fold_db::view::types::TransformView;
+use fold_db::view::types::{TransformView, WasmTransformSpec};
 use std::collections::HashMap;
 
 fn blogpost_schema_json() -> String {
@@ -184,7 +184,10 @@ async fn multi_source_view() {
             Query::new("BlogPost".to_string(), vec!["content".to_string()]),
             Query::new("Weather".to_string(), vec!["temp_celsius".to_string()]),
         ],
-        Some(vec![0, 1, 2]), // Placeholder WASM (won't be executed in registration)
+        Some(WasmTransformSpec {
+            bytes: vec![0, 1, 2],
+            max_gas: 1_000_000,
+        }), // Placeholder WASM (won't be executed in registration)
         HashMap::from([
             ("summary".to_string(), FieldValueType::String),
             ("temp".to_string(), FieldValueType::Number),
@@ -255,7 +258,10 @@ async fn register_view_with_typed_output_fields() {
             "BlogPost".to_string(),
             vec!["title".to_string(), "content".to_string()],
         )],
-        Some(vec![0, 1, 2]), // WASM placeholder
+        Some(WasmTransformSpec {
+            bytes: vec![0, 1, 2],
+            max_gas: 1_000_000,
+        }), // WASM placeholder
         HashMap::from([
             ("word_count".to_string(), FieldValueType::Integer),
             ("enriched_title".to_string(), FieldValueType::String),

--- a/tests/view_unavailable_test.rs
+++ b/tests/view_unavailable_test.rs
@@ -19,7 +19,7 @@ use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
 use fold_db::test_helpers::TestSchemaBuilder;
-use fold_db::view::types::{TransformView, UnavailableReason, ViewCacheState};
+use fold_db::view::types::{TransformView, UnavailableReason, ViewCacheState, WasmTransformSpec};
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -34,6 +34,31 @@ fn trapping_wasm() -> Vec<u8> {
         )
         (func (export "transform") (param $ptr i32) (param $len i32) (result i64)
             unreachable
+        )
+    )"#;
+    wat::parse_str(wat).expect("valid WAT")
+}
+
+/// MDT-E fixture: a module whose `transform` enters an unconditional
+/// infinite loop. Any finite `max_gas` will trap it with
+/// `Trap::OutOfFuel`, which the engine classifies as
+/// `TransformGasExceeded` and the resolver surfaces as
+/// `UnavailableReason::GasExceeded`.
+fn fuel_burner_wasm() -> Vec<u8> {
+    let wat = r#"(module
+        (memory (export "memory") 1)
+        (global $bump (mut i32) (i32.const 4096))
+        (func (export "alloc") (param $size i32) (result i32)
+            (local $ptr i32)
+            (local.set $ptr (global.get $bump))
+            (global.set $bump (i32.add (global.get $bump) (local.get $size)))
+            (local.get $ptr)
+        )
+        (func (export "transform") (param $ptr i32) (param $len i32) (result i64)
+            (loop $spin
+                (br $spin)
+            )
+            (i64.const 0)
         )
     )"#;
     wat::parse_str(wat).expect("valid WAT")
@@ -91,7 +116,10 @@ async fn compute_failure_transitions_to_unavailable_and_does_not_retry() {
             "BlogPost".to_string(),
             vec!["title".to_string()],
         )],
-        Some(trapping_wasm()),
+        Some(WasmTransformSpec {
+            bytes: trapping_wasm(),
+            max_gas: 1_000_000,
+        }),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );
     db.schema_manager().register_view(view).await.unwrap();
@@ -162,7 +190,10 @@ async fn source_mutation_clears_unavailable_to_empty() {
             "BlogPost".to_string(),
             vec!["title".to_string()],
         )],
-        Some(trapping_wasm()),
+        Some(WasmTransformSpec {
+            bytes: trapping_wasm(),
+            max_gas: 1_000_000,
+        }),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );
     db.schema_manager().register_view(view).await.unwrap();
@@ -252,5 +283,70 @@ async fn unavailable_state_persists_through_store() {
             Some(&reason),
             "round-trip failed for {reason:?}"
         );
+    }
+}
+
+// ==================== MDT-E: max_gas end-to-end ==================== //
+
+/// MDT-E: a transform that blows through its fuel budget must land in
+/// `Unavailable { GasExceeded }` (not `ExecutionError`), so callers can
+/// distinguish "compute is impossible at this budget" from "guest
+/// trapped on some other path". The sticky-per-input re-read contract
+/// is the same as every other `Unavailable` variant — verified
+/// elsewhere in this file.
+#[tokio::test]
+async fn gas_exhaustion_transitions_to_unavailable_gas_exceeded() {
+    let db = setup_db().await;
+
+    db.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager()
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+    write_blogpost(&db, "Hello", "2026-01-01").await;
+
+    // 5_000 fuel units comfortably cover module setup but the guest's
+    // loop burns them all before `transform` could return.
+    let view = TransformView::new(
+        "FuelBurnerView",
+        SchemaType::Single,
+        None,
+        vec![Query::new(
+            "BlogPost".to_string(),
+            vec!["title".to_string()],
+        )],
+        Some(WasmTransformSpec {
+            bytes: fuel_burner_wasm(),
+            max_gas: 5_000,
+        }),
+        HashMap::from([("summary".to_string(), FieldValueType::String)]),
+    );
+    db.schema_manager().register_view(view).await.unwrap();
+
+    let query = Query::new("FuelBurnerView".to_string(), vec!["summary".to_string()]);
+    let result = db.query_executor().query(query).await;
+    assert!(
+        result.is_err(),
+        "fuel-exhausted transform must surface an error, got {result:?}"
+    );
+
+    let state = db
+        .db_ops()
+        .get_view_cache_state("FuelBurnerView")
+        .await
+        .unwrap();
+    let reason = state
+        .unavailable_reason()
+        .expect("state should be Unavailable after fuel exhaustion");
+    match reason {
+        UnavailableReason::GasExceeded { input_size } => {
+            assert!(
+                *input_size > 0,
+                "input_size must reflect serialized input bytes (> 0 for a non-empty query)"
+            );
+        }
+        other => panic!("expected GasExceeded, got {other:?}"),
     }
 }

--- a/tests/view_wasm_integration_test.rs
+++ b/tests/view_wasm_integration_test.rs
@@ -9,7 +9,7 @@ use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
 use fold_db::test_helpers::TestSchemaBuilder;
-use fold_db::view::types::TransformView;
+use fold_db::view::types::{TransformView, WasmTransformSpec};
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -99,7 +99,10 @@ async fn wasm_view_query_returns_transformed_output() {
             "BlogPost".to_string(),
             vec!["title".to_string(), "content".to_string()],
         )],
-        Some(hardcoded_wasm()),
+        Some(WasmTransformSpec {
+            bytes: hardcoded_wasm(),
+            max_gas: 1_000_000,
+        }),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );
     db.schema_manager().register_view(view).await.unwrap();
@@ -150,7 +153,10 @@ async fn wasm_view_output_type_validation_works() {
             "BlogPost".to_string(),
             vec!["title".to_string()],
         )],
-        Some(hardcoded_wasm()), // Returns {"summary": {"k1": "hardcoded"}} — a String
+        Some(WasmTransformSpec {
+            bytes: hardcoded_wasm(),
+            max_gas: 1_000_000,
+        }), // Returns {"summary": {"k1": "hardcoded"}} — a String
         HashMap::from([("summary".to_string(), FieldValueType::Integer)]), // Declared as Integer
     );
     db.schema_manager().register_view(view).await.unwrap();
@@ -200,7 +206,10 @@ async fn wasm_view_cache_invalidation_works() {
             "BlogPost".to_string(),
             vec!["title".to_string()],
         )],
-        Some(hardcoded_wasm()),
+        Some(WasmTransformSpec {
+            bytes: hardcoded_wasm(),
+            max_gas: 1_000_000,
+        }),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );
     db.schema_manager().register_view(view).await.unwrap();

--- a/tests/view_write_test.rs
+++ b/tests/view_write_test.rs
@@ -7,7 +7,7 @@ use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
 use fold_db::test_helpers::TestSchemaBuilder;
 use fold_db::view::transform_field_override::TransformFieldOverride;
-use fold_db::view::types::{TransformView, ViewCacheState};
+use fold_db::view::types::{TransformView, ViewCacheState, WasmTransformSpec};
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -124,7 +124,10 @@ async fn wasm_view_write_persists_override() {
             "BlogPost".to_string(),
             vec!["content".to_string()],
         )],
-        Some(vec![0, 1, 2]), // Placeholder WASM — never executed on the write path.
+        Some(WasmTransformSpec {
+            bytes: vec![0, 1, 2],
+            max_gas: 1_000_000,
+        }), // Placeholder WASM — never executed on the write path.
         HashMap::from([("out".to_string(), FieldValueType::String)]),
     );
     db.schema_manager().register_view(view).await.unwrap();
@@ -300,7 +303,10 @@ async fn concurrent_overrides_converge_via_lww() {
             "BlogPost".to_string(),
             vec!["content".to_string()],
         )],
-        Some(vec![0, 1, 2]),
+        Some(WasmTransformSpec {
+            bytes: vec![0, 1, 2],
+            max_gas: 1_000_000,
+        }),
         HashMap::from([("out".to_string(), FieldValueType::String)]),
     );
     db.schema_manager().register_view(view).await.unwrap();

--- a/tests/wasm_determinism.rs
+++ b/tests/wasm_determinism.rs
@@ -306,7 +306,7 @@ fn wasm_transforms_produce_stable_output() {
         let wasm = wat::parse_str(&fx.wat)
             .unwrap_or_else(|e| panic!("fixture '{}' WAT failed to parse: {e}", fx.name));
         let output = engine
-            .execute(&wasm, &fx.input)
+            .execute(&wasm, &fx.input, 1_000_000_000)
             .unwrap_or_else(|e| panic!("fixture '{}' failed to execute: {e}", fx.name));
         let canonical = canonicalize(&output);
         lines.push(format!("{}\t{}", fx.name, canonical));

--- a/tests/wasm_transform_test.rs
+++ b/tests/wasm_transform_test.rs
@@ -125,7 +125,7 @@ fn wasm_engine_executes_hardcoded_output() {
     let wasm = hardcoded_output_module();
     let input = json!({"anything": "ignored"});
 
-    let result = engine.execute(&wasm, &input).unwrap();
+    let result = engine.execute(&wasm, &input, 1_000_000_000).unwrap();
 
     assert_eq!(result, json!({"fields": {"out": {"k1": "hello"}}}));
 }
@@ -136,7 +136,7 @@ fn wasm_engine_echo_returns_input() {
     let wasm = echo_module();
 
     let input = json!({"inputs": {"BlogPost": {"title": {"r1": "Hello"}}}});
-    let result = engine.execute(&wasm, &input).unwrap();
+    let result = engine.execute(&wasm, &input, 1_000_000_000).unwrap();
 
     // Echo module returns input unchanged
     assert_eq!(result, input);
@@ -148,7 +148,7 @@ fn wasm_engine_copy_returns_input() {
     let wasm = copy_module();
 
     let input = json!({"fields": {"word_count": {"r1": 42}}});
-    let result = engine.execute(&wasm, &input).unwrap();
+    let result = engine.execute(&wasm, &input, 1_000_000_000).unwrap();
 
     assert_eq!(result, input);
 }
@@ -159,8 +159,8 @@ fn wasm_engine_caches_compiled_modules() {
     let wasm = hardcoded_output_module();
 
     // Execute twice with same bytes — second should use cached module
-    let r1 = engine.execute(&wasm, &json!({})).unwrap();
-    let r2 = engine.execute(&wasm, &json!({})).unwrap();
+    let r1 = engine.execute(&wasm, &json!({}), 1_000_000_000).unwrap();
+    let r2 = engine.execute(&wasm, &json!({}), 1_000_000_000).unwrap();
 
     assert_eq!(r1, r2);
 }
@@ -170,7 +170,7 @@ fn wasm_engine_rejects_invalid_wasm() {
     let engine = WasmTransformEngine::new().unwrap();
     let invalid = vec![0, 1, 2, 3]; // Not valid WASM
 
-    let result = engine.execute(&invalid, &json!({}));
+    let result = engine.execute(&invalid, &json!({}), 1_000_000_000);
     assert!(result.is_err());
     assert!(result
         .unwrap_err()
@@ -185,7 +185,7 @@ fn wasm_engine_rejects_module_missing_exports() {
     let wasm = wat_to_wasm(wat);
 
     let engine = WasmTransformEngine::new().unwrap();
-    let result = engine.execute(&wasm, &json!({}));
+    let result = engine.execute(&wasm, &json!({}), 1_000_000_000);
     assert!(result.is_err());
     // Should mention missing alloc or transform
     let err = result.unwrap_err().to_string();
@@ -211,6 +211,129 @@ fn wasm_engine_handles_large_input() {
     }
     let input = json!({"inputs": {"LargeSchema": fields}});
 
-    let result = engine.execute(&wasm, &input).unwrap();
+    let result = engine.execute(&wasm, &input, 1_000_000_000).unwrap();
     assert_eq!(result, input);
+}
+
+// ==================== MDT-E: max_gas enforcement ==================== //
+
+/// A WASM module whose `transform` enters an unconditional infinite loop.
+/// Designed to exhaust any finite fuel budget deterministically — the
+/// inner `br 0` consumes a fixed number of fuel units per iteration, so
+/// two devices seeded with the same `max_gas` trap at the same iteration
+/// count and the same remaining fuel (which for fuel exhaustion is zero).
+fn infinite_loop_module() -> Vec<u8> {
+    let wat = r#"(module
+        (memory (export "memory") 1)
+
+        (global $bump (mut i32) (i32.const 4096))
+        (func (export "alloc") (param $size i32) (result i32)
+            (local $ptr i32)
+            (local.set $ptr (global.get $bump))
+            (global.set $bump (i32.add (global.get $bump) (local.get $size)))
+            (local.get $ptr)
+        )
+
+        ;; Burn fuel forever. The guest should be trapped with
+        ;; Trap::OutOfFuel, which the engine classifies as
+        ;; SchemaError::TransformGasExceeded.
+        (func (export "transform") (param $ptr i32) (param $len i32) (result i64)
+            (loop $spin
+                (br $spin)
+            )
+            (i64.const 0)
+        )
+    )"#;
+    wat_to_wasm(wat)
+}
+
+/// An MDT-E baseline: the hardcoded-output transform runs to completion
+/// under a generous budget. Paired with the infinite-loop test below,
+/// this establishes that the fuel path distinguishes "ran" vs. "trapped"
+/// rather than uniformly rejecting every invocation.
+#[test]
+fn max_gas_sufficient_budget_succeeds() {
+    let engine = WasmTransformEngine::new().unwrap();
+    let wasm = hardcoded_output_module();
+
+    let result = engine
+        .execute(&wasm, &json!({}), 1_000_000_000)
+        .expect("hardcoded output must finish under a generous budget");
+    assert_eq!(result, json!({"fields": {"out": {"k1": "hello"}}}));
+}
+
+/// The MDT-E contract: when a transform exceeds its fuel budget, the
+/// engine surfaces `SchemaError::TransformGasExceeded` with the
+/// deterministic `input_size` (serialized JSON byte length). The
+/// resolver maps this to `UnavailableReason::GasExceeded`; that
+/// end-to-end path is covered separately in `view_unavailable_test.rs`.
+#[test]
+fn max_gas_exhausted_returns_transform_gas_exceeded() {
+    use fold_db::schema::types::errors::SchemaError;
+
+    let engine = WasmTransformEngine::new().unwrap();
+    let wasm = infinite_loop_module();
+    let input = json!({"anything": "ignored"});
+    // Input JSON: {"anything":"ignored"} — 22 bytes — which is what
+    // the engine records as `input_size` on the error.
+    let expected_input_size = serde_json::to_vec(&input).expect("serialize input").len() as u64;
+
+    let err = engine
+        .execute(&wasm, &input, 10_000)
+        .expect_err("infinite loop must exhaust a 10_000-unit budget");
+    match err {
+        SchemaError::TransformGasExceeded { input_size } => {
+            assert_eq!(
+                input_size, expected_input_size,
+                "input_size must reflect serialized input bytes"
+            );
+        }
+        other => panic!("expected TransformGasExceeded, got {other:?}"),
+    }
+}
+
+/// Deterministic termination is the whole point of MDT-E: two
+/// independent `WasmTransformEngine` instances seeded with the same
+/// `max_gas` and the same bytes + input must trap identically. There's
+/// no device state in this test — just two engines in the same
+/// process, which is the weakest form of the invariant we can assert
+/// without a two-node harness. (The full cross-node assertion lives in
+/// the multi-device round-1 findings doc; the unit-test contract is
+/// that the fuel counter alone, without any per-device knobs, pins
+/// outcome.)
+#[test]
+fn max_gas_deterministic_across_engine_instances() {
+    use fold_db::schema::types::errors::SchemaError;
+
+    let wasm = infinite_loop_module();
+    let input = json!({"anything": "ignored"});
+    let budget = 42_000u64;
+
+    let engine_a = WasmTransformEngine::new().unwrap();
+    let engine_b = WasmTransformEngine::new().unwrap();
+
+    let err_a = engine_a
+        .execute(&wasm, &input, budget)
+        .expect_err("engine A must trap on fuel exhaustion");
+    let err_b = engine_b
+        .execute(&wasm, &input, budget)
+        .expect_err("engine B must trap on fuel exhaustion");
+
+    match (err_a, err_b) {
+        (
+            SchemaError::TransformGasExceeded {
+                input_size: input_size_a,
+            },
+            SchemaError::TransformGasExceeded {
+                input_size: input_size_b,
+            },
+        ) => {
+            assert_eq!(
+                input_size_a, input_size_b,
+                "input_size must match across engine instances — it is a pure \
+                 function of the serialized input, not of device state"
+            );
+        }
+        other => panic!("both engines must trap with TransformGasExceeded, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary

- \`WasmTransformEngine::execute\` now takes a \`max_gas: u64\`, enables \`consume_fuel(true)\` alongside MDT-C's NaN canonicalization, seeds \`Store::set_fuel(max_gas)\`, and maps \`Trap::OutOfFuel\` → \`SchemaError::TransformGasExceeded { input_size }\`.
- \`ViewResolver\` classifies the new variant to \`UnavailableReason::GasExceeded\`, landing a fuel-exhausted view in the sticky \`Unavailable\` state from MDT-A.
- \`TransformView.wasm_transform\` is now \`Option<WasmTransformSpec>\` (bytes + max_gas always travel together) — no runtime path where a view has bytes but no fuel ceiling.

Implements Open Design Item #4 of the multi-device transform design note: **max_gas must be set at registration and enforced identically on every device.** Paired with [schema_service PR #25](https://github.com/EdgeVector/schema_service/pull/25), which adds \`max_gas\` to \`TransformRecord\` / \`RegisterTransformRequest\`.

## Test plan

- [x] \`cargo test --features transform-wasm --test wasm_transform_test\` — 10 passed (incl. 3 new MDT-E tests)
- [x] \`cargo test --features transform-wasm --test view_unavailable_test\` — 4 passed (incl. new end-to-end GasExceeded)
- [x] \`cargo test --features transform-wasm --test wasm_determinism\` — passing (MDT-C fixture still byte-stable)
- [x] \`cargo clippy --workspace --all-targets --features transform-wasm -- -D warnings\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean

### MDT-E test cases

- \`max_gas_sufficient_budget_succeeds\` — baseline: generous budget + hardcoded-output transform runs to completion.
- \`max_gas_exhausted_returns_transform_gas_exceeded\` — infinite-loop WASM + 10_000-unit budget traps with \`TransformGasExceeded\` carrying the serialized-input byte length.
- \`max_gas_deterministic_across_engine_instances\` — two independent engines, same bytes + budget, identical \`input_size\` on trap. Weakest process-local form of the cross-device invariant.
- \`gas_exhaustion_transitions_to_unavailable_gas_exceeded\` — end-to-end: \`FoldDB::query_executor().query(…)\` on a fuel-burning view lands in \`Unavailable { GasExceeded }\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)