### PR TITLE
feat(observability): OTLP TRACES exporter layer (Phase 4 / T1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-http",
+ "opentelemetry-otlp",
  "opentelemetry_sdk",
  "reqwest 0.11.27",
  "serde",
@@ -2678,6 +2679,37 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -2842,6 +2874,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3012,6 +3064,29 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
@@ -3365,6 +3440,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.13",
@@ -4254,6 +4330,27 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -15,6 +15,10 @@ tracing-log = "0.2"
 opentelemetry = "0.27"
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio", "metrics"] }
 opentelemetry-http = "0.27"
+# default features pull in grpc-tonic — the OTLP traces layer (Phase 4 / T1)
+# only uses the HTTP/protobuf path via reqwest, so opt-out of the tonic stack
+# to keep build times sane.
+opentelemetry-otlp = { version = "0.27", default-features = false, features = ["http-proto", "reqwest-client", "trace"] }
 
 thiserror = "1"
 once_cell = "1"
@@ -25,7 +29,9 @@ xxhash-rust = { version = "0.8", features = ["xxh64"] }
 
 http = "1"
 reqwest = { version = "0.11", default-features = false }
-tokio = { version = "1.0", features = ["sync"] }
+# `macros` + `time` + `rt` power the OTLP traces worker thread; the rest of
+# the crate only needs `sync` (broadcast channel for the WEB layer).
+tokio = { version = "1.0", features = ["sync", "macros", "time", "rt"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/observability/src/layers/mod.rs
+++ b/crates/observability/src/layers/mod.rs
@@ -4,15 +4,18 @@
 //! - [`reload`] — runtime [`tracing_subscriber::EnvFilter`] swap (T4).
 //! - [`ring`] — bounded in-memory ring buffer for `/api/logs` (T5).
 //! - [`web`] — broadcast fan-out for `/api/logs/stream` SSE (Phase 3 / T4).
+//! - [`otlp_traces`] — OTLP HTTP/protobuf span exporter (Phase 4 / T1).
 //! - [`span_metrics`] — pre-registered span-name → latency histogram
 //!   recording for OTLP metrics export (Phase 4 / T2).
 
 pub mod fmt;
+pub mod otlp_traces;
 pub mod reload;
 pub mod ring;
 pub mod span_metrics;
 pub mod web;
 
+pub use otlp_traces::{build_otlp_traces_layer, OtlpGuard, OBS_OTLP_ENDPOINT_ENV};
 pub use ring::{build_ring_layer, LogEntry, LogLevel, RingHandle, RingLayer, OBS_RING_CAPACITY};
 pub use span_metrics::{
     build_span_metrics_layer, SpanMetricsLayer, ALLOWED_LABEL_KEYS, PRE_REGISTERED_SPANS,

--- a/crates/observability/src/layers/otlp_traces.rs
+++ b/crates/observability/src/layers/otlp_traces.rs
@@ -1,0 +1,491 @@
+//! OTLP TRACES layer — exports `tracing` spans to an OTel collector over
+//! HTTP/protobuf.
+//!
+//! Phase 4 / T1. The layer is a no-op when the `OBS_OTLP_ENDPOINT` env var is
+//! unset, so binaries can compose it unconditionally and get OTLP only when
+//! the operator opts in.
+//!
+//! ## Non-blocking contract
+//!
+//! Span emission is on the hot path of every instrumented call. Saturating
+//! the exporter (slow collector, high traffic burst) MUST NOT block the
+//! caller. We achieve that with a bounded `tokio::sync::mpsc` channel sized
+//! `MAX_QUEUE_SIZE = 2048`; `on_end` uses [`try_send`] and on full simply
+//! drops the span and increments the [`obs.spans.dropped`](OtlpGuard::dropped)
+//! counter. No retry, no panic, no spin.
+//!
+//! ## Worker thread
+//!
+//! A dedicated `obs-otlp-traces` OS thread runs a single-thread Tokio
+//! runtime. The worker batches up to `MAX_EXPORT_BATCH_SIZE = 512` spans per
+//! flush and either fills the batch or waits up to `SCHEDULED_DELAY = 5s`
+//! before exporting. The wall-clock for a slow OTLP request is absorbed by
+//! the worker, never by the application thread.
+//!
+//! Running the runtime on its own thread (rather than spawning into an
+//! ambient one) means:
+//! - the layer composes the same in CLI, Tauri, and Lambda binaries that may
+//!   not have a Tokio runtime running at subscriber-install time;
+//! - shutting down the FoldNode runtime never starves the OTLP flush.
+//!
+//! ## Drop counter
+//!
+//! [`OtlpGuard::dropped`] returns a snapshot of the lifetime drop count.
+//! Phase 4 / T3 (OTLP METRICS) will publish this as an OTel counter named
+//! `obs.spans.dropped`; for now it is queryable in-process and asserted
+//! against by the integration test.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use opentelemetry::trace::{TraceResult, TracerProvider as _};
+use opentelemetry::{Context, KeyValue};
+use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig};
+use opentelemetry_sdk::export::trace::{SpanData, SpanExporter as SpanExporterTrait};
+use opentelemetry_sdk::trace::{Span as SdkSpan, SpanProcessor, Tracer, TracerProvider};
+use opentelemetry_sdk::Resource;
+use tracing::Subscriber;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::registry::LookupSpan;
+
+/// Env var that gates the OTLP exporter. When unset (or empty) the layer is
+/// a no-op and `build_otlp_traces_layer` returns `None`.
+pub const OBS_OTLP_ENDPOINT_ENV: &str = "OBS_OTLP_ENDPOINT";
+
+/// Hard upper bound on spans buffered between the application threads and
+/// the OTLP exporter worker. Once full, new spans are dropped.
+pub const MAX_QUEUE_SIZE: usize = 2048;
+
+/// Largest batch the worker hands to a single `SpanExporter::export` call.
+pub const MAX_EXPORT_BATCH_SIZE: usize = 512;
+
+/// Maximum delay between scheduled flushes when the batch is not yet full.
+pub const SCHEDULED_DELAY: Duration = Duration::from_secs(5);
+
+/// RAII handle returned alongside the OTLP layer. Holds a clone of the
+/// dropped-span counter and the [`TracerProvider`] so its `Drop` can issue an
+/// orderly shutdown that drains any in-flight spans.
+#[must_use = "OtlpGuard must be held for the lifetime of the binary or trailing spans are lost"]
+pub struct OtlpGuard {
+    dropped: Arc<AtomicU64>,
+    provider: Option<TracerProvider>,
+}
+
+impl OtlpGuard {
+    /// Lifetime count of spans dropped because the worker channel was full.
+    /// Surfaced as the `obs.spans.dropped` self-monitoring metric.
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+}
+
+impl std::fmt::Debug for OtlpGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OtlpGuard")
+            .field("dropped", &self.dropped())
+            .field("provider", &self.provider.is_some())
+            .finish()
+    }
+}
+
+impl Drop for OtlpGuard {
+    fn drop(&mut self) {
+        if let Some(provider) = self.provider.take() {
+            // `shutdown` on a TracerProvider fans out to every registered
+            // SpanProcessor, which drains the worker channel and waits for
+            // the runtime thread to join. Errors here are non-actionable —
+            // the binary is exiting anyway.
+            let _ = provider.shutdown();
+        }
+    }
+}
+
+/// Build the OTLP traces layer + its [`OtlpGuard`].
+///
+/// Returns `None` when `OBS_OTLP_ENDPOINT` is unset or empty — that's the
+/// "OTLP off" state, not a failure.
+///
+/// Returns `None` on exporter construction error too: at startup we'd rather
+/// run without remote tracing than crash the binary because a collector URL
+/// was malformed. The error is logged via `tracing::error!` so the operator
+/// has a thread to pull on.
+pub fn build_otlp_traces_layer<S>(
+    service_name: &str,
+) -> Option<(OpenTelemetryLayer<S, Tracer>, OtlpGuard)>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let endpoint = std::env::var(OBS_OTLP_ENDPOINT_ENV).ok()?;
+    if endpoint.trim().is_empty() {
+        return None;
+    }
+
+    let exporter = match SpanExporter::builder()
+        .with_http()
+        .with_endpoint(&endpoint)
+        .with_protocol(Protocol::HttpBinary)
+        .build()
+    {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::error!(
+                target: "observability::otlp_traces",
+                error = %err,
+                endpoint = %endpoint,
+                "failed to construct OTLP span exporter; OTLP traces disabled",
+            );
+            return None;
+        }
+    };
+
+    let dropped = Arc::new(AtomicU64::new(0));
+    let processor = BoundedDropProcessor::spawn(exporter, dropped.clone());
+
+    let provider = TracerProvider::builder()
+        .with_span_processor(processor)
+        .with_resource(Resource::new(vec![KeyValue::new(
+            "service.name",
+            service_name.to_string(),
+        )]))
+        .build();
+
+    let tracer = provider.tracer(service_name.to_string());
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    Some((
+        layer,
+        OtlpGuard {
+            dropped,
+            provider: Some(provider),
+        },
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// BoundedDropProcessor — bounded, non-blocking SpanProcessor that drops on
+// saturation and counts the drops. Forwards surviving spans to the supplied
+// `SpanExporter` in batches from a dedicated worker thread.
+//
+// Span traffic and control signals (flush / shutdown) ride on **separate**
+// channels: shutdown must work even when the span queue is fully saturated,
+// or a wedged collector would deadlock the binary on exit.
+// ---------------------------------------------------------------------------
+
+struct BoundedDropProcessor {
+    span_tx: tokio::sync::mpsc::Sender<SpanData>,
+    ctrl_tx: tokio::sync::mpsc::Sender<CtrlMsg>,
+    dropped: Arc<AtomicU64>,
+    worker: Mutex<Option<std::thread::JoinHandle<()>>>,
+}
+
+enum CtrlMsg {
+    Flush(tokio::sync::oneshot::Sender<()>),
+    Shutdown(tokio::sync::oneshot::Sender<()>),
+}
+
+/// Upper bound on a single OTLP export call. A wedged collector must not
+/// keep a shutdown waiting longer than this — span drops are preferable to a
+/// hung process exit.
+const EXPORT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Hard cap on shutdown wall-clock. If the worker can't drain + ack within
+/// this budget we abandon it and let the OS reap the thread on exit.
+const SHUTDOWN_BUDGET: Duration = Duration::from_secs(3);
+
+impl std::fmt::Debug for BoundedDropProcessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BoundedDropProcessor")
+            .field("dropped", &self.dropped.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+impl BoundedDropProcessor {
+    fn spawn<E>(exporter: E, dropped: Arc<AtomicU64>) -> Self
+    where
+        E: SpanExporterTrait + 'static,
+    {
+        let (span_tx, span_rx) = tokio::sync::mpsc::channel::<SpanData>(MAX_QUEUE_SIZE);
+        // Control channel sized for one in-flight flush + one shutdown — far
+        // more than callers ever queue concurrently.
+        let (ctrl_tx, ctrl_rx) = tokio::sync::mpsc::channel::<CtrlMsg>(4);
+
+        let worker = std::thread::Builder::new()
+            .name("obs-otlp-traces".to_string())
+            .spawn(move || run_worker(exporter, span_rx, ctrl_rx))
+            .expect("spawn obs-otlp-traces worker thread");
+
+        Self {
+            span_tx,
+            ctrl_tx,
+            dropped,
+            worker: Mutex::new(Some(worker)),
+        }
+    }
+}
+
+impl SpanProcessor for BoundedDropProcessor {
+    fn on_start(&self, _span: &mut SdkSpan, _cx: &Context) {}
+
+    fn on_end(&self, span: SpanData) {
+        // try_send is the bedrock of the non-blocking contract: it returns
+        // immediately whether the channel had room or not. Both Full and
+        // Closed map to "drop and count" — Closed only happens after
+        // shutdown, where dropping is the only sane behavior anyway.
+        if self.span_tx.try_send(span).is_err() {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn force_flush(&self) -> TraceResult<()> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if self.ctrl_tx.try_send(CtrlMsg::Flush(tx)).is_err() {
+            return Ok(());
+        }
+        // force_flush callers (TracerProvider shutdown, manual operator
+        // flush) are explicitly happy to wait — the on_end hot path is the
+        // one that must stay non-blocking.
+        let _ = rx.blocking_recv();
+        Ok(())
+    }
+
+    fn shutdown(&self) -> TraceResult<()> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        // Control channel has its own capacity, so even a fully-saturated
+        // span queue cannot starve shutdown signalling.
+        if self.ctrl_tx.try_send(CtrlMsg::Shutdown(tx)).is_ok() {
+            // Wait up to SHUTDOWN_BUDGET for a clean drain. The worker may
+            // be stuck in a hanging export on a wedged collector — in that
+            // case we'd rather lose a tail of in-flight spans than hang the
+            // binary exit indefinitely.
+            let deadline = std::time::Instant::now() + SHUTDOWN_BUDGET;
+            let mut rx = rx;
+            loop {
+                match rx.try_recv() {
+                    Ok(()) => break,
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                        if std::time::Instant::now() >= deadline {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(20));
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+        if let Some(handle) = self.worker.lock().unwrap_or_else(|p| p.into_inner()).take() {
+            let _ = handle.join();
+        }
+        Ok(())
+    }
+}
+
+fn run_worker<E>(
+    mut exporter: E,
+    mut span_rx: tokio::sync::mpsc::Receiver<SpanData>,
+    mut ctrl_rx: tokio::sync::mpsc::Receiver<CtrlMsg>,
+) where
+    E: SpanExporterTrait + 'static,
+{
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(err) => {
+            tracing::error!(
+                target: "observability::otlp_traces",
+                error = %err,
+                "failed to build worker runtime; spans will be dropped",
+            );
+            return;
+        }
+    };
+
+    runtime.block_on(async move {
+        let mut buf: Vec<SpanData> = Vec::with_capacity(MAX_EXPORT_BATCH_SIZE);
+        let mut shutdown_ack: Option<tokio::sync::oneshot::Sender<()>> = None;
+
+        'main: loop {
+            let sleep = tokio::time::sleep(SCHEDULED_DELAY);
+            tokio::pin!(sleep);
+
+            tokio::select! {
+                biased;
+                ctrl = ctrl_rx.recv() => {
+                    match ctrl {
+                        Some(CtrlMsg::Flush(ack)) => {
+                            // Drain any pending spans before flushing.
+                            while buf.len() < MAX_EXPORT_BATCH_SIZE {
+                                match span_rx.try_recv() {
+                                    Ok(s) => buf.push(s),
+                                    Err(_) => break,
+                                }
+                            }
+                            if !buf.is_empty() {
+                                flush_batch(&mut exporter, &mut buf).await;
+                            }
+                            let _ = ack.send(());
+                        }
+                        Some(CtrlMsg::Shutdown(ack)) => {
+                            shutdown_ack = Some(ack);
+                            break 'main;
+                        }
+                        None => break 'main,
+                    }
+                }
+                _ = &mut sleep => {
+                    if !buf.is_empty() {
+                        flush_batch(&mut exporter, &mut buf).await;
+                    }
+                }
+                maybe = span_rx.recv() => {
+                    match maybe {
+                        Some(s) => {
+                            buf.push(s);
+                            while buf.len() < MAX_EXPORT_BATCH_SIZE {
+                                match span_rx.try_recv() {
+                                    Ok(more) => buf.push(more),
+                                    Err(_) => break,
+                                }
+                            }
+                            if buf.len() >= MAX_EXPORT_BATCH_SIZE {
+                                flush_batch(&mut exporter, &mut buf).await;
+                            }
+                        }
+                        None => break 'main,
+                    }
+                }
+            }
+        }
+
+        // Drain anything the channels still hold so we do not silently lose
+        // spans the application already handed over.
+        while let Ok(s) = span_rx.try_recv() {
+            buf.push(s);
+        }
+        if !buf.is_empty() {
+            flush_batch(&mut exporter, &mut buf).await;
+        }
+        exporter.shutdown();
+        if let Some(ack) = shutdown_ack {
+            let _ = ack.send(());
+        }
+    });
+}
+
+async fn flush_batch<E: SpanExporterTrait>(exporter: &mut E, buf: &mut Vec<SpanData>) {
+    if buf.is_empty() {
+        return;
+    }
+    let drained = std::mem::replace(buf, Vec::with_capacity(MAX_EXPORT_BATCH_SIZE));
+    // Bound each export so a wedged collector never holds the worker for
+    // longer than EXPORT_TIMEOUT. Without this, force_flush + shutdown
+    // can be held hostage by the network.
+    match tokio::time::timeout(EXPORT_TIMEOUT, exporter.export(drained)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            tracing::warn!(
+                target: "observability::otlp_traces",
+                error = %err,
+                "OTLP span export failed",
+            );
+        }
+        Err(_) => {
+            tracing::warn!(
+                target: "observability::otlp_traces",
+                "OTLP span export timed out (collector unresponsive)",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use tracing::subscriber::with_default;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Registry;
+
+    /// Cargo runs unit tests in parallel within a single process, so any test
+    /// that mutates `OBS_OTLP_ENDPOINT` races with siblings. Acquire this
+    /// lock for the duration of the env-var setup and the
+    /// `build_otlp_traces_layer` call, then release after the assertion.
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// The env-var guard ensures tests that mutate `OBS_OTLP_ENDPOINT` do not
+    /// leak that state to siblings running in the same process.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, prev }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let prev = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn returns_none_when_endpoint_unset() {
+        let _serial = env_lock();
+        let _guard = EnvGuard::unset(OBS_OTLP_ENDPOINT_ENV);
+        let layer = build_otlp_traces_layer::<Registry>("svc");
+        assert!(layer.is_none(), "must be a no-op when env var is missing");
+    }
+
+    #[test]
+    fn returns_none_when_endpoint_is_empty() {
+        let _serial = env_lock();
+        let _guard = EnvGuard::set(OBS_OTLP_ENDPOINT_ENV, "   ");
+        let layer = build_otlp_traces_layer::<Registry>("svc");
+        assert!(layer.is_none(), "whitespace-only endpoint must be no-op");
+    }
+
+    #[test]
+    fn returns_some_and_composes_into_registry() {
+        // Point at an unused TCP port. The exporter constructs lazily; a
+        // failed connect later is the worker thread's problem, not the
+        // build path's.
+        let _serial = env_lock();
+        let _guard = EnvGuard::set(OBS_OTLP_ENDPOINT_ENV, "http://127.0.0.1:1");
+
+        let (layer, otlp_guard) =
+            build_otlp_traces_layer::<Registry>("svc").expect("layer must build");
+
+        let subscriber = Registry::default().with(layer);
+        with_default(subscriber, || {
+            let _span = tracing::info_span!("compose_test").entered();
+            tracing::info!("payload");
+        });
+
+        // Drop count is best-effort: we don't expect drops on a single span
+        // emission. The point of the assert is that calling `.dropped()`
+        // works through the public surface.
+        let _ = otlp_guard.dropped();
+    }
+}

--- a/crates/observability/tests/otlp_traces_nonblocking.rs
+++ b/crates/observability/tests/otlp_traces_nonblocking.rs
@@ -1,0 +1,103 @@
+//! Integration test for the OTLP TRACES layer's non-blocking contract.
+//!
+//! Phase 4 / T1 acceptance criterion: emitting many spans rapidly to a slow
+//! collector MUST NOT block the calling thread. We point the OTLP exporter
+//! at a TCP listener that accepts connections and never replies, install a
+//! `Registry` with the layer, and verify that 5000 span emissions complete
+//! in well under one second of wall clock — the saturation must drop into
+//! the per-span `obs.spans.dropped` counter, not into the application
+//! thread.
+
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use observability::layers::otlp_traces::{build_otlp_traces_layer, OBS_OTLP_ENDPOINT_ENV};
+use tracing::subscriber::with_default;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::Registry;
+
+/// Bind to a free port, accept inbound connections, and *never* reply. This
+/// simulates a wedged OTLP collector: the worker thread's reqwest call hangs
+/// indefinitely on the response, the bounded mpsc fills, and span emissions
+/// past `MAX_QUEUE_SIZE` start dropping.
+fn spawn_blackhole(stop: Arc<AtomicBool>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind blackhole listener");
+    listener
+        .set_nonblocking(true)
+        .expect("set listener non-blocking");
+    let port = listener.local_addr().expect("local addr").port();
+
+    std::thread::Builder::new()
+        .name("otlp-blackhole".to_string())
+        .spawn(move || {
+            // Hold the accepted streams so the kernel doesn't tear them down
+            // before the test finishes.
+            let mut held = Vec::new();
+            while !stop.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        let _ = stream.set_nonblocking(false);
+                        held.push(stream);
+                    }
+                    Err(_) => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                }
+            }
+            drop(held);
+        })
+        .expect("spawn blackhole");
+
+    port
+}
+
+#[test]
+fn emit_5000_spans_does_not_block_caller() {
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_blackhole(stop.clone());
+
+    // Set the env var BEFORE building the layer. We never unset it from a
+    // peer test in this binary — Cargo runs each `tests/<name>.rs` in its
+    // own process.
+    std::env::set_var(OBS_OTLP_ENDPOINT_ENV, format!("http://127.0.0.1:{port}"));
+
+    let (layer, guard) =
+        build_otlp_traces_layer::<Registry>("nonblocking-test").expect("layer must build");
+    let subscriber = Registry::default().with(layer);
+
+    let started = Instant::now();
+    with_default(subscriber, || {
+        for i in 0..5000 {
+            let span = tracing::info_span!("hot.path", iteration = i);
+            let _entered = span.entered();
+            tracing::info!(iteration = i, "synthetic event");
+        }
+    });
+    let elapsed = started.elapsed();
+
+    // Generous bound: the BoundedDropProcessor's `try_send` is O(1) and the
+    // work per span is dominated by `tracing` machinery, not the OTLP
+    // pipeline. 5000 emissions should be sub-200ms even on a contended CI
+    // runner; allowing 1s gives a healthy safety margin while still failing
+    // loudly if a regression makes the path block on the collector.
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "caller blocked on OTLP exporter: {elapsed:?} for 5000 spans",
+    );
+
+    // Saturation should have produced drops because the blackhole holds the
+    // worker indefinitely. The exact count depends on tokio scheduling — we
+    // only assert "more than zero" so the test stays robust on fast hosts
+    // where a few spans squeak through before the channel fills.
+    let dropped = guard.dropped();
+    assert!(
+        dropped > 0,
+        "expected obs.spans.dropped to fire under blackhole saturation, got {dropped}",
+    );
+
+    stop.store(true, Ordering::Relaxed);
+    drop(guard);
+    std::env::remove_var(OBS_OTLP_ENDPOINT_ENV);
+}


### PR DESCRIPTION
## Summary

- Adds `crates/observability/src/layers/otlp_traces.rs` — HTTP/protobuf OTLP span exporter that no-ops when `OBS_OTLP_ENDPOINT` is unset.
- Custom bounded SpanProcessor: span queue cap 2048, `try_send` only — saturated exporter never blocks the caller, drops + counts via `OtlpGuard::dropped()`.
- Control-channel separation: shutdown signal rides its own channel so a wedged collector cannot deadlock process exit (3s shutdown budget, 2s per-export timeout).
- Worker thread owns its own single-thread Tokio runtime so the layer composes the same in CLI / Lambda / Tauri binaries that lack an ambient runtime.

## Out of scope (per task)

- Wiring into `init_node` / `init_lambda` / `init_tauri` — Phase 4 / T2 follow-up.
- OTLP METRICS layer — Phase 4 / T3.
- Honeycomb config + sampling — Phase 4 / T5 (already landed).
- Publishing `obs.spans.dropped` as an OTel counter — Phase 4 / T3 (needs metrics layer).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --all-targets`
- [x] `bash scripts/lint-tracing-egress.sh`
- [x] Unit: env-var unset → `None`; whitespace endpoint → `None`; valid endpoint composes into a `Registry` without panic.
- [x] Integration: 5000 spans against a TCP blackhole listener → caller returns in <1s and `dropped() > 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)