### PR TITLE
fix(sync): coordinator always polls when engine is configured

### DIFF
--- a/src/fold_db_core/sync_coordinator.rs
+++ b/src/fold_db_core/sync_coordinator.rs
@@ -98,16 +98,16 @@ impl SyncCoordinator {
                 // path and `Ok(())` on the wake path — either way, the same
                 // check-and-sync logic below fires.
                 let _ = tokio::time::timeout(current_delay, wake.notified()).await;
-                // Always run sync — even without pending writes, we need to
-                // download org data from other members.
-                let has_pending = engine.state().await == SyncState::Dirty;
-                let has_orgs = engine.has_org_sync().await;
-                if !(has_pending || has_orgs) {
-                    // Nothing to sync. Keep polling at the configured interval.
-                    current_delay = base_interval;
-                    continue;
-                }
-
+                // Always call sync() when a sync engine is configured. A
+                // passive reader on a personal prefix (another device
+                // restored from the same mnemonic) needs the poll to see
+                // peer writes, even when locally clean and without org
+                // memberships. Previous "skip if nothing to upload and no
+                // orgs" check broke multi-device convergence — it matched
+                // an equivalent bailout inside `sync()` that #607 removed,
+                // but that was only half the fix. `sync()` is cheap on a
+                // no-op cycle (one list request per target with an
+                // already-advanced cursor → typically 0 matches).
                 match engine.sync().await {
                     Ok(_) => {
                         // Success: reset backoff.


### PR DESCRIPTION
## Summary

Third piece of the multi-device personal-download fix:

- [#607](https://github.com/EdgeVector/fold_db/pull/607) removed the \`if Idle && !has_orgs { skip }\` bailout **inside** \`sync()\`
- [#609](https://github.com/EdgeVector/fold_db/pull/609) fixed the contiguity-check false positive on personal nanosecond seqs
- This PR removes the **same bailout** from **outside** \`sync()\` in the coordinator. Without this, the engine never gets called in the first place when the device is idle + has no orgs.

## Reproducer

Live dogfood right after #609 shipped:
1. Node B restored from mnemonic, bootstrap ran
2. Node A wrote an identity card update
3. Node B's \`last_sync_at\` stayed frozen — coordinator hit the outer \`continue\` at line 105 on every tick

The bailout was well-intentioned ("nothing to sync, don't ping S3") but broke the multi-device story: a passive device reading from the shared personal prefix HAS to poll. \`sync()\` on an idle cycle is cheap — one list request per target against an already-advanced cursor is typically a 200ms no-op.

## Test plan

- [x] \`cargo test --lib fold_db_core::sync_coordinator\` — 3/3 (existing coordinator tests still green)
- [x] \`cargo test --lib sync::\` — 52/52
- [x] \`cargo fmt + cargo clippy\` clean
- [ ] CI green
- [ ] Dogfood: Node B picks up Node A's writes in next 30s cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)