### PR TITLE
fix(sync): skip contiguity check on personal downloads (multi-device)

### DIFF
--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1001,35 +1001,50 @@ impl SyncEngine {
             .collect();
         new_seqs.sort();
 
-        // Loud-failure invariant: once we see any new seq, the set of new
-        // seqs must be contiguous (no holes between the smallest and
-        // largest). A hole here means S3 returned a partial view of the log
-        // — the exact silent-drop pattern 30a7b produced — and would cause
-        // `max_contiguous_seq` to advance past a seq that later appears.
-        if let (Some(&first), Some(&last)) = (new_seqs.first(), new_seqs.last()) {
-            let expected = (last - first + 1) as usize;
-            if new_seqs.len() != expected {
-                let set: std::collections::BTreeSet<u64> = new_seqs.iter().copied().collect();
-                let missing: Vec<u64> = (first..=last).filter(|s| !set.contains(s)).collect();
-                log::error!(
-                    "sync list '{}' returned non-contiguous seqs after cursor={}: first={} last={} count={} expected={} missing_sample={:?}",
-                    target.label,
-                    cursor,
-                    first,
-                    last,
-                    new_seqs.len(),
-                    expected,
-                    missing.iter().take(16).collect::<Vec<_>>()
-                );
-                return Err(SyncError::S3(format!(
-                    "non-contiguous log listing for '{}': cursor={} got {} seqs in range {}..={} (expected {})",
-                    target.label,
-                    cursor,
-                    new_seqs.len(),
-                    first,
-                    last,
-                    expected
-                )));
+        // Loud-failure invariant: for ORG prefixes, the set of new seqs must
+        // be contiguous (no holes between the smallest and largest) because
+        // org seqs are server-allocated in atomic blocks. A hole there means
+        // S3 returned a partial view of the log — the exact silent-drop
+        // pattern 30a7b produced — and would cause `max_contiguous_seq` to
+        // advance past a seq that later appears.
+        //
+        // PERSONAL prefixes (empty prefix) use client-assigned nanosecond
+        // timestamps, so the seq space is inherently sparse: a device writes
+        // at T1, then again at T1+100000, and the listing has "gaps" of
+        // hundreds of thousands of unused seq values between them. The
+        // contiguity check can't distinguish natural sparseness from S3
+        // dropping a seq, so it's skipped for personal and we trust the
+        // listing's completeness (typical path) plus cursor-replay semantics
+        // (missed seqs re-appear in future listings because cursor only
+        // advances to seqs we saw). See `designs/unified_sync.md` for the
+        // personal-vs-org split rationale.
+        let is_org_prefix = !target.prefix.is_empty();
+        if is_org_prefix {
+            if let (Some(&first), Some(&last)) = (new_seqs.first(), new_seqs.last()) {
+                let expected = (last - first + 1) as usize;
+                if new_seqs.len() != expected {
+                    let set: std::collections::BTreeSet<u64> = new_seqs.iter().copied().collect();
+                    let missing: Vec<u64> = (first..=last).filter(|s| !set.contains(s)).collect();
+                    log::error!(
+                        "sync list '{}' returned non-contiguous seqs after cursor={}: first={} last={} count={} expected={} missing_sample={:?}",
+                        target.label,
+                        cursor,
+                        first,
+                        last,
+                        new_seqs.len(),
+                        expected,
+                        missing.iter().take(16).collect::<Vec<_>>()
+                    );
+                    return Err(SyncError::S3(format!(
+                        "non-contiguous log listing for '{}': cursor={} got {} seqs in range {}..={} (expected {})",
+                        target.label,
+                        cursor,
+                        new_seqs.len(),
+                        first,
+                        last,
+                        expected
+                    )));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Follow-up to [#607](https://github.com/EdgeVector/fold_db/pull/607). After #607 made the engine poll personal targets on every sync cycle, the contiguity invariant at the top of \`download_entries\` fires every time on personal: personal seqs are client-assigned nanosecond timestamps, inherently sparse (writes separated by any wall-clock delta → huge gaps). The check can't tell natural sparseness from a partial S3 listing, so for personal it's a pure false-positive.

Gate the check on \`!target.prefix.is_empty()\` — still runs for org, where server-allocated contiguous seq blocks make the invariant meaningful. For personal, trust the listing's pagination + cursor-replay: cursor only advances past seqs we saw, so a missed seq simply re-appears in a future listing.

## Where this was caught

Live dogfood right after #666 landed. Node A wrote an identity card, sync cycle fired, upload succeeded. Then the same cycle's download-from-personal blew up with:

\`\`\`
non-contiguous log listing for 'personal':
cursor=0 got 14 seqs in range 1776991635427590000..=1776991635809020000
(expected 381430001)
\`\`\`

The nanosecond gap between the 14 writes translated into a 380-million-seq "expected" count.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --lib sync::\` — 52/52 pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [ ] CI green
- [ ] Dogfood re-run: personal downloads should succeed on every cycle; Node A sees Node B's writes via sync log

🤖 Generated with [Claude Code](https://claude.com/claude-code)