### PR TITLE
feat(view): register views as synthesized schemas (view-compute-as-mutations PR 4/5)

### DIFF
--- a/src/fold_db_core/query/query_executor.rs
+++ b/src/fold_db_core/query/query_executor.rs
@@ -88,7 +88,29 @@ impl QueryExecutor {
         access_context: Option<&AccessContext>,
         payment_gate: Option<&PaymentGate>,
     ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
-        // First: try to resolve as a schema (existing path)
+        // Views are registered as both a view (with WASM + triggers) AND a
+        // synthesized schema (the atom store for derived-mutation writes
+        // from the fire path — see `projects/view-compute-as-mutations`
+        // PR 4). The view path still owns first-class semantics: it runs
+        // the WASM transform, applies overrides, manages the per-view
+        // cache lifecycle, and enforces `Blocked` / `Unavailable` state.
+        // Falling through to the schema path first would serve the atom
+        // store alone, which is empty before the first fire. Keep the
+        // view path as the primary resolver; only fall through to the
+        // schema path for queries against non-view schemas.
+        let is_view = {
+            let registry = self
+                .schema_manager
+                .view_registry()
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
+            registry.get_view(&query.schema_name).is_some()
+        };
+
+        if is_view {
+            return self.try_query_view(&query).await;
+        }
+
         match self.schema_manager.get_schema(&query.schema_name).await? {
             Some(mut schema) => {
                 // Enforce Blocked state
@@ -123,10 +145,10 @@ impl QueryExecutor {
                     Ok(results)
                 }
             }
-            None => {
-                // Second: try to resolve as a view
-                self.try_query_view(&query).await
-            }
+            None => Err(SchemaError::InvalidData(format!(
+                "'{}' not found as schema or view",
+                query.schema_name
+            ))),
         }
     }
 

--- a/src/fold_db_core/query/source_query.rs
+++ b/src/fold_db_core/query/source_query.rs
@@ -203,7 +203,25 @@ impl SourceQueryFn for StandardSourceQuery {
         &self,
         query: &Query,
     ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
-        // Try as schema first.
+        // Views are now registered as both a view (WASM, triggers, cache)
+        // AND a synthesized schema (atom store for derived mutations —
+        // `projects/view-compute-as-mutations` PR 4). The view path still
+        // owns the primary semantics: it runs the WASM transform and
+        // applies overrides. Route view queries to the view path; only
+        // non-view schemas go down the atom-store path.
+        let is_view = {
+            let registry = self
+                .schema_manager
+                .view_registry()
+                .lock()
+                .map_err(|_| SchemaError::InvalidData("view_registry lock".to_string()))?;
+            registry.get_view(&query.schema_name).is_some()
+        };
+
+        if is_view {
+            return self.query_view(query).await;
+        }
+
         match self.schema_manager.get_schema(&query.schema_name).await? {
             Some(mut schema) => {
                 self.hash_range_processor
@@ -215,7 +233,10 @@ impl SourceQueryFn for StandardSourceQuery {
                     )
                     .await
             }
-            None => self.query_view(query).await,
+            None => Err(SchemaError::InvalidData(format!(
+                "'{}' not found as schema or view",
+                query.schema_name
+            ))),
         }
     }
 }

--- a/src/schema/core.rs
+++ b/src/schema/core.rs
@@ -560,6 +560,19 @@ impl SchemaCore {
             .store_view_state(&view_clone.name, &ViewState::Available)
             .await?;
 
+        // Also register a synthesized schema mirroring the view's output
+        // shape. `projects/view-compute-as-mutations` PR 4: derived
+        // mutations from the transform fire path target `schema_name =
+        // view.name` and flow through `MutationManager::write_mutations_batch_async`,
+        // which looks up the schema in `schemas`. Without this registration,
+        // every derived write would fail with "Schema not found" and the
+        // dual-write silently drops (the error is logged in the orchestrator
+        // but atoms never land). Keeping the synthesized schema alongside
+        // the view is what makes views queryable as first-class schemas in
+        // the PR 5+ cache-free world.
+        let synthesized = view_clone.to_synthesized_schema()?;
+        self.load_schema_internal(synthesized).await?;
+
         Ok(())
     }
 
@@ -622,6 +635,20 @@ impl SchemaCore {
         self.db_ops.delete_view(name).await?;
         self.db_ops.delete_view_state(name).await?;
         self.db_ops.clear_view_cache_state(name).await?;
+
+        // Drop the synthesized schema registered for this view so future
+        // mutations don't resolve a stale name. Best-effort: if the
+        // schema is missing (e.g. a view registered before PR 4 shipped)
+        // we fall through silently.
+        {
+            let mut schemas = lock_map(&self.schemas, "schemas")?;
+            schemas.remove(name);
+        }
+        {
+            let mut states = lock_map(&self.schema_states, "schema_states")?;
+            states.remove(name);
+        }
+
         Ok(())
     }
 

--- a/src/view/types.rs
+++ b/src/view/types.rs
@@ -315,6 +315,56 @@ impl TransformView {
         }
         Some(map)
     }
+
+    /// Synthesize a [`crate::schema::types::Schema`] (AKA
+    /// `DeclarativeSchemaDefinition`) that mirrors this view's declared
+    /// output shape. The synthesized schema is registered alongside the
+    /// view so derived mutations from the transform fire path — which
+    /// target `schema_name = view.name` — land as normal atoms via
+    /// `MutationManager::write_mutations_batch_async`.
+    ///
+    /// The synthesized schema has:
+    ///
+    /// - `name` / `schema_type` / `key` copied from the view.
+    /// - `fields` listing every output field.
+    /// - `field_types` mirroring the view's typed output fields.
+    /// - `runtime_fields` populated (via [`crate::schema::types::Schema::populate_runtime_fields`])
+    ///   so each field gets a `FieldVariant` matching the view's
+    ///   schema_type. This is what `MutationManager::write_mutations_batch_async`
+    ///   reaches for during Phase 2 (atom creation) — without it the
+    ///   mutation pipeline errors with "Schema not found".
+    /// - `source = SchemaSource::User` (views are treated as user-defined
+    ///   schemas from the runtime's perspective; their actual origin is
+    ///   recorded in the view registry).
+    ///
+    /// No data classifications are attached — the view's output inherits
+    /// whatever classification schema_service pinned at registration, and
+    /// the per-field classification check is enforced by
+    /// `load_schema_from_json`, not by `load_schema_internal`. Derived
+    /// views bypass the JSON path.
+    pub fn to_synthesized_schema(
+        &self,
+    ) -> Result<crate::schema::types::Schema, crate::schema::SchemaError> {
+        use crate::schema::types::Schema;
+
+        let field_names: Vec<String> = {
+            let mut v: Vec<String> = self.output_fields.keys().cloned().collect();
+            v.sort();
+            v
+        };
+
+        let mut schema = Schema::new(
+            self.name.clone(),
+            self.schema_type.clone(),
+            self.key_config.clone(),
+            Some(field_names),
+            None,
+            None,
+        );
+        schema.field_types = self.output_fields.clone();
+        schema.populate_runtime_fields()?;
+        Ok(schema)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

PR 4/5 on `projects/view-compute-as-mutations`. Stacked on [#619](https://github.com/EdgeVector/fold_db/pull/619) (PR 3). Rebase against mainline once #619 merges.

### The bug this fixes

PR 2 introduced a dual-write: `ViewOrchestrator::precompute_views` submits derived-provenance mutations with `schema_name = view.name` to `MutationManager::write_mutations_batch_async`. That path does `get_schema_metadata(schema_name)` and errors out when the name isn't in the `schemas` map. Views were only in `view_registry`, not `schemas`, so every derived write silently failed — the error was logged by the orchestrator's best-effort wrapper while `ViewCacheState::Cached` still got written, so tests passed but atoms never landed.

### Fix

`SchemaCore::register_view` now also registers a synthesized `DeclarativeSchemaDefinition` mirroring the view's output shape. The synthesized schema has `runtime_fields` matching the view's `schema_type` (Single/Hash/Range/HashRange) so the mutation pipeline has everything it needs for atom creation.

- New method `TransformView::to_synthesized_schema() -> Result<Schema, SchemaError>`.
- `register_view` calls `load_schema_internal(synthesized)` alongside the existing view persistence.
- `remove_view` drops the synthesized schema + state entries.
- Query routing (`QueryExecutor::query_internal` and `StandardSourceQuery::execute_query`) keeps view semantics authoritative: when the target name resolves to a registered view, route to the view path (WASM, overrides, cache lifecycle). Only non-view schemas use the atom-store path. This preserves existing read behavior — reads still go through the cache until PR 5 flips them.

### What this unblocks

With views registered as schemas, PR 2's derived mutations now actually land atoms. PR 5 can then:
- Flip the reader to prefer the schema/atom path for views.
- Delete `ViewCacheState`, `transform_cache_store`, `set_view_cache_state`/`get_view_cache_state`/`clear_view_cache_state`, the blank-provenance `FieldValue` synthesis at `resolver.rs:387-395`, and the `Empty`/`Computing`/`Cached`/`Unavailable` state-machine plumbing.

## Test plan

- [x] `cargo test -p fold_db --tests` — 767 passed, 0 failed across all integration test binaries (view_invalidation, view_wasm, view_write, view_query, view_precomputation, view_registration, trigger_runner_integration, wasm_transform, etc.).
- [x] `cargo test -p fold_db --lib -- --test-threads=1` — 624 passed, 0 failed (`test_purge_org_data` env-var flake avoided under single-thread, same as prior PRs in this project).
- [x] `cargo clippy -p fold_db --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)