### PR TITLE
feat(observability): RING layer — bounded VecDeque<LogEntry> for /api/logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,15 +738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,15 +882,6 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -2473,12 +2455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,14 +2531,14 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest 0.11.27",
+ "serde",
  "serde_json",
- "tempfile",
  "thiserror 1.0.69",
  "tracing",
- "tracing-appender",
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "uuid",
  "xxhash-rust",
 ]
 
@@ -2934,12 +2910,6 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3858,12 +3828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,37 +4025,6 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg 0.4.21",
-]
-
-[[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
 ]
 
 [[package]]
@@ -4305,19 +4238,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
-dependencies = [
- "crossbeam-channel",
- "symlink",
- "thiserror 2.0.18",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -18,7 +18,9 @@ opentelemetry-http = "0.27"
 
 thiserror = "1"
 once_cell = "1"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1.0", features = ["v4"] }
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 
 http = "1"

--- a/crates/observability/src/layers/mod.rs
+++ b/crates/observability/src/layers/mod.rs
@@ -2,8 +2,10 @@
 //!
 //! - [`fmt`] — JSON formatter with redaction (T3, stub).
 //! - [`reload`] — runtime [`tracing_subscriber::EnvFilter`] swap (T4).
-//! - [`ring`] — bounded in-memory log buffer (T5, stub).
+//! - [`ring`] — bounded in-memory ring buffer for `/api/logs` (T5).
 
 pub mod fmt;
 pub mod reload;
 pub mod ring;
+
+pub use ring::{build_ring_layer, LogEntry, LogLevel, RingHandle, RingLayer, OBS_RING_CAPACITY};

--- a/crates/observability/src/layers/ring.rs
+++ b/crates/observability/src/layers/ring.rs
@@ -1,1 +1,453 @@
-//! RING layer — bounded in-memory `VecDeque<LogEntry>` for /api/logs. Stub for T5.
+//! RING layer — bounded in-memory `VecDeque<LogEntry>` queryable in-process.
+//!
+//! Phase 1 / T5. The RING layer captures every event the registry emits into
+//! a fixed-capacity ring buffer that another part of the process can drain on
+//! demand. In Phase 3 it replaces `LoggingSystem::query_logs` and powers the
+//! `/api/logs` HTTP endpoint that the dashboard polls.
+//!
+//! ## LogEntry shape
+//!
+//! The on-the-wire JSON shape is identical to the existing
+//! `fold_db::logging::core::LogEntry` so the dashboard parser does not have
+//! to change when Phase 3 rewires the endpoint:
+//!
+//! ```json
+//! {
+//!   "id": "<uuid v4>",
+//!   "timestamp": 1714060800123,
+//!   "level": "INFO",
+//!   "event_type": "module::path",
+//!   "message": "the formatted event message",
+//!   "user_id": null,
+//!   "metadata": { "trace_id": "...", "span_id": "...", "field.name": "..." }
+//! }
+//! ```
+//!
+//! `user_id` is left as `None` here on purpose: task-local user context lives
+//! in `fold_db_core` and the observability crate has zero deps on it. Phase 3
+//! will bridge that when it consolidates logging — until then RING is the
+//! plumbing, not the policy.
+//!
+//! ## Trace correlation
+//!
+//! When a `tracing-opentelemetry` layer is also installed in the registry,
+//! the current span carries a real W3C span context. The RING layer reads
+//! that context and writes `trace_id` (32 hex chars) and `span_id` (16 hex
+//! chars) into `LogEntry.metadata` so individual log lines can be joined
+//! against distributed traces at query time.
+//!
+//! ## Concurrency
+//!
+//! `on_event` is synchronous and called on the event-emitting thread. The
+//! buffer is guarded by `std::sync::RwLock`, which is cheap on the hot write
+//! path because writes hold the lock for the duration of one `push_back` (+
+//! one `pop_front` at capacity). Queries take a read lock and clone out the
+//! slice they need.
+
+use std::collections::{HashMap, VecDeque};
+use std::fmt;
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_opentelemetry::OtelData;
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
+
+/// Default capacity for the RING buffer when `init_*` does not specify one.
+pub const OBS_RING_CAPACITY: usize = 5000;
+
+/// In-memory log entry. Wire-compatible with `fold_db::logging::core::LogEntry`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LogEntry {
+    pub id: String,
+    pub timestamp: i64,
+    pub level: LogLevel,
+    pub event_type: String,
+    pub message: String,
+    pub user_id: Option<String>,
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+/// Log level. Wire-compatible with `fold_db::logging::core::LogLevel` —
+/// serializes to UPPERCASE strings (`"TRACE"`, `"DEBUG"`, ...).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl LogLevel {
+    fn from_tracing(level: &tracing::Level) -> Self {
+        match *level {
+            tracing::Level::TRACE => LogLevel::Trace,
+            tracing::Level::DEBUG => LogLevel::Debug,
+            tracing::Level::INFO => LogLevel::Info,
+            tracing::Level::WARN => LogLevel::Warn,
+            tracing::Level::ERROR => LogLevel::Error,
+        }
+    }
+}
+
+/// Handle to a RING buffer that lets other parts of the process query the
+/// recently-emitted entries. Cheap to clone — internally an `Arc`.
+#[derive(Clone)]
+pub struct RingHandle {
+    buffer: Arc<RwLock<VecDeque<LogEntry>>>,
+    capacity: usize,
+}
+
+impl RingHandle {
+    /// Return up to `limit` most-recent entries, optionally filtered to those
+    /// with `timestamp >= from_timestamp`. Results are ordered oldest → newest
+    /// to match the existing `WebOutput::query` contract that the dashboard
+    /// already consumes.
+    pub fn query(&self, limit: Option<usize>, from_timestamp: Option<i64>) -> Vec<LogEntry> {
+        let buf = self.buffer.read().unwrap_or_else(|p| p.into_inner());
+        let from_ts = from_timestamp.unwrap_or(i64::MIN);
+
+        // Walk newest → oldest so an explicit `limit` keeps the *most recent*
+        // N entries; reverse at the end to restore chronological order.
+        let mut picked: Vec<LogEntry> = buf
+            .iter()
+            .rev()
+            .filter(|e| e.timestamp >= from_ts)
+            .take(limit.unwrap_or(usize::MAX))
+            .cloned()
+            .collect();
+        picked.reverse();
+        picked
+    }
+
+    /// Buffer capacity (the bound enforced on each push).
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Current entry count. Primarily for tests; not part of the stable API
+    /// that `/api/logs` will rely on.
+    pub fn len(&self) -> usize {
+        self.buffer.read().unwrap_or_else(|p| p.into_inner()).len()
+    }
+
+    /// `true` when no entries have been recorded yet.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Subscriber layer that records each event into a bounded ring buffer.
+pub struct RingLayer {
+    handle: RingHandle,
+}
+
+/// Build a RING layer + the handle that lets the rest of the process query
+/// it. Capacity is clamped to a minimum of 1 — a zero-capacity ring is a
+/// foot-gun that silently drops every event.
+pub fn build_ring_layer(capacity: usize) -> (RingLayer, RingHandle) {
+    let cap = capacity.max(1);
+    let handle = RingHandle {
+        buffer: Arc::new(RwLock::new(VecDeque::with_capacity(cap))),
+        capacity: cap,
+    };
+    (
+        RingLayer {
+            handle: handle.clone(),
+        },
+        handle,
+    )
+}
+
+impl<S> Layer<S> for RingLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let event_meta = event.metadata();
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+
+        let mut metadata_map = visitor.fields;
+
+        // Lift trace_id / span_id directly off the parent span's `OtelData`
+        // extension. `OtelData` is attached by `tracing-opentelemetry`'s
+        // layer during `on_new_span`. Reading it through `ctx.event_span`
+        // is the canonical layer-to-layer interop pattern; calling
+        // `Span::current().context()` from inside `on_event` is unreliable
+        // because the dispatcher's notion of "current span" depends on
+        // entry/exit ordering relative to the event hook. When no OTel
+        // layer is installed (or the event has no parent span), the
+        // extension is absent and we just skip these fields.
+        if let Some(span_ref) = ctx.event_span(event) {
+            let exts = span_ref.extensions();
+            if let Some(otel_data) = exts.get::<OtelData>() {
+                if let Some(trace_id) = otel_data.builder.trace_id {
+                    metadata_map.insert("trace_id".to_string(), format!("{:032x}", trace_id));
+                }
+                if let Some(span_id) = otel_data.builder.span_id {
+                    metadata_map.insert("span_id".to_string(), format!("{:016x}", span_id));
+                }
+            }
+        }
+
+        let entry = LogEntry {
+            id: uuid::Uuid::new_v4().to_string(),
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0),
+            level: LogLevel::from_tracing(event_meta.level()),
+            event_type: event_meta.target().to_string(),
+            message: visitor.message,
+            user_id: None,
+            metadata: if metadata_map.is_empty() {
+                None
+            } else {
+                Some(metadata_map)
+            },
+        };
+
+        let mut buf = self
+            .handle
+            .buffer
+            .write()
+            .unwrap_or_else(|p| p.into_inner());
+        if buf.len() == self.handle.capacity {
+            buf.pop_front();
+        }
+        buf.push_back(entry);
+    }
+}
+
+/// `tracing::field::Visit` impl that pulls the `message` field out separately
+/// (it's how `tracing::info!("hello")` is recorded — as a debug field named
+/// `message`) and stuffs everything else into a `String → String` map.
+#[derive(Default)]
+struct FieldVisitor {
+    message: String,
+    fields: HashMap<String, String>,
+}
+
+impl FieldVisitor {
+    fn store(&mut self, field: &Field, value: String) {
+        if field.name() == "message" {
+            self.message = value;
+        } else {
+            self.fields.insert(field.name().to_string(), value);
+        }
+    }
+}
+
+impl Visit for FieldVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.store(field, value.to_string());
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.store(field, format!("{:?}", value));
+    }
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.store(field, value.to_string());
+    }
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.store(field, value.to_string());
+    }
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.store(field, value.to_string());
+    }
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.store(field, value.to_string());
+    }
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        self.store(field, value.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::{TraceContextExt, TracerProvider};
+    use opentelemetry_sdk::trace::TracerProvider as SdkTracerProvider;
+    use tracing::subscriber::with_default;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Registry;
+
+    /// Smallest registry that drives the RING layer for tests.
+    fn registry_with(layer: RingLayer) -> impl tracing::Subscriber {
+        Registry::default().with(layer)
+    }
+
+    #[test]
+    fn captures_event_into_logentry_shape() {
+        let (layer, handle) = build_ring_layer(16);
+        let subscriber = registry_with(layer);
+
+        with_default(subscriber, || {
+            tracing::info!(target: "ring_test", user_hash = "abcd", "hello world");
+        });
+
+        let logs = handle.query(None, None);
+        assert_eq!(logs.len(), 1);
+        let entry = &logs[0];
+        assert_eq!(entry.event_type, "ring_test");
+        assert_eq!(entry.level, LogLevel::Info);
+        assert_eq!(entry.message, "hello world");
+        assert!(entry.user_id.is_none());
+
+        // The custom field should have been folded into metadata.
+        let meta = entry.metadata.as_ref().expect("metadata should be present");
+        assert_eq!(meta.get("user_hash").map(String::as_str), Some("abcd"));
+
+        // Wire shape: serializing must produce the dashboard's expected JSON keys
+        // including `level: "INFO"` (UPPERCASE) and a present `user_id` key (null).
+        let json = serde_json::to_value(entry).unwrap();
+        assert_eq!(json["level"], serde_json::json!("INFO"));
+        assert!(json.get("user_id").is_some(), "user_id key must be present");
+        assert_eq!(json["user_id"], serde_json::Value::Null);
+        for key in ["id", "timestamp", "event_type", "message", "metadata"] {
+            assert!(json.get(key).is_some(), "missing key: {key}");
+        }
+    }
+
+    #[test]
+    fn ring_fills_to_capacity_and_evicts_oldest() {
+        let (layer, handle) = build_ring_layer(3);
+        let subscriber = registry_with(layer);
+
+        with_default(subscriber, || {
+            tracing::info!(seq = 1u64, "one");
+            tracing::info!(seq = 2u64, "two");
+            tracing::info!(seq = 3u64, "three");
+            // At-capacity assertions.
+            tracing::info!(seq = 4u64, "four");
+            tracing::info!(seq = 5u64, "five");
+        });
+
+        let logs = handle.query(None, None);
+        assert_eq!(logs.len(), 3, "ring must stay bounded by capacity");
+        assert_eq!(handle.capacity(), 3);
+
+        // Oldest two were evicted — we should see messages 3, 4, 5 in order.
+        let messages: Vec<&str> = logs.iter().map(|e| e.message.as_str()).collect();
+        assert_eq!(messages, vec!["three", "four", "five"]);
+    }
+
+    #[test]
+    fn query_returns_most_recent_n_in_chronological_order() {
+        let (layer, handle) = build_ring_layer(10);
+        let subscriber = registry_with(layer);
+
+        with_default(subscriber, || {
+            for i in 0..5 {
+                tracing::info!(i = i as u64, "msg {i}");
+            }
+        });
+
+        // Limit = 3 → keep the latest 3, returned oldest → newest.
+        let logs = handle.query(Some(3), None);
+        let messages: Vec<String> = logs.iter().map(|e| e.message.clone()).collect();
+        assert_eq!(messages, vec!["msg 2", "msg 3", "msg 4"]);
+    }
+
+    #[test]
+    fn query_filters_by_from_timestamp() {
+        let (layer, handle) = build_ring_layer(10);
+        let subscriber = registry_with(layer);
+
+        with_default(subscriber, || {
+            tracing::info!("first");
+            // Sleep enough for `SystemTime::now` to advance even on hosts
+            // with coarse clocks (Windows ~16ms).
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let cutoff = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as i64;
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            tracing::info!("second");
+
+            let after_cutoff = handle.query(None, Some(cutoff));
+            let messages: Vec<String> = after_cutoff.iter().map(|e| e.message.clone()).collect();
+            assert_eq!(messages, vec!["second"]);
+        });
+    }
+
+    #[test]
+    fn trace_id_and_span_id_propagate_into_metadata() {
+        // Wire a tracing-opentelemetry layer alongside the RING layer so the
+        // parent span carries a real W3C `OtelData` extension that the RING
+        // layer can lift into `metadata`.
+        let provider = SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("ring-test");
+        let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+        let (ring_layer, handle) = build_ring_layer(16);
+        let subscriber = Registry::default().with(otel_layer).with(ring_layer);
+
+        let trace_id_hex = with_default(subscriber, || {
+            let span = tracing::info_span!("unit");
+            let _enter = span.enter();
+            tracing::info!("inside span");
+
+            // Pull the trace id off the same span via OtelSpanExt so the test
+            // asserts the *exact* id that should appear on the LogEntry.
+            let span_ctx = span.context().span().span_context().clone();
+            assert!(
+                span_ctx.is_valid(),
+                "OtelLayer must seed a valid span context"
+            );
+            format!("{:032x}", span_ctx.trace_id())
+        });
+
+        let logs = handle.query(None, None);
+        assert_eq!(logs.len(), 1);
+        let meta = logs[0]
+            .metadata
+            .as_ref()
+            .expect("trace ids should populate metadata");
+        assert_eq!(meta.get("trace_id"), Some(&trace_id_hex));
+        assert!(
+            meta.get("span_id").is_some_and(|s| s.len() == 16),
+            "span_id must be 16-char hex, got {:?}",
+            meta.get("span_id")
+        );
+    }
+
+    #[test]
+    fn no_otel_layer_means_no_trace_metadata() {
+        // Without a tracing-opentelemetry layer the parent span carries no
+        // OtelData; metadata should simply lack trace_id / span_id rather
+        // than fail or panic.
+        let (layer, handle) = build_ring_layer(4);
+        let subscriber = registry_with(layer);
+
+        with_default(subscriber, || {
+            let span = tracing::info_span!("plain");
+            let _enter = span.enter();
+            tracing::info!("event without OTel");
+        });
+
+        let logs = handle.query(None, None);
+        assert_eq!(logs.len(), 1);
+        if let Some(meta) = &logs[0].metadata {
+            assert!(!meta.contains_key("trace_id"));
+            assert!(!meta.contains_key("span_id"));
+        }
+    }
+
+    #[test]
+    fn capacity_zero_is_clamped_to_one() {
+        let (_layer, handle) = build_ring_layer(0);
+        assert_eq!(
+            handle.capacity(),
+            1,
+            "zero-capacity ring would silently drop everything"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 / T5 of the observability rollout. Adds a `tracing_subscriber::Layer` backed by an in-memory `VecDeque<LogEntry>` capped at `OBS_RING_CAPACITY` (default 5000). Other parts of the process query it through a cloneable `RingHandle`.

- `build_ring_layer(capacity) -> (RingLayer, RingHandle)` composes in any `tracing_subscriber::Registry`.
- `RingHandle::query(limit, from_timestamp) -> Vec<LogEntry>` returns most-recent-N entries oldest → newest, matching the `WebOutput::query` contract the dashboard already consumes.
- Trace correlation: when a `tracing-opentelemetry` layer is also installed, the layer lifts `trace_id` / `span_id` off the parent span's `OtelData` extension via `ctx.event_span` and writes them into `LogEntry.metadata` as zero-padded hex.

## Why this shape

`LogEntry` is duplicated inside the observability crate (rather than imported from `fold_db_core`) to keep the crate's zero-fold_db-deps invariant. Its serde shape is wire-compatible with `fold_db::logging::core::LogEntry` — `level` serializes UPPERCASE, `user_id` is always present (currently `None` — Phase 3 bridges task-local user context), `metadata` is `Option<HashMap<String, String>>`. The dashboard parser doesn't need to change when Phase 3 rewires `/api/logs`.

`Span::current().context()` from inside `on_event` is unreliable (entry/exit ordering vs. the event hook), so the layer goes through the canonical `LookupSpan` + `OtelData` extension path.

## Depends on

- #629 (workspace conversion)
- #630 (T2 — observability crate scaffold)

## Test plan

- [x] `cargo test -p observability` (14 tests, including OTel trace-id propagation + no-OTel graceful fall-through)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (full workspace stays green)
- [ ] Phase 3 will exercise this through the `/api/logs` HTTP endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)