### PR TITLE
feat(observability): trace-egress classifiers + inject_w3c (Phase 2 / T4)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
 
+      - name: Lint tracing egress classifiers
+        id: trace-egress
+        continue-on-error: true
+        run: bash scripts/lint-tracing-egress.sh
+
       - name: Check formatting
         id: fmt
         continue-on-error: true
@@ -49,13 +54,15 @@ jobs:
       - name: Rust test summary
         if: always()
         run: |
-          for step_name in fmt clippy cargo-test; do
+          for step_name in trace-egress fmt clippy cargo-test; do
             case "$step_name" in
+              trace-egress)   label="Trace Egress Lint" ;;
               fmt)            label="Rust Format" ;;
               clippy)         label="Rust Clippy" ;;
               cargo-test)     label="Rust Tests" ;;
             esac
             case "$step_name" in
+              trace-egress)   status="${{ steps.trace-egress.outcome }}" ;;
               fmt)            status="${{ steps.fmt.outcome }}" ;;
               clippy)         status="${{ steps.clippy.outcome }}" ;;
               cargo-test)     status="${{ steps.cargo-test.outcome }}" ;;
@@ -67,8 +74,9 @@ jobs:
             esac
           done
 
-      - name: Fail if clippy or tests failed
+      - name: Fail if any check failed
         if: |
+          steps.trace-egress.outcome == 'failure' ||
           steps.fmt.outcome == 'failure' ||
           steps.clippy.outcome == 'failure' ||
           steps.cargo-test.outcome == 'failure'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ dependencies = [
  "hmac",
  "image",
  "log",
+ "observability",
  "once_cell",
  "ort",
  "rand 0.8.5",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -64,6 +64,9 @@ utoipa = { version = "4", features = ["actix_extras"] }
 # HTTP client (used by schema_client in fold_db_core)
 reqwest = { version = "0.11", features = ["json", "multipart", "blocking"] }
 
+# Shared telemetry crate — provides `propagation::inject_w3c` for egress.
+observability = { path = "../observability" }
+
 # Vector embedding model for semantic search
 fastembed = "4"
 # Pin ureq to 2.x — fastembed uses ureq internally and ureq 3.x broke the TLS API

--- a/crates/core/src/fold_db_core/factory.rs
+++ b/crates/core/src/fold_db_core/factory.rs
@@ -154,6 +154,7 @@ async fn create_local_fold_db(
         let sync_crypto: Arc<dyn crate::crypto::CryptoProvider> = Arc::new(
             crate::crypto::LocalCryptoProvider::from_key(e2e_keys.encryption_key()),
         );
+        // trace-egress: propagate (shared with skip-s3 — see docs/observability/egress-classification-notes.md)
         let http = Arc::new(reqwest::Client::new());
         let s3 = crate::sync::s3::S3Client::new(http.clone());
         let auth = crate::sync::auth::AuthClient::new(http, setup.auth_url, setup.auth);

--- a/crates/core/src/fold_db_core/fold_db.rs
+++ b/crates/core/src/fold_db_core/fold_db.rs
@@ -240,6 +240,7 @@ impl FoldDB {
         let base_store: Arc<dyn crate::storage::traits::NamespacedStore> =
             Arc::new(crate::storage::SledNamespacedStore::new(pool));
 
+        // trace-egress: propagate (shared with skip-s3 — see docs/observability/egress-classification-notes.md)
         let http = Arc::new(reqwest::Client::new());
         let s3 = crate::sync::s3::S3Client::new(http.clone());
         let auth_client = crate::sync::auth::AuthClient::new(http, setup.auth_url, setup.auth);

--- a/crates/core/src/storage/syncing_namespaced_store.rs
+++ b/crates/core/src/storage/syncing_namespaced_store.rs
@@ -83,6 +83,7 @@ mod tests {
         let inner = Arc::new(InMemoryNamespacedStore::new());
         let crypto: Arc<dyn crate::crypto::CryptoProvider> =
             Arc::new(LocalCryptoProvider::from_key([0x42u8; 32]));
+        // trace-egress: loopback (test scaffold targeting unreachable localhost)
         let http = Arc::new(reqwest::Client::new());
         let s3 = S3Client::new(http.clone());
         let auth = AuthClient::new(

--- a/crates/core/src/storage/syncing_store.rs
+++ b/crates/core/src/storage/syncing_store.rs
@@ -119,6 +119,7 @@ mod tests {
 
         let crypto: Arc<dyn crate::crypto::CryptoProvider> =
             Arc::new(LocalCryptoProvider::from_key([0x42u8; 32]));
+        // trace-egress: loopback (test scaffold targeting unreachable localhost)
         let http = Arc::new(reqwest::Client::new());
         let s3 = S3Client::new(http.clone());
         let auth = AuthClient::new(

--- a/crates/core/src/sync/auth.rs
+++ b/crates/core/src/sync/auth.rs
@@ -124,6 +124,7 @@ impl AuthClient {
         let url = format!("{}{}", self.base_url, path);
         let req = self.http.post(&url).json(&body);
         let req = self.apply_auth(req).await;
+        let req = observability::propagation::inject_w3c(req);
 
         let response = req.send().await.map_err(|e| {
             if e.is_timeout() {

--- a/crates/core/src/sync/engine.rs
+++ b/crates/core/src/sync/engine.rs
@@ -2661,6 +2661,7 @@ mod tests {
         use crate::sync::auth::AuthClient;
         use crate::sync::s3::S3Client;
 
+        // trace-egress: loopback (test scaffold targeting unreachable localhost)
         let http = Arc::new(reqwest::Client::new());
         let auth = AuthClient::new(
             http.clone(),

--- a/docs/observability/egress-classification-notes.md
+++ b/docs/observability/egress-classification-notes.md
@@ -1,0 +1,81 @@
+# Egress classification notes
+
+Cross-Phase 2 notes on `// trace-egress: <class>` classifier comments and
+`observability::propagation::inject_w3c` wrapping. One file per repo where
+ambiguous or awkward sites land. Future Phase 2 sweeps in sibling repos
+should append.
+
+Classes:
+
+- `propagate` — call goes to one of our own services. Wrap eventual
+  `.send()` callers with `observability::propagation::inject_w3c(builder)`.
+- `loopback` — same as propagate but for internal localhost loopback or
+  test scaffolds. Wrap if the call actually emits.
+- `skip-s3` — presigned-URL S3 calls. DO NOT wrap; injecting headers
+  breaks the SigV4 signature.
+- `skip-3p` — third-party (Stripe, OpenRouter, etc.) that doesn't honour
+  traceparent. DO NOT wrap.
+
+## fold_db (this repo) — Phase 2 / T4 sweep
+
+### Shared `Arc<reqwest::Client>` between `propagate` (auth Lambda) and `skip-s3` (presigned URLs)
+
+Two production sites construct a single `Arc<reqwest::Client>` that flows
+into BOTH consumer types:
+
+- `crates/core/src/fold_db_core/factory.rs:157` (`build_database`)
+- `crates/core/src/fold_db_core/fold_db.rs:243` (`enable_sync_with_setup`)
+
+Each construction is `let http = Arc::new(reqwest::Client::new())` and is
+immediately handed to:
+
+1. `crate::sync::auth::AuthClient::new(http.clone(), ...)` — talks to our
+   auth Lambda via `POST {base_url}{path}`. Classified `propagate`.
+2. `crate::sync::s3::S3Client::new(http.clone())` — talks to S3 via
+   presigned URLs (PUT/GET/DELETE on `presigned.url`). Classified `skip-s3`.
+
+We classify the **construction** as `propagate` (the active class — it is
+the one with required wrapping). Per-call wrapping happens in
+`AuthClient::post` (`crates/core/src/sync/auth.rs`) via `inject_w3c`.
+`S3Client::{upload,download,delete}` deliberately do NOT call `inject_w3c` —
+attaching a `traceparent` header would change the canonical request and
+invalidate the presigned URL signature.
+
+If this gets confusing in future, the cleanup is to split into two distinct
+`Arc<reqwest::Client>` — one classified `propagate` for `AuthClient`, one
+classified `skip-s3` for `S3Client`. Today they share a single connection
+pool, which is desirable; the structural split would only be cosmetic.
+
+### Test scaffolding inside `src/`
+
+Three `#[cfg(test)] mod tests` blocks contain `reqwest::Client::new()` calls
+inside `src/` files (so the lint script catches them):
+
+- `crates/core/src/storage/syncing_store.rs:122`
+- `crates/core/src/storage/syncing_namespaced_store.rs:86`
+- `crates/core/src/sync/engine.rs:2664`
+
+These build `AuthClient`/`S3Client` for tests pointed at unreachable
+localhost addresses (`http://localhost:0`, `http://127.0.0.1:1`) and never
+emit real egress at runtime. They carry `// trace-egress: loopback`
+classifiers — a documentation-only tag — to keep the lint passable without
+teaching it to grep-skip `#[cfg(test)]` blocks.
+
+The plan's note (`projects/observability-phase-2-propagation`) says egress
+classification "matters at runtime, not in test scaffolding"; the lint
+chooses simplicity over cleverness here.
+
+## Cross-repo consistency
+
+When Phase 2 sweeps run in `fold_db_node`, `schema_service`, and
+`exemem-infra`, follow the same conventions:
+
+- One classifier comment per construction, on one of the 3 lines
+  immediately preceding `reqwest::(Client|ClientBuilder)::(new|default|builder)()`.
+- For `propagate` / `loopback` clients with multiple call sites, prefer
+  wrapping inside the lowest-level helper that builds the request (e.g.
+  the `post()`/`get()` helper on a typed client struct), so adding a new
+  endpoint method doesn't require remembering to wrap.
+- For shared-client awkwardness (like the `propagate` + `skip-s3` case
+  here), document it in this file under a per-repo heading rather than
+  splitting clients prematurely.

--- a/scripts/lint-tracing-egress.sh
+++ b/scripts/lint-tracing-egress.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# lint-tracing-egress.sh
+#
+# Enforce that every `reqwest::Client` / `reqwest::ClientBuilder` construction
+# inside `crates/*/src/` carries a `// trace-egress: <class>` classifier comment
+# within the 3 lines immediately preceding it.
+#
+# Classes (Phase 2 / observability propagation):
+#   propagate — call goes to one of our own services; .send() should be wrapped with
+#               `observability::propagation::inject_w3c`.
+#   loopback  — same as propagate but for internal localhost loopback / test fakes.
+#   skip-s3   — presigned-URL S3 calls; injecting headers would corrupt the signature.
+#   skip-3p   — third-party (Stripe, OpenRouter, etc.) that does not honour traceparent.
+#
+# Tests under `crates/*/tests/` (top-level integration tests) are out of scope —
+# classification matters at runtime, not in test scaffolding outside `src/`.
+#
+# Usage: bash scripts/lint-tracing-egress.sh
+# Exit code: 0 if every match is classified, 1 otherwise.
+
+set -euo pipefail
+
+PATTERN='reqwest::(Client|ClientBuilder)::(new|default|builder)\(\)'
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
+cd "$REPO_ROOT"
+
+if ! compgen -G "crates/*/src" > /dev/null; then
+    echo "lint-tracing-egress: no crates/*/src directories found at $REPO_ROOT" >&2
+    exit 1
+fi
+
+failed=0
+total=0
+
+while IFS= read -r match; do
+    [[ -z "$match" ]] && continue
+    total=$((total + 1))
+
+    file="${match%%:*}"
+    rest="${match#*:}"
+    lineno="${rest%%:*}"
+
+    start=$((lineno - 3))
+    [[ $start -lt 1 ]] && start=1
+    end=$((lineno - 1))
+
+    preceding=""
+    if [[ $end -ge 1 ]]; then
+        preceding=$(sed -n "${start},${end}p" "$file")
+    fi
+
+    if ! printf '%s\n' "$preceding" | grep -q '// trace-egress:'; then
+        echo "ERROR: $file:$lineno — reqwest::Client construction without // trace-egress: classifier in preceding 3 lines"
+        failed=1
+    fi
+done < <(grep -rnE "$PATTERN" crates/*/src 2>/dev/null || true)
+
+if [[ $failed -ne 0 ]]; then
+    cat >&2 <<'EOF'
+
+Add a comment like '// trace-egress: <propagate|loopback|skip-s3|skip-3p>' on
+one of the 3 lines immediately preceding each reqwest::Client construction.
+See docs/observability/egress-classification-notes.md for guidance.
+EOF
+    exit 1
+fi
+
+echo "lint-tracing-egress: ok — all $total reqwest construction sites in crates/*/src/ are classified."


### PR DESCRIPTION
## Summary

- Adds `// trace-egress: <class>` classifier comments to every `reqwest::Client` construction in `crates/core/src/` (5 sites).
- Wraps `AuthClient.post().send()` with `observability::propagation::inject_w3c` so calls to the auth Lambda participate in the W3C trace.
- Adds `scripts/lint-tracing-egress.sh` and wires it into `.github/workflows/ci-tests.yml` ahead of fmt/clippy/test, so unclassified `reqwest::Client::*()` additions short-circuit fast.
- Persists awkward-classification notes (shared `propagate` + `skip-s3` client; `#[cfg(test)]` test scaffolds inside `src/`) to `docs/observability/egress-classification-notes.md`.

## Classification map

| Site | Class | Wrapping |
| --- | --- | --- |
| `crates/core/src/fold_db_core/factory.rs:158` | `propagate` | `AuthClient::post` (`sync/auth.rs`) |
| `crates/core/src/fold_db_core/fold_db.rs:244` | `propagate` | `AuthClient::post` (`sync/auth.rs`) |
| `crates/core/src/storage/syncing_store.rs:123` | `loopback` | n/a (test scaffold) |
| `crates/core/src/storage/syncing_namespaced_store.rs:87` | `loopback` | n/a (test scaffold) |
| `crates/core/src/sync/engine.rs:2665` | `loopback` | n/a (test scaffold) |

The two production sites construct a single `Arc<reqwest::Client>` shared between `AuthClient` (our service → `propagate`, wrap) and `S3Client` (presigned URLs → `skip-s3`, must NOT wrap). The construction is classified `propagate` (the active class). S3Client deliberately does not call `inject_w3c` to preserve SigV4 signatures. See `docs/observability/egress-classification-notes.md` for the full reasoning and a future-cleanup option (split into two clients).

## Test plan

- [x] `bash scripts/lint-tracing-egress.sh` exits 0 with all 5 sites classified.
- [x] Manually deleted one classifier comment — lint exited 1 with the offending `file:line` printed.
- [x] `cargo build --workspace` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo test --workspace --all-targets` — all suites pass (623 in `fold_db` + 32 in `observability` + integration suites).

## Out of scope

- AWS SDK propagation (Phase 6).
- Egress sweeps in `fold_db_node`, `schema_service`, `exemem-infra` — separate tasks under `projects/observability-phase-2-coordination`.
- Headline E2E test (Phase 2 / T6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)