### PR TITLE
feat(observability): migrate log::*! to tracing::*! in crates/core (Phase 3 / T2)

### DIFF
--- a/crates/core/src/crypto/e2e.rs
+++ b/crates/core/src/crypto/e2e.rs
@@ -99,8 +99,8 @@ impl E2eKeys {
                 })?;
             }
 
-            log::info!("Generated new E2E key at {}", key_path.display());
-            log::warn!("Back up your E2E key! Without it, encrypted data cannot be recovered.");
+            tracing::info!("Generated new E2E key at {}", key_path.display());
+            tracing::warn!("Back up your E2E key! Without it, encrypted data cannot be recovered.");
 
             secret
         };

--- a/crates/core/src/crypto/provider.rs
+++ b/crates/core/src/crypto/provider.rs
@@ -103,11 +103,11 @@ impl LocalCryptoProvider {
                 })?;
             }
 
-            log::info!(
+            tracing::info!(
                 "Generated new local encryption key at {}",
                 key_path.display()
             );
-            log::warn!(
+            tracing::warn!(
                 "⚠️  Back up your encryption key! Without it, encrypted data cannot be recovered."
             );
 

--- a/crates/core/src/db_operations/atom_store.rs
+++ b/crates/core/src/db_operations/atom_store.rs
@@ -123,14 +123,14 @@ impl AtomStore {
             })
             .collect();
 
-        log::info!("💾 Batch storing {} atoms (after dedup)", items.len());
+        tracing::info!("💾 Batch storing {} atoms (after dedup)", items.len());
 
         self.main_store.batch_put_items(items).await.map_err(|e| {
-            log::error!("❌ Failed to batch store atoms: {}", e);
+            tracing::error!("❌ Failed to batch store atoms: {}", e);
             SchemaError::InvalidData(format!("Failed to batch store atoms: {}", e))
         })?;
 
-        log::info!("✅ Batch stored atoms successfully");
+        tracing::info!("✅ Batch stored atoms successfully");
         Ok(())
     }
 
@@ -175,14 +175,14 @@ impl AtomStore {
             })
             .collect();
 
-        log::info!("💾 Batch storing {} molecules (after dedup)", items.len());
+        tracing::info!("💾 Batch storing {} molecules (after dedup)", items.len());
 
         self.main_store.batch_put_items(items).await.map_err(|e| {
-            log::error!("❌ Failed to batch store molecules: {}", e);
+            tracing::error!("❌ Failed to batch store molecules: {}", e);
             SchemaError::InvalidData(format!("Failed to batch store molecules: {}", e))
         })?;
 
-        log::info!("✅ Batch stored molecules successfully");
+        tracing::info!("✅ Batch stored molecules successfully");
         Ok(())
     }
 
@@ -215,22 +215,22 @@ impl AtomStore {
         let base_key = format!("atom:{}", new_atom.uuid());
         let atom_key = build_storage_key(org_hash, &base_key);
 
-        log::debug!("🔍 Checking for existing atom: {}", atom_key);
+        tracing::debug!("🔍 Checking for existing atom: {}", atom_key);
         if let Some(existing_atom) =
             self.main_store
                 .get_item::<Atom>(&atom_key)
                 .await
                 .map_err(|e| {
-                    log::error!("❌ Failed to check existing atom '{}': {}", atom_key, e);
+                    tracing::error!("❌ Failed to check existing atom '{}': {}", atom_key, e);
                     SchemaError::InvalidData(format!("Failed to check existing atom: {}", e))
                 })?
         {
-            log::debug!("✅ Atom already exists, returning existing: {}", atom_key);
+            tracing::debug!("✅ Atom already exists, returning existing: {}", atom_key);
             return Ok(existing_atom);
         }
 
         // Store the new atom (deferred - no immediate flush)
-        log::info!(
+        tracing::info!(
             "💾 Writing atom: key={}, uuid={}",
             atom_key,
             new_atom.uuid()
@@ -239,10 +239,10 @@ impl AtomStore {
             .put_item(&atom_key, &new_atom)
             .await
             .map_err(|e| {
-                log::error!("❌ Failed to store atom '{}': {}", atom_key, e);
+                tracing::error!("❌ Failed to store atom '{}': {}", atom_key, e);
                 SchemaError::InvalidData(format!("Failed to store atom: {}", e))
             })?;
-        log::info!("✅ Atom written: {}", atom_key);
+        tracing::info!("✅ Atom written: {}", atom_key);
 
         Ok(new_atom)
     }

--- a/crates/core/src/db_operations/core.rs
+++ b/crates/core/src/db_operations/core.rs
@@ -117,7 +117,7 @@ impl DbOperations {
             .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
             .unwrap_or(false);
         let native_index_manager = if native_index_disabled {
-            log::info!(
+            tracing::info!(
                 "Native index disabled via FOLD_DISABLE_NATIVE_INDEX — \
                  embedding-based search will not function; hash/range queries still work."
             );

--- a/crates/core/src/db_operations/metadata_store.rs
+++ b/crates/core/src/db_operations/metadata_store.rs
@@ -70,7 +70,7 @@ impl MetadataStore {
             }
             Ok(Some(_)) | Ok(None) => {}
             Err(e) => {
-                log::warn!(
+                tracing::warn!(
                     "Failed to deserialize node_id (possibly old format): {}, creating new",
                     e
                 );

--- a/crates/core/src/db_operations/native_index/embedding_index.rs
+++ b/crates/core/src/db_operations/native_index/embedding_index.rs
@@ -130,7 +130,7 @@ impl EmbeddingIndex {
         let raw = match store.scan_prefix(EMB_PREFIX.as_bytes()).await {
             Ok(r) => r,
             Err(e) => {
-                log::warn!("Failed to scan embedding index from store: {}", e);
+                tracing::warn!("Failed to scan embedding index from store: {}", e);
                 return Vec::new();
             }
         };
@@ -151,11 +151,11 @@ impl EmbeddingIndex {
                         face_confidence: stored.face_confidence,
                     });
                 }
-                Err(e) => log::warn!("Failed to deserialize StoredEmbedding: {}", e),
+                Err(e) => tracing::warn!("Failed to deserialize StoredEmbedding: {}", e),
             }
         }
 
-        log::info!("Loaded {} embeddings from store", entries.len());
+        tracing::info!("Loaded {} embeddings from store", entries.len());
         entries
     }
 
@@ -258,7 +258,7 @@ impl EmbeddingIndex {
 
         let added = current.len() - before;
         if added > 0 {
-            log::info!("reload_from_store: added {} new embeddings to index", added);
+            tracing::info!("reload_from_store: added {} new embeddings to index", added);
         }
         added
     }
@@ -272,7 +272,7 @@ impl EmbeddingIndex {
         entries.retain(|e| !e.schema.starts_with(&prefix));
         let removed = before - entries.len();
         if removed > 0 {
-            log::info!(
+            tracing::info!(
                 "purge_org: removed {} embeddings for org {}",
                 removed,
                 &org_hash[..12.min(org_hash.len())]

--- a/crates/core/src/db_operations/native_index/face/model.rs
+++ b/crates/core/src/db_operations/native_index/face/model.rs
@@ -80,7 +80,7 @@ impl ModelManager {
         std::fs::rename(&tmp, &dest).map_err(|e| {
             SchemaError::InvalidData(format!("Failed to rename {tmp:?} -> {dest:?}: {e}"))
         })?;
-        log::info!(
+        tracing::info!(
             "Extracted bundled face model {} ({} bytes)",
             dest.display(),
             bytes.len()

--- a/crates/core/src/db_operations/native_index/face/pipeline.rs
+++ b/crates/core/src/db_operations/native_index/face/pipeline.rs
@@ -69,7 +69,7 @@ impl FaceProcessor for OnnxFaceProcessor {
                     });
                 }
                 Err(e) => {
-                    log::warn!("Failed to embed face: {}", e);
+                    tracing::warn!("Failed to embed face: {}", e);
                 }
             }
         }

--- a/crates/core/src/db_operations/native_index/mod.rs
+++ b/crates/core/src/db_operations/native_index/mod.rs
@@ -146,7 +146,7 @@ impl NativeIndexManager {
 
         let total = sled_count.max(mem_count);
         if total > 0 {
-            log::info!(
+            tracing::info!(
                 "purge_org_embeddings: deleted {} from store, {} from memory for org {}",
                 sled_count,
                 mem_count,
@@ -230,7 +230,7 @@ impl NativeIndexManager {
         }
 
         if count > 0 {
-            log::info!(
+            tracing::info!(
                 "index_faces: indexed {} face(s) for schema={} key={:?}",
                 count,
                 schema,

--- a/crates/core/src/db_operations/org_operations.rs
+++ b/crates/core/src/db_operations/org_operations.rs
@@ -59,7 +59,7 @@ impl DbOperations {
             total_deleted += emb_count;
         }
 
-        log::info!(
+        tracing::info!(
             "successfully purged {} keys for org {}",
             total_deleted,
             org_hash

--- a/crates/core/src/fold_db_core/event_monitor.rs
+++ b/crates/core/src/fold_db_core/event_monitor.rs
@@ -7,7 +7,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use log::info;
+use tracing::info;
 
 pub use super::event_statistics::{EventStatistics, MutationStats, QueryStats};
 use crate::messaging::{AsyncMessageBus, Event};

--- a/crates/core/src/fold_db_core/factory.rs
+++ b/crates/core/src/fold_db_core/factory.rs
@@ -74,15 +74,15 @@ pub async fn create_fold_db_with_pool_and_auth_refresh(
     if let Some(cloud) = &config.cloud_sync {
         if let Some(cs) = db.config_store() {
             if let Err(e) = cs.set("cloud:api_url", &cloud.api_url) {
-                log::warn!("failed to persist cloud api_url to Sled: {e}");
+                tracing::warn!("failed to persist cloud api_url to Sled: {e}");
             }
             if let Some(ref uh) = cloud.user_hash {
                 if let Err(e) = cs.set("cloud:user_hash", uh) {
-                    log::warn!("failed to persist cloud user_hash to Sled: {e}");
+                    tracing::warn!("failed to persist cloud user_hash to Sled: {e}");
                 }
             }
             if let Err(e) = cs.set("cloud:enabled", "true") {
-                log::warn!("failed to persist cloud:enabled to Sled: {e}");
+                tracing::warn!("failed to persist cloud:enabled to Sled: {e}");
             }
         }
     }
@@ -178,10 +178,10 @@ async fn create_local_fold_db(
         let namespaces = base_store.list_namespaces().await.unwrap_or_default();
         let has_user_data = namespaces.iter().any(|ns| ns != "__sled__default");
         if !has_user_data {
-            log::info!("empty local database with sync enabled — bootstrapping from cloud");
+            tracing::info!("empty local database with sync enabled — bootstrapping from cloud");
             match engine.bootstrap().await {
-                Ok(seq) => log::info!("bootstrap complete: restored to seq {seq}"),
-                Err(e) => log::warn!("bootstrap failed (starting fresh): {e}"),
+                Ok(seq) => tracing::info!("bootstrap complete: restored to seq {seq}"),
+                Err(e) => tracing::warn!("bootstrap failed (starting fresh): {e}"),
             }
         }
 
@@ -240,7 +240,7 @@ async fn create_local_fold_db(
                 crate::db_operations::native_index::face::OnnxFaceProcessor::new(&home_path),
             );
             mgr.set_face_processor(processor);
-            log::info!(
+            tracing::info!(
                 "Face detection processor initialized (models at {}/models/)",
                 home_path.display()
             );

--- a/crates/core/src/fold_db_core/fold_db.rs
+++ b/crates/core/src/fold_db_core/fold_db.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 // External crate imports
-use log::{debug, info};
+use tracing::{debug, info};
 
 // Internal crate imports
 use crate::db_operations::{DbOperations, IndexResult};
@@ -98,7 +98,7 @@ impl FoldDB {
             "Shutting down FoldDB: flushing sync and storage"
         );
         if let Err(e) = self.stop_sync().await {
-            log::warn!("sync flush on shutdown failed: {e}");
+            tracing::warn!("sync flush on shutdown failed: {e}");
         }
         self.flush().await
     }
@@ -366,7 +366,7 @@ impl FoldDB {
                     crate::db_operations::native_index::face::OnnxFaceProcessor::new(&home_path),
                 );
                 mgr.set_face_processor(processor);
-                log::info!(
+                tracing::info!(
                     "Face detection processor initialized (models at {}/models/)",
                     home_path.display()
                 );

--- a/crates/core/src/fold_db_core/mutation_manager.rs
+++ b/crates/core/src/fold_db_core/mutation_manager.rs
@@ -20,9 +20,9 @@ use crate::schema::types::{KeyValue, Mutation, Schema};
 use crate::schema::{SchemaCore, SchemaError};
 use crate::storage::SledPool;
 use chrono::Utc;
-use log::{debug, error, warn};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
+use tracing::{debug, error, warn};
 
 /// Manages mutation operations for the FoldDB system
 pub struct MutationManager {
@@ -238,11 +238,11 @@ impl MutationManager {
         // Phase 0: Redirect identity view mutations to source schemas
         let mutations = self.view_orchestrator.redirect_mutation(mutations).await?;
 
-        log::info!(
+        tracing::info!(
             "🔄 write_mutations_batch_async: Starting batch of {} mutations",
             mutations.len()
         );
-        log::debug!(
+        tracing::debug!(
             "DEBUG: MutationManager::write_mutations_batch_async started for {} mutations",
             mutations.len()
         );
@@ -257,14 +257,14 @@ impl MutationManager {
         timing_breakdown.insert("idempotency_check", idem_start.elapsed());
 
         if new_mutations.is_empty() {
-            log::info!(
+            tracing::info!(
                 "All {} mutations were idempotency duplicates, skipping processing",
                 already_seen_ids.len()
             );
             return Ok(already_seen_ids);
         }
 
-        log::debug!(
+        tracing::debug!(
             "Idempotency: {} new, {} duplicates",
             new_mutations.len(),
             already_seen_ids.len()
@@ -421,7 +421,7 @@ impl MutationManager {
         let mut all_ids = already_seen_ids;
         all_ids.extend(mutation_ids.iter().cloned());
 
-        log::info!(
+        tracing::info!(
             "✅ write_mutations_batch_async: Completed {} mutations ({} new, {} cached) in {:.2}ms",
             all_ids.len(),
             mutation_ids.len(),
@@ -439,7 +439,7 @@ impl MutationManager {
         timing_breakdown: &HashMap<&str, std::time::Duration>,
         total_time: std::time::Duration,
     ) {
-        log::debug!(
+        tracing::debug!(
             "Batch mutation timing breakdown (total: {:.2}ms):",
             total_time.as_millis()
         );
@@ -479,7 +479,7 @@ impl MutationManager {
                 .await
             {
                 Ok(Some(cached_id)) => {
-                    log::debug!(
+                    tracing::debug!(
                         "Idempotency hit for mutation hash {}, returning cached id {}",
                         hash,
                         cached_id
@@ -607,7 +607,7 @@ impl MutationManager {
 
         // Batch store all atoms at once
         if !atoms_to_store.is_empty() {
-            log::info!("💾 Batch storing {} atoms", atoms_to_store.len());
+            tracing::info!("💾 Batch storing {} atoms", atoms_to_store.len());
             self.db_ops
                 .batch_store_atoms(atoms_to_store.clone(), schema.org_hash.as_deref())
                 .await?;
@@ -789,7 +789,7 @@ impl MutationManager {
 
         // Batch store all molecules at once
         if !molecules_to_store.is_empty() {
-            log::info!("💾 Batch storing {} molecules", molecules_to_store.len());
+            tracing::info!("💾 Batch storing {} molecules", molecules_to_store.len());
             self.db_ops
                 .batch_store_molecules(molecules_to_store.clone(), schema.org_hash.as_deref())
                 .await?;
@@ -798,7 +798,7 @@ impl MutationManager {
         // Store mutation events for point-in-time queries
         if !mutation_events.is_empty() {
             let phase4_start = std::time::Instant::now();
-            log::debug!("💾 Storing {} mutation events", mutation_events.len());
+            tracing::debug!("💾 Storing {} mutation events", mutation_events.len());
             self.db_ops
                 .batch_store_mutation_events(mutation_events.clone(), schema.org_hash.as_deref())
                 .await?;
@@ -916,14 +916,14 @@ impl MutationManager {
         timing_breakdown: &mut HashMap<&str, std::time::Duration>,
     ) -> Result<(), SchemaError> {
         // Single flush for entire batch (async)
-        log::debug!("💾 Flushing database after batch mutations");
+        tracing::debug!("💾 Flushing database after batch mutations");
         let flush_start = std::time::Instant::now();
         self.db_ops.flush().await.map_err(|e| {
-            log::error!("❌ Failed to flush database after batch mutations: {}", e);
+            tracing::error!("❌ Failed to flush database after batch mutations: {}", e);
             SchemaError::InvalidData(format!("Flush failed: {}", e))
         })?;
         timing_breakdown.insert("flush", flush_start.elapsed());
-        log::debug!("✅ Database flushed in {:?}", flush_start.elapsed());
+        tracing::debug!("✅ Database flushed in {:?}", flush_start.elapsed());
 
         // Store idempotency entries for successfully processed mutations
         let idem_store_start = std::time::Instant::now();
@@ -937,7 +937,7 @@ impl MutationManager {
                 .batch_put_idempotency(idem_entries)
                 .await
                 .map_err(|e| {
-                    log::error!("Failed to store idempotency entries: {}", e);
+                    tracing::error!("Failed to store idempotency entries: {}", e);
                     e
                 })?;
         }

--- a/crates/core/src/fold_db_core/orchestration/index_status.rs
+++ b/crates/core/src/fold_db_core/orchestration/index_status.rs
@@ -102,7 +102,7 @@ impl IndexStatusTracker {
 
     /// Mark the start of a batch indexing operation
     pub async fn start_batch(&self, batch_size: usize) {
-        log::debug!("IndexStatusTracker: Starting batch of size {}", batch_size);
+        tracing::debug!("IndexStatusTracker: Starting batch of size {}", batch_size);
         let mut status = self.load_status().await.unwrap_or_default();
 
         status.state = IndexingState::Indexing;
@@ -111,18 +111,18 @@ impl IndexStatusTracker {
         status.current_batch_start_time = Some(Self::current_timestamp());
 
         if let Err(e) = self.save_status(&status).await {
-            log::error!(
+            tracing::error!(
                 "IndexStatusTracker: Failed to save status in start_batch: {}",
                 e
             );
         } else {
-            log::debug!("IndexStatusTracker: Batch started, status saved");
+            tracing::debug!("IndexStatusTracker: Batch started, status saved");
         }
     }
 
     /// Mark the completion of a batch indexing operation
     pub async fn complete_batch(&self, batch_size: usize, duration_ms: u128) {
-        log::debug!(
+        tracing::debug!(
             "IndexStatusTracker: Completing batch of size {}, duration {}ms",
             batch_size,
             duration_ms
@@ -133,7 +133,7 @@ impl IndexStatusTracker {
         if let Some(start_time) = status.current_batch_start_time {
             let elapsed = Self::current_timestamp() - start_time;
             if elapsed < 500 {
-                log::debug!(
+                tracing::debug!(
                     "IndexStatusTracker: Sleeping for {}ms to ensure visibility",
                     500 - elapsed
                 );
@@ -164,12 +164,12 @@ impl IndexStatusTracker {
         }
 
         if let Err(e) = self.save_status(&status).await {
-            log::error!(
+            tracing::error!(
                 "IndexStatusTracker: Failed to save status in complete_batch: {}",
                 e
             );
         } else {
-            log::debug!(
+            tracing::debug!(
                 "IndexStatusTracker: Batch completed, status saved. Total ops: {}",
                 status.total_operations_processed
             );
@@ -181,7 +181,7 @@ impl IndexStatusTracker {
         let mut status = self.load_status().await.unwrap_or_default();
         status.operations_queued = count;
         if let Err(e) = self.save_status(&status).await {
-            log::error!(
+            tracing::error!(
                 "IndexStatusTracker: Failed to save status in set_queued: {}",
                 e
             );
@@ -192,12 +192,12 @@ impl IndexStatusTracker {
     pub async fn get_status(&self) -> IndexingStatus {
         match self.load_status().await {
             Ok(status) => {
-                log::debug!("IndexStatusTracker: get_status loaded: {:?}", status);
+                tracing::debug!("IndexStatusTracker: get_status loaded: {:?}", status);
                 status
             }
             Err(e) => {
                 // If it fails (e.g. timeout), log and return default
-                log::error!("IndexStatusTracker: Failed to load status: {}", e);
+                tracing::error!("IndexStatusTracker: Failed to load status: {}", e);
                 IndexingStatus::default()
             }
         }

--- a/crates/core/src/fold_db_core/pending_task_tracker.rs
+++ b/crates/core/src/fold_db_core/pending_task_tracker.rs
@@ -1,8 +1,8 @@
-use log::{debug, info, warn};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
+use tracing::{debug, info, warn};
 
 /// Tracks pending background tasks to ensure clean shutdown in serverless environments.
 ///

--- a/crates/core/src/fold_db_core/process_results_subscriber.rs
+++ b/crates/core/src/fold_db_core/process_results_subscriber.rs
@@ -42,7 +42,7 @@ impl ProcessResultsSubscriber {
                         Self::handle_event(&e, &db_ops).await;
                     }
                 }
-                log::warn!("ProcessResultsSubscriber: consumer disconnected");
+                tracing::warn!("ProcessResultsSubscriber: consumer disconnected");
             })
             .await
         });
@@ -77,7 +77,7 @@ impl ProcessResultsSubscriber {
         // Write: key = "{progress_id}:mut:{mutation_id}"
         let key = format!("{}:mut:{}", progress_id, mutation_id);
         if let Err(e) = db_ops.metadata().put_process_result(&key, &result).await {
-            log::error!(
+            tracing::error!(
                 "ProcessResultsSubscriber: failed to write result for key '{}': {}",
                 key,
                 e

--- a/crates/core/src/fold_db_core/query/hash_range_query.rs
+++ b/crates/core/src/fold_db_core/query/hash_range_query.rs
@@ -44,7 +44,7 @@ impl HashRangeQueryProcessor {
         as_of: Option<DateTime<Utc>>,
     ) -> Result<HashMap<String, HashMap<KeyValue, FieldValue>>, SchemaError> {
         let current_user = crate::logging::core::get_current_user_id();
-        log::info!(
+        tracing::info!(
             "🔍 HashRangeQueryProcessor: schema={}, filter={:?}, user_context={:?}",
             schema.name,
             filter,
@@ -66,13 +66,13 @@ impl HashRangeQueryProcessor {
             if !return_all && !fields.contains(field_name) {
                 continue;
             }
-            log::debug!("🔍 Resolving field: {}", field_name);
+            tracing::debug!("🔍 Resolving field: {}", field_name);
 
             // Resolve against the schema's native namespace (personal or org).
             let mut field_value = field
                 .resolve_value(&self.db_ops, filter.clone(), as_of)
                 .await?;
-            log::debug!(
+            tracing::debug!(
                 "✅ Field '{}' resolved {} values from own namespace",
                 field_name,
                 field_value.len()
@@ -85,7 +85,7 @@ impl HashRangeQueryProcessor {
                     .await
                 {
                     Ok(mut shared) => {
-                        log::debug!(
+                        tracing::debug!(
                             "✅ Field '{}' resolved {} values from namespace '{}'",
                             field_name,
                             shared.len(),
@@ -125,7 +125,7 @@ impl HashRangeQueryProcessor {
 
             result.insert(field_name.clone(), field_value);
         }
-        log::debug!(
+        tracing::debug!(
             "✅ HashRangeQueryProcessor::query_with_filter: returning {} fields",
             result.len()
         );
@@ -146,7 +146,7 @@ impl HashRangeQueryProcessor {
         let subs = match crate::sharing::store::list_share_subscriptions(pool) {
             Ok(s) => s,
             Err(e) => {
-                log::error!(
+                tracing::error!(
                     "HashRangeQueryProcessor: failed to list share subscriptions: {}",
                     e
                 );
@@ -167,7 +167,7 @@ impl HashRangeQueryProcessor {
                     }
                 }
                 None => {
-                    log::error!(
+                    tracing::error!(
                         "HashRangeQueryProcessor: subscription has unparseable \
                          share_prefix '{}' (expected 'share:{{sender}}:{{recipient}}'); \
                          skipping.",

--- a/crates/core/src/fold_db_core/query/query_executor.rs
+++ b/crates/core/src/fold_db_core/query/query_executor.rs
@@ -290,7 +290,7 @@ impl QueryExecutor {
                     .iter()
                     .map(|v| v.name.clone())
                     .collect();
-                log::error!(
+                tracing::error!(
                     "'{}' not found as schema or view. Schemas: {:?}, Views: {:?}",
                     query.schema_name,
                     schema_names,

--- a/crates/core/src/fold_db_core/sync_coordinator.rs
+++ b/crates/core/src/fold_db_core/sync_coordinator.rs
@@ -7,8 +7,8 @@
 
 use std::sync::{Mutex, RwLock};
 
-use log::{debug, warn};
 use tokio::task::JoinHandle;
+use tracing::{debug, warn};
 
 use std::sync::Arc;
 
@@ -120,7 +120,7 @@ impl SyncCoordinator {
                         if let Some(pool) = &sled_pool {
                             let _ =
                                 crate::org::operations::delete_org(pool, org_hash).map_err(|err| {
-                                    log::error!("Failed to delete org structure: {}", err)
+                                    tracing::error!("Failed to delete org structure: {}", err)
                                 });
                         }
 
@@ -128,7 +128,7 @@ impl SyncCoordinator {
                         let _ = db_ops
                             .purge_org_data(org_hash)
                             .await
-                            .map_err(|err| log::error!("Failed to purge org data: {}", err));
+                            .map_err(|err| tracing::error!("Failed to purge org data: {}", err));
 
                         // Membership-revoked is not a transient retry target —
                         // stay responsive.

--- a/crates/core/src/fold_db_core/trigger_runner.rs
+++ b/crates/core/src/fold_db_core/trigger_runner.rs
@@ -37,12 +37,12 @@
 //!   middle of a coalesce window doesn't drop events.
 
 use async_trait::async_trait;
-use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
+use tracing::{debug, info, warn};
 
 use super::view_orchestrator::ViewOrchestrator;
 use crate::schema::types::{KeyValue, Mutation};
@@ -2517,40 +2517,66 @@ mod tests {
         );
     }
 
-    /// Process-wide capture logger for asserting log emission in tests.
-    /// `log::set_boxed_logger` is global and one-shot; we install once via
-    /// `Once`, and the buffer survives across tests in this binary. Tests
-    /// that care about emitted lines call `drain_capture` to read since
-    /// the last drain, then filter for their target message.
+    /// Process-wide capture subscriber for asserting tracing event emission
+    /// in tests. `tracing::subscriber::set_global_default` is global and
+    /// one-shot; we install once via `Once`, and the buffer survives across
+    /// tests in this binary. Tests that care about emitted lines call
+    /// `drain_capture` to read since the last drain, then filter for their
+    /// target message.
     static CAPTURE_INIT: std::sync::Once = std::sync::Once::new();
     static CAPTURE_BUFFER: once_cell::sync::Lazy<std::sync::Mutex<Vec<String>>> =
         once_cell::sync::Lazy::new(|| std::sync::Mutex::new(Vec::new()));
 
-    struct CaptureLogger;
+    struct CaptureLayer;
 
-    impl log::Log for CaptureLogger {
-        fn enabled(&self, metadata: &log::Metadata) -> bool {
-            metadata.level() <= log::Level::Info
-        }
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let metadata = event.metadata();
+            let level = match *metadata.level() {
+                tracing::Level::ERROR => "ERROR",
+                tracing::Level::WARN => "WARN",
+                tracing::Level::INFO => "INFO",
+                _ => return,
+            };
 
-        fn log(&self, record: &log::Record) {
-            if !self.enabled(record.metadata()) {
-                return;
+            struct MessageVisitor(String);
+            impl tracing::field::Visit for MessageVisitor {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "message" {
+                        self.0 = format!("{:?}", value);
+                    }
+                }
+                fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                    if field.name() == "message" {
+                        self.0 = value.to_string();
+                    }
+                }
             }
-            let line = format!("{} {} {}", record.level(), record.target(), record.args());
+            let mut visitor = MessageVisitor(String::new());
+            event.record(&mut visitor);
+
+            let line = format!("{} {} {}", level, metadata.target(), visitor.0);
             CAPTURE_BUFFER.lock().unwrap().push(line);
         }
-
-        fn flush(&self) {}
     }
 
     fn install_capture_logger() {
         CAPTURE_INIT.call_once(|| {
-            // If another logger was installed first (e.g. by another test
-            // binary or a future LoggingSystem call), fall through silently —
-            // capture-dependent tests will be skipped, not crashed.
-            let _ = log::set_boxed_logger(Box::new(CaptureLogger));
-            log::set_max_level(log::LevelFilter::Info);
+            use tracing_subscriber::layer::SubscriberExt;
+            let subscriber = tracing_subscriber::Registry::default().with(CaptureLayer);
+            // If another subscriber was installed first (e.g. by another
+            // test binary or a future LoggingSystem call), fall through
+            // silently — capture-dependent tests will be skipped, not
+            // crashed.
+            let _ = tracing::subscriber::set_global_default(subscriber);
         });
     }
 

--- a/crates/core/src/fold_db_core/view_orchestrator.rs
+++ b/crates/core/src/fold_db_core/view_orchestrator.rs
@@ -324,7 +324,7 @@ impl ViewOrchestrator {
         let lineage = db_ops.lineage();
         for uuid in mutation_uuids {
             if let Err(e) = lineage.insert(&uuid, sources).await {
-                log::warn!(
+                tracing::warn!(
                     "Lineage index insert failed for derived mutation '{}' on view '{}': {}",
                     uuid,
                     view.name,

--- a/crates/core/src/logging/core.rs
+++ b/crates/core/src/logging/core.rs
@@ -160,7 +160,7 @@ impl Logger for MultiAsyncLogger {
 
 /// Bridge that forwards Rust's log crate to custom Logger
 ///
-/// This allows all internal FoldDB logging (using `log::info!()`, etc.)
+/// This allows all internal FoldDB logging (using `tracing::info!()`, etc.)
 /// to be captured and sent to your custom logger implementation.
 ///
 /// **Note**: LogEntry does not contain user_id. Your logger implementation
@@ -168,7 +168,7 @@ impl Logger for MultiAsyncLogger {
 ///
 /// Bridge that forwards Rust's log crate to custom Logger
 ///
-/// This allows all internal FoldDB logging (using `log::info!()`, etc.)
+/// This allows all internal FoldDB logging (using `tracing::info!()`, etc.)
 /// to be captured and sent to your custom logger implementation.
 ///
 /// **Note**: LogEntry does not contain user_id. Your logger implementation

--- a/crates/core/src/schema/core.rs
+++ b/crates/core/src/schema/core.rs
@@ -151,7 +151,7 @@ impl SchemaCore {
         }
 
         if changed > 0 {
-            log::info!(
+            tracing::info!(
                 "reload_from_store: refreshed {} schema(s) in cache",
                 changed
             );
@@ -223,7 +223,7 @@ impl SchemaCore {
             .unwrap_or_default();
 
         if current_state == SchemaState::Blocked {
-            log::debug!(
+            tracing::debug!(
                 "Skipping approve for blocked schema '{}' — it has been superseded",
                 schema_name
             );
@@ -294,7 +294,7 @@ impl SchemaCore {
         }
 
         if !names_to_remove.is_empty() {
-            log::info!(
+            tracing::info!(
                 "purged {} org schemas for org {}: {:?}",
                 names_to_remove.len(),
                 org_hash,
@@ -362,7 +362,7 @@ impl SchemaCore {
             };
 
             if let Some(new_name) = successor {
-                log::info!(
+                tracing::info!(
                     "Schema '{}' is blocked with successor, redirecting to '{}'",
                     schema_name,
                     new_name
@@ -384,7 +384,7 @@ impl SchemaCore {
             {
                 // Update memory
                 self.load_schema_internal(schema.clone()).await?;
-                log::info!(
+                tracing::info!(
                     "Refreshed schema '{}' from database (stale cache)",
                     schema.name
                 );
@@ -439,7 +439,7 @@ impl SchemaCore {
                         .is_some_and(|m| !m.is_empty());
                     if cached_has_molecules {
                         // Cached schema has molecule state, incoming doesn't — preserve cache
-                        log::debug!(
+                        tracing::debug!(
                             "load_schema_internal: preserving cached molecule state for '{}'",
                             name
                         );

--- a/crates/core/src/schema/field_mapper.rs
+++ b/crates/core/src/schema/field_mapper.rs
@@ -96,7 +96,7 @@ impl FieldMapperService {
             };
 
             let Some(source_field) = source_schema.runtime_fields.get(mapper.source_field()) else {
-                log::warn!(
+                tracing::warn!(
                     "apply_field_mappers: source field '{}.{}' not in runtime_fields, skipping",
                     source_schema_name,
                     mapper.source_field()
@@ -111,7 +111,7 @@ impl FieldMapperService {
             };
 
             let Some(target_runtime_field) = schema.runtime_fields.get_mut(&target_field) else {
-                log::warn!(
+                tracing::warn!(
                     "apply_field_mappers: target field '{}' not in runtime_fields, skipping",
                     target_field
                 );
@@ -160,14 +160,14 @@ impl FieldMapperService {
             let fetched = match self.db_ops.get_schema(source_schema_name).await {
                 Ok(Some(s)) => s,
                 Ok(None) => {
-                    log::warn!(
+                    tracing::warn!(
                         "apply_field_mappers: source schema '{}' not found, skipping its mappers",
                         source_schema_name
                     );
                     return None;
                 }
                 Err(e) => {
-                    log::warn!(
+                    tracing::warn!(
                         "apply_field_mappers: error loading source schema '{}': {}, skipping",
                         source_schema_name,
                         e

--- a/crates/core/src/schema/types/field/base.rs
+++ b/crates/core/src/schema/types/field/base.rs
@@ -62,7 +62,7 @@ where
                 Err(e) => {
                     // Non-fatal: molecule ref may be in an old serialization format.
                     // The field still works — data is read from atoms directly.
-                    log::warn!(
+                    tracing::warn!(
                         "FieldBase: skipping molecule ref for {}: {}",
                         molecule_uuid,
                         e
@@ -74,12 +74,17 @@ where
             if self.inner.org_hash().is_some() {
                 match store.get_item::<M>(&base_key).await {
                     Ok(Some(molecule)) => {
-                        log::debug!("FieldBase: resolved molecule via pre-tag (unprefixed) key");
+                        tracing::debug!(
+                            "FieldBase: resolved molecule via pre-tag (unprefixed) key"
+                        );
                         self.molecule = Some(molecule);
                     }
                     Ok(None) => {}
                     Err(e) => {
-                        log::warn!("FieldBase: pre-tag fallback for molecule ref failed: {}", e);
+                        tracing::warn!(
+                            "FieldBase: pre-tag fallback for molecule ref failed: {}",
+                            e
+                        );
                     }
                 }
             }

--- a/crates/core/src/schema/types/field/common.rs
+++ b/crates/core/src/schema/types/field/common.rs
@@ -162,7 +162,7 @@ macro_rules! impl_field {
             }
 
             async fn refresh_from_db(&mut self, db_ops: &$crate::db_operations::DbOperations) {
-                log::error!("refresh_from_db not implemented for {}", stringify!($t));
+                tracing::error!("refresh_from_db not implemented for {}", stringify!($t));
             }
 
             fn write_mutation(
@@ -171,7 +171,7 @@ macro_rules! impl_field {
                 ctx: $crate::schema::types::field::WriteContext,
             ) {
                 let _ = (key_value, ctx);
-                log::error!("write_mutation not implemented for {}", stringify!($t));
+                tracing::error!("write_mutation not implemented for {}", stringify!($t));
             }
 
             async fn resolve_value(
@@ -186,7 +186,7 @@ macro_rules! impl_field {
                 >,
                 $crate::schema::types::SchemaError,
             > {
-                log::error!("resolve_value not implemented for {}", stringify!($t));
+                tracing::error!("resolve_value not implemented for {}", stringify!($t));
                 Err($crate::schema::types::SchemaError::InvalidField(format!(
                     "resolve_value not implemented for {}",
                     stringify!($t)

--- a/crates/core/src/schema/types/field/filter_utils.rs
+++ b/crates/core/src/schema/types/field/filter_utils.rs
@@ -139,7 +139,7 @@ pub async fn fetch_atoms_with_key_metadata_async_with_org(
             Ok(None) => {
                 let key_str = key.to_string();
                 if org_hash.is_some() {
-                    log::warn!(
+                    tracing::warn!(
                         "Skipping unresolvable atom ref — pre-tag molecule ref leaked \
                          without atom data (alpha BLOCKER 4b171)"
                     );

--- a/crates/core/src/schema/types/field/hash_range_field.rs
+++ b/crates/core/src/schema/types/field/hash_range_field.rs
@@ -92,7 +92,7 @@ impl crate::schema::types::field::Field for HashRangeField {
                 }
             }
             _ => {
-                log::warn!(
+                tracing::warn!(
                     "HashRangeField::write_mutation: atom {} not indexed — hash={:?}, range={:?}. \
                      Both hash and range keys are required for HashRange fields.",
                     ctx.atom.uuid(),

--- a/crates/core/src/storage/encrypting_store.rs
+++ b/crates/core/src/storage/encrypting_store.rs
@@ -121,7 +121,7 @@ impl EncryptingKvStore {
 
         // No ENC: prefix — this is either plaintext or raw binary
         if self.migration_mode {
-            log::debug!("No ENC: prefix in migration mode, returning raw data as plaintext");
+            tracing::debug!("No ENC: prefix in migration mode, returning raw data as plaintext");
             Ok(data)
         } else {
             Err(StorageError::EncryptionError(

--- a/crates/core/src/storage/node_config_store.rs
+++ b/crates/core/src/storage/node_config_store.rs
@@ -195,7 +195,7 @@ impl NodeConfigStore {
         let private_key = match self.decrypt_sensitive(stored_private) {
             Ok(p) => p,
             Err(e) => {
-                log::error!("failed to load encrypted node identity: {}", e);
+                tracing::error!("failed to load encrypted node identity: {}", e);
                 return None;
             }
         };

--- a/crates/core/src/storage/sled_pool.rs
+++ b/crates/core/src/storage/sled_pool.rs
@@ -145,7 +145,7 @@ impl SledPool {
                     && inner.active_ops == 0
                     && inner.last_activity.elapsed() >= idle_timeout
                 {
-                    log::debug!(
+                    tracing::debug!(
                         "SledPool: releasing idle database at {}",
                         pool.path.display()
                     );

--- a/crates/core/src/sync/engine.rs
+++ b/crates/core/src/sync/engine.rs
@@ -344,14 +344,14 @@ impl SyncEngine {
         let kv = match self.store.open_namespace("sync_cursors").await {
             Ok(kv) => kv,
             Err(e) => {
-                log::warn!("Failed to open sync_cursors namespace: {}", e);
+                tracing::warn!("Failed to open sync_cursors namespace: {}", e);
                 return;
             }
         };
         let entries = match kv.scan_prefix(b"cursor:").await {
             Ok(entries) => entries,
             Err(e) => {
-                log::warn!("Failed to scan cursor keys: {}", e);
+                tracing::warn!("Failed to scan cursor keys: {}", e);
                 return;
             }
         };
@@ -366,7 +366,7 @@ impl SyncEngine {
             }
         }
         if !cursors.is_empty() {
-            log::info!("Loaded {} download cursors from storage", cursors.len());
+            tracing::info!("Loaded {} download cursors from storage", cursors.len());
         }
     }
 
@@ -409,13 +409,13 @@ impl SyncEngine {
         if let Some(reloader) = reloader_slot.lock().await.as_ref() {
             match reloader().await {
                 Ok(count) if count > 0 => {
-                    log::info!(
+                    tracing::info!(
                         "{kind} reloader added {count} item(s) after sync from '{target_label}'"
                     );
                 }
                 Ok(_) => {}
                 Err(e) => {
-                    log::warn!("failed to reload {kind}s after sync: {e}");
+                    tracing::warn!("failed to reload {kind}s after sync: {e}");
                 }
             }
         }
@@ -478,7 +478,7 @@ impl SyncEngine {
             // Dropping pending entries silently would cause permanent data
             // loss on peers — upgrade from warn to error so this is
             // unmissable in logs (alpha BLOCKER 4439b class of bug).
-            log::error!(
+            tracing::error!(
                 "SYNC DATA LOSS: pending queue exceeded max_pending ({}), dropping {} oldest entries — these writes will NOT reach sync peers",
                 max,
                 overflow
@@ -601,7 +601,7 @@ impl SyncEngine {
         {
             let mut state = self.state.lock().await;
             if *state == SyncState::Syncing {
-                log::info!("sync skipped: already syncing");
+                tracing::info!("sync skipped: already syncing");
                 return Ok(false);
             }
             *state = SyncState::Syncing;
@@ -619,7 +619,7 @@ impl SyncEngine {
             Ok(()) => true,
             Err(SyncError::Auth(_)) => false, // auth error — will be caught by do_sync
             Err(e) => {
-                log::warn!("failed to acquire sync lock (proceeding anyway): {e}");
+                tracing::warn!("failed to acquire sync lock (proceeding anyway): {e}");
                 false
             }
         };
@@ -634,7 +634,7 @@ impl SyncEngine {
         // Always release the lock, even on error
         if lock_held {
             if let Err(e) = self.release_lock().await {
-                log::warn!("failed to release sync lock: {e}");
+                tracing::warn!("failed to release sync lock: {e}");
             }
         }
 
@@ -673,14 +673,14 @@ impl SyncEngine {
             None => return Err(SyncError::Auth("authentication failed".to_string())),
         };
 
-        log::info!("{context} auth failed, attempting token refresh");
+        tracing::info!("{context} auth failed, attempting token refresh");
         let new_auth = refresh_cb().await.map_err(|e| {
-            log::warn!("{context} token refresh failed: {e}");
+            tracing::warn!("{context} token refresh failed: {e}");
             SyncError::Auth("authentication failed after token refresh failure".to_string())
         })?;
 
         self.auth.update_auth(new_auth).await;
-        log::info!("{context} token refreshed");
+        tracing::info!("{context} token refreshed");
         Ok(())
     }
 
@@ -713,7 +713,7 @@ impl SyncEngine {
             // Upload each bucket with its target's crypto
             let mut upload_auth_error = false;
             for (target_idx, bucket) in &buckets {
-                log::info!(
+                tracing::info!(
                     "uploading {} entries to target {} ('{}')",
                     bucket.len(),
                     target_idx,
@@ -726,10 +726,10 @@ impl SyncEngine {
                 match self.upload_entries(target, bucket).await {
                     Ok(n) => uploaded += n,
                     Err(ref e) if matches!(e, SyncError::Auth(_)) => {
-                        log::warn!("upload to '{}' failed (auth): {e}", target.label);
+                        tracing::warn!("upload to '{}' failed (auth): {e}", target.label);
                         upload_auth_error = true;
                     }
-                    Err(e) => log::warn!("upload to '{}' failed: {e}", target.label),
+                    Err(e) => tracing::warn!("upload to '{}' failed: {e}", target.label),
                 }
             }
 
@@ -748,7 +748,7 @@ impl SyncEngine {
                 let count = entries.len().min(pending.len());
                 pending.drain(..count);
             } else if uploaded > 0 {
-                log::warn!(
+                tracing::warn!(
                     "partial upload: {}/{} entries succeeded, keeping all in pending for retry",
                     uploaded,
                     entries.len()
@@ -766,7 +766,7 @@ impl SyncEngine {
         for target in &targets {
             match self.download_with_auth_retry(target).await {
                 Ok(n) => downloaded += n,
-                Err(e) => log::warn!("download from '{}' failed: {e}", target.label),
+                Err(e) => tracing::warn!("download from '{}' failed: {e}", target.label),
             }
         }
 
@@ -775,7 +775,7 @@ impl SyncEngine {
             let current_seq = *self.seq.lock().await;
             if current_seq > 0 {
                 if let Err(e) = self.compact(current_seq).await {
-                    log::warn!("compaction failed (non-fatal): {e}");
+                    tracing::warn!("compaction failed (non-fatal): {e}");
                 }
             }
         }
@@ -901,7 +901,7 @@ impl SyncEngine {
                 Err(e) if matches!(&e, SyncError::Auth(_)) => return Err(e),
                 Err(e) => {
                     let delay_ms = 500 * 2u64.pow(attempt);
-                    log::warn!(
+                    tracing::warn!(
                         "{}: attempt {}/{} failed ({}), retrying in {}ms",
                         label,
                         attempt + 1,
@@ -944,7 +944,7 @@ impl SyncEngine {
                 Ok(n) => total += n,
                 Err(e) => {
                     if total > 0 {
-                        log::warn!(
+                        tracing::warn!(
                             "upload to '{}' partial: {}/{} entries uploaded across chunks before {}",
                             target.label,
                             total,
@@ -1047,7 +1047,7 @@ impl SyncEngine {
             Ok(n) => Ok(n),
             Err(ref e) if matches!(e, SyncError::Auth(_)) => {
                 if let Some(ref refresh_cb) = self.auth_refresh {
-                    log::info!(
+                    tracing::info!(
                         "org download from '{}' auth failed, refreshing",
                         target.label
                     );
@@ -1127,7 +1127,7 @@ impl SyncEngine {
                 if new_seqs.len() != expected {
                     let set: std::collections::BTreeSet<u64> = new_seqs.iter().copied().collect();
                     let missing: Vec<u64> = (first..=last).filter(|s| !set.contains(s)).collect();
-                    log::error!(
+                    tracing::error!(
                         "sync list '{}' returned non-contiguous seqs after cursor={}: first={} last={} count={} expected={} missing_sample={:?}",
                         target.label,
                         cursor,
@@ -1151,7 +1151,7 @@ impl SyncEngine {
         }
 
         if new_seqs.is_empty() {
-            log::info!(
+            tracing::info!(
                 "download '{}': 0 new entries (cursor={})",
                 target.label,
                 cursor
@@ -1159,7 +1159,7 @@ impl SyncEngine {
             return Ok(0);
         }
 
-        log::info!(
+        tracing::info!(
             "download '{}': {} new entries after cursor={}",
             target.label,
             new_seqs.len(),
@@ -1197,7 +1197,7 @@ impl SyncEngine {
                     })
                     .await?;
                 let bytes = downloaded.ok_or_else(|| {
-                    log::error!(
+                    tracing::error!(
                         "sync replay aborted: entry not found in '{}' seq={} (server listed this seq but S3 returned 404); cursor will NOT advance past seq={}",
                         target.label,
                         seq,
@@ -1212,7 +1212,7 @@ impl SyncEngine {
                     }
                 })?;
                 let entry = LogEntry::unseal(&bytes, &target.crypto).await.map_err(|e| {
-                    log::error!(
+                    tracing::error!(
                         "sync replay aborted: failed to unseal entry in '{}' seq={}: {}; cursor will NOT advance past seq={}",
                         target.label,
                         seq,
@@ -1233,14 +1233,14 @@ impl SyncEngine {
                     "native_index" => embeddings_replayed = true,
                     _ => {}
                 }
-                log::info!(
+                tracing::info!(
                     "replay '{}' seq={}: {}",
                     target.label,
                     seq,
                     entry.op.describe()
                 );
                 self.replay_entry(&entry, Some(target)).await.map_err(|e| {
-                    log::error!(
+                    tracing::error!(
                         "sync replay aborted: apply failed in '{}' seq={}: {}; cursor will NOT advance past seq={}",
                         target.label,
                         seq,
@@ -1287,14 +1287,14 @@ impl SyncEngine {
                     .put(cursor_key.as_bytes(), seq.to_be_bytes().to_vec())
                     .await
                 {
-                    log::error!(
+                    tracing::error!(
                         "failed to save download cursor for '{}' at seq {}: {} — next restart will re-download from last saved cursor",
                         prefix, seq, e
                     );
                 }
             }
             Err(e) => {
-                log::error!(
+                tracing::error!(
                     "failed to open sync_cursors namespace for '{}': {} — cursor not persisted",
                     prefix,
                     e
@@ -1308,7 +1308,7 @@ impl SyncEngine {
     // =========================================================================
 
     async fn compact(&self, last_seq: u64) -> SyncResult<()> {
-        log::info!("compacting: creating snapshot at seq {last_seq}");
+        tracing::info!("compacting: creating snapshot at seq {last_seq}");
 
         let snapshot = Snapshot::create(self.store.as_ref(), &self.device_id, last_seq).await?;
 
@@ -1341,7 +1341,7 @@ impl SyncEngine {
                             Ok(delete_urls) => {
                                 for url in &delete_urls {
                                     if let Err(e) = self.s3.delete(url).await {
-                                        log::warn!(
+                                        tracing::warn!(
                                             "failed to delete compacted log (non-fatal): {e}"
                                         );
                                     }
@@ -1355,19 +1355,21 @@ impl SyncEngine {
                         }
                     }
                     if let Some(e) = presign_err {
-                        log::warn!("failed to get delete URLs for compacted logs (non-fatal): {e}");
+                        tracing::warn!(
+                            "failed to get delete URLs for compacted logs (non-fatal): {e}"
+                        );
                     }
                     if deleted > 0 {
-                        log::info!("deleted {} compacted log entries", deleted);
+                        tracing::info!("deleted {} compacted log entries", deleted);
                     }
                 }
             }
             Err(e) => {
-                log::warn!("failed to list logs for compaction cleanup (non-fatal): {e}");
+                tracing::warn!("failed to list logs for compaction cleanup (non-fatal): {e}");
             }
         }
 
-        log::info!("compaction complete: snapshot at seq {last_seq}");
+        tracing::info!("compaction complete: snapshot at seq {last_seq}");
         Ok(())
     }
 
@@ -1429,7 +1431,7 @@ impl SyncEngine {
             targets[idx].clone()
         };
 
-        log::info!(
+        tracing::info!(
             "bootstrapping target '{}' (idx={}, prefix='{}')",
             target.label,
             idx,
@@ -1447,7 +1449,7 @@ impl SyncEngine {
                 Some(data) => {
                     let snapshot = Snapshot::unseal(&data, &target.crypto).await?;
                     let last_seq = snapshot.last_seq;
-                    log::info!(
+                    tracing::info!(
                         "restoring snapshot for '{}': {} namespaces, last_seq={}",
                         target.label,
                         snapshot.namespaces.len(),
@@ -1457,7 +1459,7 @@ impl SyncEngine {
                     last_seq
                 }
                 None => {
-                    log::info!("no snapshot found for '{}' — starting fresh", target.label);
+                    tracing::info!("no snapshot found for '{}' — starting fresh", target.label);
                     0
                 }
             }
@@ -1479,7 +1481,7 @@ impl SyncEngine {
         let mut entries_replayed: usize = 0;
 
         if !log_seqs.is_empty() {
-            log::info!(
+            tracing::info!(
                 "replaying {} log entries for '{}' (seq {}..={})",
                 log_seqs.len(),
                 target.label,
@@ -1492,7 +1494,7 @@ impl SyncEngine {
             for (seq, url) in log_seqs.iter().zip(urls.iter()) {
                 let data = self.s3.download(url).await?;
                 let bytes = data.ok_or_else(|| {
-                    log::error!(
+                    tracing::error!(
                         "bootstrap aborted: log entry for '{}' seq={seq} not found in S3 after listing",
                         target.label
                     );
@@ -1507,7 +1509,7 @@ impl SyncEngine {
                 let entry = LogEntry::unseal(&bytes, &target.crypto)
                     .await
                     .map_err(|e| {
-                        log::error!(
+                        tracing::error!(
                             "bootstrap aborted: failed to unseal log entry for '{}' seq={seq}: {e}",
                             target.label
                         );
@@ -1523,7 +1525,7 @@ impl SyncEngine {
                     "native_index" => embeddings_replayed = true,
                     _ => {}
                 }
-                log::info!(
+                tracing::info!(
                     "bootstrap replay '{}' seq={}: {}",
                     target.label,
                     seq,
@@ -1555,7 +1557,7 @@ impl SyncEngine {
             self.save_download_cursor(&target.prefix, last_seq).await;
         }
 
-        log::info!(
+        tracing::info!(
             "bootstrap of '{}' complete at seq {} ({} entries replayed)",
             target.label,
             last_seq,
@@ -1590,7 +1592,7 @@ impl SyncEngine {
         // Snapshot target count and release the lock before iterating so
         // per-target calls can reacquire it.
         let target_count = self.targets.lock().await.len();
-        log::info!("bootstrap_all: starting restore of {target_count} target(s)");
+        tracing::info!("bootstrap_all: starting restore of {target_count} target(s)");
 
         let mut outcomes: Vec<BootstrapOutcome> = Vec::with_capacity(target_count);
         for idx in 0..target_count {
@@ -1626,7 +1628,7 @@ impl SyncEngine {
                 .await;
         }
 
-        log::info!(
+        tracing::info!(
             "bootstrap_all: completed {} target(s) successfully",
             outcomes.len()
         );
@@ -1672,7 +1674,7 @@ impl SyncEngine {
                 for (idx, (key, value)) in items.iter().enumerate() {
                     let final_key =
                         Self::rewrite_key_if_needed(namespace, key, target).map_err(|e| {
-                            log::error!(
+                            tracing::error!(
                                 "replay BatchPut abort: key rewrite failed at item {}/{} ns={}: {}",
                                 idx + 1,
                                 total,
@@ -1690,7 +1692,7 @@ impl SyncEngine {
                     )
                     .await
                     .map_err(|e| {
-                        log::error!(
+                        tracing::error!(
                             "replay BatchPut abort: item {}/{} ns={} failed to apply: {}",
                             idx + 1,
                             total,
@@ -1968,7 +1970,7 @@ impl SyncEngine {
 
     async fn backup_snapshot_once(&self) -> SyncResult<u64> {
         let current_seq = *self.seq.lock().await;
-        log::info!(
+        tracing::info!(
             "backup_snapshot: creating snapshot at seq {} (device='{}')",
             current_seq,
             self.device_id,
@@ -1985,7 +1987,7 @@ impl SyncEngine {
         let latest_url = self.auth.presign_snapshot_upload("latest.enc").await?;
         self.s3.upload(&latest_url, sealed).await?;
 
-        log::info!(
+        tracing::info!(
             "backup_snapshot: uploaded {} namespaces at seq {} as 'latest.enc' and '{}' (device='{}')",
             namespace_count,
             current_seq,
@@ -2042,7 +2044,7 @@ impl SyncEngine {
         self.acquire_lock().await?;
         let result = self.purge_personal_log_inner().await;
         if let Err(e) = self.release_lock().await {
-            log::warn!("purge_personal_log: failed to release device lock (non-fatal): {e}");
+            tracing::warn!("purge_personal_log: failed to release device lock (non-fatal): {e}");
         }
         result
     }
@@ -2086,7 +2088,7 @@ impl SyncEngine {
             // keys come back as `snapshots/{name}` — we want the bare
             // `{name}` for the delete request.
             let Some(name) = obj.key.strip_prefix("snapshots/") else {
-                log::warn!(
+                tracing::warn!(
                     "purge_personal_log: skipping snapshot key '{}' that doesn't start with 'snapshots/'",
                     obj.key
                 );
@@ -2097,7 +2099,7 @@ impl SyncEngine {
             outcome.deleted_snapshots += 1;
         }
 
-        log::info!(
+        tracing::info!(
             "purge_personal_log: deleted {} log objects, {} snapshots",
             outcome.deleted_log_objects,
             outcome.deleted_snapshots,


### PR DESCRIPTION
## Summary

Cohort B follow-up to T1 (log_feature! macro redirect, #638). Sweeps the remaining direct `log::` macro call sites and macro imports in `crates/core/src/`.

- **150** fully-qualified `log::{info,warn,error,debug,trace}!` call sites → `tracing::{level}!`
- **6** `use log::{macros}` imports in `crates/core/src/fold_db_core/` → `use tracing::{macros}`
- Replaced `trigger_runner` test's `CaptureLogger` (impl `log::Log`) with a `tracing_subscriber::Layer` using `field::Visit` to extract the implicit `message` field, preserving the existing `"{LEVEL} {target} {message}"` capture shape so test assertions are unchanged.

## Out of scope (per Phase 3 plan)

- The four `crates/core/src/logging/outputs/*.rs` appenders impl `log::Log` and keep their `use log::{LevelFilter, Metadata, Record}` imports — they're trait-impl types, not macro callers. The appender rewrite + `log` dep removal land in T7.
- `fold_db_node` sweep → P3-T2-fdnode (separate task)
- `schema_service` sweep → P3-T2-schemasvc

## DoD grep state

```
$ grep -RnE '\b(log::(info|warn|error|debug|trace)!|log_enabled!)' crates/core/src/
(no matches)

$ grep -RnE 'use log::' crates/core/src/
crates/core/src/logging/outputs/web.rs:6:use log::LevelFilter;
crates/core/src/logging/outputs/structured.rs:4:use log::{LevelFilter, Metadata, Record};
crates/core/src/logging/outputs/file.rs:4:use log::{LevelFilter, Metadata, Record};
crates/core/src/logging/outputs/console.rs:5:use log::{LevelFilter, Metadata, Record};
```

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --all-targets` — all green
- [x] `bash scripts/lint-tracing-egress.sh` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)