### PR TITLE
feat(sync): add SyncEngine::purge_personal_log + AuthClient delete helpers

### DIFF
--- a/src/sync/auth.rs
+++ b/src/sync/auth.rs
@@ -250,6 +250,17 @@ impl AuthClient {
         .await
     }
 
+    /// Presign a DELETE URL for a snapshot object (e.g., `latest.enc` or
+    /// `{seq}.enc`). Used by the cloud-aware reset path that purges the
+    /// personal sync log along with its snapshots.
+    pub async fn presign_snapshot_delete(&self, snapshot_name: &str) -> SyncResult<PresignedUrl> {
+        self.presign_single_url(serde_json::json!({
+            "action": "presign_snapshot_delete",
+            "snapshot_name": snapshot_name,
+        }))
+        .await
+    }
+
     /// Acquire the device lock.
     pub async fn acquire_lock(&self, device_id: &str, ttl_secs: u64) -> SyncResult<bool> {
         let body = serde_json::json!({
@@ -430,6 +441,34 @@ impl AuthClient {
         target: &super::org_sync::SyncTarget,
     ) -> SyncResult<Vec<S3ObjectInfo>> {
         self.list_log_objects_after(target, None).await
+    }
+
+    /// List snapshot objects (`snapshots/*.enc`) under a sync target's prefix.
+    ///
+    /// Used by the cloud-aware reset path to enumerate every snapshot
+    /// (including `latest.enc` and any compacted `{seq}.enc`) so each can
+    /// be deleted via `presign_snapshot_delete`.
+    pub async fn list_snapshot_objects(
+        &self,
+        target: &super::org_sync::SyncTarget,
+    ) -> SyncResult<Vec<S3ObjectInfo>> {
+        let mut body = serde_json::json!({
+            "action": "list_objects",
+            "prefix": "snapshots/",
+        });
+        if !target.prefix.is_empty() {
+            body["org_hash"] = serde_json::Value::String(target.prefix.clone());
+        }
+        let resp = self.post("/api/sync/list", body).await?;
+        let parsed: ListObjectsResponse = serde_json::from_value(resp)?;
+        if !parsed.ok {
+            return Err(SyncError::Auth(
+                parsed
+                    .error
+                    .unwrap_or_else(|| "list snapshot objects failed".to_string()),
+            ));
+        }
+        Ok(parsed.objects)
     }
 
     /// List log objects for a sync target, optionally starting after a given key.

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -42,6 +42,17 @@ pub struct SyncStatus {
     pub last_error: Option<String>,
 }
 
+/// Outcome of `SyncEngine::purge_personal_log`. Counts of cloud-side
+/// objects deleted, returned to the caller for logging and progress
+/// reporting.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct PurgeOutcome {
+    /// Number of `{user_hash}/log/{seq}.enc` objects deleted.
+    pub deleted_log_objects: usize,
+    /// Number of `{user_hash}/snapshots/*.enc` objects deleted.
+    pub deleted_snapshots: usize,
+}
+
 /// A merge conflict detected during sync replay.
 /// Stored at key `conflict:{mol_uuid}:{ts}` for efficient scanning.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1884,6 +1895,92 @@ impl SyncEngine {
         self.auth
             .renew_lock(&self.device_id, self.config.lock_ttl_secs)
             .await
+    }
+
+    // =========================================================================
+    // Cloud-aware reset
+    // =========================================================================
+
+    /// Delete every cloud-side log entry and snapshot for the personal
+    /// target, leaving the prefix empty.
+    ///
+    /// Used by `fold_db_node`'s `reset-database` flow to make local wipe
+    /// actually stick: without this, the next sync cycle would re-bootstrap
+    /// from `latest.enc` and replay the full personal log, undoing the
+    /// reset.
+    ///
+    /// Org targets (`targets[1..]`) are intentionally untouched. Org logs
+    /// are shared state across members; leaving an org is a separate flow
+    /// the user must perform explicitly.
+    ///
+    /// The device write lock is acquired for the duration of the purge so
+    /// no other device can race uploads against us. The lock is released
+    /// best-effort on the way out — a stuck lock self-heals via TTL.
+    pub async fn purge_personal_log(&self) -> SyncResult<PurgeOutcome> {
+        self.acquire_lock().await?;
+        let result = self.purge_personal_log_inner().await;
+        if let Err(e) = self.release_lock().await {
+            log::warn!("purge_personal_log: failed to release device lock (non-fatal): {e}");
+        }
+        result
+    }
+
+    async fn purge_personal_log_inner(&self) -> SyncResult<PurgeOutcome> {
+        let personal = self.targets.lock().await[0].clone();
+        if !personal.prefix.is_empty() {
+            // Defense-in-depth: targets[0] is always personal (empty
+            // prefix) by construction. If this ever changes upstream we
+            // want to fail loud, not nuke the wrong prefix.
+            return Err(SyncError::Auth(
+                "purge_personal_log: targets[0] is not the personal target".to_string(),
+            ));
+        }
+
+        let mut outcome = PurgeOutcome::default();
+
+        // 1) Delete every log object: list → presign DELETE in chunks of
+        //    1000 (Lambda cap) → DELETE each presigned URL.
+        let log_objects = self.auth.list_log_objects(&personal).await?;
+        let log_seqs: Vec<u64> = log_objects
+            .iter()
+            .filter_map(|obj| parse_flat_log_key(&obj.key))
+            .collect();
+
+        for chunk in log_seqs.chunks(1000) {
+            let urls = self.auth.presign_log_delete(chunk).await?;
+            for url in &urls {
+                self.s3.delete(url).await?;
+            }
+            outcome.deleted_log_objects += urls.len();
+        }
+
+        // 2) Delete every snapshot under `snapshots/`. Includes
+        //    `latest.enc` plus any compacted `{seq}.enc` left behind by
+        //    prior compactions. Listing first (rather than only attempting
+        //    `latest.enc`) ensures the prefix is fully empty after reset.
+        let snapshot_objects = self.auth.list_snapshot_objects(&personal).await?;
+        for obj in snapshot_objects {
+            // The Lambda strips the scope prefix on list responses, so
+            // keys come back as `snapshots/{name}` — we want the bare
+            // `{name}` for the delete request.
+            let Some(name) = obj.key.strip_prefix("snapshots/") else {
+                log::warn!(
+                    "purge_personal_log: skipping snapshot key '{}' that doesn't start with 'snapshots/'",
+                    obj.key
+                );
+                continue;
+            };
+            let url = self.auth.presign_snapshot_delete(name).await?;
+            self.s3.delete(&url).await?;
+            outcome.deleted_snapshots += 1;
+        }
+
+        log::info!(
+            "purge_personal_log: deleted {} log objects, {} snapshots",
+            outcome.deleted_log_objects,
+            outcome.deleted_snapshots,
+        );
+        Ok(outcome)
     }
 
     // =========================================================================

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -69,7 +69,9 @@ pub mod s3;
 pub mod snapshot;
 
 pub use auth::AuthRefreshCallback;
-pub use engine::{BootstrapOutcome, SyncConfig, SyncConflict, SyncEngine, SyncState, SyncStatus};
+pub use engine::{
+    BootstrapOutcome, PurgeOutcome, SyncConfig, SyncConflict, SyncEngine, SyncState, SyncStatus,
+};
 pub use error::{SyncError, SyncResult};
 pub use org_sync::{SyncDestination, SyncPartitioner};
 


### PR DESCRIPTION
## Summary

- New `SyncEngine::purge_personal_log()` — acquires the device lock, lists+deletes every `{user_hash}/log/*.enc` and every `{user_hash}/snapshots/*.enc`, releases the lock. Org targets are explicitly untouched (shared state; leaving an org is a separate flow).
- New `AuthClient::presign_snapshot_delete(name)` and `AuthClient::list_snapshot_objects(target)` — parallel to the existing snapshot upload/download and log-list helpers.
- New `PurgeOutcome` struct exported from `sync` module — `{ deleted_log_objects, deleted_snapshots }` for caller-side logging and progress reporting.
- Defensive guard: rejects the call if `targets[0].prefix` is non-empty so a future refactor that relocates the personal target can't silently nuke the wrong prefix.

## Why now

`fold_db_node`'s database reset has been silently undone by cloud sync ever since cloud sync shipped: `remove_dir_all(db_path)` wipes Sled, then on next startup `bootstrap_target(0)` downloads `latest.enc` and replays the log, fully reconstructing the just-deleted state.

This PR is the engine-side primitive the new reset orchestration needs (in fold_db_node, separate PR). Used together: stop sync → purge cloud → wipe local → restore preserved trees (identity + org memberships).

## Companion PRs

- `EdgeVector/exemem-infra#128` — adds the `presign_log_delete` / `presign_snapshot_delete` Lambda arms this engine code depends on. Currently those calls 404 silently in production.
- `EdgeVector/fold_db_node#TBD` — wires `purge_personal_log` into `perform_database_reset` and adds identity/org-membership preservation.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --lib sync::` — 52/52 pass
- [x] Full lib test suite — 626/626 pass
- [ ] End-to-end with deployed Lambda once exemem-infra#128 ships to dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)