### PR TITLE
chore(dev): committed cargo-fmt pre-commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Pre-commit hook: cargo fmt gate.
+#
+# Why this exists: CI runs `cargo fmt --all -- --check`. Forgetting to run
+# fmt locally before committing → push → PR fails CI → churn of manual
+# fmt-fix commits. This hook catches that at commit time.
+#
+# To install (idempotent): scripts/install-hooks.sh
+# To bypass (use sparingly): git commit --no-verify
+
+set -euo pipefail
+
+# Only gate when .rs files are staged.
+RS_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.rs$' || true)
+if [ -z "$RS_FILES" ]; then
+    exit 0
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "pre-commit: cargo not on PATH — skipping fmt check" >&2
+    exit 0
+fi
+
+if ! cargo fmt --all -- --check >/dev/null 2>&1; then
+    echo "pre-commit: cargo fmt --check FAILED." >&2
+    echo "pre-commit: run \`cargo fmt --all\`, re-stage, and commit again." >&2
+    echo "pre-commit: (or \`git commit --no-verify\` to skip — don't.)" >&2
+    exit 1
+fi
+
+exit 0

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
-set -e
+# Install the committed git hooks into this clone's .git/hooks/.
+# Idempotent — safe to re-run.
+#
+# Why committed hooks: keeps every checkout gated on `cargo fmt --check`
+# (and anything else we add to `hooks/`) without a separate tool like
+# husky or pre-commit. Each developer runs this once after clone.
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-HOOK_SRC="$SCRIPT_DIR/pre-commit"
-HOOK_DST="$REPO_DIR/.git/hooks/pre-commit"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_SRC="$REPO_ROOT/hooks"
 
-if [ ! -f "$HOOK_SRC" ]; then
-    echo "Error: pre-commit script not found at $HOOK_SRC"
-    exit 1
-fi
+# Resolve real .git dir (works for both regular repos and submodule worktrees).
+GITDIR=$(git -C "$REPO_ROOT" rev-parse --git-dir)
+case "$GITDIR" in
+    /*) HOOKS_DST="$GITDIR/hooks" ;;
+    *)  HOOKS_DST="$REPO_ROOT/$GITDIR/hooks" ;;
+esac
 
-cp "$HOOK_SRC" "$HOOK_DST"
-chmod +x "$HOOK_DST"
-echo "Pre-commit hook installed at $HOOK_DST"
+mkdir -p "$HOOKS_DST"
+for hook in "$HOOKS_SRC"/*; do
+    name=$(basename "$hook")
+    cp "$hook" "$HOOKS_DST/$name"
+    chmod +x "$HOOKS_DST/$name"
+    echo "installed: $HOOKS_DST/$name"
+done


### PR DESCRIPTION
## Summary

CI runs \`cargo fmt --all -- --check\` and blocks merges on drift. Adds a local pre-commit hook so this gets caught at commit time, not after push. Mirrors the same hook in fold_db_node.

- \`hooks/pre-commit\` — runs \`cargo fmt --all -- --check\` when any \`.rs\` file is staged.
- \`scripts/install-hooks.sh\` — idempotent copy into local \`.git/hooks/\`. Works for both regular clones and submodule worktrees.

Install once per clone: \`./scripts/install-hooks.sh\`. Bypass: \`git commit --no-verify\` (don't).

## Test plan

- [x] Hook installed locally, triggers on \`.rs\` commits, no-op on doc commits.
- [ ] CI green (doc-only change, no code impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)