### PR TITLE
fix(sync): thread node signer through SyncEngine for merge signatures

### DIFF
--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -124,6 +124,18 @@ async fn create_local_fold_db(
     let base_store: Arc<dyn crate::storage::traits::NamespacedStore> =
         Arc::new(crate::storage::SledNamespacedStore::new(Arc::clone(&pool)));
 
+    // Build the node signer once and share it with both SyncEngine (for signing
+    // merged molecules during replay) and FoldDB (used by MutationManager for
+    // signing local writes). Same keypair = merged writes trace to the same
+    // node identity as direct writes.
+    // TODO: Load this from the node's persistent identity in NodeConfigStore
+    // instead of generating per-process. Tracked alongside the matching TODO
+    // in `FoldDB::initialize_from_db_ops_with_sled`.
+    let node_signer = Arc::new(
+        crate::security::Ed25519KeyPair::generate()
+            .expect("Ed25519 key generation must not fail"),
+    );
+
     // Build the store stack, optionally inserting sync layer
     #[allow(clippy::type_complexity)]
     let (store, sync_engine, sync_interval_ms, enc_store_ref): (
@@ -149,6 +161,7 @@ async fn create_local_fold_db(
             auth,
             base_store.clone(),
             sync_config,
+            Arc::clone(&node_signer),
         );
         if let Some(cb) = setup.auth_refresh {
             engine.set_auth_refresh(cb);
@@ -238,6 +251,7 @@ async fn create_local_fold_db(
         "local".to_string(),
         Some(pool),
         enc_store_ref,
+        Some(node_signer),
     )
     .await
     .map_err(|e| FoldDbError::Config(e.to_string()))?;

--- a/src/fold_db_core/factory.rs
+++ b/src/fold_db_core/factory.rs
@@ -132,8 +132,7 @@ async fn create_local_fold_db(
     // instead of generating per-process. Tracked alongside the matching TODO
     // in `FoldDB::initialize_from_db_ops_with_sled`.
     let node_signer = Arc::new(
-        crate::security::Ed25519KeyPair::generate()
-            .expect("Ed25519 key generation must not fail"),
+        crate::security::Ed25519KeyPair::generate().expect("Ed25519 key generation must not fail"),
     );
 
     // Build the store stack, optionally inserting sync layer

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -251,6 +251,7 @@ impl FoldDB {
             auth_client,
             base_store,
             sync_config,
+            Arc::clone(&self.signer),
         );
         if let Some(cb) = auth_refresh {
             engine.set_auth_refresh(cb);
@@ -363,6 +364,7 @@ impl FoldDB {
             "local".to_string(),
             Some(pool),
             None,
+            None,
         )
         .await
     }
@@ -374,12 +376,18 @@ impl FoldDB {
         job_store: Option<Arc<dyn JobStore>>,
         user_id: String,
     ) -> Result<Self, StorageError> {
-        Self::initialize_from_db_ops_with_sled(db_ops, db_path, job_store, user_id, None, None)
+        Self::initialize_from_db_ops_with_sled(db_ops, db_path, job_store, user_id, None, None, None)
             .await
     }
 
     /// Internal initializer that optionally retains the SledPool handle.
     /// The pool is needed by org operations and org sync configuration.
+    ///
+    /// `signer`, when supplied, is the node signing keypair shared with the
+    /// sync engine so merged-molecule writes during replay carry the same
+    /// node identity as direct writes via `MutationManager`. When `None`, a
+    /// fresh keypair is generated for this process (sync replay would then
+    /// run with a different keypair — the factory always passes `Some`).
     pub async fn initialize_from_db_ops_with_sled(
         db_ops: Arc<DbOperations>,
         _db_path: &str,
@@ -387,6 +395,7 @@ impl FoldDB {
         user_id: String,
         sled_pool: Option<Arc<SledPool>>,
         encrypting_store: Option<Arc<crate::storage::EncryptingNamespacedStore>>,
+        signer: Option<Arc<crate::security::Ed25519KeyPair>>,
     ) -> Result<Self, StorageError> {
         // Initialize message bus
         let message_bus = Arc::new(AsyncMessageBus::new());
@@ -439,12 +448,16 @@ impl FoldDB {
         // The sled_pool is plumbed through so the manager can consult the
         // org memberships tree and reject mutations against org-scoped
         // schemas the node is not a member of.
-        // Generate a signing keypair for molecule signatures.
+        // Reuse the caller-provided signer when present (sync engine and
+        // mutation manager must trace to the same node identity); otherwise
+        // generate one for this process.
         // TODO: In production, this should be loaded from the node's persistent identity key.
-        let signer = Arc::new(
-            crate::security::Ed25519KeyPair::generate()
-                .expect("Ed25519 key generation must not fail"),
-        );
+        let signer = signer.unwrap_or_else(|| {
+            Arc::new(
+                crate::security::Ed25519KeyPair::generate()
+                    .expect("Ed25519 key generation must not fail"),
+            )
+        });
 
         let mutation_manager = Arc::new(MutationManager::new(
             Arc::clone(&db_ops),

--- a/src/fold_db_core/fold_db.rs
+++ b/src/fold_db_core/fold_db.rs
@@ -376,8 +376,10 @@ impl FoldDB {
         job_store: Option<Arc<dyn JobStore>>,
         user_id: String,
     ) -> Result<Self, StorageError> {
-        Self::initialize_from_db_ops_with_sled(db_ops, db_path, job_store, user_id, None, None, None)
-            .await
+        Self::initialize_from_db_ops_with_sled(
+            db_ops, db_path, job_store, user_id, None, None, None,
+        )
+        .await
     }
 
     /// Internal initializer that optionally retains the SledPool handle.

--- a/src/storage/syncing_namespaced_store.rs
+++ b/src/storage/syncing_namespaced_store.rs
@@ -91,6 +91,7 @@ mod tests {
             SyncAuth::ApiKey("test".to_string()),
         );
 
+        let signer = Arc::new(crate::security::Ed25519KeyPair::generate().unwrap());
         let engine = Arc::new(SyncEngine::new(
             "test-device".to_string(),
             crypto,
@@ -98,6 +99,7 @@ mod tests {
             auth,
             inner.clone(),
             SyncConfig::default(),
+            signer,
         ));
 
         let syncing = SyncingNamespacedStore::new(inner, engine.clone());

--- a/src/storage/syncing_store.rs
+++ b/src/storage/syncing_store.rs
@@ -128,6 +128,7 @@ mod tests {
         );
         let ns_store_arc: Arc<dyn NamespacedStore> = Arc::new(ns_store);
 
+        let signer = Arc::new(crate::security::Ed25519KeyPair::generate().unwrap());
         let engine = Arc::new(SyncEngine::new(
             "test-device".to_string(),
             crypto,
@@ -135,6 +136,7 @@ mod tests {
             auth,
             ns_store_arc,
             SyncConfig::default(),
+            signer,
         ));
 
         let syncing = Arc::new(SyncingKvStore::new(

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -9,6 +9,7 @@ use crate::atom::{
     MutationEvent,
 };
 use crate::crypto::CryptoProvider;
+use crate::security::Ed25519KeyPair;
 use crate::storage::traits::NamespacedStore;
 use chrono::Utc;
 use serde::Serialize;
@@ -115,42 +116,57 @@ pub type StatusCallback = Box<dyn Fn(SyncState, Option<&str>) + Send + Sync>;
 /// Each molecule type has a `merge` method but with slightly different return types
 /// (`Vec<MergeConflict>` vs `Option<MergeConflict>`). This trait normalizes them
 /// into a single `Vec<MergeConflict>` so `try_merge` can be generic.
+///
+/// The `keypair` is the node signer plumbed through `SyncEngine`. For `Molecule`
+/// (single-atom) merges it signs the resulting canonical bytes so a remote peer
+/// can attribute the merged write to this node. Collection-typed merges
+/// (`MoleculeHash`, `MoleculeRange`, `MoleculeHashRange`) preserve per-entry
+/// signatures from the original writers, so the keypair is unused there.
 trait MergeMolecule {
-    fn merge_into_conflicts(&mut self, other: &Self) -> Vec<MergeConflict>;
+    fn merge_into_conflicts(
+        &mut self,
+        other: &Self,
+        keypair: &Ed25519KeyPair,
+    ) -> Vec<MergeConflict>;
 }
 
 impl MergeMolecule for MoleculeHash {
-    fn merge_into_conflicts(&mut self, other: &Self) -> Vec<MergeConflict> {
-        // TODO: Thread node signer through sync engine for proper keypair usage.
-        // Collection merges preserve per-entry signatures so the keypair is unused.
-        let kp = crate::security::Ed25519KeyPair::generate()
-            .expect("Ed25519 key generation must not fail");
-        self.merge(other, &kp)
+    fn merge_into_conflicts(
+        &mut self,
+        other: &Self,
+        keypair: &Ed25519KeyPair,
+    ) -> Vec<MergeConflict> {
+        self.merge(other, keypair)
     }
 }
 
 impl MergeMolecule for MoleculeRange {
-    fn merge_into_conflicts(&mut self, other: &Self) -> Vec<MergeConflict> {
-        let kp = crate::security::Ed25519KeyPair::generate()
-            .expect("Ed25519 key generation must not fail");
-        self.merge(other, &kp)
+    fn merge_into_conflicts(
+        &mut self,
+        other: &Self,
+        keypair: &Ed25519KeyPair,
+    ) -> Vec<MergeConflict> {
+        self.merge(other, keypair)
     }
 }
 
 impl MergeMolecule for MoleculeHashRange {
-    fn merge_into_conflicts(&mut self, other: &Self) -> Vec<MergeConflict> {
-        let kp = crate::security::Ed25519KeyPair::generate()
-            .expect("Ed25519 key generation must not fail");
-        self.merge(other, &kp)
+    fn merge_into_conflicts(
+        &mut self,
+        other: &Self,
+        keypair: &Ed25519KeyPair,
+    ) -> Vec<MergeConflict> {
+        self.merge(other, keypair)
     }
 }
 
 impl MergeMolecule for Molecule {
-    fn merge_into_conflicts(&mut self, other: &Self) -> Vec<MergeConflict> {
-        // TODO: Thread node signer through sync engine for proper merge signing.
-        let kp = crate::security::Ed25519KeyPair::generate()
-            .expect("Ed25519 key generation must not fail");
-        self.merge(other, &kp).into_iter().collect()
+    fn merge_into_conflicts(
+        &mut self,
+        other: &Self,
+        keypair: &Ed25519KeyPair,
+    ) -> Vec<MergeConflict> {
+        self.merge(other, keypair).into_iter().collect()
     }
 }
 
@@ -255,6 +271,10 @@ pub struct SyncEngine {
     /// at most one pending notification across multiple writes — concurrent
     /// writes coalesce into the next sync cycle naturally.
     wake: Arc<tokio::sync::Notify>,
+    /// Node signing keypair, shared with `MutationManager`. Used to sign
+    /// `Molecule` merge results during sync replay so a peer can attribute the
+    /// merged write to this node's identity instead of an ephemeral keypair.
+    node_signer: Arc<Ed25519KeyPair>,
 }
 
 impl SyncEngine {
@@ -265,6 +285,7 @@ impl SyncEngine {
         auth: AuthClient,
         store: Arc<dyn NamespacedStore>,
         config: SyncConfig,
+        node_signer: Arc<Ed25519KeyPair>,
     ) -> Self {
         Self {
             state: Arc::new(Mutex::new(SyncState::Idle)),
@@ -290,6 +311,7 @@ impl SyncEngine {
             embedding_reloader: Arc::new(Mutex::new(None)),
             auth_refresh: None,
             wake: Arc::new(tokio::sync::Notify::new()),
+            node_signer,
         }
     }
 
@@ -387,6 +409,13 @@ impl SyncEngine {
     /// Get the device identifier.
     pub fn device_id(&self) -> &str {
         &self.device_id
+    }
+
+    /// Returns the node signing keypair used to sign merge results during replay.
+    /// Shared with `MutationManager` so local writes and merged writes trace to
+    /// the same node identity.
+    pub fn node_signer(&self) -> &Arc<Ed25519KeyPair> {
+        &self.node_signer
     }
 
     /// Get the current sync state.
@@ -1686,7 +1715,7 @@ impl SyncEngine {
             match local_bytes {
                 Some(local) => {
                     // Both exist — try molecule merge
-                    let (merged_bytes, conflicts) = Self::merge_molecules(&local, &value_bytes)?;
+                    let (merged_bytes, conflicts) = self.merge_molecules(&local, &value_bytes)?;
                     kv.put(&key_bytes, merged_bytes).await?;
 
                     // Store any merge conflicts
@@ -1712,6 +1741,7 @@ impl SyncEngine {
     fn try_merge<T>(
         local_bytes: &[u8],
         incoming_bytes: &[u8],
+        keypair: &Ed25519KeyPair,
     ) -> Option<SyncResult<(Vec<u8>, Vec<MergeConflict>)>>
     where
         T: serde::de::DeserializeOwned + serde::Serialize + MergeMolecule,
@@ -1723,7 +1753,7 @@ impl SyncEngine {
             (Ok(l), Ok(i)) => (l, i),
             _ => return None,
         };
-        let conflicts = local.merge_into_conflicts(&incoming);
+        let conflicts = local.merge_into_conflicts(&incoming, keypair);
         Some(
             serde_json::to_vec(&local)
                 .map(|merged| (merged, conflicts))
@@ -1732,21 +1762,27 @@ impl SyncEngine {
     }
 
     /// Attempt molecule merge by trying each molecule type in order.
-    /// Returns the serialized merged result and any conflicts.
+    /// Returns the serialized merged result and any conflicts. The node signer
+    /// is used to re-sign single-`Molecule` merge results so a peer can verify
+    /// the merge was committed by this node.
     fn merge_molecules(
+        &self,
         local_bytes: &[u8],
         incoming_bytes: &[u8],
     ) -> SyncResult<(Vec<u8>, Vec<MergeConflict>)> {
-        if let Some(result) = Self::try_merge::<MoleculeHash>(local_bytes, incoming_bytes) {
+        let kp = self.node_signer.as_ref();
+        if let Some(result) = Self::try_merge::<MoleculeHash>(local_bytes, incoming_bytes, kp) {
             return result;
         }
-        if let Some(result) = Self::try_merge::<MoleculeRange>(local_bytes, incoming_bytes) {
+        if let Some(result) = Self::try_merge::<MoleculeRange>(local_bytes, incoming_bytes, kp) {
             return result;
         }
-        if let Some(result) = Self::try_merge::<MoleculeHashRange>(local_bytes, incoming_bytes) {
+        if let Some(result) =
+            Self::try_merge::<MoleculeHashRange>(local_bytes, incoming_bytes, kp)
+        {
             return result;
         }
-        if let Some(result) = Self::try_merge::<Molecule>(local_bytes, incoming_bytes) {
+        if let Some(result) = Self::try_merge::<Molecule>(local_bytes, incoming_bytes, kp) {
             return result;
         }
 
@@ -2509,6 +2545,7 @@ mod tests {
         let s3 = S3Client::new(http);
         let crypto: Arc<dyn CryptoProvider> = Arc::new(LocalCryptoProvider::from_key([0x77u8; 32]));
         let store: Arc<dyn NamespacedStore> = Arc::new(InMemoryNamespacedStore::new());
+        let signer = Arc::new(Ed25519KeyPair::generate().unwrap());
         SyncEngine::new(
             "test-device".to_string(),
             crypto,
@@ -2516,6 +2553,7 @@ mod tests {
             auth,
             store,
             SyncConfig::default(),
+            signer,
         )
     }
 

--- a/src/sync/engine.rs
+++ b/src/sync/engine.rs
@@ -1777,8 +1777,7 @@ impl SyncEngine {
         if let Some(result) = Self::try_merge::<MoleculeRange>(local_bytes, incoming_bytes, kp) {
             return result;
         }
-        if let Some(result) =
-            Self::try_merge::<MoleculeHashRange>(local_bytes, incoming_bytes, kp)
+        if let Some(result) = Self::try_merge::<MoleculeHashRange>(local_bytes, incoming_bytes, kp)
         {
             return result;
         }

--- a/tests/convergent_replay_test.rs
+++ b/tests/convergent_replay_test.rs
@@ -32,6 +32,7 @@ fn make_engine(store: Arc<dyn NamespacedStore>) -> SyncEngine {
         auth,
         store,
         SyncConfig::default(),
+        Arc::new(Ed25519KeyPair::generate().unwrap()),
     )
 }
 

--- a/tests/org_sync_encrypted_e2e_test.rs
+++ b/tests/org_sync_encrypted_e2e_test.rs
@@ -19,6 +19,7 @@ use fold_db::schema::types::operations::MutationType;
 use fold_db::schema::types::operations::Query;
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
+use fold_db::security::Ed25519KeyPair;
 use fold_db::storage::traits::NamespacedStore;
 use fold_db::sync::auth::{AuthClient, SyncAuth};
 use fold_db::sync::log::{LogEntry, LogOp};
@@ -109,6 +110,7 @@ fn build_replay_engine(
         auth,
         store,
         SyncConfig::default(),
+        Arc::new(Ed25519KeyPair::generate().unwrap()),
     )
 }
 

--- a/tests/org_sync_replay_batch_drops_test.rs
+++ b/tests/org_sync_replay_batch_drops_test.rs
@@ -24,6 +24,7 @@ use fold_db::org::operations as org_ops;
 use fold_db::schema::types::operations::{MutationType, Query};
 use fold_db::schema::types::{KeyValue, Mutation};
 use fold_db::schema::SchemaState;
+use fold_db::security::Ed25519KeyPair;
 use fold_db::storage::traits::NamespacedStore;
 use fold_db::sync::auth::{AuthClient, SyncAuth};
 use fold_db::sync::log::{LogEntry, LogOp};
@@ -93,6 +94,7 @@ fn build_replay_engine(
         auth,
         store,
         SyncConfig::default(),
+        Arc::new(Ed25519KeyPair::generate().unwrap()),
     )
 }
 

--- a/tests/sync_integration_test.rs
+++ b/tests/sync_integration_test.rs
@@ -8,6 +8,7 @@
 
 use fold_db::crypto::provider::LocalCryptoProvider;
 use fold_db::crypto::CryptoProvider;
+use fold_db::security::Ed25519KeyPair;
 use fold_db::storage::encrypting_namespaced_store::EncryptingNamespacedStore;
 use fold_db::storage::inmemory_backend::InMemoryNamespacedStore;
 use fold_db::storage::syncing_namespaced_store::SyncingNamespacedStore;
@@ -17,6 +18,10 @@ use fold_db::sync::s3::S3Client;
 use fold_db::sync::snapshot::Snapshot;
 use fold_db::sync::{SyncConfig, SyncEngine, SyncState};
 use std::sync::Arc;
+
+fn test_signer() -> Arc<Ed25519KeyPair> {
+    Arc::new(Ed25519KeyPair::generate().unwrap())
+}
 
 fn test_crypto() -> Arc<dyn CryptoProvider> {
     Arc::new(LocalCryptoProvider::from_key([0x42u8; 32]))
@@ -46,6 +51,7 @@ async fn build_stack() -> (
         auth,
         base.clone() as Arc<dyn NamespacedStore>,
         SyncConfig::default(),
+        test_signer(),
     ));
 
     // Stack: base → syncing → encrypting
@@ -278,6 +284,7 @@ async fn reconfigure_sharing_replaces_extra_targets_atomically() {
         auth,
         base.clone() as Arc<dyn NamespacedStore>,
         SyncConfig::default(),
+        test_signer(),
     );
 
     // Personal-only at startup.


### PR DESCRIPTION
## Summary

- `SyncEngine` previously generated a fresh `Ed25519KeyPair` on the fly inside each `MergeMolecule` impl, so every replayed `Molecule` merge was signed with an ephemeral key — peers had no way to attribute a merged write back to this node.
- Take the signer as an explicit `SyncEngine::new` parameter (`Arc<Ed25519KeyPair>`) and plumb it into `MergeMolecule::merge_into_conflicts`, `try_merge`, and `merge_molecules` (now an instance method) so single-`Molecule` merges sign with the persistent node keypair.
- Reuse the same `Arc<Ed25519KeyPair>` already held by `FoldDB::signer` / `MutationManager`, so merged writes trace to the same node identity as direct writes. The factory builds the keypair once and threads it through both `SyncEngine` and `FoldDB::initialize_from_db_ops_with_sled` (now signer-aware). `start_sync_engine_runtime` reuses `self.signer`.
- Loading from the persistent node identity in `NodeConfigStore` is still the open TODO and left for a follow-up — this PR only collapses the four ephemeral keypairs to one shared keypair per process.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` — 626/626 pass
- [x] Sync-touching integration tests (`sync_integration_test`, `convergent_replay_test`, `org_sync_replay_batch_drops_test`, `org_sync_encrypted_e2e_test`) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)