### PR TITLE
feat(observability): init helpers wiring FMT + RELOAD + RING (Phase 1 / T6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +891,15 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -2455,6 +2473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,8 +2557,10 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tracing",
+ "tracing-appender",
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2910,6 +2936,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3828,6 +3860,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,6 +4063,37 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -4238,6 +4307,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/observability/src/init.rs
+++ b/crates/observability/src/init.rs
@@ -1,6 +1,399 @@
 //! Initialization helpers for each runtime target (node / Lambda / Tauri / CLI).
 //!
-//! Stub for Phase 1 / T6. The plan's shape: each helper installs the FMT +
-//! RELOAD + RING layers, returns a guard that holds non-blocking writer
-//! handles, and is `OnceCell`-guarded so a second call returns
-//! [`crate::ObsError::AlreadyInitialized`].
+//! Phase 1 / T6. Each helper composes the FMT + RELOAD + RING layers into a
+//! `Registry` and installs it as the global tracing subscriber. The returned
+//! [`ObsGuard`] holds the non-blocking writer's worker handle plus the
+//! [`RingHandle`] / [`ReloadHandle`] the rest of the binary uses to query the
+//! ring buffer or swap the active filter at runtime.
+//!
+//! ## Per-target shape
+//!
+//! | helper        | FMT target               | RELOAD | RING |
+//! |---------------|--------------------------|--------|------|
+//! | [`init_node`]   | `~/.folddb/observability.jsonl` (or `OBS_FILE_PATH`) | yes | yes |
+//! | [`init_lambda`] | stdout                   | yes    | no   |
+//! | [`init_tauri`]  | inherits from embedded server, else delegates to [`init_node`] | conditional | conditional |
+//! | [`init_cli`]    | stderr                   | no     | no   |
+//!
+//! ## Single-init invariant
+//!
+//! A process-global [`once_cell::sync::OnceCell`] enforces exactly one
+//! installation. The first successful call wins; every subsequent call
+//! returns [`crate::ObsError::AlreadyInitialized`] without panicking and
+//! without touching the installed subscriber. [`init_tauri`] is the lone
+//! exception — when it sees the cell already set, it assumes the embedded
+//! fold_db server already booted observability and returns a degraded
+//! "attached" guard rather than an error, so the Tauri shell can keep
+//! running on top of the server's subscriber.
+//!
+//! ## Contract for callers
+//!
+//! - `service_name` must be non-empty. Empty input panics — this is a
+//!   programming error, not a runtime one.
+//! - The returned [`ObsGuard`] **must** be held for the lifetime of the
+//!   binary. Dropping it stops the FMT worker thread mid-flush; any log
+//!   lines still in the channel are lost.
+
+use std::path::PathBuf;
+use std::{fs, io};
+
+use once_cell::sync::OnceCell;
+use opentelemetry::global;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use tracing_log::LogTracer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+use crate::layers::fmt::{build_fmt_writer, FmtGuard, FmtTarget, RedactingFormat};
+use crate::layers::reload::{build_reload_layer, ReloadHandle};
+use crate::layers::ring::{build_ring_layer, RingHandle, OBS_RING_CAPACITY};
+use crate::ObsError;
+
+/// Override for the node log file path. Read once per `init_node` call.
+const OBS_FILE_PATH_ENV: &str = "OBS_FILE_PATH";
+
+/// Process-global guard against double init. Set on the first successful
+/// `init_*` call; remains set for the lifetime of the process.
+static INIT_ONCE: OnceCell<()> = OnceCell::new();
+
+/// RAII handle returned by every `init_*` helper.
+///
+/// Holds:
+/// - the FMT layer's [`tracing_appender::non_blocking`] worker guard (when
+///   this process did the install) so the background flush thread keeps
+///   draining the queue,
+/// - the [`RingHandle`] for in-process `/api/logs` queries (when RING is
+///   wired — currently only [`init_node`] / [`init_tauri`] full path),
+/// - the [`ReloadHandle`] for runtime `EnvFilter` updates (when RELOAD is
+///   wired — every helper except [`init_cli`]).
+///
+/// The OTLP shutdown handle slot is reserved for Phase 4; for now it is
+/// always `None`.
+#[must_use = "ObsGuard must be held for the lifetime of the binary or log lines may be dropped"]
+pub struct ObsGuard {
+    fmt_guard: Option<FmtGuard>,
+    ring: Option<RingHandle>,
+    reload: Option<ReloadHandle>,
+    otlp_shutdown: Option<OtlpShutdown>,
+}
+
+/// Reserved for Phase 4 (OTLP exporter wiring). Holding the placeholder type
+/// here lets us add the real shutdown call without changing `ObsGuard`'s shape.
+struct OtlpShutdown;
+
+impl ObsGuard {
+    /// Handle to the in-memory ring buffer. `None` for targets that don't
+    /// install the RING layer (Lambda, CLI) or for the Tauri "attached"
+    /// degraded guard.
+    pub fn ring(&self) -> Option<&RingHandle> {
+        self.ring.as_ref()
+    }
+
+    /// Handle to swap the active `EnvFilter` at runtime. `None` for targets
+    /// that don't install the RELOAD layer (CLI) or for the Tauri "attached"
+    /// degraded guard.
+    pub fn reload(&self) -> Option<&ReloadHandle> {
+        self.reload.as_ref()
+    }
+}
+
+impl std::fmt::Debug for ObsGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ObsGuard")
+            .field("fmt_guard", &self.fmt_guard.is_some())
+            .field("ring", &self.ring.is_some())
+            .field("reload", &self.reload.is_some())
+            .field("otlp_shutdown", &self.otlp_shutdown.is_some())
+            .finish()
+    }
+}
+
+impl Drop for ObsGuard {
+    fn drop(&mut self) {
+        // Phase 4 will call `otlp_shutdown.shutdown()` here. Today the slot
+        // is always None; the FmtGuard's own Drop drains the writer queue.
+        if let Some(_otlp) = self.otlp_shutdown.take() {
+            // no-op until Phase 4
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public init helpers
+// ---------------------------------------------------------------------------
+
+/// Initialize observability for a long-running node binary.
+///
+/// Layers: redacting JSON FMT writing to `~/.folddb/observability.jsonl`
+/// (override with `OBS_FILE_PATH`) + RELOAD + RING.
+///
+/// Also installs the W3C [`TraceContextPropagator`] globally and the
+/// `tracing-log` bridge so third-party `log::*` calls flow through the
+/// subscriber.
+pub fn init_node(service_name: &'static str, _version: &str) -> Result<ObsGuard, ObsError> {
+    assert_service_name(service_name);
+    try_claim_init(&INIT_ONCE)?;
+
+    let path = default_node_log_path()?;
+    let (writer, fmt_guard) = build_fmt_writer(FmtTarget::File(path))?;
+    let (reload_layer, reload) = build_reload_layer::<Registry>(default_env_filter());
+    let (ring_layer, ring) = build_ring_layer(OBS_RING_CAPACITY);
+    // The fmt layer is constructed inline so the compiler infers its
+    // `Subscriber` type parameter from the composition site, which
+    // includes the reload Layered<...> wrapping below.
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .event_format(RedactingFormat::from_env())
+        .with_writer(writer);
+
+    let subscriber = Registry::default()
+        .with(reload_layer)
+        .with(fmt_layer)
+        .with(ring_layer);
+    install_subscriber(subscriber)?;
+    install_globals();
+
+    Ok(ObsGuard {
+        fmt_guard: Some(fmt_guard),
+        ring: Some(ring),
+        reload: Some(reload),
+        otlp_shutdown: None,
+    })
+}
+
+/// Initialize observability for an AWS Lambda handler.
+///
+/// Layers: redacting JSON FMT to stdout + RELOAD. Lambda's own log capture
+/// pipes stdout to CloudWatch, so a file appender would be wasted IO. RING
+/// is omitted — Lambda invocations are too short-lived for an in-process
+/// query buffer to be useful.
+pub fn init_lambda(service_name: &'static str, _version: &str) -> Result<ObsGuard, ObsError> {
+    assert_service_name(service_name);
+    try_claim_init(&INIT_ONCE)?;
+
+    let (writer, fmt_guard) = build_fmt_writer(FmtTarget::Stdout)?;
+    let (reload_layer, reload) = build_reload_layer::<Registry>(default_env_filter());
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .event_format(RedactingFormat::from_env())
+        .with_writer(writer);
+
+    let subscriber = Registry::default().with(reload_layer).with(fmt_layer);
+    install_subscriber(subscriber)?;
+    install_globals();
+
+    Ok(ObsGuard {
+        fmt_guard: Some(fmt_guard),
+        ring: None,
+        reload: Some(reload),
+        otlp_shutdown: None,
+    })
+}
+
+/// Initialize observability inside a Tauri shell.
+///
+/// The Tauri desktop app embeds a full fold_db server, which calls
+/// [`init_node`] from `start_server()`. By the time the Tauri runtime
+/// invokes this helper, the global subscriber is already installed — so we
+/// detect that and return a degraded "attached" [`ObsGuard`] rather than
+/// fail. When the embedded server has *not* run (e.g. dev shell pointed at
+/// a remote server), we fall through to a full [`init_node`] install.
+///
+/// `app_handle` is taken by reference but unused in Phase 1; Phase 3 will
+/// wire `tauri-plugin-log` as an additional sink. The generic parameter
+/// avoids pulling Tauri into the observability crate's dependency graph —
+/// callers in the desktop binary pass `&tauri::AppHandle`.
+pub fn init_tauri<H>(
+    service_name: &'static str,
+    version: &str,
+    _app_handle: &H,
+) -> Result<ObsGuard, ObsError> {
+    assert_service_name(service_name);
+
+    if INIT_ONCE.get().is_some() {
+        // Embedded server already initialized. We can't compose new layers
+        // onto an installed global subscriber, so the Tauri shell rides on
+        // top of the server's. Phase 3 will swap this for a real
+        // tauri-plugin-log attachment.
+        return Ok(ObsGuard {
+            fmt_guard: None,
+            ring: None,
+            reload: None,
+            otlp_shutdown: None,
+        });
+    }
+
+    init_node(service_name, version)
+}
+
+/// Initialize observability for a short-lived CLI binary.
+///
+/// Layers: redacting JSON FMT to stderr only. No RELOAD (CLIs run to
+/// completion — runtime filter swaps add no value), no RING (no in-process
+/// reader on the other end), no file appender (no daemon to flush).
+/// stderr is chosen so the CLI can keep stdout reserved for its own
+/// program output.
+pub fn init_cli(service_name: &'static str, _version: &str) -> Result<ObsGuard, ObsError> {
+    assert_service_name(service_name);
+    try_claim_init(&INIT_ONCE)?;
+
+    let (writer, fmt_guard) = build_fmt_writer(FmtTarget::Stderr)?;
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .event_format(RedactingFormat::from_env())
+        .with_writer(writer);
+
+    let subscriber = Registry::default().with(fmt_layer);
+    install_subscriber(subscriber)?;
+    install_globals();
+
+    Ok(ObsGuard {
+        fmt_guard: Some(fmt_guard),
+        ring: None,
+        reload: None,
+        otlp_shutdown: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+#[inline]
+fn assert_service_name(name: &str) {
+    assert!(!name.is_empty(), "service_name required");
+}
+
+/// Atomically claim the one-shot init slot. Returns
+/// [`ObsError::AlreadyInitialized`] when another caller already set it.
+fn try_claim_init(cell: &OnceCell<()>) -> Result<(), ObsError> {
+    cell.set(()).map_err(|_| ObsError::AlreadyInitialized)
+}
+
+fn default_env_filter() -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
+}
+
+/// Path the node binary appends JSON events to.
+///
+/// Order of resolution:
+/// 1. `$OBS_FILE_PATH` if set — used as-is, with no parent-directory
+///    creation. The caller chose the path; the caller is responsible.
+/// 2. `~/.folddb/observability.jsonl` — `~/.folddb` is created if absent.
+fn default_node_log_path() -> Result<PathBuf, ObsError> {
+    if let Ok(p) = std::env::var(OBS_FILE_PATH_ENV) {
+        return Ok(PathBuf::from(p));
+    }
+    let home = std::env::var("HOME").map_err(|_| {
+        ObsError::Io(io::Error::new(
+            io::ErrorKind::NotFound,
+            "HOME not set; set OBS_FILE_PATH to choose a log path explicitly",
+        ))
+    })?;
+    let mut dir = PathBuf::from(home);
+    dir.push(".folddb");
+    fs::create_dir_all(&dir)?;
+    dir.push("observability.jsonl");
+    Ok(dir)
+}
+
+fn install_subscriber<S>(subscriber: S) -> Result<(), ObsError>
+where
+    S: tracing::Subscriber + Send + Sync + 'static,
+{
+    tracing::subscriber::set_global_default(subscriber)
+        .map_err(|e| ObsError::SubscriberInstall(e.to_string()))
+}
+
+/// Install process-global telemetry plumbing that lives outside the
+/// subscriber: the W3C text-map propagator and the `log` → `tracing` bridge.
+///
+/// Both are idempotent in practice — the propagator setter overwrites,
+/// `LogTracer::init` returns `Err` on the second call which we deliberately
+/// swallow. Called only after `install_subscriber` succeeds.
+fn install_globals() {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    // `LogTracer::init` errors only when called twice in the same process;
+    // that's expected for retries / multiple test cases and not actionable.
+    let _ = LogTracer::init();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "service_name required")]
+    fn empty_service_name_panics() {
+        assert_service_name("");
+    }
+
+    #[test]
+    fn non_empty_service_name_does_not_panic() {
+        assert_service_name("ok");
+    }
+
+    #[test]
+    fn try_claim_init_returns_err_on_second_call() {
+        let cell: OnceCell<()> = OnceCell::new();
+        try_claim_init(&cell).expect("first claim succeeds");
+        let err = try_claim_init(&cell).expect_err("second claim must fail");
+        assert!(matches!(err, ObsError::AlreadyInitialized), "got: {err:?}");
+    }
+
+    #[test]
+    fn obs_file_path_env_overrides_default() {
+        // Use a path with no $HOME dependency so the test is hermetic
+        // regardless of the parent process environment.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("custom.jsonl");
+        let prev = std::env::var(OBS_FILE_PATH_ENV).ok();
+        std::env::set_var(OBS_FILE_PATH_ENV, &target);
+
+        let resolved = default_node_log_path().expect("path resolves");
+
+        match prev {
+            Some(v) => std::env::set_var(OBS_FILE_PATH_ENV, v),
+            None => std::env::remove_var(OBS_FILE_PATH_ENV),
+        }
+
+        assert_eq!(resolved, target);
+    }
+
+    #[test]
+    fn default_env_filter_falls_back_to_info() {
+        // We can't easily assert the filter's parsed shape, but we can at
+        // least confirm the function returns without panicking when no
+        // `RUST_LOG` is set in a way that would parse-fail. The fallback
+        // path in `unwrap_or_else` covers both unset and parse-error cases.
+        let _filter = default_env_filter();
+    }
+
+    /// Smoke-test that `ObsGuard`'s public surface is what callers will
+    /// touch — `ring()` / `reload()` accessors return the inner handles.
+    #[test]
+    fn obs_guard_accessors_match_inner_state() {
+        let guard = ObsGuard {
+            fmt_guard: None,
+            ring: None,
+            reload: None,
+            otlp_shutdown: None,
+        };
+        assert!(guard.ring().is_none());
+        assert!(guard.reload().is_none());
+        // Debug impl exists and doesn't panic.
+        let _ = format!("{guard:?}");
+    }
+
+    /// Confirm the public exports compile through `crate::*` so consumers
+    /// can write `use observability::{init_node, init_lambda, ...}`.
+    #[test]
+    fn public_exports_resolve() {
+        let _: fn(&'static str, &str) -> Result<ObsGuard, ObsError> = init_node;
+        let _: fn(&'static str, &str) -> Result<ObsGuard, ObsError> = init_lambda;
+        let _: fn(&'static str, &str) -> Result<ObsGuard, ObsError> = init_cli;
+        // init_tauri is generic over H; bind it to () for the type-check.
+        let _: fn(&'static str, &str, &()) -> Result<ObsGuard, ObsError> = init_tauri::<()>;
+    }
+}

--- a/crates/observability/src/layers/fmt.rs
+++ b/crates/observability/src/layers/fmt.rs
@@ -31,7 +31,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::{Map, Value};
 use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
-use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
@@ -69,10 +69,29 @@ pub struct FmtGuard {
 /// lifetime of the process. The layer applies the format-time redaction
 /// deny-list (static names + `OBS_REDACT_EXTRA` env var) regardless of
 /// what the call site passed for those fields.
+///
+/// This convenience constructor fixes the layer's `Subscriber` type
+/// parameter to `S`, which limits how it can compose with other layers.
+/// For multi-layer registries (FMT + RELOAD + RING), prefer
+/// [`build_fmt_writer`] and inline the [`tracing_subscriber::fmt::layer`]
+/// call so the compiler can infer the right `S` at the composition site.
 pub fn build_fmt_layer<S>(target: FmtTarget) -> Result<(impl Layer<S>, FmtGuard), ObsError>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
+    let (writer, guard) = build_fmt_writer(target)?;
+    let layer = tracing_subscriber::fmt::layer()
+        .event_format(RedactingFormat::from_env())
+        .with_writer(writer);
+    Ok((layer, guard))
+}
+
+/// Open the target sink and wrap it in [`tracing_appender::non_blocking`].
+///
+/// Used by [`build_fmt_layer`] above and by the multi-layer init helpers in
+/// [`crate::init`], which build the fmt layer inline so the layer's
+/// `Subscriber` type parameter is inferred at the composition site.
+pub(crate) fn build_fmt_writer(target: FmtTarget) -> Result<(NonBlocking, FmtGuard), ObsError> {
     let writer: Box<dyn io::Write + Send + 'static> = match target {
         FmtTarget::File(path) => {
             let file = OpenOptions::new().create(true).append(true).open(&path)?;
@@ -82,10 +101,7 @@ where
         FmtTarget::Stderr => Box::new(io::stderr()),
     };
     let (non_blocking, worker) = tracing_appender::non_blocking(writer);
-    let layer = tracing_subscriber::fmt::layer()
-        .event_format(RedactingFormat::from_env())
-        .with_writer(non_blocking);
-    Ok((layer, FmtGuard { _worker: worker }))
+    Ok((non_blocking, FmtGuard { _worker: worker }))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -6,19 +6,24 @@
 //! so it can be consumed from sibling crates and external repos without
 //! pulling the world.
 //!
-//! Phase 1 / T2 ships:
+//! Phase 1 ships:
 //!
 //! - [`attrs`] — canonical attribute keys + the [`redact!`] / [`redact_id!`]
-//!   macros used at log call-sites for PII opacity.
+//!   macros used at log call-sites for PII opacity (T2).
 //! - [`propagation`] — W3C `traceparent` inject on `reqwest` egress and
-//!   extract from `http::HeaderMap` on ingress.
-//! - [`init`] and [`layers`] — empty stubs; future tasks (T3..T6) populate
-//!   the FMT, RELOAD, RING layers and the `init_*` helpers.
+//!   extract from `http::HeaderMap` on ingress (T2).
+//! - [`layers`] — FMT (redacting JSON formatter, T3), RELOAD (runtime
+//!   `EnvFilter` swap, T4), RING (bounded in-memory log buffer, T5).
+//! - [`init`] — `init_node` / `init_lambda` / `init_tauri` / `init_cli`
+//!   helpers (T6) that compose the layers per binary type and return an
+//!   [`ObsGuard`] for the lifetime of the process.
 
 pub mod attrs;
 pub mod init;
 pub mod layers;
 pub mod propagation;
+
+pub use init::{init_cli, init_lambda, init_node, init_tauri, ObsGuard};
 
 /// Errors raised by `init_*` helpers and other crate-level operations.
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## Summary

- Adds `init_node` / `init_lambda` / `init_tauri` / `init_cli` plus `ObsGuard` that compose the FMT + RELOAD + RING layers per binary type.
- `OnceCell<()>` enforces single-init across the process; second call returns `ObsError::AlreadyInitialized` cleanly without panicking. Empty `service_name` panics with `\"service_name required\"`.
- `init_tauri` is the one exception — when the embedded fold_db server already initialized, it returns a degraded \"attached\" guard rather than failing, so the Tauri shell rides on top of the server's subscriber.
- Each successful init also installs the W3C `TraceContextPropagator` globally and the `tracing-log::LogTracer` bridge for third-party `log::*` calls.
- Adds `pub(crate) build_fmt_writer` next to the existing `build_fmt_layer` so the multi-layer init paths can construct the fmt layer inline (the convenience `build_fmt_layer<S> -> impl Layer<S>` fixes the subscriber type and blocks `Layered<reload, Registry>` composition).

### Per-target shape

| helper        | FMT target                                              | RELOAD | RING |
|---------------|---------------------------------------------------------|--------|------|
| `init_node`   | `~/.folddb/observability.jsonl` (`OBS_FILE_PATH` override) | yes    | yes  |
| `init_lambda` | stdout                                                  | yes    | no   |
| `init_tauri`  | inherits embedded server install, else delegates to `init_node` | conditional | conditional |
| `init_cli`    | stderr                                                  | no     | no   |

Phase 1 plan: `projects/observability-phase-1-foundation`. Depends on T3 (FMT, #633), T4 (RELOAD, #631), T5 (RING, #632) — all merged.

## Test plan

- [x] `cargo test -p observability --lib` — 32 tests pass (5 new in `init::tests` covering empty-name panic, `try_claim_init`, `OBS_FILE_PATH` override, `default_env_filter` fallback, public-export resolution).
- [x] `cargo test --workspace --all-targets` — green workspace-wide.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [ ] T7 will add the integration test that boots a real subscriber, emits an event, and asserts it lands in file + RING + survives a RELOAD swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)