### PR TITLE
ci(discord-notify): add explicit empty permissions block

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -10,6 +10,8 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: {}` to the Discord notification workflow — addresses CodeQL "Workflow does not contain permissions" finding. The workflow only makes outbound HTTPS calls; no GITHUB_TOKEN access needed.

Same change applied to all 9 EdgeVector repos.