### PR TITLE
feat(sync): write-driven flush — wake coordinator on local writes

### DIFF
--- a/src/fold_db_core/sync_coordinator.rs
+++ b/src/fold_db_core/sync_coordinator.rs
@@ -83,12 +83,21 @@ impl SyncCoordinator {
             None => return,
         };
 
+        let wake = engine.wake_handle();
+
         let handle = tokio::spawn(async move {
             let base_interval = tokio::time::Duration::from_millis(interval_ms);
             let max_delay = MAX_OFFLINE_BACKOFF;
             let mut current_delay = base_interval;
             loop {
-                tokio::time::sleep(current_delay).await;
+                // Sleep up to `current_delay`, or wake early if a local write
+                // arrived. A write fires `engine.wake.notify_one()`, which
+                // resolves the `notified()` future and aborts the timeout so
+                // the flush happens near-immediately instead of waiting the
+                // full polling interval. `timeout` returns `Err` on the timer
+                // path and `Ok(())` on the wake path — either way, the same
+                // check-and-sync logic below fires.
+                let _ = tokio::time::timeout(current_delay, wake.notified()).await;
                 // Always run sync — even without pending writes, we need to
                 // download org data from other members.
                 let has_pending = engine.state().await == SyncState::Dirty;

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -237,6 +237,13 @@ pub struct SyncEngine {
     /// When set, the sync engine will call this on `SyncError::Auth`, update
     /// the `AuthClient`, and retry the sync cycle once before giving up.
     auth_refresh: Option<AuthRefreshCallback>,
+    /// Wake handle notified by `record_op` whenever a new local write appends
+    /// to the pending queue. The background sync coordinator races its next
+    /// sleep against this notification so a write can trigger a near-immediate
+    /// flush instead of waiting the full `sync_interval_ms`. A `Notify` holds
+    /// at most one pending notification across multiple writes — concurrent
+    /// writes coalesce into the next sync cycle naturally.
+    wake: Arc<tokio::sync::Notify>,
 }
 
 impl SyncEngine {
@@ -271,7 +278,16 @@ impl SyncEngine {
             schema_reloader: Arc::new(Mutex::new(None)),
             embedding_reloader: Arc::new(Mutex::new(None)),
             auth_refresh: None,
+            wake: Arc::new(tokio::sync::Notify::new()),
         }
+    }
+
+    /// Handle to the wake notification. The background sync coordinator holds
+    /// a clone and races its next sleep against `wake.notified()`, so local
+    /// writes can trigger an immediate sync cycle instead of waiting out the
+    /// full `sync_interval_ms`.
+    pub fn wake_handle(&self) -> Arc<tokio::sync::Notify> {
+        self.wake.clone()
     }
 
     /// Load persisted download cursors from storage.
@@ -416,6 +432,12 @@ impl SyncEngine {
         }
         drop(pending);
         self.set_state(SyncState::Dirty, None).await;
+        // Wake the background sync coordinator so a flush fires near-immediately
+        // instead of waiting out the full `sync_interval_ms`. Safe under burst
+        // writes: `Notify` holds at most one pending notification, so a rapid
+        // sequence of writes coalesces into a single early wake-up, and the
+        // subsequent sync cycle drains every pending entry in one batch.
+        self.wake.notify_one();
     }
 
     /// Record a put operation for sync.
@@ -2448,5 +2470,37 @@ mod tests {
             ),
             other => panic!("expected SyncError::Auth, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn record_put_notifies_wake_handle() {
+        // record_put must fire the wake notification so the background sync
+        // coordinator can flush immediately on local writes instead of waiting
+        // out the full sync interval. Without this, two devices writing to the
+        // same account see up to 2× sync_interval_ms of latency before the
+        // second device sees the first device's change.
+        let engine = make_auth_refresh_engine();
+        let wake = engine.wake_handle();
+
+        // Arm the notification listener BEFORE the write so we don't miss a
+        // notify_one that already fired (Notify only holds one pending).
+        let notified = wake.notified();
+        tokio::pin!(notified);
+
+        // Nothing should have fired yet.
+        assert!(
+            futures::future::poll_immediate(&mut notified)
+                .await
+                .is_none(),
+            "wake must be idle before any write"
+        );
+
+        // A single record_put fires notify_one.
+        engine.record_put("main", b"k", b"v").await;
+
+        // The pinned notified future must now be ready.
+        tokio::time::timeout(tokio::time::Duration::from_millis(50), notified)
+            .await
+            .expect("record_put must wake the coordinator within 50ms");
     }
 }


### PR DESCRIPTION
## Summary

The sync coordinator flushed pending writes only when its fixed \`sync_interval_ms\` timer fired (default 30s). A write at T+0 waited up to 30s to upload, and the peer waited up to another sync cycle to download — worst case ~60s of cross-device latency that should feel like seconds.

This PR adds a \`tokio::sync::Notify\` wake handle on \`SyncEngine\`:

- \`record_op\` fires \`wake.notify_one()\` after appending to pending and flipping state to \`Dirty\`.
- \`SyncCoordinator::start_background_sync\` grabs the wake handle and races the next sleep against \`wake.notified()\` via \`tokio::time::timeout\`. A write wakes the loop near-immediately; the same check-and-sync runs in both branches.

\`Notify\` holds at most one pending notification across multiple writes, so burst writes coalesce into a single early flush that drains the whole batch — no thundering herd.

Combined with the per-op exponential backoff from [#604](https://github.com/EdgeVector/fold_db/pull/604), the coordinator is now event-driven on the happy path and polite during outages.

Finding #4C from the multi-device sync eng review (gbrain \`projects/cloud-sync-activation-review\`).

## Test plan

- [x] New unit test \`record_put_notifies_wake_handle\` — passes
- [x] \`cargo test --lib sync::\` — 52/52 (51 existing + 1 new)
- [x] \`cargo test --lib fold_db_core::sync_coordinator\` — 3/3 from #604 still pass
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [ ] CI green
- [ ] Cascade: fold_db_node Cargo.lock bump after merge (batched with #604's cascade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)