### PR TITLE
feat(view): MDT-F Phase 2 (2/3) — runtime envelope rejection

### DIFF
--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -9,6 +9,8 @@ pub use dependency_tracker::DependencyTracker;
 pub use registry::ViewRegistry;
 pub use resolver::ViewResolver;
 pub use transform_field_override::TransformFieldOverride;
-pub use types::{TransformView, UnavailableReason, ViewCacheState};
+pub use types::{
+    FieldId, GasModel, InputDimension, TransformView, UnavailableReason, ViewCacheState,
+};
 pub use wasm_engine::WasmTransformEngine;
 pub mod invertibility;

--- a/src/view/registry.rs
+++ b/src/view/registry.rs
@@ -471,6 +471,7 @@ mod tests {
             Some(WasmTransformSpec {
                 bytes: vec![0, 1, 2],
                 max_gas: 1_000_000,
+                gas_model: None,
             }),
             HashMap::from([("out".to_string(), FieldValueType::Any)]),
         );
@@ -490,6 +491,7 @@ mod tests {
             Some(WasmTransformSpec {
                 bytes: vec![0, 1, 2],
                 max_gas: 1_000_000,
+                gas_model: None,
             }),
             HashMap::from([("out".to_string(), FieldValueType::Any)]),
         );
@@ -503,6 +505,7 @@ mod tests {
             Some(WasmTransformSpec {
                 bytes: vec![0, 1, 2],
                 max_gas: 1_000_000,
+                gas_model: None,
             }),
             HashMap::from([("out".to_string(), FieldValueType::Any)]),
         );
@@ -573,6 +576,7 @@ mod tests {
             Some(WasmTransformSpec {
                 bytes: vec![0, 1, 2],
                 max_gas: 1_000_000,
+                gas_model: None,
             }), // Placeholder WASM
             HashMap::from([
                 ("enriched_title".to_string(), FieldValueType::String),

--- a/src/view/resolver.rs
+++ b/src/view/resolver.rs
@@ -3,7 +3,7 @@ use crate::schema::types::field::FieldValue;
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::operations::Query;
 use crate::view::transform_field_override::TransformFieldOverride;
-use crate::view::types::{TransformView, UnavailableReason, ViewCacheState};
+use crate::view::types::{InputDimension, TransformView, UnavailableReason, ViewCacheState};
 use crate::view::wasm_engine::WasmTransformEngine;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -161,6 +161,31 @@ impl ViewResolver {
                 .entry(query.schema_name.clone())
                 .or_default()
                 .extend(query_results);
+        }
+
+        // MDT-F Phase 2 — runtime envelope rejection.
+        //
+        // If the transform has a calibrated gas model, reject inputs that
+        // fall outside the envelope BEFORE entering the WASM. This is
+        // distinct from `GasExceeded` (which is a runtime fuel trap): no
+        // fuel is burned here, and the failure is deterministic across
+        // devices because the measurement is over the input JSON shape,
+        // which every replayer sees identically.
+        if let Some(spec) = &view.wasm_transform {
+            if let Some(model) = &spec.gas_model {
+                let measured = measure_input(&all_query_results, &model.coefficients);
+                if measured > model.max_input_size {
+                    return Ok((
+                        HashMap::new(),
+                        ViewCacheState::Unavailable {
+                            reason: UnavailableReason::ExceedsCalibratedEnvelope {
+                                measured,
+                                limit: model.max_input_size,
+                            },
+                        },
+                    ));
+                }
+            }
         }
 
         // Compute output. WASM failures become an `Unavailable` state
@@ -379,6 +404,58 @@ impl ViewResolver {
     pub fn wasm_engine(&self) -> &Arc<WasmTransformEngine> {
         &self.wasm_engine
     }
+}
+
+/// Compute the measured input size for the runtime envelope check
+/// (MDT-F Phase 2).
+///
+/// Iterates the gas-model coefficient list and sums a per-dimension size
+/// across `all_query_results`. The coefficient *weights* are irrelevant
+/// for the envelope check — only the dimension identity matters — so
+/// they are ignored here; budget derivation (Phase 2 task 3/3) is a
+/// separate calculation that does use them.
+///
+/// Per-dimension measurement:
+/// * [`InputDimension::FieldBytes`]: sum of `serde_json::to_vec(value).len()`
+///   over every `(key, value)` entry on the named `(schema, field)`.
+///   Serialization failures fall back to `0` rather than panicking — the
+///   envelope check must stay permissive for values that can still be
+///   passed to the WASM.
+/// * [`InputDimension::FieldCount`]: number of `(key, value)` entries on
+///   the named `(schema, field)`. A plain row count is the intuitive
+///   meaning of "count" at the view-input level and composes with
+///   `FieldBytes` when a transform is priced on both axes.
+///
+/// The return type is `u64` so the sum can be compared directly against
+/// [`crate::view::types::GasModel::max_input_size`].
+fn measure_input(
+    all_query_results: &HashMap<String, HashMap<String, HashMap<KeyValue, FieldValue>>>,
+    coefficients: &[(InputDimension, f64)],
+) -> u64 {
+    let mut total: u64 = 0;
+    for (dim, _weight) in coefficients {
+        let (field_id, is_bytes) = match dim {
+            InputDimension::FieldBytes(id) => (id, true),
+            InputDimension::FieldCount(id) => (id, false),
+        };
+        let Some(schema_map) = all_query_results.get(&field_id.schema) else {
+            continue;
+        };
+        let Some(field_entries) = schema_map.get(&field_id.field) else {
+            continue;
+        };
+        if is_bytes {
+            for fv in field_entries.values() {
+                let n = serde_json::to_vec(&fv.value)
+                    .map(|v| v.len() as u64)
+                    .unwrap_or(0);
+                total = total.saturating_add(n);
+            }
+        } else {
+            total = total.saturating_add(field_entries.len() as u64);
+        }
+    }
+    total
 }
 
 /// Reverse of `KeyValue::Display`: `"hash:range"` → hash+range,

--- a/src/view/types.rs
+++ b/src/view/types.rs
@@ -27,6 +27,12 @@ pub enum UnavailableReason {
     /// WASM runtime error during execution (trap, alloc failure, output
     /// parse error, type-validation failure).
     ExecutionError { message: String },
+    /// Measured input for this invocation exceeded the transform's
+    /// calibrated [`GasModel::max_input_size`] envelope. Rejected BEFORE
+    /// `execute_wasm_transform` is called — no fuel is burned — so the
+    /// failure is cleanly distinguishable from `GasExceeded` (which is a
+    /// runtime fuel trap during execution).
+    ExceedsCalibratedEnvelope { measured: u64, limit: u64 },
 }
 
 impl std::fmt::Display for UnavailableReason {
@@ -38,6 +44,12 @@ impl std::fmt::Display for UnavailableReason {
             Self::CompileError { message } => write!(f, "compile error: {message}"),
             Self::TransformBytesUnavailable => write!(f, "transform bytes unavailable"),
             Self::ExecutionError { message } => write!(f, "execution error: {message}"),
+            Self::ExceedsCalibratedEnvelope { measured, limit } => {
+                write!(
+                    f,
+                    "input exceeds calibrated envelope (measured={measured}, limit={limit})"
+                )
+            }
         }
     }
 }
@@ -108,6 +120,61 @@ impl ViewCacheState {
     }
 }
 
+/// Fully-qualified reference to a field on a source schema. Used by
+/// [`InputDimension`] to name the input slice a gas-model coefficient is
+/// measured against.
+///
+/// Mirrored from the schema-service gas-model fit output (MDT-F Phase 1);
+/// fold_db owns the canonical shape now and schema_service will adopt it in
+/// a follow-up so a future merge is trivial.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FieldId {
+    pub schema: String,
+    pub field: String,
+}
+
+/// A single input dimension the gas-model fit measures against. The
+/// coefficient weights themselves are irrelevant for the runtime envelope
+/// check (MDT-F Phase 2) — we only need to know which `(schema, field)`
+/// slices of input to size — but they are carried through for the later
+/// fuel-budget derivation (MDT-F Phase 2 task 3/3).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum InputDimension {
+    /// Sum of JSON-encoded byte length over every entry in the named
+    /// field. Used when the transform's cost scales with content bulk.
+    FieldBytes(FieldId),
+    /// Row count (number of `(key, value)` entries) on the named field.
+    /// Used when the transform's cost scales with cardinality.
+    FieldCount(FieldId),
+}
+
+/// Calibrated gas model fit for a transform. Produced once by the
+/// schema-service fit harness (MDT-F Phase 1) and carried forward on the
+/// [`WasmTransformSpec`]. The runtime uses it two ways:
+///
+/// 1. **Envelope rejection** (Phase 2 task 2/3 — this PR): before executing
+///    the WASM, sum the measured sizes along each [`InputDimension`] and
+///    reject with [`UnavailableReason::ExceedsCalibratedEnvelope`] if the
+///    total exceeds `max_input_size`. No fuel is burned on rejection.
+/// 2. **Budget derivation** (Phase 2 task 3/3 — follow-up): derive the
+///    per-invocation `max_gas` from `base + Σ coefficient_i * size_i`.
+///
+/// `coefficients` is ordered to match the schema-service fit output; the
+/// runtime iterates it as a flat list and does not rely on order.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GasModel {
+    /// Constant overhead added to the fit regardless of input shape.
+    pub base: u64,
+    /// Per-dimension coefficients as `(dimension, weight)`. Weight is an
+    /// f64 because the fit output is real-valued; runtime envelope check
+    /// ignores the weight and uses only the dimension identity.
+    pub coefficients: Vec<(InputDimension, f64)>,
+    /// Upper bound on `Σ size_i(input)` summed across every dimension.
+    /// Inputs above this ceiling are rejected pre-execution so we stay
+    /// inside the calibrated regime where the fit is trustworthy.
+    pub max_input_size: u64,
+}
+
 /// A WASM transform attached to a view: compiled bytes + the per-invocation
 /// fuel ceiling enforced on every device that executes it.
 ///
@@ -118,6 +185,11 @@ impl ViewCacheState {
 /// produce state that other devices can't reproduce. The schema service
 /// enforces `0 < max_gas <= 10^18` at registration (see
 /// `schema_service_core::state_transforms::MAX_GAS_CEILING`).
+///
+/// `gas_model` is optional because views registered before MDT-F Phase 1
+/// have no fit. When present, the runtime enforces the calibrated
+/// [`GasModel::max_input_size`] envelope pre-execution (MDT-F Phase 2) and
+/// — in a later task — derives `max_gas` from the coefficients.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WasmTransformSpec {
     /// Compiled WASM module bytes.
@@ -125,6 +197,12 @@ pub struct WasmTransformSpec {
     /// Per-invocation fuel ceiling. Wasmtime fuel is set to exactly this
     /// value on every `Store` before `transform` is called.
     pub max_gas: u64,
+    /// Calibrated gas model from the MDT-F Phase 1 fit harness. `None`
+    /// for views that predate the fit — those views skip envelope
+    /// rejection and run under `max_gas` alone. `#[serde(default)]` so
+    /// existing persisted views deserialize without migration.
+    #[serde(default)]
+    pub gas_model: Option<GasModel>,
 }
 
 /// The view definition — a multi-query typed view.
@@ -301,6 +379,10 @@ mod tests {
             UnavailableReason::ExecutionError {
                 message: "trap: unreachable".to_string(),
             },
+            UnavailableReason::ExceedsCalibratedEnvelope {
+                measured: 98_765,
+                limit: 50_000,
+            },
         ];
         for reason in reasons {
             let state = ViewCacheState::Unavailable {
@@ -322,6 +404,56 @@ mod tests {
             UnavailableReason::TransformBytesUnavailable.to_string(),
             "transform bytes unavailable"
         );
+        assert_eq!(
+            UnavailableReason::ExceedsCalibratedEnvelope {
+                measured: 2048,
+                limit: 1024
+            }
+            .to_string(),
+            "input exceeds calibrated envelope (measured=2048, limit=1024)"
+        );
+    }
+
+    #[test]
+    fn test_wasm_transform_spec_gas_model_default_deserializes() {
+        // `gas_model` is `#[serde(default)]` so legacy WasmTransformSpec
+        // values persisted before Phase 2 deserialize cleanly with
+        // `gas_model = None`. This pins the compatibility contract.
+        let legacy_json =
+            serde_json::json!({ "bytes": [1, 2, 3], "max_gas": 1_000_000 });
+        let spec: WasmTransformSpec = serde_json::from_value(legacy_json).expect("deserialize");
+        assert!(spec.gas_model.is_none());
+        assert_eq!(spec.max_gas, 1_000_000);
+    }
+
+    #[test]
+    fn test_gas_model_round_trip() {
+        // The new GasModel / InputDimension / FieldId types must round-trip
+        // through serde since they're embedded in WasmTransformSpec which
+        // is persisted via TypedKvStore.
+        let model = GasModel {
+            base: 100,
+            coefficients: vec![
+                (
+                    InputDimension::FieldBytes(FieldId {
+                        schema: "BlogPost".to_string(),
+                        field: "content".to_string(),
+                    }),
+                    2.5,
+                ),
+                (
+                    InputDimension::FieldCount(FieldId {
+                        schema: "Author".to_string(),
+                        field: "name".to_string(),
+                    }),
+                    1.0,
+                ),
+            ],
+            max_input_size: 65_536,
+        };
+        let bytes = serde_json::to_vec(&model).expect("serialize");
+        let decoded: GasModel = serde_json::from_slice(&bytes).expect("deserialize");
+        assert_eq!(decoded, model);
     }
 
     #[test]
@@ -392,6 +524,7 @@ mod tests {
             Some(WasmTransformSpec {
                 bytes: vec![0, 1, 2],
                 max_gas: 1_000_000,
+                gas_model: None,
             }),
             HashMap::new(),
         );

--- a/src/view/types.rs
+++ b/src/view/types.rs
@@ -419,8 +419,7 @@ mod tests {
         // `gas_model` is `#[serde(default)]` so legacy WasmTransformSpec
         // values persisted before Phase 2 deserialize cleanly with
         // `gas_model = None`. This pins the compatibility contract.
-        let legacy_json =
-            serde_json::json!({ "bytes": [1, 2, 3], "max_gas": 1_000_000 });
+        let legacy_json = serde_json::json!({ "bytes": [1, 2, 3], "max_gas": 1_000_000 });
         let spec: WasmTransformSpec = serde_json::from_value(legacy_json).expect("deserialize");
         assert!(spec.gas_model.is_none());
         assert_eq!(spec.max_gas, 1_000_000);

--- a/tests/view_query_test.rs
+++ b/tests/view_query_test.rs
@@ -300,6 +300,7 @@ async fn wasm_view_write_persists_override_in_view_query_test() {
         Some(WasmTransformSpec {
             bytes: vec![0, 1, 2],
             max_gas: 1_000_000,
+            gas_model: None,
         }), // Placeholder WASM — never executed on the write path.
         HashMap::from([("out".to_string(), FieldValueType::String)]),
     );

--- a/tests/view_registration_test.rs
+++ b/tests/view_registration_test.rs
@@ -187,6 +187,7 @@ async fn multi_source_view() {
         Some(WasmTransformSpec {
             bytes: vec![0, 1, 2],
             max_gas: 1_000_000,
+            gas_model: None,
         }), // Placeholder WASM (won't be executed in registration)
         HashMap::from([
             ("summary".to_string(), FieldValueType::String),
@@ -261,6 +262,7 @@ async fn register_view_with_typed_output_fields() {
         Some(WasmTransformSpec {
             bytes: vec![0, 1, 2],
             max_gas: 1_000_000,
+            gas_model: None,
         }), // WASM placeholder
         HashMap::from([
             ("word_count".to_string(), FieldValueType::Integer),

--- a/tests/view_unavailable_test.rs
+++ b/tests/view_unavailable_test.rs
@@ -19,7 +19,10 @@ use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
 use fold_db::test_helpers::TestSchemaBuilder;
-use fold_db::view::types::{TransformView, UnavailableReason, ViewCacheState, WasmTransformSpec};
+use fold_db::view::types::{
+    FieldId, GasModel, InputDimension, TransformView, UnavailableReason, ViewCacheState,
+    WasmTransformSpec,
+};
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -119,6 +122,7 @@ async fn compute_failure_transitions_to_unavailable_and_does_not_retry() {
         Some(WasmTransformSpec {
             bytes: trapping_wasm(),
             max_gas: 1_000_000,
+            gas_model: None,
         }),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );
@@ -193,6 +197,7 @@ async fn source_mutation_clears_unavailable_to_empty() {
         Some(WasmTransformSpec {
             bytes: trapping_wasm(),
             max_gas: 1_000_000,
+            gas_model: None,
         }),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );
@@ -320,6 +325,7 @@ async fn gas_exhaustion_transitions_to_unavailable_gas_exceeded() {
         Some(WasmTransformSpec {
             bytes: fuel_burner_wasm(),
             max_gas: 5_000,
+            gas_model: None,
         }),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );
@@ -349,4 +355,203 @@ async fn gas_exhaustion_transitions_to_unavailable_gas_exceeded() {
         }
         other => panic!("expected GasExceeded, got {other:?}"),
     }
+}
+
+// ============= MDT-F Phase 2 — runtime envelope rejection ============= //
+
+/// An identity-looking WASM whose `transform` traps unconditionally. If
+/// the envelope check fails to short-circuit and we actually enter the
+/// guest, the surfaced reason would be `ExecutionError` (from the trap)
+/// rather than `ExceedsCalibratedEnvelope`. So this module serves as a
+/// canary: any test that expects `ExceedsCalibratedEnvelope` and gets
+/// `ExecutionError` has regressed the pre-execution envelope short-circuit.
+fn always_trapping_wasm() -> Vec<u8> {
+    trapping_wasm()
+}
+
+/// Oversized input should be rejected by the envelope check BEFORE the
+/// WASM runs. We detect "WASM did not run" by using a trapping module —
+/// if the envelope check short-circuits correctly, the surfaced reason is
+/// `ExceedsCalibratedEnvelope`; if it fails to short-circuit, the trap
+/// fires and the reason would be `ExecutionError`.
+#[tokio::test]
+async fn exceeds_envelope_rejects_before_wasm_runs() {
+    let db = setup_db().await;
+
+    db.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager()
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+    // A 500-character title JSON-encodes to ~502 bytes, well above the
+    // 100-byte limit below.
+    let big_title = "x".repeat(500);
+    write_blogpost(&db, &big_title, "2026-01-01").await;
+
+    let view = TransformView::new(
+        "EnvelopeView",
+        SchemaType::Single,
+        None,
+        vec![Query::new(
+            "BlogPost".to_string(),
+            vec!["title".to_string()],
+        )],
+        Some(WasmTransformSpec {
+            bytes: always_trapping_wasm(),
+            max_gas: 1_000_000,
+            gas_model: Some(GasModel {
+                base: 0,
+                coefficients: vec![(
+                    InputDimension::FieldBytes(FieldId {
+                        schema: "BlogPost".to_string(),
+                        field: "title".to_string(),
+                    }),
+                    1.0,
+                )],
+                max_input_size: 100,
+            }),
+        }),
+        HashMap::from([("summary".to_string(), FieldValueType::String)]),
+    );
+    db.schema_manager().register_view(view).await.unwrap();
+
+    let query = Query::new("EnvelopeView".to_string(), vec!["summary".to_string()]);
+    let result = db.query_executor().query(query).await;
+    assert!(
+        result.is_err(),
+        "query on oversized input must surface an error, got {result:?}"
+    );
+
+    let state = db
+        .db_ops()
+        .get_view_cache_state("EnvelopeView")
+        .await
+        .unwrap();
+    let reason = state
+        .unavailable_reason()
+        .expect("state should be Unavailable after envelope rejection");
+    match reason {
+        UnavailableReason::ExceedsCalibratedEnvelope { measured, limit } => {
+            assert_eq!(*limit, 100);
+            assert!(
+                *measured > 100,
+                "measured must exceed the limit (got {measured})"
+            );
+        }
+        other => panic!(
+            "expected ExceedsCalibratedEnvelope — WASM must NOT have run; got {other:?}"
+        ),
+    }
+}
+
+/// Input below the envelope runs the WASM normally. With a trapping WASM
+/// the surfaced reason is `ExecutionError`, confirming the envelope check
+/// did not reject and control reached the guest. This is the mirror of
+/// the oversized test — together they pin down the branch.
+#[tokio::test]
+async fn below_envelope_proceeds_to_wasm() {
+    let db = setup_db().await;
+
+    db.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager()
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+    // A 5-char title JSON-encodes well under 100 bytes.
+    write_blogpost(&db, "hi", "2026-01-01").await;
+
+    let view = TransformView::new(
+        "SmallEnvelopeView",
+        SchemaType::Single,
+        None,
+        vec![Query::new(
+            "BlogPost".to_string(),
+            vec!["title".to_string()],
+        )],
+        Some(WasmTransformSpec {
+            bytes: always_trapping_wasm(),
+            max_gas: 1_000_000,
+            gas_model: Some(GasModel {
+                base: 0,
+                coefficients: vec![(
+                    InputDimension::FieldBytes(FieldId {
+                        schema: "BlogPost".to_string(),
+                        field: "title".to_string(),
+                    }),
+                    1.0,
+                )],
+                max_input_size: 10_000,
+            }),
+        }),
+        HashMap::from([("summary".to_string(), FieldValueType::String)]),
+    );
+    db.schema_manager().register_view(view).await.unwrap();
+
+    let query = Query::new("SmallEnvelopeView".to_string(), vec!["summary".to_string()]);
+    let _ = db.query_executor().query(query).await;
+
+    let state = db
+        .db_ops()
+        .get_view_cache_state("SmallEnvelopeView")
+        .await
+        .unwrap();
+    let reason = state
+        .unavailable_reason()
+        .expect("below-envelope run still traps — should be Unavailable via trap");
+    assert!(
+        matches!(reason, UnavailableReason::ExecutionError { .. }),
+        "envelope check must have passed and WASM must have run; got {reason:?}"
+    );
+}
+
+/// `ExceedsCalibratedEnvelope` must round-trip through the storage serde
+/// path alongside the pre-existing variants, so the new state survives a
+/// restart exactly like the others do.
+#[tokio::test]
+async fn exceeds_envelope_state_persists_through_store() {
+    let db = setup_db().await;
+
+    db.load_schema_from_json(&blogpost_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager()
+        .set_schema_state("BlogPost", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let view = TransformView::new(
+        "EnvelopeRoundTrip",
+        SchemaType::Single,
+        None,
+        vec![Query::new(
+            "BlogPost".to_string(),
+            vec!["title".to_string()],
+        )],
+        None,
+        HashMap::from([("title".to_string(), FieldValueType::Any)]),
+    );
+    db.schema_manager().register_view(view).await.unwrap();
+
+    let reason = UnavailableReason::ExceedsCalibratedEnvelope {
+        measured: 12_345,
+        limit: 1_000,
+    };
+    let state = ViewCacheState::Unavailable {
+        reason: reason.clone(),
+    };
+    db.db_ops()
+        .set_view_cache_state("EnvelopeRoundTrip", &state)
+        .await
+        .unwrap();
+
+    let loaded = db
+        .db_ops()
+        .get_view_cache_state("EnvelopeRoundTrip")
+        .await
+        .unwrap();
+    assert_eq!(loaded.unavailable_reason(), Some(&reason));
 }

--- a/tests/view_unavailable_test.rs
+++ b/tests/view_unavailable_test.rs
@@ -440,9 +440,9 @@ async fn exceeds_envelope_rejects_before_wasm_runs() {
                 "measured must exceed the limit (got {measured})"
             );
         }
-        other => panic!(
-            "expected ExceedsCalibratedEnvelope — WASM must NOT have run; got {other:?}"
-        ),
+        other => {
+            panic!("expected ExceedsCalibratedEnvelope — WASM must NOT have run; got {other:?}")
+        }
     }
 }
 

--- a/tests/view_wasm_integration_test.rs
+++ b/tests/view_wasm_integration_test.rs
@@ -102,6 +102,7 @@ async fn wasm_view_query_returns_transformed_output() {
         Some(WasmTransformSpec {
             bytes: hardcoded_wasm(),
             max_gas: 1_000_000,
+            gas_model: None,
         }),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );
@@ -156,6 +157,7 @@ async fn wasm_view_output_type_validation_works() {
         Some(WasmTransformSpec {
             bytes: hardcoded_wasm(),
             max_gas: 1_000_000,
+            gas_model: None,
         }), // Returns {"summary": {"k1": "hardcoded"}} — a String
         HashMap::from([("summary".to_string(), FieldValueType::Integer)]), // Declared as Integer
     );
@@ -209,6 +211,7 @@ async fn wasm_view_cache_invalidation_works() {
         Some(WasmTransformSpec {
             bytes: hardcoded_wasm(),
             max_gas: 1_000_000,
+            gas_model: None,
         }),
         HashMap::from([("summary".to_string(), FieldValueType::String)]),
     );

--- a/tests/view_write_test.rs
+++ b/tests/view_write_test.rs
@@ -127,6 +127,7 @@ async fn wasm_view_write_persists_override() {
         Some(WasmTransformSpec {
             bytes: vec![0, 1, 2],
             max_gas: 1_000_000,
+            gas_model: None,
         }), // Placeholder WASM — never executed on the write path.
         HashMap::from([("out".to_string(), FieldValueType::String)]),
     );
@@ -306,6 +307,7 @@ async fn concurrent_overrides_converge_via_lww() {
         Some(WasmTransformSpec {
             bytes: vec![0, 1, 2],
             max_gas: 1_000_000,
+            gas_model: None,
         }),
         HashMap::from([("out".to_string(), FieldValueType::String)]),
     );


### PR DESCRIPTION
## Summary

Adds the runtime envelope check that makes a view's calibrated gas model (from MDT-F Phase 1, schema_service#24) **rejective rather than advisory**. Before entering the WASM, the resolver sums measured input size along each `InputDimension` and — if the total exceeds `GasModel::max_input_size` — returns `Unavailable { reason: ExceedsCalibratedEnvelope }` without burning any fuel.

This is distinct from `GasExceeded` (a runtime fuel trap) and deterministic across devices because the measurement is over the input JSON shape, which every replayer sees identically.

## What's in the diff

**Types (`src/view/types.rs`)**
- New `FieldId`, `InputDimension`, `GasModel` — fold_db owns the canonical shape now; schema_service_core will adopt in a follow-up.
- `WasmTransformSpec::gas_model: Option<GasModel>` with `#[serde(default)]` so pre-Phase-2 views deserialize cleanly.
- New `UnavailableReason::ExceedsCalibratedEnvelope { measured, limit }` + `Display` rendering.

**Resolver (`src/view/resolver.rs`)**
- `measure_input`: free function that iterates coefficient dimensions and sums `FieldBytes` (serde_json byte length) or `FieldCount` (row count) over the relevant `(schema, field)` slice. Weights are irrelevant for the envelope check — they'll be used for budget derivation (task 3/3). `saturating_add` + fallback-to-0 on serde errors keep the check permissive.
- Envelope check lives between `all_query_results` population and the WASM execution branch. No new locks, no async structure changes (explicit anti-scope).

**Tests**
- 3 new integration tests in `view_unavailable_test.rs`:
  - `exceeds_envelope_rejects_before_wasm_runs` — oversized input plus a trapping WASM must surface `ExceedsCalibratedEnvelope` (NOT `ExecutionError`), proving short-circuit.
  - `below_envelope_proceeds_to_wasm` — small input reaches the trap, so reason is `ExecutionError`; pins the happy path.
  - `exceeds_envelope_state_persists_through_store` — new variant round-trips through the view-cache store.
- Updated `types.rs` unit tests: extended round-trip coverage to include the new variant, added `GasModel` serde round-trip, pinned legacy-deserialization for `gas_model: None`.

## Anti-scope

- **Not** wiring `gas_model` from `TransformRecord` into `WasmTransformSpec` — fold_db_node will do that in a later PR.
- **Not** deriving `max_gas` from the gas model (task 3/3, kanban aab64).
- **Not** touching schema_service.
- **No new mutexes or async refactoring** — previous attempt (b2d3f) stalled on a mutex-adjacent hang; this PR only adds the size-check between existing statements.

## Context

- MDT-A (fold_db#598) shipped the `Unavailable { reason }` base enum.
- MDT-E (fold_db#601) shipped `max_gas` fuel enforcement.
- MDT-F Phase 1 (schema_service#24) shipped the gas-model fit.

This PR composes cleanly with all three.

## Test plan

- [x] `cargo check -p fold_db --features transform-wasm`
- [x] `cargo clippy -p fold_db --all-targets --features transform-wasm -- -D warnings`
- [x] `cargo test -p fold_db --features transform-wasm view_unavailable_test` — 7/7 pass (incl. 3 new)
- [x] `cargo test -p fold_db --features transform-wasm view` — all view tests green
- [x] `cargo test -p fold_db --lib --features transform-wasm view::types::tests` — 10/10 pass (incl. 3 new/updated)
- [x] `cargo check --workspace` — downstream unaffected

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>