### PR TITLE
feat(observability): instrument trigger_runner spawns + propagation test (Phase 3 / T6)

### DIFF
--- a/crates/core/src/fold_db_core/trigger_runner.rs
+++ b/crates/core/src/fold_db_core/trigger_runner.rs
@@ -42,7 +42,7 @@ use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
-use tracing::{debug, info, warn};
+use tracing::{debug, info, warn, Instrument};
 
 use super::view_orchestrator::ViewOrchestrator;
 use crate::schema::types::{KeyValue, Mutation};
@@ -541,12 +541,15 @@ impl<C: Clock> TriggerRunner<C> {
         let runner = Arc::clone(self);
         let rt = Arc::clone(rt);
         let view_name = view_name.to_string();
-        tokio::spawn(async move {
-            runner
-                .run_fire_with_refire_loop(&view_name, trigger_index, &rt)
-                .await;
-            rt.dispatch_in_flight.store(false, Ordering::SeqCst);
-        });
+        tokio::spawn(
+            async move {
+                runner
+                    .run_fire_with_refire_loop(&view_name, trigger_index, &rt)
+                    .await;
+                rt.dispatch_in_flight.store(false, Ordering::SeqCst);
+            }
+            .instrument(tracing::Span::current()),
+        );
     }
 
     /// Inline dispatch: claim the slot, run ONE fire synchronously,
@@ -594,15 +597,18 @@ impl<C: Clock> TriggerRunner<C> {
         let runner = Arc::clone(self);
         let rt_clone = Arc::clone(rt);
         let view_name = view_name.to_string();
-        tokio::spawn(async move {
-            // Sleep before the retry — backoff driven by fail_streak.
-            let streak = rt_clone.persisted.lock().await.fail_streak;
-            runner.clock.sleep(exp_backoff_ms(streak)).await;
-            runner
-                .run_fire_with_refire_loop(&view_name, trigger_index, &rt_clone)
-                .await;
-            rt_clone.dispatch_in_flight.store(false, Ordering::SeqCst);
-        });
+        tokio::spawn(
+            async move {
+                // Sleep before the retry — backoff driven by fail_streak.
+                let streak = rt_clone.persisted.lock().await.fail_streak;
+                runner.clock.sleep(exp_backoff_ms(streak)).await;
+                runner
+                    .run_fire_with_refire_loop(&view_name, trigger_index, &rt_clone)
+                    .await;
+                rt_clone.dispatch_in_flight.store(false, Ordering::SeqCst);
+            }
+            .instrument(tracing::Span::current()),
+        );
     }
 
     /// Execute one fire attempt and persist results. Returns true when

--- a/crates/observability/src/layers/ring.rs
+++ b/crates/observability/src/layers/ring.rs
@@ -450,4 +450,62 @@ mod tests {
             "zero-capacity ring would silently drop everything"
         );
     }
+
+    /// INVARIANT: a future spawned with `tokio::spawn(fut.instrument(Span::current()))`
+    /// runs under the parent span's context, so events emitted inside the
+    /// spawned task carry the parent's `trace_id` in the RING `LogEntry`.
+    ///
+    /// Without `.instrument(...)` the spawned task starts with no current span
+    /// and the event's `trace_id` would be missing — that's the regression
+    /// guard. We use a `current_thread` runtime so the thread-local default
+    /// subscriber is visible to spawned tasks.
+    #[test]
+    fn instrument_propagates_trace_id_across_tokio_spawn() {
+        use tracing::Instrument;
+
+        let provider = SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("spawn-test");
+        let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        let (ring_layer, handle) = build_ring_layer(16);
+        let subscriber = Registry::default().with(otel_layer).with(ring_layer);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current_thread runtime");
+
+        let parent_trace_id = with_default(subscriber, || {
+            runtime.block_on(async {
+                let parent = tracing::info_span!("parent.request");
+                let trace_id_hex =
+                    format!("{:032x}", parent.context().span().span_context().trace_id());
+
+                let join = parent.in_scope(|| {
+                    tokio::spawn(
+                        async {
+                            tracing::info!("from-spawned-task");
+                        }
+                        .instrument(tracing::Span::current()),
+                    )
+                });
+                join.await.expect("spawned task joins cleanly");
+
+                trace_id_hex
+            })
+        });
+
+        let logs = handle.query(None, None);
+        let spawned = logs
+            .iter()
+            .find(|e| e.message == "from-spawned-task")
+            .expect("spawned event must be captured");
+        let meta = spawned
+            .metadata
+            .as_ref()
+            .expect("spawned event must carry metadata with trace_id");
+        assert_eq!(
+            meta.get("trace_id"),
+            Some(&parent_trace_id),
+            "spawned task must inherit parent's trace_id via .instrument(Span::current())"
+        );
+    }
 }

--- a/docs/observability/tokio-spawn-instrument-notes.md
+++ b/docs/observability/tokio-spawn-instrument-notes.md
@@ -1,0 +1,103 @@
+# tokio::spawn `.instrument(Span::current())` audit (Phase 3 / T6)
+
+Cross-Phase 3 notes on which `tokio::spawn(...)` sites in `crates/*/src/`
+need `.instrument(tracing::Span::current())` so the spawned task inherits
+its caller's span context (and thus `trace_id`, `span_id`, and any
+`user.hash` / `schema.name` fields the parent span carries).
+
+Phase 5 will add a CI lint that flags new bare `tokio::spawn(...)` calls —
+this doc records why each existing site was classified the way it was so
+the lint's allow-list (and reviewers) have a written precedent.
+
+## Heuristic
+
+- **YES (wrap with `.instrument(Span::current())`)**: the spawn lives in a
+  function reachable from a request handler, ingestion path, or any caller
+  that already has user/schema/request span context. Without `.instrument`,
+  the spawned future starts with an empty span stack — the trace breaks at
+  the spawn boundary.
+- **NO (leave bare)**: the spawn is a perpetual worker started once at
+  process boot (`init_*`, constructors), or it lives inside `#[cfg(test)]`
+  scaffolding. There is no parent request span to propagate; tagging events
+  with the boot-time span would be actively misleading.
+
+`Span::current()` is always safe — when there is no enclosing span it
+resolves to a disabled root, which the OTel layer simply skips. The choice
+to leave a site bare is documentation, not correctness.
+
+## fold_db (this repo) — Phase 3 / T6 sweep
+
+Fresh `grep -RnE 'tokio::spawn\(' crates/*/src/` enumerated 16 sites. The
+codex-flagged paths from the brief (`crates/core/src/ingestion.rs:223`,
+`crates/core/src/handlers/auth.rs:276`) do not exist in the current
+workspace layout — there is no `handlers/` module under `crates/core/src/`
+and the only `ingestion.rs` is the LLM prompt template at
+`crates/core/src/llm_registry/prompts/ingestion.rs`, which contains no
+spawn. The grep below is authoritative for this PR.
+
+### YES — wrapped with `.instrument(tracing::Span::current())`
+
+- `crates/core/src/fold_db_core/trigger_runner.rs:544` (`dispatch_nonblocking`)
+- `crates/core/src/fold_db_core/trigger_runner.rs:597` (`dispatch_inline_once`
+  retry hand-off)
+
+Both live inside `dispatch_*` async methods reachable from
+`on_mutation_notified` (the per-mutation entry point). The retry path's own
+comment — *"Failure: hand off retries to the background so the mutation
+path isn't stuck"* — is the giveaway: the caller is the user's mutation
+request, so its span carries `user.hash` / `schema.name` / `trace_id`. We
+want the deferred fire's logs to join up with the originating mutation in
+the trace.
+
+`use tracing::Instrument;` was added to the file once at the top.
+
+### NO — perpetual workers spawned at boot, no parent context
+
+| Site | Why bare |
+| --- | --- |
+| `crates/core/src/storage/sled_pool.rs:139` | Idle reaper started once by `start_idle_reaper`; no per-request caller. |
+| `crates/core/src/fold_db_core/event_monitor.rs:36, 50, 64, 78, 97` | Five subscriber loops created in `EventMonitor::new` at startup. Events flowing through them already carry their own per-emission context if any — the spawn itself does not. |
+| `crates/core/src/fold_db_core/process_results_subscriber.rs:38` | `start_event_listener` spawns one subscriber loop at boot. Same reasoning as `event_monitor`. |
+| `crates/core/src/fold_db_core/fold_db.rs:537` | `run_scheduler_loop` for `TriggerRunner`, started once at `FoldDB` construction. |
+| `crates/core/src/fold_db_core/sync_coordinator.rs:88` | Background sync poll loop started once via `start_background_sync`. |
+| `crates/core/src/fold_db_core/mutation_manager.rs:1003` | `start_event_listener` spawns one loop at boot to drain `MutationRequest` events. |
+
+Tagging any of these with `.instrument(Span::current())` would stamp every
+log line with whichever boot-time span happened to be current when
+`new()` ran — not useful, and actively misleading on dashboards.
+
+### NO — `#[cfg(test)]` scaffolding
+
+| Site | Notes |
+| --- | --- |
+| `crates/core/src/triggers/clock.rs:192` | `mock_clock_advance_wakes_sleeper` test driver. |
+| `crates/core/src/fold_db_core/trigger_runner.rs:1925` | Quarantine test driver. |
+| `crates/core/src/fold_db_core/trigger_runner.rs:2014` | Coalesce-refire test driver. |
+| `crates/core/src/fold_db_core/trigger_runner.rs:3051` | Backoff/quarantine restart test driver. |
+
+Tests are out of scope for the lint — the Phase 5 enforcement should
+exclude `cfg(test)` and `tests/` paths.
+
+## Out of scope (covered elsewhere)
+
+- `tokio::task::spawn_blocking(...)` calls in `crates/core/src/storage/sled_backend.rs`
+  and other storage paths. `spawn_blocking` takes a synchronous closure,
+  not a future, so `.instrument()` does not apply. If Phase 5 wants context
+  propagation across blocking work it needs a separate helper (capture
+  `Span::current()`, `let _e = span.enter()` inside the closure).
+- Spawns inside `fold_db_node` or `schema_service` — these live in sibling
+  workspaces and will be swept independently per the brief.
+
+## Verification
+
+A new unit test —
+`crates/observability/src/layers/ring.rs::tests::instrument_propagates_trace_id_across_tokio_spawn`
+— drives a `current_thread` runtime under a registry with an OTel layer +
+RING layer, opens a parent span to seed a real W3C trace_id, then
+`tokio::spawn(... .instrument(parent))` and asserts the spawned task's
+event lands in the RING with the parent's trace_id (32 hex chars, exact
+match). The test was confirmed to fail when the `.instrument(...)` call
+is removed (the spawned event's metadata lacks `trace_id` because the
+spawned task has no current span). This is the pattern test the Phase 5
+lint should treat as the canonical "correct" shape for context-bearing
+spawns.


### PR DESCRIPTION
## Summary
- Wraps 2 `tokio::spawn(...)` sites inside `TriggerRunner::dispatch_nonblocking` and `dispatch_inline_once` with `.instrument(tracing::Span::current())` so deferred view fires inherit the originating mutation's `trace_id`/`user.hash`/`schema.name` span context.
- Classifies the other 14 spawn sites in `crates/*/src/` as correctly bare (perpetual init-time workers + `#[cfg(test)]` drivers) — see `docs/observability/tokio-spawn-instrument-notes.md` for the full audit, intended as the reference doc for the Phase 5 lint allow-list.
- Adds a regression-guard unit test in `crates/observability/src/layers/ring.rs` that wires an OTel + RING registry on a `current_thread` runtime, opens a parent span, `tokio::spawn(... .instrument(...))`s, and asserts the spawned task's RING entry carries the parent's `trace_id`. Confirmed to fail when `.instrument(...)` is removed.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --all-targets` (all green; new test `layers::ring::tests::instrument_propagates_trace_id_across_tokio_spawn` passes and was confirmed to fail without `.instrument(...)`)
- [x] `bash scripts/lint-tracing-egress.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)