### PR TITLE
test(observability): integration test for init_node→emit→capture (Phase 1 / T7)

### DIFF
--- a/crates/observability/src/init.rs
+++ b/crates/observability/src/init.rs
@@ -39,7 +39,9 @@ use std::{fs, io};
 
 use once_cell::sync::OnceCell;
 use opentelemetry::global;
+use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::TracerProvider as SdkTracerProvider;
 use tracing_log::LogTracer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{EnvFilter, Registry};
@@ -138,15 +140,29 @@ pub fn init_node(service_name: &'static str, _version: &str) -> Result<ObsGuard,
     let (writer, fmt_guard) = build_fmt_writer(FmtTarget::File(path))?;
     let (reload_layer, reload) = build_reload_layer::<Registry>(default_env_filter());
     let (ring_layer, ring) = build_ring_layer(OBS_RING_CAPACITY);
+    // No-op TracerProvider: gives every span a real W3C trace/span id so the
+    // RING layer can stamp `trace_id` / `span_id` onto each entry and so
+    // `propagation::inject_w3c` (Phase 2) has a real context to propagate.
+    // No exporter is wired in Phase 1 — Phase 4 swaps this for OTLP.
+    let tracer_provider = SdkTracerProvider::builder().build();
+    let tracer = tracer_provider.tracer(service_name);
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
     // The fmt layer is constructed inline so the compiler infers its
     // `Subscriber` type parameter from the composition site, which
     // includes the reload Layered<...> wrapping below.
     let fmt_layer = tracing_subscriber::fmt::layer()
-        .event_format(RedactingFormat::from_env())
+        .event_format(RedactingFormat::from_env_with_service(service_name))
         .with_writer(writer);
 
+    // RELOAD is innermost so its `S = Registry` type binding matches; the
+    // remaining layers are generic over `S` and the compiler infers each one
+    // from the composition site. By the time RING's `on_event` runs, OTel's
+    // `on_new_span` has already attached `OtelData` to the parent span, so
+    // RING's extension lookup finds the trace/span ids regardless of layer
+    // ordering at this level.
     let subscriber = Registry::default()
         .with(reload_layer)
+        .with(otel_layer)
         .with(fmt_layer)
         .with(ring_layer);
     install_subscriber(subscriber)?;

--- a/crates/observability/src/layers/fmt.rs
+++ b/crates/observability/src/layers/fmt.rs
@@ -167,12 +167,24 @@ impl DenyList {
 #[derive(Clone, Debug)]
 pub(crate) struct RedactingFormat {
     deny_list: DenyList,
+    service_name: Option<String>,
 }
 
 impl RedactingFormat {
     pub(crate) fn from_env() -> Self {
         Self {
             deny_list: DenyList::from_env(),
+            service_name: None,
+        }
+    }
+
+    /// Like [`Self::from_env`] but stamps every formatted line with the OTel
+    /// resource attribute `service.name = <name>`. Used by [`crate::init_node`]
+    /// so a binary's file output is self-identifying.
+    pub(crate) fn from_env_with_service(service_name: &str) -> Self {
+        Self {
+            deny_list: DenyList::from_env(),
+            service_name: Some(service_name.to_string()),
         }
     }
 
@@ -180,6 +192,7 @@ impl RedactingFormat {
     pub(crate) fn with_extras(extras: &[&str]) -> Self {
         Self {
             deny_list: DenyList::with_extras(extras),
+            service_name: None,
         }
     }
 }
@@ -219,6 +232,9 @@ where
             "target".into(),
             Value::String(metadata.target().to_string()),
         );
+        if let Some(name) = self.service_name.as_deref() {
+            obj.insert("service.name".into(), Value::String(name.to_string()));
+        }
         if let Some(span) = ctx.lookup_current() {
             obj.insert("span".into(), Value::String(span.name().to_string()));
         }

--- a/crates/observability/tests/integration.rs
+++ b/crates/observability/tests/integration.rs
@@ -1,0 +1,218 @@
+//! End-to-end integration test for the observability crate.
+//!
+//! Phase 1 / T7 — exit criterion. A single test exercises the full
+//! init → emit → capture → reload path that each binary will use at startup:
+//!
+//! 1. Set `OBS_FILE_PATH` to a tempfile and call `init_node`.
+//! 2. Emit a structured event inside a span.
+//! 3. Verify the FMT layer wrote a JSON line carrying `service.name`,
+//!    `severity_text=INFO`, and the call-site fields.
+//! 4. Verify the RING layer captured the event with `trace_id` populated
+//!    (proving the OTel layer wired by `init_node` produces real W3C ids).
+//! 5. Flip the RELOAD handle to `warn`, re-emit at info, and assert the new
+//!    event is suppressed in both ring and file.
+//! 6. Confirm a second `init_node` returns `AlreadyInitialized`.
+//!
+//! `init_node` installs a process-global `tracing` subscriber, which can
+//! happen exactly once per process. Cargo runs each `tests/<name>.rs` in its
+//! own binary, but `#[test]` functions inside the same file share a process —
+//! so the happy path is structured as one test, with the empty-`service_name`
+//! panic case in a separate test that bails out before touching the global.
+
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use observability::{init_node, ObsError};
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// Pin a `TempDir` for the lifetime of the test process so the log path the
+/// global subscriber holds open does not get unlinked while the worker thread
+/// is still draining its queue.
+fn shared_tempdir() -> &'static TempDir {
+    static DIR: OnceLock<TempDir> = OnceLock::new();
+    DIR.get_or_init(|| tempfile::tempdir().expect("create tempdir"))
+}
+
+/// Wait for at least one non-empty JSON line to appear in `path`. The FMT
+/// layer's `tracing_appender::non_blocking` worker flushes asynchronously, so
+/// even after dropping the guard we may need a beat for the queue to drain on
+/// CI runners. 2 s is far above the worst case observed locally and bounds
+/// the test against an indefinite hang if the writer ever stops flushing.
+fn wait_for_log_lines(path: &std::path::Path, deadline: Duration) -> String {
+    let started = Instant::now();
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if contents.lines().any(|l| !l.is_empty()) {
+                return contents;
+            }
+        }
+        if started.elapsed() >= deadline {
+            return std::fs::read_to_string(path).unwrap_or_default();
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn init_emit_capture_reload_then_already_initialized() {
+    let dir = shared_tempdir();
+    let log_path = dir.path().join("observability.jsonl");
+    // SAFETY: this test owns `OBS_FILE_PATH` for the binary. The other
+    // `#[test]` in this file (`empty_service_name_panics`) panics in
+    // `assert_service_name` before reading any env, so there is no race.
+    std::env::set_var("OBS_FILE_PATH", &log_path);
+    // A bare `info` baseline — the RELOAD step below changes it to `warn`.
+    std::env::set_var("RUST_LOG", "info");
+
+    let guard = init_node("test_node", "0.0.0").expect("init_node should succeed");
+
+    let ring = guard
+        .ring()
+        .expect("init_node installs a RING handle")
+        .clone();
+    let reload = guard.reload().expect("init_node installs a RELOAD handle");
+
+    // ---------------------------------------------------------------------
+    // Step 1 — emit one structured event inside a span. The span is the
+    // mechanism that gives the RING layer an `OtelData` extension to read,
+    // which is how `trace_id` ends up on the entry.
+    // ---------------------------------------------------------------------
+    {
+        let span = tracing::info_span!("integration_test");
+        let _enter = span.enter();
+        tracing::info!(
+            user.hash = %"abc123",
+            schema.name = %"PhotoMetadata",
+            "schema registered",
+        );
+    }
+
+    // RING capture is synchronous, so we can assert immediately.
+    let entries_before_reload = ring.query(None, None);
+    assert_eq!(
+        entries_before_reload.len(),
+        1,
+        "expected exactly one captured event, got {entries_before_reload:?}",
+    );
+    let entry = &entries_before_reload[0];
+    assert_eq!(entry.message, "schema registered");
+    assert_eq!(
+        entry.level,
+        observability::layers::LogLevel::Info,
+        "level should round-trip as INFO",
+    );
+
+    let metadata = entry
+        .metadata
+        .as_ref()
+        .expect("event metadata should be present");
+    assert_eq!(
+        metadata.get("user.hash").map(String::as_str),
+        Some("abc123")
+    );
+    assert_eq!(
+        metadata.get("schema.name").map(String::as_str),
+        Some("PhotoMetadata"),
+    );
+    let trace_id = metadata
+        .get("trace_id")
+        .expect("OTel layer must populate trace_id on RING entries");
+    assert_eq!(
+        trace_id.len(),
+        32,
+        "trace_id should be 32-char hex, got {trace_id:?}",
+    );
+    assert!(
+        trace_id.chars().all(|c| c.is_ascii_hexdigit()),
+        "trace_id should be hex, got {trace_id:?}",
+    );
+    assert_ne!(
+        trace_id,
+        &"0".repeat(32),
+        "trace_id should not be the all-zero invalid context",
+    );
+
+    // ---------------------------------------------------------------------
+    // Step 2 — flip the filter to `warn` and emit at `info`. The new event
+    // must NOT show up in either sink.
+    // ---------------------------------------------------------------------
+    reload
+        .update("warn")
+        .expect("reload to `warn` directive should succeed");
+    {
+        let span = tracing::info_span!("post_reload");
+        let _enter = span.enter();
+        tracing::info!("dropped after reload");
+    }
+
+    let entries_after_reload = ring.query(None, None);
+    assert_eq!(
+        entries_after_reload.len(),
+        1,
+        "info event after RELOAD update(warn) must be filtered out of RING; saw {entries_after_reload:?}",
+    );
+    assert_eq!(
+        entries_after_reload[0].message, "schema registered",
+        "RING contents should be unchanged after the suppressed event",
+    );
+
+    // ---------------------------------------------------------------------
+    // Step 3 — drop the guard so the FMT non-blocking worker flushes its
+    // queue, then read the file. We assert positively on the first event's
+    // shape and negatively on the suppressed one.
+    // ---------------------------------------------------------------------
+    drop(guard);
+
+    let contents = wait_for_log_lines(&log_path, Duration::from_secs(2));
+    assert!(
+        !contents.is_empty(),
+        "FMT writer produced no output to {log_path:?}",
+    );
+    assert!(
+        !contents.contains("dropped after reload"),
+        "RELOAD update(warn) should have suppressed the post-reload event in the file too; got: {contents}",
+    );
+
+    let json_lines: Vec<Value> = contents
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("each FMT line should be valid JSON"))
+        .collect();
+    assert_eq!(
+        json_lines.len(),
+        1,
+        "expected exactly one logged line, got {json_lines:?}",
+    );
+    let line = &json_lines[0];
+    assert_eq!(line["body"], "schema registered");
+    assert_eq!(line["severity_text"], "INFO");
+    assert_eq!(
+        line["service.name"], "test_node",
+        "FMT must stamp the service name passed to init_node",
+    );
+    let attrs = line["attributes"]
+        .as_object()
+        .expect("attributes object on the formatted line");
+    assert_eq!(attrs["user.hash"], "abc123");
+    assert_eq!(attrs["schema.name"], "PhotoMetadata");
+
+    // ---------------------------------------------------------------------
+    // Step 4 — second init must surface as AlreadyInitialized rather than
+    // silently re-installing the subscriber.
+    // ---------------------------------------------------------------------
+    let err = init_node("test_node", "0.0.0").expect_err("second init_node call must fail");
+    assert!(
+        matches!(err, ObsError::AlreadyInitialized),
+        "expected AlreadyInitialized, got {err:?}",
+    );
+}
+
+#[test]
+#[should_panic(expected = "service_name required")]
+fn empty_service_name_panics() {
+    // `init_node` asserts `service_name` non-empty BEFORE claiming the
+    // process-global `INIT_ONCE`, so this test does not interfere with the
+    // happy-path test running in parallel in the same binary.
+    let _ = init_node("", "0.0.0");
+}


### PR DESCRIPTION
## Summary

- Adds `crates/observability/tests/integration.rs` covering the full init → emit → capture → reload → already-initialized path. This is Phase 1's exit criterion (T7 of `projects/observability-phase-1-foundation`).
- Pulls `service.name` into FMT output via `RedactingFormat::from_env_with_service(name)`; only used by `init_node`. Other init helpers and existing tests stay on `from_env()` (no behavior change).
- Wires a no-op `SdkTracerProvider` + `tracing_opentelemetry::layer()` into `init_node` so spans carry real W3C trace/span ids. RING was already coded to lift `OtelData` from the parent span — without the tracer the field would always be absent. Phase 4 will swap the no-op provider for OTLP.

The integration test sets `OBS_FILE_PATH` to a tempfile, calls `init_node("test_node", "0.0.0")`, emits one structured event inside a span, then asserts:
- RING entry has `user.hash` / `schema.name` fields, `level=INFO`, and a non-zero 32-char hex `trace_id`.
- After `reload.update("warn")`, an `info!` event is suppressed in both RING and the file.
- Dropped guard flushes the FMT non-blocking worker; the file contains exactly one JSON line with `service.name=test_node`, `severity_text=INFO`, the call-site fields, and no trace of the post-reload event.
- Second `init_node` call returns `ObsError::AlreadyInitialized`.
- Separate `#[should_panic]` test confirms `init_node("", ...)` panics in `assert_service_name` before touching the global `INIT_ONCE`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (all 31 binaries green; 2 new integration tests + 32 existing observability unit tests pass)
- [x] `cargo test -p observability --test integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)