### PR TITLE
feat(observability): env-driven sampler + Honeycomb setup docs (Phase 4 / T5)

### DIFF
--- a/crates/observability/src/init.rs
+++ b/crates/observability/src/init.rs
@@ -144,8 +144,13 @@ pub fn init_node(service_name: &'static str, _version: &str) -> Result<ObsGuard,
     // No-op TracerProvider: gives every span a real W3C trace/span id so the
     // RING layer can stamp `trace_id` / `span_id` onto each entry and so
     // `propagation::inject_w3c` (Phase 2) has a real context to propagate.
-    // No exporter is wired in Phase 1 — Phase 4 swaps this for OTLP.
-    let tracer_provider = SdkTracerProvider::builder().build();
+    // No OTLP exporter is wired yet — Phase 4 / T7 will plumb that in. The
+    // sampler is configured here so that head-sampling decisions are made
+    // consistently from the moment any exporter is added; until then the
+    // sampler still gates `is_recording()` for downstream layers.
+    let sampler = crate::sampling::parse_sampler()
+        .map_err(|e| ObsError::SubscriberInstall(format!("OBS_SAMPLER: {e}")))?;
+    let tracer_provider = SdkTracerProvider::builder().with_sampler(sampler).build();
     let tracer = tracer_provider.tracer(service_name);
     let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
     // The fmt layer is constructed inline so the compiler infers its

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -22,8 +22,10 @@ pub mod attrs;
 pub mod init;
 pub mod layers;
 pub mod propagation;
+pub mod sampling;
 
 pub use init::{init_cli, init_lambda, init_node, init_tauri, ObsGuard};
+pub use sampling::{parse_sampler, parse_sampler_spec, SamplerParseError, OBS_SAMPLER_ENV};
 
 /// Errors raised by `init_*` helpers and other crate-level operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/observability/src/sampling.rs
+++ b/crates/observability/src/sampling.rs
@@ -1,0 +1,330 @@
+//! OTLP-compatible head sampling configuration parsed from the `OBS_SAMPLER`
+//! env var.
+//!
+//! Phase 4 / T5. The OTel spec defines a small set of built-in samplers
+//! (`always_on`, `always_off`, `traceidratio`, `parentbased_traceidratio`,
+//! …). Honeycomb, the OTel Collector, and the OTel SDKs in other languages
+//! all read the same `OTEL_TRACES_SAMPLER` env var with the same syntax;
+//! we mirror that under our own `OBS_SAMPLER` name so operators can copy
+//! tuning advice across stacks.
+//!
+//! ## Why parent-based by default
+//!
+//! `parentbased_traceidratio:1.0` (the default when `OBS_SAMPLER` is unset)
+//! keeps 100% of traces in dev — useful when the operator is the only
+//! consumer and every trace matters. The `parentbased_` prefix means a
+//! distributed parent's sampling decision is honoured: if an upstream
+//! service already decided "drop" we drop too, and "keep" we keep too.
+//! This is the right default for any service that participates in a
+//! W3C-propagated trace graph (which fold_db does — see
+//! [`crate::propagation`]).
+//!
+//! ## Why error-keeping is independent
+//!
+//! Errors must always reach the SaaS sink so on-call can debug them.
+//! Head sampling decides whether spans are *recorded* in the first place;
+//! the Sentry / error-routing layer is wired separately and reads
+//! `tracing::Event` levels regardless of the trace decision. Dropping a
+//! span here does not drop the corresponding error event.
+
+use std::env;
+
+use opentelemetry_sdk::trace::Sampler;
+
+/// Env var name parsed by [`parse_sampler`]. Mirrors OTel's
+/// `OTEL_TRACES_SAMPLER` syntax under a fold_db-scoped name.
+pub const OBS_SAMPLER_ENV: &str = "OBS_SAMPLER";
+
+/// Default sampler used when `OBS_SAMPLER` is unset. Dev-safe: keeps every
+/// trace, but honours an upstream "drop" decision so this service stays
+/// consistent inside a propagated trace graph.
+pub const DEFAULT_SAMPLER_SPEC: &str = "parentbased_traceidratio:1.0";
+
+/// Failure modes for [`parse_sampler_spec`]. Returned as a structured error
+/// so callers can distinguish "your env var is malformed" from "we couldn't
+/// reach Honeycomb" at startup time.
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum SamplerParseError {
+    #[error(
+        "OBS_SAMPLER ratio for `{kind}` is not a valid f64 between 0.0 and 1.0: got {value:?}"
+    )]
+    InvalidRatio { kind: &'static str, value: String },
+    #[error("OBS_SAMPLER `{kind}` requires a `:<ratio>` suffix (e.g. `{kind}:0.1`); got {raw:?}")]
+    MissingRatio { kind: &'static str, raw: String },
+    #[error(
+        "OBS_SAMPLER value {raw:?} is not a recognized sampler. Expected one of: \
+         always_on, always_off, traceidratio:<f>, parentbased_traceidratio:<f>"
+    )]
+    UnknownSampler { raw: String },
+}
+
+/// Resolve the active sampler from the process environment.
+///
+/// Order of resolution:
+/// 1. `$OBS_SAMPLER` if set — parsed via [`parse_sampler_spec`].
+/// 2. [`DEFAULT_SAMPLER_SPEC`] — `parentbased_traceidratio:1.0` (100%,
+///    parent-honouring).
+///
+/// A malformed env var is a *programmer-visible* error: we surface it via
+/// the `Result` rather than silently falling back to the default, because
+/// silent fallback would mask a typo that drops the operator's intended
+/// sampling rate.
+pub fn parse_sampler() -> Result<Sampler, SamplerParseError> {
+    match env::var(OBS_SAMPLER_ENV) {
+        Ok(raw) if !raw.trim().is_empty() => parse_sampler_spec(raw.trim()),
+        _ => parse_sampler_spec(DEFAULT_SAMPLER_SPEC),
+    }
+}
+
+/// Parse one OTel-spec sampler string. Public so tests can drive it
+/// directly without mutating the real environment.
+pub fn parse_sampler_spec(raw: &str) -> Result<Sampler, SamplerParseError> {
+    // Split on the first `:` so values that include further punctuation in
+    // the future (e.g. parentbased delegates) parse without rewrites.
+    let (kind, arg) = match raw.split_once(':') {
+        Some((k, v)) => (k.trim(), Some(v.trim())),
+        None => (raw.trim(), None),
+    };
+
+    match (kind, arg) {
+        ("always_on", None) => Ok(Sampler::AlwaysOn),
+        ("always_off", None) => Ok(Sampler::AlwaysOff),
+        ("traceidratio", Some(arg)) => Ok(Sampler::TraceIdRatioBased(parse_ratio(
+            "traceidratio",
+            arg,
+        )?)),
+        ("parentbased_traceidratio", Some(arg)) => {
+            let ratio = parse_ratio("parentbased_traceidratio", arg)?;
+            Ok(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
+                ratio,
+            ))))
+        }
+        ("traceidratio", None) => Err(SamplerParseError::MissingRatio {
+            kind: "traceidratio",
+            raw: raw.to_string(),
+        }),
+        ("parentbased_traceidratio", None) => Err(SamplerParseError::MissingRatio {
+            kind: "parentbased_traceidratio",
+            raw: raw.to_string(),
+        }),
+        // `always_on:0.5` and friends — a ratio was supplied where none was
+        // expected. Treat as unknown rather than ignoring; the operator
+        // probably meant `traceidratio:0.5`.
+        _ => Err(SamplerParseError::UnknownSampler {
+            raw: raw.to_string(),
+        }),
+    }
+}
+
+fn parse_ratio(kind: &'static str, value: &str) -> Result<f64, SamplerParseError> {
+    let parsed: f64 = value.parse().map_err(|_| SamplerParseError::InvalidRatio {
+        kind,
+        value: value.to_string(),
+    })?;
+    // Reject NaN, negative, or >1 — the OTel SDK clamps these silently to
+    // [0,1], but a clamp masks operator typos. Surface the bad value so the
+    // boot log shows it.
+    if !parsed.is_finite() || !(0.0..=1.0).contains(&parsed) {
+        return Err(SamplerParseError::InvalidRatio {
+            kind,
+            value: value.to_string(),
+        });
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Probe a `Sampler` value by asking it whether a given trace id should
+    /// be sampled. We don't assert variant identity directly because
+    /// `Sampler::ParentBased` wraps a `Box<dyn ShouldSample>` and
+    /// `TraceIdRatioBased` carries an `f64` — pattern matching is fragile
+    /// across SDK upgrades. Behavioural probes are stable.
+    fn record_decision(sampler: &Sampler, trace_id: opentelemetry::trace::TraceId) -> bool {
+        use opentelemetry::trace::{SamplingDecision, SpanKind};
+        use opentelemetry_sdk::trace::ShouldSample;
+        let result = sampler.should_sample(None, trace_id, "probe", &SpanKind::Internal, &[], &[]);
+        matches!(
+            result.decision,
+            SamplingDecision::RecordAndSample | SamplingDecision::RecordOnly
+        )
+    }
+
+    /// `TraceId::from_u128` was removed from `opentelemetry` somewhere along
+    /// the way. The byte-array constructor is the stable path.
+    fn trace_id_of(seed: u128) -> opentelemetry::trace::TraceId {
+        opentelemetry::trace::TraceId::from_bytes(seed.to_be_bytes())
+    }
+
+    #[test]
+    fn parses_always_on() {
+        let s = parse_sampler_spec("always_on").expect("always_on parses");
+        assert!(record_decision(&s, trace_id_of(1)));
+    }
+
+    #[test]
+    fn parses_always_off() {
+        let s = parse_sampler_spec("always_off").expect("always_off parses");
+        assert!(!record_decision(&s, trace_id_of(1)));
+    }
+
+    #[test]
+    fn parses_traceidratio_zero() {
+        let s = parse_sampler_spec("traceidratio:0.0").expect("ratio:0 parses");
+        // ratio 0 must drop everything
+        assert!(!record_decision(&s, trace_id_of(1)));
+    }
+
+    #[test]
+    fn parses_traceidratio_one() {
+        let s = parse_sampler_spec("traceidratio:1.0").expect("ratio:1 parses");
+        // ratio 1 must keep everything
+        assert!(record_decision(&s, trace_id_of(0xdead_beef),));
+    }
+
+    #[test]
+    fn parses_parentbased_traceidratio_one() {
+        // No parent context → falls back to root sampler (ratio 1) → keep.
+        let s =
+            parse_sampler_spec("parentbased_traceidratio:1.0").expect("parentbased ratio:1 parses");
+        assert!(record_decision(&s, trace_id_of(7)));
+    }
+
+    #[test]
+    fn parses_parentbased_traceidratio_zero() {
+        // No parent context → falls back to root sampler (ratio 0) → drop.
+        let s =
+            parse_sampler_spec("parentbased_traceidratio:0.0").expect("parentbased ratio:0 parses");
+        assert!(!record_decision(&s, trace_id_of(7)));
+    }
+
+    #[test]
+    fn tolerates_surrounding_whitespace() {
+        // Useful when the env var is set via a shell heredoc that leaks
+        // trailing whitespace.
+        let s = parse_sampler_spec("  always_on  ").expect("trim works");
+        assert!(record_decision(&s, trace_id_of(1)));
+    }
+
+    #[test]
+    fn rejects_malformed_ratio() {
+        let err = parse_sampler_spec("traceidratio:abc").expect_err("must error");
+        assert!(
+            matches!(
+                err,
+                SamplerParseError::InvalidRatio {
+                    kind: "traceidratio",
+                    ..
+                }
+            ),
+            "got: {err:?}"
+        );
+        // The error message must include the bad value so the boot log is
+        // self-explanatory.
+        assert!(err.to_string().contains("abc"), "msg={}", err);
+    }
+
+    #[test]
+    fn rejects_out_of_range_ratio() {
+        let err = parse_sampler_spec("traceidratio:1.5").expect_err("clamp must surface");
+        assert!(matches!(err, SamplerParseError::InvalidRatio { .. }));
+    }
+
+    #[test]
+    fn rejects_missing_ratio() {
+        let err = parse_sampler_spec("traceidratio").expect_err("missing ratio");
+        assert!(matches!(
+            err,
+            SamplerParseError::MissingRatio {
+                kind: "traceidratio",
+                ..
+            }
+        ));
+        let err = parse_sampler_spec("parentbased_traceidratio").expect_err("missing ratio");
+        assert!(matches!(
+            err,
+            SamplerParseError::MissingRatio {
+                kind: "parentbased_traceidratio",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_sampler() {
+        let err = parse_sampler_spec("jaeger_remote").expect_err("unknown");
+        assert!(matches!(err, SamplerParseError::UnknownSampler { .. }));
+    }
+
+    #[test]
+    fn rejects_arg_on_argless_sampler() {
+        // `always_on:0.5` is a typo — the user probably meant
+        // `traceidratio:0.5`. We must not silently accept the arg.
+        let err = parse_sampler_spec("always_on:0.5").expect_err("argless+arg → error");
+        assert!(matches!(err, SamplerParseError::UnknownSampler { .. }));
+    }
+
+    /// Mutating env vars from tests is racy when other tests in the same
+    /// binary read the same var concurrently. We serialize this single
+    /// env-touching test behind a mutex local to the module.
+    #[test]
+    fn parse_sampler_falls_back_to_default_when_env_absent() {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _g = ENV_LOCK.lock().unwrap();
+
+        let prev = env::var(OBS_SAMPLER_ENV).ok();
+        env::remove_var(OBS_SAMPLER_ENV);
+
+        let sampler = parse_sampler().expect("default parses");
+
+        // restore
+        if let Some(v) = prev {
+            env::set_var(OBS_SAMPLER_ENV, v);
+        }
+
+        // Default is parentbased_traceidratio:1.0 → with no parent, root
+        // sampler (ratio 1) → keep.
+        assert!(record_decision(&sampler, trace_id_of(42),));
+    }
+
+    #[test]
+    fn parse_sampler_reads_env_when_set() {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _g = ENV_LOCK.lock().unwrap();
+
+        let prev = env::var(OBS_SAMPLER_ENV).ok();
+        env::set_var(OBS_SAMPLER_ENV, "always_off");
+
+        let sampler = parse_sampler().expect("env parses");
+
+        match prev {
+            Some(v) => env::set_var(OBS_SAMPLER_ENV, v),
+            None => env::remove_var(OBS_SAMPLER_ENV),
+        }
+
+        assert!(!record_decision(&sampler, trace_id_of(99),));
+    }
+
+    #[test]
+    fn parse_sampler_treats_blank_env_as_unset() {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _g = ENV_LOCK.lock().unwrap();
+
+        let prev = env::var(OBS_SAMPLER_ENV).ok();
+        env::set_var(OBS_SAMPLER_ENV, "   ");
+
+        let sampler = parse_sampler().expect("blank → default, not error");
+
+        match prev {
+            Some(v) => env::set_var(OBS_SAMPLER_ENV, v),
+            None => env::remove_var(OBS_SAMPLER_ENV),
+        }
+
+        assert!(record_decision(&sampler, trace_id_of(1),));
+    }
+}

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,38 @@
+# Observability docs
+
+Operator-facing documentation for the `observability` crate
+(`crates/observability`). Designed for someone bringing up a new fold_db
+node, debugging trace propagation, or tuning what reaches Honeycomb.
+
+## Setup
+
+- **[Honeycomb dev setup](honeycomb-setup.md)** — point a node at a
+  Honeycomb environment, choose an `OBS_SAMPLER` setting, and project
+  ingest cost per env. Start here.
+
+## Implementation notes (one per phase / sweep)
+
+These are working notes, not a tutorial. Each documents the decisions
+behind a phase of the observability rollout so future contributors can
+see *why* something was wired the way it is.
+
+- [Sampling config](sampling-config-notes.md) — Phase 4 / T5. `OBS_SAMPLER`
+  parser, default values, follow-ups.
+- [tokio::spawn instrumentation](tokio-spawn-instrument-notes.md) — Phase 3 / T6.
+  Where `.instrument(Span::current())` was applied to keep trace context
+  across spawn boundaries.
+- [LoggingSystem retirement](loggingsystem-retirement-notes.md) — Phase 3 / T7.
+  Removal of the legacy `LoggingSystem` and the last `log` crate
+  references.
+- [Egress classification](egress-classification-notes.md) — Phase 2 / T4.
+  `// trace-egress: <class>` comments at HTTP call sites and which calls
+  do or don't get `inject_w3c` wrapping.
+
+## Source-of-truth pointers
+
+- Crate sources: `crates/observability/src/`
+- Init helpers: `crates/observability/src/init.rs`
+  (`init_node` / `init_lambda` / `init_tauri` / `init_cli`)
+- Layers: `crates/observability/src/layers/` (FMT, RELOAD, RING, WEB)
+- Sampling: `crates/observability/src/sampling.rs`
+- W3C propagation: `crates/observability/src/propagation.rs`

--- a/docs/observability/honeycomb-setup.md
+++ b/docs/observability/honeycomb-setup.md
@@ -1,0 +1,126 @@
+# Honeycomb dev setup
+
+How to point a fold_db node at a Honeycomb environment for trace ingest, and
+how to pick a sampling rate that fits the environment's budget.
+
+> **Status.** Phase 4 / T5. The `OBS_SAMPLER` env var is plumbed through
+> `init_node` today (controls head-sampling decisions on the local
+> `TracerProvider`). The OTLP traces *exporter* (`OBS_OTLP_ENDPOINT`,
+> `OBS_OTLP_HEADERS`) is wired by Phase 4 / T7 — until that lands, this
+> doc describes the shape of the deploy-time setup so the env vars and
+> sampling rates can be staged in advance.
+
+## 1. Create a Honeycomb environment
+
+1. Sign in to <https://ui.honeycomb.io>. fold_db's account lives under the
+   `edgevector` team; ask in #observability for an invite if you don't see
+   it.
+2. **Environments → New Environment.** Name it after the deploy stage:
+   - `fold-db-dev-<your-handle>` for personal dev work
+   - `fold-db-staging` for the shared staging account
+   - `fold-db-prod` for production
+3. **Environment Settings → API Keys → Create API Key.** Scope:
+   - `Send Events` ✅
+   - everything else ❌
+4. Copy the key — it starts with `hcaik_…` for ingest keys. Store it the
+   same way you store any other credential (1Password, deploy-tool secret
+   manager, etc.). Do not commit it.
+
+## 2. Point a local node at Honeycomb
+
+Honeycomb speaks OTLP/HTTP at `https://api.honeycomb.io/v1/traces` (US) or
+`https://api.eu1.honeycomb.io/v1/traces` (EU). The ingest key goes in the
+`x-honeycomb-team` header.
+
+Add to your local `.envrc` (or shell rc) — keep this file out of git:
+
+```sh
+export OBS_OTLP_ENDPOINT="https://api.honeycomb.io/v1/traces"
+export OBS_OTLP_HEADERS="x-honeycomb-team=hcaik_replace_with_real_key"
+export OBS_SAMPLER="parentbased_traceidratio:1.0"   # 100% in dev
+```
+
+Run a node:
+
+```sh
+cargo run -p fold_db_node
+```
+
+Open Honeycomb → your env → **Query** and filter on
+`service.name = fold_db_node`. The first trace usually shows up within
+2-5 seconds of the first request handled.
+
+## 3. Sampling configuration: `OBS_SAMPLER`
+
+The env var mirrors OTel's [`OTEL_TRACES_SAMPLER`][otel-sampler-spec]
+syntax so tuning advice copies cleanly across stacks. Recognized values:
+
+| Spec string                        | Meaning                                                     |
+|------------------------------------|-------------------------------------------------------------|
+| `always_on`                        | Keep every span. Good for one-off load tests.               |
+| `always_off`                       | Drop every span. Useful when isolating non-trace overhead.  |
+| `traceidratio:<f>`                 | Keep `<f>` of traces. Ignores upstream parent decision.     |
+| `parentbased_traceidratio:<f>`     | Honour parent's decision; for root spans, use ratio `<f>`.  |
+
+`<f>` is a float in `[0.0, 1.0]`. Out-of-range, NaN, or non-numeric
+values cause the node to refuse to boot — silent clamping is forbidden
+because it masks operator typos.
+
+When `OBS_SAMPLER` is unset, the default is `parentbased_traceidratio:1.0`
+(100%, parent-honouring). Safe in dev; **must be tuned down before any
+prod deploy** to avoid blowing the Honeycomb monthly event budget.
+
+### Recommended per-env settings
+
+| Env       | `OBS_SAMPLER` value                  | Why                                                                                           |
+|-----------|--------------------------------------|-----------------------------------------------------------------------------------------------|
+| dev       | `parentbased_traceidratio:1.0`       | Operator is the only consumer; lose nothing.                                                  |
+| staging   | `parentbased_traceidratio:0.5`       | Half-rate keeps representative coverage at half the event cost.                               |
+| prod      | `parentbased_traceidratio:0.1`       | 10% head sampling. Errors still flow via the Sentry layer; head sampling does not gate them.  |
+
+`parentbased_` is what we want everywhere: when an upstream service
+decides to keep a trace, we keep our part too — the alternative is
+half-broken trees in the Honeycomb waterfall view.
+
+### Cost projection
+
+Honeycomb's free tier is 20M events/month; Pro is metered above that
+([calculator][honeycomb-pricing]).  Using a rough back-of-envelope of
+**~50 spans per fold_db request** (handler + storage + propagation
+hops):
+
+| Sampling | Requests/day for 20M/month free tier |
+|----------|--------------------------------------|
+| 100%     | ~13K req/day                          |
+| 50%      | ~26K req/day                          |
+| 10%      | ~133K req/day                         |
+| 1%       | ~1.3M req/day                         |
+
+Numbers are rough — the real per-request span count moves around as we
+add instrumentation (Phase 4 / T6 LLM tracing will roughly double it).
+Re-run the math when production traffic hits ~1K req/day so the next
+budget cycle is informed.
+
+## 4. Errors are independent of head sampling
+
+Head sampling decides whether spans are *recorded*. The Sentry / error
+routing layer reads `tracing::Event` levels regardless of the sampler
+decision, so:
+
+- A dropped trace **still emits its error events** to Sentry.
+- A `tracing::error!` inside an unsampled span **still pages on-call**.
+
+Don't lower the sampler in an attempt to silence noisy errors — fix the
+errors upstream. Lowering the sampler only blinds you to the trace
+context that explains *why* an error happened.
+
+## 5. Tail sampling (deferred)
+
+The right answer for "keep all error traces, drop most successful ones"
+is a tail sampler running in an OTel Collector between fold_db and
+Honeycomb. We're deferring that until prod throughput justifies the
+operational cost of running the Collector. Track this in the deferred
+follow-up list at the bottom of `docs/observability/sampling-config-notes.md`.
+
+[otel-sampler-spec]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration
+[honeycomb-pricing]: https://www.honeycomb.io/pricing

--- a/docs/observability/sampling-config-notes.md
+++ b/docs/observability/sampling-config-notes.md
@@ -1,0 +1,100 @@
+# Sampling config notes
+
+Phase 4 / T5 implementation notes for `OBS_SAMPLER` env-driven head
+sampling and the Honeycomb setup doc. Captures decisions, what was
+intentionally left out, and the follow-ups that fall out.
+
+## What landed
+
+- `crates/observability/src/sampling.rs`
+  - `parse_sampler() -> Result<Sampler, SamplerParseError>` reads
+    `OBS_SAMPLER` from the env.
+  - `parse_sampler_spec(&str)` parses one spec string in OTel-spec
+    syntax. Public so tests don't have to mutate the real environment.
+  - Recognized variants: `always_on`, `always_off`,
+    `traceidratio:<f>`, `parentbased_traceidratio:<f>`.
+  - Default when env unset: `parentbased_traceidratio:1.0` (100%,
+    parent-honouring — dev-safe, must be tuned down for prod).
+  - Errors are structured: `InvalidRatio`, `MissingRatio`,
+    `UnknownSampler`. The error string includes the bad value so the
+    boot log is self-explanatory.
+- `crates/observability/src/init.rs::init_node`
+  - Sampler is constructed via `parse_sampler()` and applied with
+    `SdkTracerProvider::builder().with_sampler(sampler)` *before* the
+    OTLP exporter is wired (Phase 4 / T7). Today the exporter is still
+    a no-op, but the sampler decision already gates `is_recording()`
+    for downstream layers, so observable behaviour is consistent from
+    the moment the exporter lands.
+- `docs/observability/honeycomb-setup.md`
+  - How to create a Honeycomb env + ingest key.
+  - Where to set `OBS_OTLP_ENDPOINT` / `OBS_OTLP_HEADERS` (those env
+    vars are not yet read by code — that's Phase 4 / T7 — but the doc
+    fixes the names so we don't bikeshed them later).
+  - Recommended `OBS_SAMPLER` per env: dev=100%, staging=50%, prod=10%.
+  - Cost projection table tied to a back-of-envelope ~50 spans per
+    fold_db request.
+- `docs/observability/README.md` — index across the existing
+  observability notes; was missing.
+
+## Decisions worth flagging
+
+1. **Reject bad ratios at boot rather than clamping.** The OTel SDK
+   silently clamps `traceidratio:1.5` to `1.0`. We don't — the node
+   refuses to start. Reason: silent clamping would mask operator typos
+   that move sampling rates by 10x. Better to fail loudly.
+2. **Default is `parentbased_traceidratio:1.0`, not `always_on`.** Both
+   keep 100% of traces in dev. The parent-based form additionally
+   honours an upstream "drop" decision, which matters the moment a
+   distributed trace from a sampling-aware caller hits a fold_db node.
+   `always_on` would override that and produce half-broken trees.
+3. **Used `Builder::with_sampler(...)` directly.** The task brief
+   suggested `Config::default().with_sampler(...)`, but `Config` is
+   `#[deprecated(since = "0.27.1")]` in `opentelemetry_sdk` ≥ 0.27.
+   The two paths are wire-compatible; the non-deprecated one keeps
+   future SDK upgrades quieter.
+4. **Sampler errors surface as `ObsError::SubscriberInstall`.** No new
+   error variant — a malformed `OBS_SAMPLER` is still an init-time
+   failure from the caller's perspective, and the existing variant
+   already serializes a string. Worth revisiting if a downstream caller
+   needs to programmatically distinguish "sampler malformed" from
+   "subscriber install failed".
+5. **Behavioural test probes, not pattern matches.** `Sampler` is a
+   non-`PartialEq` enum that owns a `Box<dyn ShouldSample>` for the
+   `ParentBased` variant. Test assertions probe the sampler's
+   `should_sample` output for known trace ids instead of matching on
+   variants — that pins the *behaviour* we care about and survives
+   SDK version bumps.
+
+## Out of scope (intentional)
+
+- **Provisioning the Honeycomb account** — manual ops step described in
+  the setup doc.
+- **OTLP exporter wiring** — Phase 4 / T7. Until then the sampler runs
+  on a no-op `TracerProvider`; spans are decided-on but not exported.
+- **Tail sampling Collector deployment** — deferred until prod throughput
+  justifies the Collector's operational cost.
+- **`OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` compat** — we read
+  our own `OBS_SAMPLER` only. The OTel-standard env vars are an obvious
+  add when there's demand from a sibling crate that already reads them.
+- **Moving `honeycomb-setup.md` to `exemem-workspace/docs/observability/`**
+  — task brief explicitly defers this. The doc was created in
+  `fold_db/docs/observability/` for now; a follow-up task moves it.
+
+## Follow-ups to file
+
+- Move `docs/observability/honeycomb-setup.md` into
+  `exemem-workspace/docs/observability/` once that repo has a docs tree
+  for it. Leave a redirect stub here.
+- Wire `OBS_OTLP_ENDPOINT` + `OBS_OTLP_HEADERS` to a real OTLP/HTTP
+  exporter on the `TracerProvider` (Phase 4 / T7). The setup doc
+  already names these vars.
+- Phase 4 / T6 (LLM tracing) is expected to roughly double per-request
+  span count. When that lands, re-derive the cost-projection table in
+  `honeycomb-setup.md`.
+- Add a workspace-level boot test that flips `OBS_SAMPLER=garbage` and
+  asserts the node refuses to start. The unit tests cover the parser
+  in isolation; an integration test would catch a regression in the
+  init-time wiring.
+- Decide whether to also accept the upstream
+  `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` env vars so OTel
+  Collector sidecars can configure us with their existing playbooks.


### PR DESCRIPTION
## Summary
- New `OBS_SAMPLER` env var parses OTel-spec sampler strings (`always_on`, `always_off`, `traceidratio:<f>`, `parentbased_traceidratio:<f>`); default is `parentbased_traceidratio:1.0`. Bad ratios refuse boot rather than silently clamping.
- Wired the parsed `Sampler` into `init_node`'s `TracerProvider` so head-sampling is consistent the moment the OTLP exporter (Phase 4 / T7) lands.
- Documented Honeycomb dev setup, per-env sampler recommendations (dev 100% / staging 50% / prod 10%), cost projection, plus an index README for `docs/observability/` and implementation notes for future contributors.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` passes (15 new sampling unit tests + full workspace suite)
- [ ] Reviewer eyeballs `docs/observability/honeycomb-setup.md` for operator clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)