### PR TITLE
feat(observability/phase-3): redirect log_feature! macro to tracing::

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -43,6 +43,7 @@ seahash = "4.1"
 once_cell = "1"
 colored = "3.1.1"
 log = { version = "0.4", features = ["std"] }
+tracing = "0.1"
 
 # Async runtime
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "sync", "time", "fs", "signal", "io-util"] }
@@ -98,7 +99,6 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "full"] }
 reqwest = { version = "0.11", features = ["json"] }
 
 tracing-subscriber = "0.3"
-tracing = "0.1"
 wat = "1"
 temp-env = "0.3"
 serial_test = "3"

--- a/crates/core/src/logging/features.rs
+++ b/crates/core/src/logging/features.rs
@@ -36,12 +36,131 @@ impl LogFeature {
     }
 }
 
-/// Generic logging macro for all features
+/// Generic logging macro for all features.
+///
+/// Expands to a `match` on the `LogFeature` so each arm hands `tracing::$level!`
+/// a `&'static str` target literal — `tracing` stores `target` in a static
+/// `Metadata` callsite, so it cannot accept a runtime method call like
+/// `feature.target()`. The match keeps targets in lockstep with
+/// `LogFeature::target()` above; both must be updated together.
 #[macro_export]
 macro_rules! log_feature {
-    ($feature:expr, $level:ident, $($arg:tt)*) => {
-        log::$level!(target: $feature.target(), $($arg)*)
-    };
+    ($feature:expr, $level:ident, $($arg:tt)*) => {{
+        match $feature {
+            $crate::logging::features::LogFeature::Transform => {
+                tracing::$level!(target: "fold_node::transform", $($arg)*)
+            }
+            $crate::logging::features::LogFeature::Network => {
+                tracing::$level!(target: "fold_node::network", $($arg)*)
+            }
+            $crate::logging::features::LogFeature::Database => {
+                tracing::$level!(target: "fold_node::database", $($arg)*)
+            }
+            $crate::logging::features::LogFeature::Schema => {
+                tracing::$level!(target: "fold_node::schema", $($arg)*)
+            }
+            $crate::logging::features::LogFeature::Query => {
+                tracing::$level!(target: "fold_node::query", $($arg)*)
+            }
+            $crate::logging::features::LogFeature::Mutation => {
+                tracing::$level!(target: "fold_node::mutation", $($arg)*)
+            }
+            $crate::logging::features::LogFeature::Permissions => {
+                tracing::$level!(target: "fold_node::permissions", $($arg)*)
+            }
+            $crate::logging::features::LogFeature::HttpServer => {
+                tracing::$level!(target: "fold_node::http_server", $($arg)*)
+            }
+            $crate::logging::features::LogFeature::TcpServer => {
+                tracing::$level!(target: "fold_node::tcp_server", $($arg)*)
+            }
+            $crate::logging::features::LogFeature::Ingestion => {
+                tracing::$level!(target: "fold_node::ingestion", $($arg)*)
+            }
+        }
+    }};
 }
 
 pub use crate::log_feature;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing::{Event, Subscriber};
+    use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+    use tracing_subscriber::registry::{LookupSpan, Registry};
+
+    #[derive(Default)]
+    struct MessageVisitor {
+        message: String,
+    }
+
+    impl Visit for MessageVisitor {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                self.message = format!("{:?}", value);
+            }
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct CaptureLayer {
+        captured: Arc<Mutex<Vec<(String, String, String)>>>,
+    }
+
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let meta = event.metadata();
+            let mut visitor = MessageVisitor::default();
+            event.record(&mut visitor);
+            self.captured.lock().unwrap().push((
+                meta.target().to_string(),
+                meta.level().to_string(),
+                visitor.message,
+            ));
+        }
+    }
+
+    /// `log_feature!` must route through `tracing::$level!`, not `log::$level!`.
+    /// Assert by installing a tracing-only subscriber and confirming the event
+    /// arrives with the feature's `target()` and the requested level.
+    #[test]
+    fn log_feature_routes_through_tracing() {
+        let layer = CaptureLayer::default();
+        let captured = layer.captured.clone();
+        let subscriber = Registry::default().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            log_feature!(LogFeature::Schema, info, "schema event {}", 7);
+            log_feature!(LogFeature::HttpServer, warn, "server warn");
+        });
+
+        let entries = captured.lock().unwrap();
+        assert_eq!(
+            entries.len(),
+            2,
+            "expected two captured events: {entries:?}"
+        );
+
+        assert_eq!(entries[0].0, LogFeature::Schema.target());
+        assert_eq!(entries[0].1, "INFO");
+        assert!(
+            entries[0].2.contains("schema event 7"),
+            "message body should contain the formatted args, got {:?}",
+            entries[0].2,
+        );
+
+        assert_eq!(entries[1].0, LogFeature::HttpServer.target());
+        assert_eq!(entries[1].1, "WARN");
+        assert!(
+            entries[1].2.contains("server warn"),
+            "message body should contain the literal, got {:?}",
+            entries[1].2,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Phase 3 / T1: change `log_feature!`'s macro body from `log::$level!` to `tracing::$level!` so every existing call site (~12 in tree) instantly routes through the `tracing` subscriber installed by `observability::init_node`. Macro signature is unchanged; bulk renames (T2) and the eventual removal of the `log` crate (T7) are still out of scope here.
- The naive swap doesn't compile: `tracing::$level!(target: …)` stores `target` in a static `Metadata` callsite, so it cannot accept a runtime method call like `feature.target()` (the `log` crate evaluated `target:` lazily, masking this). Macro body is now a `match` over `LogFeature` whose arms pass literal `&'static str` targets. Targets are duplicated between `LogFeature::target()` and the match arms; both must be updated together.
- `tracing` was a dev-dep on `crates/core`, which left `tracing::…` paths unresolvable from production callers. Promoted it to `[dependencies]` alongside `log`.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` — full suite passes (624 lib tests; observability + integration tests; no regressions)
- [x] New unit test `crates/core/src/logging/features.rs::tests::log_feature_routes_through_tracing` installs a `tracing_subscriber::Layer`, emits two events via `log_feature!` (Schema/INFO and HttpServer/WARN), and asserts target/level/body — would fail under the old `log::*` body since no `LogTracer` is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)