### PR TITLE
feat(atom): wire Provenance::User through Molecule, AtomEntry, MutationEvent (molecule-provenance-dag PR 5/6)

### DIFF
--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -32,6 +32,13 @@ pub struct AtomEntry {
     /// Signature scheme version (1 = hand-rolled canonical concat).
     #[serde(default)]
     pub signature_version: u8,
+    /// Writer identity and verifiability info. Additive during the
+    /// `projects/molecule-provenance-dag` migration: `None` on pre-PR-5
+    /// entries; `Some(Provenance::User{..})` on signed entries. Kept
+    /// alongside `writer_pubkey` / `signature` (not in place of) until a
+    /// follow-up PR removes them after full wire-through.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<Provenance>,
 }
 
 /// Returns the current time in nanoseconds since the Unix epoch.
@@ -70,4 +77,105 @@ pub struct KeyMetadata {
     pub source_file_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<std::collections::HashMap<String, String>>,
+}
+
+#[cfg(test)]
+mod atom_entry_provenance_tests {
+    //! molecule-provenance-dag PR 5 — additive `AtomEntry.provenance`.
+
+    use super::*;
+
+    /// Pre-PR-5 on-disk shape — no `provenance` field. Deserializes to
+    /// `None` and re-serializes byte-for-byte identical.
+    const GOLDEN_PRE_PR5_ATOM_ENTRY_JSON: &str = r#"{"atom_uuid":"atom-1","written_at":42,"writer_pubkey":"","signature":"","signature_version":0}"#;
+
+    #[test]
+    fn pre_pr5_atom_entry_json_round_trips_unchanged() {
+        let parsed: AtomEntry = serde_json::from_str(GOLDEN_PRE_PR5_ATOM_ENTRY_JSON)
+            .expect("deserialize pre-PR-5 atom entry");
+        assert!(parsed.provenance.is_none());
+        let reserialized = serde_json::to_string(&parsed).expect("serialize");
+        assert_eq!(reserialized, GOLDEN_PRE_PR5_ATOM_ENTRY_JSON);
+    }
+
+    #[test]
+    fn atom_entry_round_trips_with_provenance_user() {
+        let entry = AtomEntry {
+            atom_uuid: "atom-1".to_string(),
+            written_at: 7,
+            writer_pubkey: "pk".to_string(),
+            signature: "sig".to_string(),
+            signature_version: 1,
+            provenance: Some(Provenance::user("pk".to_string(), "sig".to_string())),
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(json.contains(r#""provenance":{"kind":"user""#));
+        let back: AtomEntry = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, entry);
+    }
+
+    /// Signed range insert must populate `Provenance::User` with the same
+    /// pubkey and signature that land in the legacy fields. The
+    /// consistency property — `writer_pubkey == Provenance::User.pubkey`
+    /// when both are populated — is what the drift debug-assert on
+    /// Molecule protects; entries don't have a helper of their own yet,
+    /// but the invariant is the same and is checked here.
+    #[test]
+    fn molecule_range_signed_entry_provenance_matches_legacy_fields() {
+        let kp = crate::security::Ed25519KeyPair::generate().unwrap();
+        let mut mol = crate::atom::MoleculeRange::new("s", "f");
+        mol.set_atom_uuid("k1".to_string(), "atom-1".to_string(), &kp);
+        let entry = mol.get_atom_entry("k1").expect("entry present");
+        match entry.provenance.as_ref().expect("signed entry has provenance") {
+            Provenance::User {
+                pubkey,
+                signature,
+                signature_version,
+            } => {
+                assert_eq!(pubkey, &entry.writer_pubkey);
+                assert_eq!(signature, &entry.signature);
+                assert_eq!(*signature_version, 1);
+            }
+            _ => panic!("expected User variant"),
+        }
+    }
+
+    #[test]
+    fn molecule_hash_signed_entry_provenance_matches_legacy_fields() {
+        let kp = crate::security::Ed25519KeyPair::generate().unwrap();
+        let mut mol = crate::atom::MoleculeHash::new("s", "f");
+        mol.set_atom_uuid("k1".to_string(), "atom-1".to_string(), &kp);
+        let entry = mol.get_atom_entry("k1").expect("entry present");
+        match entry.provenance.as_ref().expect("signed entry has provenance") {
+            Provenance::User {
+                pubkey, signature, ..
+            } => {
+                assert_eq!(pubkey, &entry.writer_pubkey);
+                assert_eq!(signature, &entry.signature);
+            }
+            _ => panic!("expected User variant"),
+        }
+    }
+
+    #[test]
+    fn molecule_hash_range_signed_entry_provenance_matches_legacy_fields() {
+        let kp = crate::security::Ed25519KeyPair::generate().unwrap();
+        let mut mol = crate::atom::MoleculeHashRange::new("s", "f");
+        mol.set_atom_uuid_from_values(
+            "h1".to_string(),
+            "r1".to_string(),
+            "atom-1".to_string(),
+            &kp,
+        );
+        let entry = mol.get_atom_entry("h1", "r1").expect("entry present");
+        match entry.provenance.as_ref().expect("signed entry has provenance") {
+            Provenance::User {
+                pubkey, signature, ..
+            } => {
+                assert_eq!(pubkey, &entry.writer_pubkey);
+                assert_eq!(signature, &entry.signature);
+            }
+            _ => panic!("expected User variant"),
+        }
+    }
 }

--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -126,7 +126,11 @@ mod atom_entry_provenance_tests {
         let mut mol = crate::atom::MoleculeRange::new("s", "f");
         mol.set_atom_uuid("k1".to_string(), "atom-1".to_string(), &kp);
         let entry = mol.get_atom_entry("k1").expect("entry present");
-        match entry.provenance.as_ref().expect("signed entry has provenance") {
+        match entry
+            .provenance
+            .as_ref()
+            .expect("signed entry has provenance")
+        {
             Provenance::User {
                 pubkey,
                 signature,
@@ -146,7 +150,11 @@ mod atom_entry_provenance_tests {
         let mut mol = crate::atom::MoleculeHash::new("s", "f");
         mol.set_atom_uuid("k1".to_string(), "atom-1".to_string(), &kp);
         let entry = mol.get_atom_entry("k1").expect("entry present");
-        match entry.provenance.as_ref().expect("signed entry has provenance") {
+        match entry
+            .provenance
+            .as_ref()
+            .expect("signed entry has provenance")
+        {
             Provenance::User {
                 pubkey, signature, ..
             } => {
@@ -168,7 +176,11 @@ mod atom_entry_provenance_tests {
             &kp,
         );
         let entry = mol.get_atom_entry("h1", "r1").expect("entry present");
-        match entry.provenance.as_ref().expect("signed entry has provenance") {
+        match entry
+            .provenance
+            .as_ref()
+            .expect("signed entry has provenance")
+        {
             Provenance::User {
                 pubkey, signature, ..
             } => {

--- a/src/atom/molecule.rs
+++ b/src/atom/molecule.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{deterministic_molecule_uuid, now_nanos, MergeConflict};
+use crate::atom::provenance::Provenance;
 use crate::security::Ed25519KeyPair;
 
 /// A reference to a single atom version.
@@ -29,6 +30,16 @@ pub struct Molecule {
     /// Signature scheme version (1 = hand-rolled canonical concat).
     #[serde(default)]
     signature_version: u8,
+    /// Writer identity and verifiability info. Additive during the
+    /// `projects/molecule-provenance-dag` migration: `None` on pre-PR-5
+    /// molecules; `Some(Provenance::User{..})` once the signing path
+    /// populates it. Kept alongside `writer_pubkey` / `signature` /
+    /// `signature_version` (not in place of) until a follow-up PR removes
+    /// them after full wire-through. NOT included in the canonical signed
+    /// bytes — it duplicates pubkey + signature in a typed form and must
+    /// not perturb the signature verification payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provenance: Option<Provenance>,
 }
 
 impl Molecule {
@@ -46,6 +57,7 @@ impl Molecule {
             writer_pubkey: String::new(),
             signature: String::new(),
             signature_version: 0,
+            provenance: None,
         }
     }
 
@@ -79,9 +91,11 @@ impl Molecule {
             self.written_at,
         );
         let (sig, pubkey) = crate::security::sign_molecule_update(&canonical, keypair);
-        self.signature = sig;
-        self.writer_pubkey = pubkey;
+        self.signature = sig.clone();
+        self.writer_pubkey = pubkey.clone();
         self.signature_version = 1;
+        self.provenance = Some(Provenance::user(pubkey, sig));
+        self.debug_assert_provenance_consistent();
     }
 
     /// Returns the version counter for this molecule.
@@ -142,6 +156,40 @@ impl Molecule {
     #[must_use]
     pub fn signature_version(&self) -> u8 {
         self.signature_version
+    }
+
+    /// Returns the typed provenance, when populated.
+    ///
+    /// Additive metadata alongside `writer_pubkey` / `signature` during the
+    /// `projects/molecule-provenance-dag` migration. `None` on molecules
+    /// written before PR 5 (or never signed).
+    #[must_use]
+    pub fn provenance(&self) -> Option<&Provenance> {
+        self.provenance.as_ref()
+    }
+
+    /// Debug-only assertion that `provenance` and the legacy
+    /// `writer_pubkey` / `signature` fields agree when both are populated.
+    ///
+    /// During the migration window `Provenance::User` duplicates the
+    /// existing fields. If a code path sets one and not the other — or
+    /// sets them to different values — that drift is a bug. In debug
+    /// builds this fires on the spot; in release it compiles out.
+    fn debug_assert_provenance_consistent(&self) {
+        debug_assert!(
+            matches!(
+                &self.provenance,
+                Some(Provenance::User {
+                    pubkey,
+                    signature,
+                    ..
+                }) if pubkey == &self.writer_pubkey && signature == &self.signature
+            ),
+            "Molecule.provenance drift: writer_pubkey={:?} signature={:?} provenance={:?}",
+            self.writer_pubkey,
+            self.signature,
+            self.provenance
+        );
     }
 
     /// Builds canonical bytes for signing/verification.
@@ -215,9 +263,11 @@ impl Molecule {
             self.written_at,
         );
         let (sig, pubkey) = crate::security::sign_molecule_update(&canonical, keypair);
-        self.signature = sig;
-        self.writer_pubkey = pubkey;
+        self.signature = sig.clone();
+        self.writer_pubkey = pubkey.clone();
         self.signature_version = 1;
+        self.provenance = Some(Provenance::user(pubkey, sig));
+        self.debug_assert_provenance_consistent();
 
         Some(MergeConflict {
             key: "single".to_string(),
@@ -341,5 +391,99 @@ mod tests {
     fn test_unsigned_molecule_verify_returns_false() {
         let mol = Molecule::new("atom-1".to_string(), "s", "f");
         assert!(!mol.verify(), "unsigned molecule should not verify");
+    }
+
+    // ------------------------------------------------------------------
+    // molecule-provenance-dag PR 5 — additive `provenance: Option<Provenance>`.
+    // ------------------------------------------------------------------
+
+    /// Pre-PR-5 serialized shape — no `provenance` field. This is what sits
+    /// in every sync log and every on-disk molecule written before the
+    /// migration. It must deserialize cleanly into `provenance: None` and
+    /// re-serialize byte-for-byte identical.
+    const GOLDEN_PRE_PR5_MOLECULE_JSON: &str = r#"{"molecule_uuid":"mol-1","atom_uuid":"atom-1","written_at":42,"updated_at":"2026-01-01T00:00:00Z","version":1,"writer_pubkey":"","signature":"","signature_version":0}"#;
+
+    #[test]
+    fn pre_pr5_molecule_json_round_trips_unchanged() {
+        let parsed: Molecule = serde_json::from_str(GOLDEN_PRE_PR5_MOLECULE_JSON)
+            .expect("deserialize pre-PR-5 molecule shape");
+        assert!(parsed.provenance().is_none());
+        let reserialized = serde_json::to_string(&parsed).expect("serialize");
+        assert_eq!(reserialized, GOLDEN_PRE_PR5_MOLECULE_JSON);
+    }
+
+    #[test]
+    fn molecule_round_trips_with_provenance_user() {
+        let kp = test_keypair();
+        let mut mol = Molecule::new("atom-1".to_string(), "s", "f");
+        mol.set_atom_uuid("atom-2".to_string(), &kp);
+        assert!(matches!(mol.provenance(), Some(Provenance::User { .. })));
+        let json = serde_json::to_string(&mol).expect("serialize");
+        assert!(json.contains(r#""provenance":{"kind":"user""#));
+        let back: Molecule = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.provenance(), mol.provenance());
+    }
+
+    /// When a molecule is signed via `set_atom_uuid`, the `Provenance::User`
+    /// value must match the legacy `writer_pubkey` / `signature` fields.
+    /// This is the whole point of the additive migration.
+    #[test]
+    fn set_atom_uuid_populates_provenance_user_matching_legacy_fields() {
+        let kp = test_keypair();
+        let mut mol = Molecule::new("atom-1".to_string(), "s", "f");
+        mol.set_atom_uuid("atom-2".to_string(), &kp);
+        let prov = mol.provenance().expect("signed molecule has provenance");
+        match prov {
+            Provenance::User {
+                pubkey,
+                signature,
+                signature_version,
+            } => {
+                assert_eq!(pubkey, mol.writer_pubkey());
+                assert_eq!(signature, mol.signature());
+                assert_eq!(*signature_version, 1);
+            }
+            _ => panic!("expected User variant"),
+        }
+    }
+
+    /// `merge`'s sign-after-merge path must populate provenance too,
+    /// matching the merged-in signature.
+    #[test]
+    fn merge_populates_provenance_user_matching_legacy_fields() {
+        let kp = test_keypair();
+        let mut mol1 = Molecule::new("atom-1".to_string(), "s", "f");
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        let mol2 = Molecule::new("atom-2".to_string(), "s", "f");
+        mol1.merge(&mol2, &kp).expect("should conflict");
+        let prov = mol1.provenance().expect("merge-signed molecule has provenance");
+        match prov {
+            Provenance::User {
+                pubkey, signature, ..
+            } => {
+                assert_eq!(pubkey, mol1.writer_pubkey());
+                assert_eq!(signature, mol1.signature());
+            }
+            _ => panic!("expected User variant"),
+        }
+    }
+
+    /// Adding `provenance` must not change the canonical signed bytes.
+    /// The canonical bytes commit to `molecule_uuid | atom_uuid | version |
+    /// written_at`; anything else included there invalidates every
+    /// pre-existing signature. Pinned with a known hex vector.
+    #[test]
+    fn canonical_bytes_are_not_affected_by_provenance_field() {
+        let bytes = Molecule::build_canonical_bytes("mol-x", "atom-x", 3, 0x0102_0304_0506_0708_u64);
+        let expected: Vec<u8> = [
+            b"mol-x".as_slice(),
+            &[0x00],
+            b"atom-x".as_slice(),
+            &[0x00],
+            &[0, 0, 0, 0, 0, 0, 0, 3],
+            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
+        ]
+        .concat();
+        assert_eq!(bytes, expected);
     }
 }

--- a/src/atom/molecule.rs
+++ b/src/atom/molecule.rs
@@ -456,7 +456,9 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(1));
         let mol2 = Molecule::new("atom-2".to_string(), "s", "f");
         mol1.merge(&mol2, &kp).expect("should conflict");
-        let prov = mol1.provenance().expect("merge-signed molecule has provenance");
+        let prov = mol1
+            .provenance()
+            .expect("merge-signed molecule has provenance");
         match prov {
             Provenance::User {
                 pubkey, signature, ..
@@ -474,7 +476,8 @@ mod tests {
     /// pre-existing signature. Pinned with a known hex vector.
     #[test]
     fn canonical_bytes_are_not_affected_by_provenance_field() {
-        let bytes = Molecule::build_canonical_bytes("mol-x", "atom-x", 3, 0x0102_0304_0506_0708_u64);
+        let bytes =
+            Molecule::build_canonical_bytes("mol-x", "atom-x", 3, 0x0102_0304_0506_0708_u64);
         let expected: Vec<u8> = [
             b"mol-x".as_slice(),
             &[0x00],

--- a/src/atom/molecule_hash.rs
+++ b/src/atom/molecule_hash.rs
@@ -62,9 +62,10 @@ impl MoleculeHash {
             AtomEntry {
                 atom_uuid,
                 written_at,
-                writer_pubkey: pubkey,
-                signature: sig,
+                writer_pubkey: pubkey.clone(),
+                signature: sig.clone(),
                 signature_version: 1,
+                provenance: Some(super::Provenance::user(pubkey, sig)),
             },
         );
         self.updated_at = Utc::now();
@@ -132,6 +133,7 @@ impl MoleculeHash {
                 writer_pubkey: String::new(),
                 signature: String::new(),
                 signature_version: 0,
+                provenance: None,
             },
         );
         self.updated_at = Utc::now();

--- a/src/atom/molecule_hash_range.rs
+++ b/src/atom/molecule_hash_range.rs
@@ -86,6 +86,7 @@ impl MoleculeHashRange {
                                 writer_pubkey: String::new(),
                                 signature: String::new(),
                                 signature_version: 0,
+                                provenance: None,
                             },
                         )
                     })
@@ -149,9 +150,10 @@ impl MoleculeHashRange {
             AtomEntry {
                 atom_uuid,
                 written_at,
-                writer_pubkey: pubkey,
-                signature: sig,
+                writer_pubkey: pubkey.clone(),
+                signature: sig.clone(),
                 signature_version: 1,
+                provenance: Some(super::Provenance::user(pubkey, sig)),
             },
         );
         self.updated_at = Utc::now();
@@ -186,9 +188,10 @@ impl MoleculeHashRange {
             AtomEntry {
                 atom_uuid,
                 written_at,
-                writer_pubkey: pubkey,
-                signature: sig,
+                writer_pubkey: pubkey.clone(),
+                signature: sig.clone(),
                 signature_version: 1,
+                provenance: Some(super::Provenance::user(pubkey, sig)),
             },
         );
         self.updated_at = Utc::now();
@@ -334,6 +337,7 @@ impl MoleculeHashRange {
                 writer_pubkey: String::new(),
                 signature: String::new(),
                 signature_version: 0,
+                provenance: None,
             },
         );
         self.updated_at = Utc::now();

--- a/src/atom/molecule_range.rs
+++ b/src/atom/molecule_range.rs
@@ -68,9 +68,10 @@ impl MoleculeRange {
             AtomEntry {
                 atom_uuid,
                 written_at,
-                writer_pubkey: pubkey,
-                signature: sig,
+                writer_pubkey: pubkey.clone(),
+                signature: sig.clone(),
                 signature_version: 1,
+                provenance: Some(super::Provenance::user(pubkey, sig)),
             },
         );
         self.updated_at = Utc::now();
@@ -133,6 +134,7 @@ impl MoleculeRange {
                 writer_pubkey: String::new(),
                 signature: String::new(),
                 signature_version: 0,
+                provenance: None,
             },
         );
         self.updated_at = Utc::now();

--- a/src/atom/mutation_event.rs
+++ b/src/atom/mutation_event.rs
@@ -1,3 +1,4 @@
+use crate::atom::provenance::Provenance;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +26,13 @@ pub struct MutationEvent {
     /// Base64-encoded Ed25519 signature from the molecule at the time of the mutation.
     #[serde(default)]
     pub signature: String,
+    /// Writer identity and verifiability info. Additive during the
+    /// `projects/molecule-provenance-dag` migration: propagated from the
+    /// originating `Mutation.provenance` when available; `None` otherwise
+    /// (including for merge-conflict-originated events). Kept alongside
+    /// `writer_pubkey` / `signature` until a follow-up PR removes them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<Provenance>,
 }
 
 /// Identifies which slot in the molecule was changed
@@ -53,6 +61,7 @@ mod tests {
             conflict_loser_atom: None,
             writer_pubkey: String::new(),
             signature: String::new(),
+            provenance: None,
         };
 
         let json = serde_json::to_string(&event).unwrap();
@@ -97,6 +106,7 @@ mod tests {
             conflict_loser_atom: None,
             writer_pubkey: String::new(),
             signature: String::new(),
+            provenance: None,
         };
 
         let json = serde_json::to_string(&event).unwrap();
@@ -119,6 +129,7 @@ mod tests {
             conflict_loser_atom: None,
             writer_pubkey: String::new(),
             signature: String::new(),
+            provenance: None,
         };
 
         let ts = event.timestamp.timestamp_nanos_opt().unwrap_or(0);
@@ -129,5 +140,44 @@ mod tests {
         // Timestamp part should be 20 digits (zero-padded)
         let parts: Vec<&str> = key.splitn(3, ':').collect();
         assert_eq!(parts[2].len(), 20);
+    }
+
+    // ------------------------------------------------------------------
+    // molecule-provenance-dag PR 5 — additive `provenance: Option<Provenance>`.
+    // ------------------------------------------------------------------
+
+    /// Pre-PR-5 serialized shape — no `provenance` field. Deserializes to
+    /// `None` and re-serializes byte-for-byte identical. Using a fixed
+    /// epoch timestamp so the literal is stable.
+    const GOLDEN_PRE_PR5_MUTATION_EVENT_JSON: &str = r#"{"molecule_uuid":"mol-1","timestamp":"2026-01-01T00:00:00Z","field_key":"Single","old_atom_uuid":null,"new_atom_uuid":"atom-1","version":0,"is_conflict":false,"writer_pubkey":"","signature":""}"#;
+
+    #[test]
+    fn pre_pr5_mutation_event_json_round_trips_unchanged() {
+        let parsed: MutationEvent = serde_json::from_str(GOLDEN_PRE_PR5_MUTATION_EVENT_JSON)
+            .expect("deserialize pre-PR-5 mutation event");
+        assert!(parsed.provenance.is_none());
+        let reserialized = serde_json::to_string(&parsed).expect("serialize");
+        assert_eq!(reserialized, GOLDEN_PRE_PR5_MUTATION_EVENT_JSON);
+    }
+
+    #[test]
+    fn mutation_event_round_trips_with_provenance_user() {
+        let event = MutationEvent {
+            molecule_uuid: "mol-1".to_string(),
+            timestamp: Utc::now(),
+            field_key: FieldKey::Single,
+            old_atom_uuid: None,
+            new_atom_uuid: "atom-1".to_string(),
+            version: 0,
+            is_conflict: false,
+            conflict_loser_atom: None,
+            writer_pubkey: "pk".to_string(),
+            signature: "sig".to_string(),
+            provenance: Some(Provenance::user("pk".to_string(), "sig".to_string())),
+        };
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert!(json.contains(r#""provenance":{"kind":"user""#));
+        let back: MutationEvent = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.provenance, event.provenance);
     }
 }

--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -737,6 +737,12 @@ impl MutationManager {
                         conflict_loser_atom: None,
                         writer_pubkey: String::new(),
                         signature: String::new(),
+                        // Propagate the originating mutation's provenance onto
+                        // the event. If the mutation was submitted with a
+                        // signature (`Some(Provenance::User{..})`), the event
+                        // records it; otherwise `None`, matching pre-PR-5
+                        // behavior.
+                        provenance: mutation.provenance.clone(),
                     });
                 }
             }

--- a/src/schema/types/field/variant.rs
+++ b/src/schema/types/field/variant.rs
@@ -400,6 +400,7 @@ mod tests {
                 conflict_loser_atom: None,
                 writer_pubkey: String::new(),
                 signature: String::new(),
+                provenance: None,
             },
             MutationEvent {
                 molecule_uuid: mol_uuid.to_string(),
@@ -412,6 +413,7 @@ mod tests {
                 conflict_loser_atom: None,
                 writer_pubkey: String::new(),
                 signature: String::new(),
+                provenance: None,
             },
         ];
         db_ops
@@ -460,6 +462,7 @@ mod tests {
             conflict_loser_atom: None,
             writer_pubkey: String::new(),
             signature: String::new(),
+            provenance: None,
         }];
         db_ops
             .batch_store_mutation_events(events, None)
@@ -509,6 +512,7 @@ mod tests {
                 conflict_loser_atom: None,
                 writer_pubkey: String::new(),
                 signature: String::new(),
+                provenance: None,
             },
             MutationEvent {
                 molecule_uuid: mol_uuid.to_string(),
@@ -523,6 +527,7 @@ mod tests {
                 conflict_loser_atom: None,
                 writer_pubkey: String::new(),
                 signature: String::new(),
+                provenance: None,
             },
         ];
         db_ops
@@ -578,6 +583,7 @@ mod tests {
                 conflict_loser_atom: None,
                 writer_pubkey: String::new(),
                 signature: String::new(),
+                provenance: None,
             },
             MutationEvent {
                 molecule_uuid: mol_uuid.to_string(),
@@ -593,6 +599,7 @@ mod tests {
                 conflict_loser_atom: None,
                 writer_pubkey: String::new(),
                 signature: String::new(),
+                provenance: None,
             },
         ];
         db_ops
@@ -646,6 +653,7 @@ mod tests {
                 conflict_loser_atom: None,
                 writer_pubkey: String::new(),
                 signature: String::new(),
+                provenance: None,
             },
             MutationEvent {
                 molecule_uuid: mol_uuid.to_string(),
@@ -658,6 +666,7 @@ mod tests {
                 conflict_loser_atom: None,
                 writer_pubkey: String::new(),
                 signature: String::new(),
+                provenance: None,
             },
             MutationEvent {
                 molecule_uuid: mol_uuid.to_string(),
@@ -670,6 +679,7 @@ mod tests {
                 conflict_loser_atom: None,
                 writer_pubkey: String::new(),
                 signature: String::new(),
+                provenance: None,
             },
         ];
         db_ops

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1781,6 +1781,10 @@ impl SyncEngine {
                 conflict_loser_atom: Some(conflict.loser_atom.clone()),
                 writer_pubkey: String::new(),
                 signature: String::new(),
+                // Conflict-originated events are synthesized during merge
+                // resolution and have no originating user mutation in scope;
+                // leave provenance `None`.
+                provenance: None,
             };
             let event_key = format!("history:{}:{:020}", mol_uuid, ts_nanos);
             let event_bytes = serde_json::to_vec(&event)?;

--- a/tests/mutation_provenance_test.rs
+++ b/tests/mutation_provenance_test.rs
@@ -134,8 +134,7 @@ async fn mutation_provenance_propagates_to_mutation_event() {
     fields.insert("name".to_string(), json!("Carol"));
     fields.insert("created_at".to_string(), json!("2026-01-03"));
 
-    let provenance =
-        Provenance::user("submitter-pubkey".to_string(), "submitter-sig".to_string());
+    let provenance = Provenance::user("submitter-pubkey".to_string(), "submitter-sig".to_string());
     let mutation = Mutation::new(
         "Person".to_string(),
         fields,

--- a/tests/mutation_provenance_test.rs
+++ b/tests/mutation_provenance_test.rs
@@ -1,11 +1,13 @@
 //! End-to-end integration test for `Mutation.provenance` — the additive
-//! `Option<Provenance>` field added in `projects/molecule-provenance-dag`
-//! PR 4. The field is not yet persisted to atoms/molecules (PR 5), so
-//! "round-trip" here means: a `Mutation` carrying `Provenance::User`
-//! survives serde, feeds cleanly into `MutationManager::write_mutations_batch_async`,
-//! and the underlying data lands on the target schema just as it would for
-//! a pre-PR-4 mutation.
+//! `Option<Provenance>` field added in `projects/molecule-provenance-dag`.
+//!
+//! PR 4 added the field on `Mutation`. PR 5 wires it through the write
+//! path so that `MutationEvent` records propagate the originating
+//! mutation's provenance. The underlying `Molecule` / `AtomEntry` also
+//! carry `Some(Provenance::User{..})` after signing (populated from the
+//! local signer, not the submitter's claimed provenance).
 
+use fold_db::atom::deterministic_molecule_uuid;
 use fold_db::atom::provenance::Provenance;
 use fold_db::fold_db_core::FoldDB;
 use fold_db::schema::types::operations::{MutationType, Query};
@@ -111,4 +113,59 @@ async fn mutation_without_provenance_still_writes() {
         .write_mutations_batch_async(vec![mutation])
         .await
         .expect("write should succeed with provenance = None");
+}
+
+/// PR 5 — the originating mutation's `Provenance::User` must appear on the
+/// resulting `MutationEvent` record. This is the end-to-end propagation
+/// guarantee: a submitter who signs once has that signature recorded at
+/// every durable layer, not only on the in-flight `Mutation` struct.
+#[tokio::test]
+async fn mutation_provenance_propagates_to_mutation_event() {
+    let db = setup_db().await;
+    db.load_schema_from_json(&person_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager()
+        .set_schema_state("Person", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert("name".to_string(), json!("Carol"));
+    fields.insert("created_at".to_string(), json!("2026-01-03"));
+
+    let provenance =
+        Provenance::user("submitter-pubkey".to_string(), "submitter-sig".to_string());
+    let mutation = Mutation::new(
+        "Person".to_string(),
+        fields,
+        KeyValue::new(None, Some("2026-01-03".to_string())),
+        "pk".to_string(),
+        MutationType::Create,
+    )
+    .with_provenance(provenance.clone());
+
+    db.mutation_manager()
+        .write_mutations_batch_async(vec![mutation])
+        .await
+        .expect("write should succeed");
+
+    let mol_uuid = deterministic_molecule_uuid("Person", "name");
+    let events = db
+        .db_ops()
+        .get_mutation_events(&mol_uuid, None)
+        .await
+        .expect("read events");
+    assert!(
+        !events.is_empty(),
+        "expected at least one event for Person.name"
+    );
+    assert!(
+        events
+            .iter()
+            .all(|e| e.provenance.as_ref() == Some(&provenance)),
+        "every MutationEvent for Person.name must carry the submitter's \
+         provenance; got {:?}",
+        events.iter().map(|e| &e.provenance).collect::<Vec<_>>()
+    );
 }


### PR DESCRIPTION
## Summary

Additive `Option<Provenance>` field on `Molecule`, `AtomEntry`, and
`MutationEvent`, mirroring the pattern established for `Mutation` in PR
4 of `projects/molecule-provenance-dag`.

- Every pre-PR-5 JSON shape round-trips byte-for-byte identical (golden
  vectors pinned per type via `pre_pr5_*_json_round_trips_unchanged`).
- Signing paths (`Molecule::set_atom_uuid`, `Molecule::merge`, and the
  signed `set_atom_uuid*` variants on `MoleculeRange` /
  `MoleculeHash` / `MoleculeHashRange`) populate
  `Some(Provenance::User{..})` alongside the existing
  `writer_pubkey` / `signature` / `signature_version` fields.
- Canonical signed bytes in `Molecule::build_canonical_bytes` are
  **unchanged** — provenance is metadata *alongside* the signature, not
  part of what the signature covers. All pre-existing sign/verify tests
  pass unmodified.
- `MutationEvent.provenance` propagates from the originating mutation
  (`mutation.provenance.clone()`) in `MutationManager`, so a signed
  submission's attribution survives end-to-end from `Mutation` →
  durable history event.
- `Molecule::debug_assert_provenance_consistent` surfaces drift between
  `writer_pubkey` / `signature` and `Provenance::User.pubkey` /
  `.signature` during the migration window.

## Non-goals (strict)

- `writer_pubkey` / `signature` / `signature_version` are **not**
  removed. That cleanup is a later PR after full wire-through and
  production soak.
- No `Provenance::Derived` constructors. Transform output wiring is
  project 2 (`projects/view-compute-as-mutations`).
- No changes to canonical signed bytes, atom content-address, or
  `transform_cache_store` / `ViewCacheState`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo check --workspace --all-features` — compiles
- [x] `cargo test --workspace --all-targets -- --test-threads=1` — all green (597 lib + integration)
- [x] `tests/mutation_provenance_test.rs` — end-to-end `Provenance::User`
  propagation from `Mutation` to `MutationEvent` verified
- [x] Pre-PR-5 JSON golden vectors for Molecule / AtomEntry /
  MutationEvent round-trip byte-identical

Part of `projects/molecule-provenance-dag`. Next: PR 6 (forward +
reverse lineage indexes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)