### PR TITLE
feat(observability): Sentry-tracing ERROR layer (Phase 4 / T4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,169 @@
 version = 4
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93acb4a42f64936f9b8cae4a433b237599dd6eb6ed06124eb67132ef8cc90662"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "bitflags 2.11.0",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "http 0.2.12",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
+dependencies = [
+ "bytestring",
+ "cfg-if",
+ "http 0.2.12",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff87453bc3b56e9b2b23c1cc0b1be8797184accf51d2abe0f8a33ec275d316bf"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "derive_more",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2 0.6.2",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
 ]
 
 [[package]]
@@ -275,6 +432,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line 0.25.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +507,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytestring"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +589,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -560,6 +756,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,7 +850,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.31.1",
  "hashbrown 0.14.5",
  "log",
  "regalloc2",
@@ -880,6 +1085,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
+ "serde",
  "uuid",
 ]
 
@@ -890,6 +1096,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -945,6 +1161,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1234,16 @@ dependencies = [
  "libc",
  "redox_users 0.4.6",
  "winapi",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
 ]
 
 [[package]]
@@ -1274,7 +1523,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ts-rs",
- "ureq",
+ "ureq 2.12.1",
  "utoipa",
  "uuid",
  "wasmtime",
@@ -1512,6 +1761,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1853,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hf-hub"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,7 +1875,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "ureq",
+ "ureq 2.12.1",
  "windows-sys 0.60.2",
 ]
 
@@ -1634,6 +1895,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -1998,6 +2270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
+name = "impl-more"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2496,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
@@ -2345,6 +2635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2418,6 +2709,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -2525,6 +2828,165 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,6 +3019,8 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "reqwest 0.11.27",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "tempfile",
@@ -2760,7 +3224,23 @@ dependencies = [
  "pkg-config",
  "sha2",
  "tar",
- "ureq",
+ "ureq 2.12.1",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2831,6 +3311,15 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2914,7 +3403,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "spki",
 ]
 
@@ -3385,6 +3874,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,6 +3967,45 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -3665,6 +4199,106 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "sentry"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "native-tls",
+ "reqwest 0.13.3",
+ "sentry-actix",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-tracing",
+ "tokio",
+ "ureq 3.3.0",
+]
+
+[[package]]
+name = "sentry-actix"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9453d18fc9a45d841636004aad50288d80cc07c34a9e88cd4397cb66e6356f67"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "bytes",
+ "futures-util",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a8c2c1bd5c1f735e84f28b48e7d72efcaafc362b7541bc8253e60e8fcdffc6"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b88a90baa654d7f0e1f4b667f6b434293d9f72c71bef16b197c76af5b7d5803"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
+dependencies = [
+ "rand 0.9.2",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
+dependencies = [
+ "bitflags 2.11.0",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3892,7 +4526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -4403,6 +5037,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4550,6 +5185,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4631,6 +5275,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "der 0.8.0",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4640,7 +5313,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4920,7 +5600,7 @@ version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11976a250672556d1c4c04c6d5d7656ac9192ac9edc42a4587d6c21460010e69"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "anyhow",
  "async-trait",
  "bitflags 2.11.0",
@@ -4929,7 +5609,7 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "fxprof-processed-profile",
- "gimli",
+ "gimli 0.31.1",
  "hashbrown 0.14.5",
  "indexmap",
  "ittapi",
@@ -5035,7 +5715,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli",
+ "gimli 0.31.1",
  "itertools 0.12.1",
  "log",
  "object 0.36.7",
@@ -5057,7 +5737,7 @@ dependencies = [
  "cpp_demangle",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli",
+ "gimli 0.31.1",
  "indexmap",
  "log",
  "object 0.36.7",
@@ -5146,7 +5826,7 @@ checksum = "fdbabfb8f20502d5e1d81092b9ead3682ae59988487aafcd7567387b7a43cf8f"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "gimli",
+ "gimli 0.31.1",
  "object 0.36.7",
  "target-lexicon",
  "wasmparser 0.221.3",
@@ -5207,6 +5887,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5272,7 +5961,7 @@ checksum = "2f849ef2c5f46cb0a20af4b4487aaa239846e52e2c03f13fa3c784684552859c"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "gimli",
+ "gimli 0.31.1",
  "regalloc2",
  "smallvec",
  "target-lexicon",

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -20,6 +20,15 @@ opentelemetry-http = "0.27"
 # to keep build times sane.
 opentelemetry-otlp = { version = "0.27", default-features = false, features = ["http-proto", "reqwest-client", "trace"] }
 
+# Sentry integration. Phase 4 / T4: ERROR-only Sentry sink driven by
+# `OBS_SENTRY_DSN`. `default-features = false` opts out of the panic
+# integration (binaries register their own panic handlers) and the heavy
+# `debug-images` feature; we keep `transport` (reqwest + native-tls) and
+# `contexts` so events carry runtime metadata. `sentry-tracing` is the
+# tracing-subscriber bridge and stays compatible with `tracing-subscriber 0.3`.
+sentry = { version = "0.47", default-features = false, features = ["backtrace", "contexts", "release-health", "transport"] }
+sentry-tracing = "0.47"
+
 thiserror = "1"
 once_cell = "1"
 serde = { version = "1.0", features = ["derive"] }
@@ -37,3 +46,7 @@ tokio = { version = "1.0", features = ["sync", "macros", "time", "rt"] }
 tempfile = "3"
 tokio = { version = "1.0", features = ["sync", "macros", "rt"] }
 log = "0.4"
+# `test` enables `sentry::test::with_captured_events`, used to assert that
+# the Phase 4 / T4 ERROR layer captures events with the right tags without
+# hitting a real Sentry server.
+sentry = { version = "0.47", default-features = false, features = ["test"] }

--- a/crates/observability/src/layers/error.rs
+++ b/crates/observability/src/layers/error.rs
@@ -1,0 +1,349 @@
+//! ERROR layer — promote `tracing::error!` events into Sentry issues.
+//!
+//! Phase 4 / T4. The layer wraps [`sentry_tracing::layer`] with its own
+//! per-layer filter ([`FilterFn`]) so Sentry only ever sees ERROR-level
+//! events, regardless of how loose the global RELOAD filter is.
+//! Each captured Sentry event is enriched with the W3C `trace_id` and
+//! `span_id` lifted off the parent span's [`OtelData`] extension (set by
+//! `tracing-opentelemetry`) so an alert page can deep-link back to the trace
+//! in Honeycomb (or any other OTLP backend).
+//!
+//! ## When the layer is wired
+//!
+//! [`build_error_layer`] returns `None` whenever `OBS_SENTRY_DSN` is unset,
+//! making the layer a strict opt-in. When set, the layer takes ownership of a
+//! [`sentry::ClientInitGuard`] (re-exported as [`SentryGuard`]) that the
+//! caller must hold for the lifetime of the binary — dropping it flushes any
+//! buffered events.
+//!
+//! ## Layer composition
+//!
+//! Sentry is one of several sinks the registry feeds. Composing with
+//! `Layer::with_filter` keeps the ERROR-only filter local to this layer and
+//! independent of the rest of the pipeline. Concretely, the node binary will
+//! end up with:
+//!
+//! ```text
+//! Registry::default()
+//!     .with(reload_layer)        // global RELOAD filter (info/debug/...)
+//!     .with(otel_layer)          // attaches OtelData -> spans
+//!     .with(fmt_layer)           // JSONL on disk
+//!     .with(ring_layer)          // /api/logs
+//!     .with(web_layer)           // SSE fan-out
+//!     .with(error_layer)         // <-- this layer, ERROR-only Sentry sink
+//! ```
+
+use std::env;
+
+use sentry_tracing::EventMapping;
+use tracing::{Level, Metadata, Subscriber};
+use tracing_opentelemetry::OtelData;
+use tracing_subscriber::filter::{filter_fn, FilterFn, Filtered};
+use tracing_subscriber::layer::Layer;
+use tracing_subscriber::registry::LookupSpan;
+
+/// Environment variable that gates Sentry initialization. When unset (or
+/// empty), [`build_error_layer`] returns `None` and the rest of the pipeline
+/// runs unchanged.
+pub const OBS_SENTRY_DSN_ENV: &str = "OBS_SENTRY_DSN";
+
+/// RAII guard returned by [`build_error_layer`].
+///
+/// Wraps the [`sentry::ClientInitGuard`] that the SDK hands back from
+/// [`sentry::init`]. Holding the guard keeps the Sentry transport alive;
+/// dropping it triggers a final flush. Stored inside [`crate::ObsGuard`] so
+/// the binary's existing lifetime contract carries over.
+#[must_use = "SentryGuard must be held for the lifetime of the binary or buffered events may be dropped"]
+pub struct SentryGuard {
+    _client: sentry::ClientInitGuard,
+}
+
+impl std::fmt::Debug for SentryGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SentryGuard").finish_non_exhaustive()
+    }
+}
+
+/// Concrete return type of [`build_error_layer`]. Wrapping `SentryLayer`
+/// inside a [`Filtered`] keeps the ERROR-only filter scoped to this layer
+/// (the global RELOAD filter is left alone) and lets callers compose the
+/// result with `.with(...)` without naming the layer's full type.
+///
+/// The wrapped filter is a [`FilterFn`] (not a plain `EnvFilter`) because
+/// per-layer `EnvFilter("error")` would also hide INFO/DEBUG *spans* from
+/// the layer — `Context::event_span` then returns `None` and we lose the
+/// trace context. Letting all spans through but only enabling ERROR
+/// *events* keeps `event_span` working while still gating Sentry to errors.
+pub type ErrorLayer<S> = Filtered<sentry_tracing::SentryLayer<S>, FilterFn, S>;
+
+/// Build the per-layer filter used by [`build_error_layer`]: pass every span
+/// through (so trace context lookup succeeds in `on_event`) but only allow
+/// `Level::ERROR` events to reach Sentry.
+fn error_only_event_filter() -> FilterFn {
+    filter_fn(|meta: &Metadata<'_>| {
+        if meta.is_event() {
+            *meta.level() == Level::ERROR
+        } else {
+            true
+        }
+    })
+}
+
+/// Build the Sentry ERROR-layer when `OBS_SENTRY_DSN` is set.
+///
+/// Returns `None` when the env var is unset or empty so callers can treat
+/// "no DSN configured" as a clean no-op without branching on errors. When
+/// set, the function:
+///
+/// 1. Calls [`sentry::init`] with `release = CARGO_PKG_VERSION`. The returned
+///    [`sentry::ClientInitGuard`] is wrapped in [`SentryGuard`] for lifetime
+///    management.
+/// 2. Builds a [`sentry_tracing::SentryLayer`] with a custom `event_mapper`
+///    that lifts `trace_id` / `span_id` from the parent span's [`OtelData`]
+///    extension and attaches them to the outgoing event as Sentry tags.
+/// 3. Wraps the layer in [`Layer::with_filter`] using
+///    [`error_only_event_filter`] so only `tracing::error!` events ever
+///    reach Sentry while leaving span tracking untouched (a per-layer
+///    `EnvFilter("error")` would also hide INFO/DEBUG spans, which would
+///    break `Context::event_span` and lose the trace context).
+pub fn build_error_layer<S>() -> Option<(ErrorLayer<S>, SentryGuard)>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let dsn = match env::var(OBS_SENTRY_DSN_ENV) {
+        Ok(v) if !v.is_empty() => v,
+        _ => return None,
+    };
+
+    let options = sentry::ClientOptions {
+        release: Some(env!("CARGO_PKG_VERSION").into()),
+        ..Default::default()
+    };
+    let client = sentry::init((dsn, options));
+
+    let layer = sentry_tracing::layer()
+        .event_mapper(event_mapper_with_trace_context::<S>)
+        .with_filter(error_only_event_filter());
+
+    Some((layer, SentryGuard { _client: client }))
+}
+
+/// Custom `event_mapper` for [`sentry_tracing::SentryLayer`].
+///
+/// Every ERROR event is mapped to a [`sentry::protocol::Event`] (via the
+/// crate's own [`sentry_tracing::event_from_event`] helper, which preserves
+/// the standard message / target / fields layout). We then walk up to the
+/// parent span via the `Context`, look up the [`OtelData`] extension that
+/// `tracing-opentelemetry` attaches in `on_new_span`, and copy the W3C
+/// `trace_id` / `span_id` onto the Sentry event as tags. When the span has
+/// no `OtelData` (no OTel layer wired, or no parent span at all) we emit the
+/// event without trace context — the event is still useful, it just won't
+/// deep-link.
+fn event_mapper_with_trace_context<S>(
+    event: &tracing::Event<'_>,
+    ctx: tracing_subscriber::layer::Context<'_, S>,
+) -> EventMapping
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let mut sentry_event = sentry_tracing::event_from_event(event, Some(&ctx));
+
+    if let Some(span_ref) = ctx.event_span(event) {
+        let exts = span_ref.extensions();
+        if let Some(otel_data) = exts.get::<OtelData>() {
+            if let Some(trace_id) = otel_data.builder.trace_id {
+                sentry_event
+                    .tags
+                    .insert("trace_id".to_string(), format!("{:032x}", trace_id));
+            }
+            if let Some(span_id) = otel_data.builder.span_id {
+                sentry_event
+                    .tags
+                    .insert("span_id".to_string(), format!("{:016x}", span_id));
+            }
+        }
+    }
+
+    EventMapping::Event(sentry_event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::{Mutex, OnceLock};
+
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::TracerProvider as SdkTracerProvider;
+    use tracing::subscriber::with_default;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Registry;
+
+    /// Serialize tests that touch the process-global `OBS_SENTRY_DSN` env var
+    /// and the global Sentry hub. `cargo test` runs unit tests in parallel by
+    /// default; without serialization, one test's `set_var` could be observed
+    /// by another's `build_error_layer` call.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn with_env_lock<F, R>(f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        f()
+    }
+
+    #[test]
+    fn returns_none_when_dsn_unset() {
+        with_env_lock(|| {
+            let prev = std::env::var(OBS_SENTRY_DSN_ENV).ok();
+            std::env::remove_var(OBS_SENTRY_DSN_ENV);
+
+            let result = build_error_layer::<Registry>();
+            assert!(
+                result.is_none(),
+                "build_error_layer must no-op when {OBS_SENTRY_DSN_ENV} is unset"
+            );
+
+            if let Some(v) = prev {
+                std::env::set_var(OBS_SENTRY_DSN_ENV, v);
+            }
+        });
+    }
+
+    #[test]
+    fn returns_none_when_dsn_empty() {
+        with_env_lock(|| {
+            let prev = std::env::var(OBS_SENTRY_DSN_ENV).ok();
+            std::env::set_var(OBS_SENTRY_DSN_ENV, "");
+
+            let result = build_error_layer::<Registry>();
+            assert!(
+                result.is_none(),
+                "empty {OBS_SENTRY_DSN_ENV} must be treated like unset"
+            );
+
+            match prev {
+                Some(v) => std::env::set_var(OBS_SENTRY_DSN_ENV, v),
+                None => std::env::remove_var(OBS_SENTRY_DSN_ENV),
+            }
+        });
+    }
+
+    /// When the DSN is set, the layer composes into a `Registry` without
+    /// panicking and the returned guard is `Some`. We use a syntactically
+    /// valid placeholder DSN so `sentry::init` accepts it; the test transport
+    /// captures any events so nothing leaves the process.
+    #[test]
+    fn returns_some_when_dsn_set_and_composes_in_registry() {
+        with_env_lock(|| {
+            let prev = std::env::var(OBS_SENTRY_DSN_ENV).ok();
+            std::env::set_var(OBS_SENTRY_DSN_ENV, "https://public@o0.ingest.sentry.io/0");
+
+            let (layer, _guard) = build_error_layer::<Registry>()
+                .expect("build_error_layer must return Some when DSN set");
+
+            // The composition itself is the assertion — `with_default` will
+            // panic if the subscriber type doesn't satisfy the expected
+            // bounds.
+            let subscriber = Registry::default().with(layer);
+            with_default(subscriber, || {
+                tracing::info!("composed layer accepts events");
+            });
+
+            match prev {
+                Some(v) => std::env::set_var(OBS_SENTRY_DSN_ENV, v),
+                None => std::env::remove_var(OBS_SENTRY_DSN_ENV),
+            }
+        });
+    }
+
+    /// End-to-end: emit a `tracing::error!` inside an OpenTelemetry span and
+    /// assert the captured Sentry event carries the correct `trace_id` tag.
+    /// Uses `sentry::test::with_captured_events` so nothing hits the network.
+    ///
+    /// The sentry layer is constructed inline (rather than via
+    /// [`build_error_layer`]) because `with_captured_events` already binds a
+    /// test Sentry client, and inline construction lets the closure mapper
+    /// pick up `S = Layered<OtelLayer, Registry>` via type inference. The
+    /// real production path goes through `build_error_layer` and is exercised
+    /// by `returns_some_when_dsn_set_and_composes_in_registry`.
+    #[test]
+    fn error_event_attaches_trace_id_tag() {
+        with_env_lock(|| {
+            let provider = SdkTracerProvider::builder().build();
+            let tracer = provider.tracer("error-layer-test");
+            let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+            let sentry_layer = sentry_tracing::layer()
+                .event_mapper(event_mapper_with_trace_context)
+                .with_filter(error_only_event_filter());
+
+            let subscriber = Registry::default().with(otel_layer).with(sentry_layer);
+
+            let captured_trace_id = std::cell::RefCell::new(String::new());
+            let events = sentry::test::with_captured_events(|| {
+                with_default(subscriber, || {
+                    use opentelemetry::trace::TraceContextExt;
+                    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+                    let span = tracing::info_span!("unit-of-work");
+                    let _enter = span.enter();
+                    let trace_id_hex =
+                        format!("{:032x}", span.context().span().span_context().trace_id());
+                    *captured_trace_id.borrow_mut() = trace_id_hex;
+
+                    tracing::error!("kaboom");
+                });
+            });
+
+            assert_eq!(
+                events.len(),
+                1,
+                "exactly one ERROR event must be captured by Sentry, got {} (events: {events:?})",
+                events.len()
+            );
+            let event = &events[0];
+            let trace_id_hex = captured_trace_id.borrow();
+            assert_eq!(
+                event.tags.get("trace_id"),
+                Some(&*trace_id_hex),
+                "captured Sentry event must carry the originating span's trace_id as a tag"
+            );
+            assert!(
+                event.tags.get("span_id").is_some_and(|s| s.len() == 16),
+                "span_id must be a 16-char hex string, got {:?}",
+                event.tags.get("span_id")
+            );
+        });
+    }
+
+    /// Non-error events must be filtered out by the layer's per-layer
+    /// `FilterFn` (events allowed only at `Level::ERROR`) — Sentry should
+    /// never see them, even if the global RELOAD filter is wide open.
+    #[test]
+    fn non_error_events_are_filtered_out() {
+        with_env_lock(|| {
+            let sentry_layer = sentry_tracing::layer()
+                .event_mapper(event_mapper_with_trace_context)
+                .with_filter(error_only_event_filter());
+
+            let subscriber = Registry::default().with(sentry_layer);
+
+            let events = sentry::test::with_captured_events(|| {
+                with_default(subscriber, || {
+                    tracing::info!("info");
+                    tracing::warn!("warn");
+                });
+            });
+
+            assert!(
+                events.is_empty(),
+                "INFO/WARN must not reach Sentry, got: {events:?}"
+            );
+        });
+    }
+}

--- a/crates/observability/src/layers/mod.rs
+++ b/crates/observability/src/layers/mod.rs
@@ -7,7 +7,10 @@
 //! - [`otlp_traces`] — OTLP HTTP/protobuf span exporter (Phase 4 / T1).
 //! - [`span_metrics`] — pre-registered span-name → latency histogram
 //!   recording for OTLP metrics export (Phase 4 / T2).
+//! - [`error`] — ERROR-only Sentry sink with W3C trace tagging
+//!   (Phase 4 / T4).
 
+pub mod error;
 pub mod fmt;
 pub mod otlp_traces;
 pub mod reload;
@@ -15,6 +18,7 @@ pub mod ring;
 pub mod span_metrics;
 pub mod web;
 
+pub use error::{build_error_layer, ErrorLayer, SentryGuard, OBS_SENTRY_DSN_ENV};
 pub use otlp_traces::{build_otlp_traces_layer, OtlpGuard, OBS_OTLP_ENDPOINT_ENV};
 pub use ring::{build_ring_layer, LogEntry, LogLevel, RingHandle, RingLayer, OBS_RING_CAPACITY};
 pub use span_metrics::{


### PR DESCRIPTION
## Summary
- Adds `crates/observability/src/layers/error.rs` exporting `build_error_layer`, an opt-in Sentry sink driven by `OBS_SENTRY_DSN`. Returns `None` when the env var is unset; otherwise initializes the Sentry SDK with `release = CARGO_PKG_VERSION` and returns the layer + a `SentryGuard` (wraps `sentry::ClientInitGuard`) for the binary to hold.
- Filter is a `FilterFn` that lets every span through but only `Level::ERROR` events out — a per-layer `EnvFilter("error")` would also hide INFO/DEBUG spans from the layer's view, breaking `Context::event_span` and losing trace context.
- Each captured Sentry event is enriched with `trace_id` / `span_id` tags lifted off the parent span's `tracing_opentelemetry::OtelData` extension so alert pages can deep-link to Honeycomb (or any OTLP backend).
- Crate version notes (sentry 0.47, sentry-tracing 0.47, tracing-subscriber 0.3.22 compat) captured in `docs/observability/error-sentry-layer-notes.md` (separate notes-repo).

## Out of scope
- `init_*` wiring → Phase 4 / T7
- E2E error → Sentry test against a real project → Phase 4 / T10
- `OBS_SENTRY_DSN` env provisioning per environment (separate ops task)

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --all-targets` (42 observability lib tests pass, including the 5 new error-layer tests)
- [x] Unit: `build_error_layer` returns `None` when `OBS_SENTRY_DSN` unset / empty
- [x] Unit: returns `Some` and composes into a `Registry` when DSN set
- [x] Integration: `tracing::error!` inside an OTel span produces a captured Sentry event whose `tags["trace_id"]` matches `span.context().span().span_context().trace_id()`; `tags["span_id"]` is 16-char hex
- [x] Integration: INFO / WARN events do not reach Sentry (filter holds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)