### PR TITLE
chore: rename default branch mainline → main

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -69,7 +69,7 @@ git commit -m "Release v0.1.6"
 
 # 3. Create and push version tag
 git tag v0.1.6
-git push origin mainline --tags
+git push origin main --tags
 
 # 4. GitHub Actions will automatically:
 #    - Build binaries for all platforms

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Enable auto-merge on all open PRs
         if: github.event_name == 'check_suite'
         run: |
-          prs=$(gh pr list --base mainline --state open --json number --jq '.[].number' --repo ${{ github.repository }})
+          prs=$(gh pr list --base main --state open --json number --jq '.[].number' --repo ${{ github.repository }})
           for pr in $prs; do
             gh pr merge "$pr" --auto --squash --repo ${{ github.repository }} 2>&1 || true
           done

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,7 +2,7 @@ name: Test Suite
 
 on:
   push:
-    branches: [mainline]
+    branches: [main]
   pull_request:
   merge_group:
 

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -2,7 +2,7 @@ name: Discord Notifications
 
 on:
   push:
-    branches: [mainline]
+    branches: [main]
   pull_request:
     types: [opened, closed, reopened]
   issues:

--- a/.github/workflows/wasm-determinism.yml
+++ b/.github/workflows/wasm-determinism.yml
@@ -24,7 +24,7 @@ name: WASM Determinism (x86 vs ARM)
 
 on:
   push:
-    branches: [mainline]
+    branches: [main]
   pull_request:
   merge_group:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ pub async fn handle_query(
 Before every push, first fetch and rebase on the latest base branch:
 ```bash
 git fetch origin
-git rebase origin/<base-branch>   # e.g. origin/mainline
+git rebase origin/<base-branch>   # e.g. origin/main
 ```
 
 Then run CI checks:


### PR DESCRIPTION
Updates branch-name references in workflows and docs to target main. Part of org-wide branch standardization.