### PR TITLE
feat(view): dual-write derived mutations on fire (view-compute-as-mutations PR 2/5)

### DIFF
--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -478,6 +478,20 @@ impl FoldDB {
             &trigger_runner,
         ))) as Arc<dyn TriggerDispatcher>);
 
+        // Wire the mutation manager into the view orchestrator as the
+        // derived-mutation writer. Same post-construction late-binding
+        // pattern as `set_trigger_dispatcher` — both directions of the
+        // `ViewOrchestrator` ↔ `MutationManager` edge need to exist, and
+        // construction can only build one at a time.
+        //
+        // `projects/view-compute-as-mutations` PR 2: the fire path now
+        // dual-writes derived mutations through this writer alongside the
+        // existing `ViewCacheState::Cached`.
+        view_orchestrator
+            .set_derived_mutation_writer(Arc::clone(&mutation_manager)
+                as Arc<dyn super::view_orchestrator::DerivedMutationWriter>)
+            .await;
+
         let trigger_shutdown = Arc::new(tokio::sync::Notify::new());
         {
             let runner = Arc::clone(&trigger_runner);

--- a/src/fold_db_core/mutation_manager.rs
+++ b/src/fold_db_core/mutation_manager.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use super::orchestration::index_status::IndexStatusTracker;
 use super::trigger_runner::TriggerDispatcher;
-use super::view_orchestrator::ViewOrchestrator;
+use super::view_orchestrator::{DerivedMutationWriter, ViewOrchestrator};
 use crate::atom::{Atom, FieldKey, MutationEvent};
 use crate::db_operations::{DbOperations, MoleculeData};
 use crate::messaging::events::query_events::MutationExecuted;
@@ -1037,5 +1037,20 @@ impl MutationManager {
             .await
         });
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl DerivedMutationWriter for MutationManager {
+    async fn write_derived_batch(
+        &self,
+        mutations: Vec<Mutation>,
+    ) -> Result<Vec<String>, SchemaError> {
+        // Derived mutations skip the access-control wrapper because they are
+        // produced internally by the view fire path — there is no user
+        // identity to authorize against. The pipeline itself enforces the
+        // `Provenance::Derived` pass-through in `ViewOrchestrator::redirect_mutation`,
+        // so from here on they flow through exactly like any other batch.
+        self.write_mutations_batch_async(mutations).await
     }
 }

--- a/src/fold_db_core/view_orchestrator.rs
+++ b/src/fold_db_core/view_orchestrator.rs
@@ -12,20 +12,54 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use crate::atom::provenance::{MoleculeRef, Provenance};
 use crate::db_operations::DbOperations;
-use crate::schema::types::Mutation;
+use crate::schema::types::operations::MutationType;
+use crate::schema::types::{KeyValue, Mutation};
 use crate::schema::{SchemaCore, SchemaError};
+use crate::view::derived_metadata::DerivedMetadata;
 use crate::view::resolver::ViewResolver;
 use crate::view::transform_field_override::TransformFieldOverride;
-use crate::view::types::ViewCacheState;
+use crate::view::types::{TransformView, ViewCacheState};
 
 use super::query::StandardSourceQuery;
+
+/// Back-door that lets [`ViewOrchestrator`] submit derived mutations through
+/// [`super::mutation_manager::MutationManager`] without forming a static
+/// circular dependency. `ViewOrchestrator` is constructed first (and owned by
+/// `MutationManager`), so the writer is wired post-construction via
+/// [`ViewOrchestrator::set_derived_mutation_writer`], mirroring the existing
+/// `set_trigger_dispatcher` pattern in `fold_db.rs`.
+///
+/// The trait abstraction also keeps the orchestrator testable — tests can
+/// plug in a mock writer that records submitted mutations without spinning
+/// up a real `MutationManager`.
+#[async_trait]
+pub trait DerivedMutationWriter: Send + Sync {
+    /// Submit a batch of derived-provenance mutations. Mirrors
+    /// `MutationManager::write_mutations_batch_async` in every respect except
+    /// that it is expected to bypass identity-view redirection and
+    /// override-persistence when the mutation carries `Provenance::Derived`.
+    async fn write_derived_batch(
+        &self,
+        mutations: Vec<Mutation>,
+    ) -> Result<Vec<String>, SchemaError>;
+}
 
 /// Orchestrates view lifecycle: dependency-graph traversal, invalidation,
 /// and precomputation of derived views triggered by mutations.
 pub struct ViewOrchestrator {
     schema_manager: Arc<SchemaCore>,
     db_ops: Arc<DbOperations>,
+    /// Post-construction late-binding slot for the derived-mutation writer.
+    /// `None` in tests and until `fold_db.rs` wires the `MutationManager` in.
+    /// When `None`, the orchestrator still updates `ViewCacheState::Cached` as
+    /// before — the derived-mutation path is the additive side of the
+    /// dual-write phase of `projects/view-compute-as-mutations`.
+    derived_writer: Arc<RwLock<Option<Arc<dyn DerivedMutationWriter>>>>,
 }
 
 impl ViewOrchestrator {
@@ -34,7 +68,21 @@ impl ViewOrchestrator {
         Self {
             schema_manager,
             db_ops,
+            derived_writer: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Wire in the derived-mutation writer after construction. Idempotent —
+    /// re-calling replaces the prior writer. Called once from `fold_db.rs`
+    /// after both `ViewOrchestrator` and `MutationManager` exist.
+    pub async fn set_derived_mutation_writer(&self, writer: Arc<dyn DerivedMutationWriter>) {
+        *self.derived_writer.write().await = Some(writer);
+    }
+
+    /// Accessor used by the background precompute task to grab the current
+    /// writer (if set) without holding the lock across the write operation.
+    async fn snapshot_derived_writer(&self) -> Option<Arc<dyn DerivedMutationWriter>> {
+        self.derived_writer.read().await.clone()
     }
 
     /// Route mutations targeting transform views.
@@ -58,6 +106,18 @@ impl ViewOrchestrator {
         let mut result = Vec::with_capacity(mutations.len());
 
         for mutation in mutations {
+            // `Provenance::Derived` mutations are produced by the transform
+            // fire path itself (see `precompute_views` below). They are writes
+            // to the view's own output molecules, NOT user-originated writes
+            // against the view, so they must bypass identity-view redirection
+            // AND override persistence — both of which assume a user pin.
+            // Pass them straight through to the normal mutation pipeline so
+            // atoms land on the view schema's fields.
+            if matches!(mutation.provenance, Some(Provenance::Derived { .. })) {
+                result.push(mutation);
+                continue;
+            }
+
             let view_info = {
                 let registry = self.schema_manager.view_registry().lock().map_err(|_| {
                     SchemaError::InvalidData("Failed to acquire view_registry lock".to_string())
@@ -334,9 +394,12 @@ impl ViewOrchestrator {
         // Spawn background task that computes ALL views bottom-up
         let schema_manager = Arc::clone(&self.schema_manager);
         let db_ops = Arc::clone(&self.db_ops);
+        let derived_writer = self.snapshot_derived_writer().await;
 
         tokio::spawn(async move {
-            if let Err(e) = Self::precompute_views(schema_manager, db_ops, all_ordered).await {
+            if let Err(e) =
+                Self::precompute_views(schema_manager, db_ops, all_ordered, derived_writer).await
+            {
                 log::error!("Background view precomputation failed: {}", e);
             }
         });
@@ -350,6 +413,7 @@ impl ViewOrchestrator {
         schema_manager: Arc<SchemaCore>,
         db_ops: Arc<DbOperations>,
         views_to_compute: Vec<String>,
+        derived_writer: Option<Arc<dyn DerivedMutationWriter>>,
     ) -> Result<(), SchemaError> {
         let wasm_engine = {
             let registry = schema_manager
@@ -412,7 +476,7 @@ impl ViewOrchestrator {
                 .scan_transform_field_overrides(view_name)
                 .await?;
             match resolver
-                .resolve_with_overrides(
+                .resolve_with_overrides_and_derived(
                     &view,
                     &[],
                     &ViewCacheState::Empty,
@@ -421,7 +485,7 @@ impl ViewOrchestrator {
                 )
                 .await
             {
-                Ok((_, new_cache)) => {
+                Ok((output, new_cache, derived)) => {
                     // Only store if not re-invalidated since we started
                     // (e.g., a source mutation landed mid-compute and moved
                     // the view back to Empty). Persist both successful
@@ -439,6 +503,37 @@ impl ViewOrchestrator {
                                 );
                             }
                             _ => log::info!("View '{}' precomputed successfully", view_name),
+                        }
+                    }
+
+                    // Dual-write to the atom layer: on a successful WASM fire
+                    // (`derived` is `Some`), submit the output as a batch of
+                    // mutations carrying `Provenance::Derived` through
+                    // `MutationManager`. The cache write above keeps reads
+                    // working while PR 4 flips the read path to atoms; the
+                    // mutation write is what the future cache-free world
+                    // consumes. Identity views, sticky-Unavailable, and the
+                    // no-writer-configured case all land in this branch with
+                    // `derived = None` and skip the dual-write.
+                    if let (Some(metadata), Some(writer)) = (derived, derived_writer.as_ref()) {
+                        if let Err(e) = Self::write_derived_mutations(
+                            writer.as_ref(),
+                            &db_ops,
+                            &view,
+                            &output,
+                            metadata,
+                        )
+                        .await
+                        {
+                            // Derived-write failure should not abort
+                            // precomputation — the cache write already
+                            // happened, so the view is readable. Log loudly
+                            // so regressions surface in integration tests.
+                            log::error!(
+                                "Derived-mutation dual-write failed for view '{}': {}",
+                                view_name,
+                                e
+                            );
                         }
                     }
                 }
@@ -460,5 +555,268 @@ impl ViewOrchestrator {
         }
 
         Ok(())
+    }
+
+    /// Turn a successful WASM fire's output into a batch of derived-provenance
+    /// mutations and submit them through the configured writer. The output is
+    /// pivoted from `field -> key -> value` to `key -> (field -> value)` so
+    /// each resulting mutation writes every field for a single row, matching
+    /// `MutationManager::write_mutations_batch_async`'s expectation that one
+    /// `Mutation` corresponds to one `(schema, key)` tuple. After the writer
+    /// returns, lineage index entries are inserted so reverse queries
+    /// ("which derived molecules came from source X?") can find these mutations.
+    ///
+    /// Best-effort: errors here do NOT abort precomputation — the cache write
+    /// is the authoritative result for readers until PR 4 of
+    /// `projects/view-compute-as-mutations` flips the read path.
+    async fn write_derived_mutations(
+        writer: &dyn DerivedMutationWriter,
+        db_ops: &Arc<DbOperations>,
+        view: &TransformView,
+        output: &HashMap<String, HashMap<KeyValue, crate::schema::types::field::FieldValue>>,
+        metadata: DerivedMetadata,
+    ) -> Result<(), SchemaError> {
+        let mutations = build_derived_mutations(view, output, &metadata);
+        if mutations.is_empty() {
+            return Ok(());
+        }
+
+        // Mutation uuids are stable from construction; remember them so we
+        // can seed the forward lineage index keyed by the same uuid the
+        // mutation pipeline persists.
+        let mutation_uuids: Vec<String> = mutations.iter().map(|m| m.uuid.clone()).collect();
+        let sources: &[MoleculeRef] = &metadata.sources;
+
+        // Submit the batch. Propagate the mutation-pipeline error rather than
+        // swallowing it — the caller logs and continues.
+        let _ids = writer.write_derived_batch(mutations).await?;
+
+        // Populate lineage forward/reverse entries for every derived mutation.
+        // Uses the `Mutation::uuid` as the derived identifier so the index is
+        // keyed the same way mutation events are emitted. Best-effort per
+        // uuid so a single failure doesn't starve the rest.
+        let lineage = db_ops.lineage();
+        for uuid in mutation_uuids {
+            if let Err(e) = lineage.insert(&uuid, sources).await {
+                log::warn!(
+                    "Lineage index insert failed for derived mutation '{}' on view '{}': {}",
+                    uuid,
+                    view.name,
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Pivot the `field -> key -> value` output map from the resolver into one
+/// [`Mutation`] per distinct key. Each mutation targets the view's own
+/// schema, carries `Provenance::Derived` built from [`DerivedMetadata`], and
+/// writes every field that produced a value for that row.
+///
+/// Free function (not a method) so it can be unit-tested without constructing
+/// a full `ViewOrchestrator` / database stack.
+fn build_derived_mutations(
+    view: &TransformView,
+    output: &HashMap<String, HashMap<KeyValue, crate::schema::types::field::FieldValue>>,
+    metadata: &DerivedMetadata,
+) -> Vec<Mutation> {
+    // Gather every key that appears anywhere in the output, then collect the
+    // per-field values for each key. HashMap iteration is unordered, so the
+    // resulting mutation batch is unordered — `MutationManager` does not
+    // require ordering.
+    let mut by_key: HashMap<KeyValue, HashMap<String, serde_json::Value>> = HashMap::new();
+    for (field_name, entries) in output {
+        for (key, fv) in entries {
+            by_key
+                .entry(key.clone())
+                .or_default()
+                .insert(field_name.clone(), fv.value.clone());
+        }
+    }
+
+    let provenance = Provenance::derived(
+        metadata.wasm_hash.clone(),
+        metadata.input_snapshot_hash.clone(),
+        metadata.sources_merkle_root.clone(),
+    );
+
+    by_key
+        .into_iter()
+        .map(|(key_value, fields_and_values)| {
+            Mutation {
+                uuid: uuid::Uuid::new_v4().to_string(),
+                schema_name: view.name.clone(),
+                fields_and_values,
+                key_value,
+                // `pub_key` is left empty for derived writes — the writer's
+                // identity lives in `provenance.wasm_hash`, not in a human
+                // key. The follow-up cleanup PR that removes `pub_key`
+                // outright after full wire-through will drop this altogether.
+                pub_key: String::new(),
+                mutation_type: MutationType::Create,
+                synchronous: None,
+                source_file_name: None,
+                metadata: None,
+                provenance: Some(provenance.clone()),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod derived_mutation_tests {
+    //! `build_derived_mutations` is pure — no DB, no async. Exercise it
+    //! directly so the row-pivot logic is pinned against regressions.
+
+    use super::*;
+    use crate::schema::types::field::FieldValue;
+    use crate::schema::types::field_value_type::FieldValueType;
+    use crate::schema::types::operations::Query;
+    use crate::schema::types::schema::DeclarativeSchemaType;
+    use serde_json::json;
+
+    fn view(name: &str) -> TransformView {
+        TransformView::new(
+            name,
+            DeclarativeSchemaType::Single,
+            None,
+            vec![Query::new("Src".to_string(), vec!["f".to_string()])],
+            None,
+            HashMap::from([
+                ("title".to_string(), FieldValueType::String),
+                ("count".to_string(), FieldValueType::Integer),
+            ]),
+        )
+    }
+
+    fn fv(value: serde_json::Value) -> FieldValue {
+        FieldValue {
+            value,
+            atom_uuid: String::new(),
+            source_file_name: None,
+            metadata: None,
+            molecule_uuid: None,
+            molecule_version: None,
+            writer_pubkey: None,
+            written_at: None,
+        }
+    }
+
+    fn metadata() -> DerivedMetadata {
+        DerivedMetadata {
+            wasm_hash: "w".repeat(64),
+            input_snapshot_hash: "i".repeat(64),
+            sources_merkle_root: "r".repeat(64),
+            sources: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn one_mutation_per_key_carries_every_field_for_that_row() {
+        let v = view("V");
+        let key_a = KeyValue::new(Some("a".to_string()), None);
+        let key_b = KeyValue::new(Some("b".to_string()), None);
+
+        let mut title_entries = HashMap::new();
+        title_entries.insert(key_a.clone(), fv(json!("A-title")));
+        title_entries.insert(key_b.clone(), fv(json!("B-title")));
+        let mut count_entries = HashMap::new();
+        count_entries.insert(key_a.clone(), fv(json!(1)));
+        count_entries.insert(key_b.clone(), fv(json!(2)));
+
+        let mut output = HashMap::new();
+        output.insert("title".to_string(), title_entries);
+        output.insert("count".to_string(), count_entries);
+
+        let muts = build_derived_mutations(&v, &output, &metadata());
+        assert_eq!(muts.len(), 2);
+        for m in &muts {
+            assert_eq!(m.schema_name, "V");
+            assert_eq!(m.mutation_type, MutationType::Create);
+            assert!(m.pub_key.is_empty(), "derived writes have no user writer");
+            assert!(m.provenance.is_some(), "derived provenance must be set");
+            assert!(matches!(m.provenance, Some(Provenance::Derived { .. })));
+            assert_eq!(m.fields_and_values.len(), 2);
+        }
+
+        let by_key: HashMap<&KeyValue, &HashMap<String, serde_json::Value>> = muts
+            .iter()
+            .map(|m| (&m.key_value, &m.fields_and_values))
+            .collect();
+        assert_eq!(by_key[&key_a]["title"], json!("A-title"));
+        assert_eq!(by_key[&key_a]["count"], json!(1));
+        assert_eq!(by_key[&key_b]["title"], json!("B-title"));
+        assert_eq!(by_key[&key_b]["count"], json!(2));
+    }
+
+    #[test]
+    fn missing_field_on_some_keys_yields_partial_mutations() {
+        // When a field has no entry for a particular key, the resulting
+        // mutation for that key should still be emitted — just without that
+        // field in its `fields_and_values`. This matches the resolver's
+        // tolerance for non-uniform output shapes.
+        let v = view("V");
+        let key_only_title = KeyValue::new(Some("a".to_string()), None);
+        let key_only_count = KeyValue::new(Some("b".to_string()), None);
+
+        let mut title_entries = HashMap::new();
+        title_entries.insert(key_only_title.clone(), fv(json!("only")));
+        let mut count_entries = HashMap::new();
+        count_entries.insert(key_only_count.clone(), fv(json!(99)));
+
+        let mut output = HashMap::new();
+        output.insert("title".to_string(), title_entries);
+        output.insert("count".to_string(), count_entries);
+
+        let muts = build_derived_mutations(&v, &output, &metadata());
+        assert_eq!(muts.len(), 2);
+
+        let by_key: HashMap<&KeyValue, &HashMap<String, serde_json::Value>> = muts
+            .iter()
+            .map(|m| (&m.key_value, &m.fields_and_values))
+            .collect();
+        assert_eq!(by_key[&key_only_title].len(), 1);
+        assert_eq!(by_key[&key_only_count].len(), 1);
+    }
+
+    #[test]
+    fn empty_output_produces_no_mutations() {
+        let v = view("V");
+        let muts = build_derived_mutations(&v, &HashMap::new(), &metadata());
+        assert!(muts.is_empty());
+    }
+
+    #[test]
+    fn derived_provenance_fields_propagate_from_metadata() {
+        let v = view("V");
+        let key = KeyValue::new(Some("a".to_string()), None);
+        let mut title = HashMap::new();
+        title.insert(key, fv(json!("t")));
+        let mut output = HashMap::new();
+        output.insert("title".to_string(), title);
+
+        let md = DerivedMetadata {
+            wasm_hash: "abc".to_string(),
+            input_snapshot_hash: "def".to_string(),
+            sources_merkle_root: "ghi".to_string(),
+            sources: Vec::new(),
+        };
+        let muts = build_derived_mutations(&v, &output, &md);
+        let Some(Provenance::Derived {
+            wasm_hash,
+            input_snapshot_hash,
+            sources_merkle_root,
+            encoding_version,
+        }) = muts[0].provenance.clone()
+        else {
+            panic!("expected Derived provenance");
+        };
+        assert_eq!(wasm_hash, "abc");
+        assert_eq!(input_snapshot_hash, "def");
+        assert_eq!(sources_merkle_root, "ghi");
+        assert_eq!(encoding_version, 1);
     }
 }

--- a/src/view/resolver.rs
+++ b/src/view/resolver.rs
@@ -2,6 +2,7 @@ use crate::schema::types::errors::SchemaError;
 use crate::schema::types::field::FieldValue;
 use crate::schema::types::key_value::KeyValue;
 use crate::schema::types::operations::Query;
+use crate::view::derived_metadata::{compute_derived_metadata, DerivedMetadata};
 use crate::view::transform_field_override::TransformFieldOverride;
 use crate::view::types::{InputDimension, TransformView, UnavailableReason, ViewCacheState};
 use crate::view::wasm_engine::WasmTransformEngine;
@@ -110,6 +111,43 @@ impl ViewResolver {
         ),
         SchemaError,
     > {
+        let (result, state, _derived) = self
+            .resolve_with_overrides_and_derived(
+                view,
+                requested_fields,
+                cache_state,
+                source_query,
+                overrides,
+            )
+            .await?;
+        Ok((result, state))
+    }
+
+    /// Like [`resolve_with_overrides`] but additionally returns the
+    /// [`DerivedMetadata`] for the just-executed fire.
+    ///
+    /// `DerivedMetadata` is `Some` only when the resolver actually executed a
+    /// WASM transform on fresh input and produced a `ViewCacheState::Cached`
+    /// result. It is `None` when we took the cached short-circuit, when the
+    /// view is identity pass-through (no derivation happened), or when the
+    /// fire ended in `Unavailable`. Callers use the returned metadata to
+    /// build `Provenance::Derived` mutations downstream
+    /// (`projects/view-compute-as-mutations` PR 2).
+    pub async fn resolve_with_overrides_and_derived(
+        &self,
+        view: &TransformView,
+        requested_fields: &[String],
+        cache_state: &ViewCacheState,
+        source_query: &dyn SourceQueryFn,
+        overrides: &[(String, String, TransformFieldOverride)],
+    ) -> Result<
+        (
+            HashMap<String, HashMap<KeyValue, FieldValue>>,
+            ViewCacheState,
+            Option<DerivedMetadata>,
+        ),
+        SchemaError,
+    > {
         // Determine which fields to return
         let fields_to_return: Vec<String> = if requested_fields.is_empty() {
             view.output_fields.keys().cloned().collect()
@@ -136,7 +174,7 @@ impl ViewResolver {
             // Cached path still consults overrides — overrides are sticky and
             // must beat anything in the per-view cache too.
             self.apply_overrides(&mut result, overrides);
-            return Ok((result, cache_state.clone()));
+            return Ok((result, cache_state.clone(), None));
         }
 
         // Sticky-per-input: if the prior compute on this input already
@@ -149,6 +187,7 @@ impl ViewResolver {
                 ViewCacheState::Unavailable {
                     reason: reason.clone(),
                 },
+                None,
             ));
         }
 
@@ -183,6 +222,7 @@ impl ViewResolver {
                                 limit: model.max_input_size,
                             },
                         },
+                        None,
                     ));
                 }
             }
@@ -192,16 +232,22 @@ impl ViewResolver {
         // rather than a hard error: they are per-input compute failures,
         // so the caller should persist the state (no retry) but callers
         // above the resolver are free to surface it to the user.
-        let mut output = if let Some(spec) = &view.wasm_transform {
+        //
+        // Only WASM views produce `DerivedMetadata` — identity views are
+        // pass-through and have no derivation to record.
+        let (mut output, derived) = if let Some(spec) = &view.wasm_transform {
             match self.execute_wasm_transform(&spec.bytes, spec.max_gas, &all_query_results) {
-                Ok(output) => output,
+                Ok(output) => {
+                    let metadata = compute_derived_metadata(&spec.bytes, &all_query_results);
+                    (output, Some(metadata))
+                }
                 Err(e) => {
                     let reason = classify_wasm_failure(&e);
-                    return Ok((HashMap::new(), ViewCacheState::Unavailable { reason }));
+                    return Ok((HashMap::new(), ViewCacheState::Unavailable { reason }, None));
                 }
             }
         } else {
-            self.identity_pass_through(&all_query_results, view)?
+            (self.identity_pass_through(&all_query_results, view)?, None)
         };
 
         // Apply overrides BEFORE type validation so the user-supplied value
@@ -223,7 +269,7 @@ impl ViewResolver {
                                 view.name, field_name, e
                             ),
                         };
-                        return Ok((HashMap::new(), ViewCacheState::Unavailable { reason }));
+                        return Ok((HashMap::new(), ViewCacheState::Unavailable { reason }, None));
                     }
                 }
             }
@@ -253,7 +299,7 @@ impl ViewResolver {
             result.insert(field_name.clone(), field_entries);
         }
 
-        Ok((result, new_cache))
+        Ok((result, new_cache, derived))
     }
 
     /// Substitute override values into an already-shaped result map.


### PR DESCRIPTION
## Summary

PR 2/5 on `projects/view-compute-as-mutations`. After a WASM view's background precompute produces `ViewCacheState::Cached`, the output is now also submitted as a batch of `Provenance::Derived` mutations through `MutationManager::write_mutations_batch_async`. This is the dual-write phase — the cache continues to serve reads until PR 4 flips the read path.

### Changes
- **New trait `DerivedMutationWriter`** in `fold_db_core::view_orchestrator`, implemented on `MutationManager` via `write_mutations_batch_async`. Late-bound to `ViewOrchestrator` via `set_derived_mutation_writer(...)` after construction (mirrors the existing `set_trigger_dispatcher` pattern — avoids a static Arc cycle).
- **`Provenance::Derived` pass-through in `redirect_mutation`**: derived mutations bypass identity-view redirection and override-persistence since they're writes to the view's own output, not user writes against the view.
- **Resolver API**: new `resolve_with_overrides_and_derived` returning `(output, state, Option<DerivedMetadata>)`. `DerivedMetadata` is `Some` only when a WASM transform actually executed on fresh input; cached short-circuits, identity pass-throughs, and sticky-Unavailable all return `None`. Original `resolve_with_overrides` delegates and drops the 3rd element so all other callers stay unchanged.
- **Row pivot + mutation build**: `build_derived_mutations` turns the resolver's `field -> key -> value` output into one `Mutation` per distinct `key_value`, each carrying `Provenance::derived(wasm_hash, input_snapshot_hash, sources_merkle_root)` from the returned metadata. `pub_key` is empty for derived writes — there's no user identity to attribute.
- **Lineage index population**: after a successful derived batch submission, each `Mutation::uuid` is inserted into `LineageIndex` as the derived identifier with the metadata's source `MoleculeRef` set. Populates both forward (`derived_uuid -> sources`) and reverse (`source -> derived_uuids`) entries.
- **Best-effort**: a derived-write failure logs and continues — the cache is still written so reads keep working. Idempotency cache + existing pipeline safeguards cover normal resilience.

## Test plan

- [x] `cargo test -p fold_db --all-targets` — 760 passed, 0 failed.
- [x] 4 new unit tests on `build_derived_mutations` pin pivot semantics (one mutation per key; every field on each row; partial fields tolerated; empty output → no mutations; provenance propagation from metadata).
- [x] 9 unit tests from PR 1 continue to cover `compute_derived_metadata`.
- [x] `cargo clippy -p fold_db --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

## Staged on #617

Stacked on [#617](https://github.com/EdgeVector/fold_db/pull/617) (PR 1 — DerivedMetadata plumbing). Already rebased onto mainline post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)