### PR TITLE
feat(schema): add SchemaSource enum to track schema origin

### DIFF
--- a/src/schema/types/declarative_schemas.rs
+++ b/src/schema/types/declarative_schemas.rs
@@ -140,6 +140,8 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
             trust_domain: Option<String>,
             #[serde(default)]
             field_access_policies: HashMap<String, crate::access::types::FieldAccessPolicy>,
+            #[serde(default)]
+            source: SchemaSource,
         }
 
         // Deserialize into the helper struct
@@ -225,9 +227,44 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
         schema.org_hash = helper.org_hash;
         schema.trust_domain = helper.trust_domain;
         schema.field_access_policies = helper.field_access_policies;
+        schema.source = helper.source;
 
         Ok(schema)
     }
+}
+
+/// Origin of a schema in the service.
+///
+/// Everything the schema service pre-loads at startup is a **seed**. Seeds differ
+/// by ownership: `SystemSeed` schemas are service primitives that the code
+/// references by name (fingerprint subsystem, etc.) and must not be deleted;
+/// `StarterSeed` schemas are pre-classified starter buckets (e.g. Schema.org
+/// types) that users can adopt, fork, or ignore. `User` schemas are created by
+/// node operators via `/v1/schemas/propose` and are not seeds.
+///
+/// This field is `#[serde(default)]` so existing stored schemas without a
+/// `source` marker deserialize as `User`, which is the safe default (no
+/// service-side dependency implied).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, utoipa::ToSchema)]
+#[cfg_attr(feature = "ts-bindings", derive(TS))]
+#[cfg_attr(
+    feature = "ts-bindings",
+    ts(
+        export,
+        export_to = "bindings/src/fold_node/static-react/src/types/generated.ts"
+    )
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SchemaSource {
+    /// Service-owned primitive (fingerprint subsystem, canonical junction schemas, etc.).
+    /// Service code depends on these by name; must not be deleted.
+    SystemSeed,
+    /// Pre-classified starter bucket loaded at service startup (e.g. Schema.org types).
+    /// Safe to ignore, fork, or supersede with a user schema.
+    StarterSeed,
+    /// Node-created schema via `/v1/schemas/propose`. Default.
+    #[default]
+    User,
 }
 
 /// Declarative schema definition - the primary schema representation.
@@ -316,6 +353,11 @@ pub struct DeclarativeSchemaDefinition {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub field_access_policies: HashMap<String, crate::access::types::FieldAccessPolicy>,
 
+    /// Origin of this schema in the service. See [`SchemaSource`] for variants.
+    /// Existing stored schemas without this field deserialize as `User`.
+    #[serde(default)]
+    pub source: SchemaSource,
+
     // Runtime state fields (not serialized)
     /// Runtime field storage with molecules (for database operations)
     #[serde(skip)]
@@ -366,6 +408,7 @@ impl PartialEq for DeclarativeSchemaDefinition {
             && self.org_hash == other.org_hash
             && self.trust_domain == other.trust_domain
             && self.field_access_policies == other.field_access_policies
+            && self.source == other.source
         // Exclude runtime_fields, inputs_schema_fields, source_schemas, and hash mappings
         // These are derived/runtime state and don't affect schema identity
     }
@@ -533,6 +576,7 @@ impl DeclarativeSchemaDefinition {
             org_hash: None,
             trust_domain: None,
             field_access_policies: HashMap::new(),
+            source: SchemaSource::User,
             runtime_fields: HashMap::new(),
             inputs_schema_fields: Vec::new(),
             source_schemas: Vec::new(),
@@ -995,5 +1039,93 @@ mod tests {
             s1, s2,
             "schemas with different trust_domain should not be equal"
         );
+    }
+
+    #[test]
+    fn schema_source_default_is_user() {
+        assert_eq!(SchemaSource::default(), SchemaSource::User);
+    }
+
+    #[test]
+    fn schema_source_round_trips_through_serde() {
+        for variant in [
+            SchemaSource::SystemSeed,
+            SchemaSource::StarterSeed,
+            SchemaSource::User,
+        ] {
+            let json = serde_json::to_string(&variant).expect("serialize");
+            let back: SchemaSource = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(
+                variant, back,
+                "round-trip failed for {:?} (json: {})",
+                variant, json
+            );
+        }
+    }
+
+    #[test]
+    fn schema_source_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&SchemaSource::SystemSeed).unwrap(),
+            "\"system_seed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SchemaSource::StarterSeed).unwrap(),
+            "\"starter_seed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SchemaSource::User).unwrap(),
+            "\"user\""
+        );
+    }
+
+    #[test]
+    fn schema_missing_source_field_deserializes_as_user() {
+        // Existing stored schemas lack the source field; they must deserialize as User
+        // so we don't accidentally promote untagged schemas to SystemSeed / StarterSeed.
+        let json = r#"{
+            "name": "legacy",
+            "schema_type": "Single",
+            "fields": []
+        }"#;
+        let schema: DeclarativeSchemaDefinition = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(schema.source, SchemaSource::User);
+    }
+
+    #[test]
+    fn schema_preserves_source_through_round_trip() {
+        let mut schema = DeclarativeSchemaDefinition::new(
+            "test".to_string(),
+            SchemaType::Single,
+            None,
+            Some(vec![]),
+            None,
+            None,
+        );
+        schema.source = SchemaSource::StarterSeed;
+
+        let json = serde_json::to_string(&schema).expect("serialize");
+        let back: DeclarativeSchemaDefinition = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.source, SchemaSource::StarterSeed);
+    }
+
+    #[test]
+    fn schema_partial_eq_considers_source() {
+        let mut s1 = DeclarativeSchemaDefinition::new(
+            "test".to_string(),
+            SchemaType::Single,
+            None,
+            Some(vec![]),
+            None,
+            None,
+        );
+        let mut s2 = s1.clone();
+        assert_eq!(s1, s2);
+
+        s1.source = SchemaSource::SystemSeed;
+        assert_ne!(s1, s2, "schemas with different source should not be equal");
+
+        s2.source = SchemaSource::SystemSeed;
+        assert_eq!(s1, s2, "schemas with same source should be equal again");
     }
 }

--- a/src/schema/types/mod.rs
+++ b/src/schema/types/mod.rs
@@ -10,7 +10,9 @@ pub mod operations;
 pub mod schema;
 pub mod transform;
 pub use data_classification::DataClassification;
-pub use declarative_schemas::{DeclarativeSchemaDefinition, FieldDefinition, FieldMapper};
+pub use declarative_schemas::{
+    DeclarativeSchemaDefinition, FieldDefinition, FieldMapper, SchemaSource,
+};
 pub use errors::SchemaError;
 pub use field::{Field, FieldType, FieldVariant, RangeField, SingleField};
 pub use field_value_type::FieldValueType;


### PR DESCRIPTION
## Summary

Prep PR for the Schema.org starter-seed feature ([projects/schema-org-seeding](https://github.com/EdgeVector/exemem-workspace)).

Adds \`SchemaSource { SystemSeed, StarterSeed, User }\` and a \`source\` field on \`DeclarativeSchemaDefinition\` to distinguish:

- **SystemSeed** — service primitives (fingerprint subsystem, etc.). Service code depends on these by name; must not be deleted.
- **StarterSeed** — pre-classified starter buckets loaded at startup (future: Schema.org types). Safe to ignore, fork, or supersede.
- **User** — node-created via \`/v1/schemas/propose\`. Default.

## Why

Tom 2026-04-23: *"These are pre-loaded schemas, but they're not system schemas. They're just original seeds so that every user can have buckets that semantically fall into and that way there is less new schema generation for user onboarding."*

Today there is no way to distinguish the ~12 service-owned fingerprint schemas from user-proposed ones or from future starter buckets. This field adds that distinction without changing any existing behavior.

## Migration

The \`source\` field is \`#[serde(default)]\` — existing stored schemas without the marker deserialize as \`User\`, which is the safe default (no service-side dependency implied). No data migration needed. Follow-up PR in \`schema_service\` marks the 12 fingerprint schemas as \`SystemSeed\` explicitly.

## Test plan

- [x] \`cargo fmt\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] New unit tests: default value, serde round-trip, snake_case serialization, backwards-compat deserialization of schemas without the field, PartialEq includes the field
- [x] All 12 tests in the \`declarative_schemas::tests\` module pass
- [x] Full workspace test suite passes (pre-existing flake in \`test_purge_org_data\` is unrelated — confirmed on clean mainline)