### PR TITLE
feat(observability): redaction CI lint (Phase 5 / T1)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -11,6 +11,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint-redaction:
+    name: Redaction Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install ripgrep
+        run: |
+          if ! command -v rg >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends ripgrep
+          fi
+
+      - name: Run redaction lint
+        run: sh scripts/lint-redaction.sh
+
   rust-tests:
     name: Rust Tests
     runs-on: ubuntu-latest

--- a/crates/observability/src/layers/fmt.rs
+++ b/crates/observability/src/layers/fmt.rs
@@ -407,6 +407,7 @@ mod tests {
     #[test]
     fn password_field_is_redacted() {
         let lines = capture(RedactingFormat::with_extras(&[]), || {
+            // lint:redaction-ok FMT-layer test must emit raw value to verify deny-list redaction
             tracing::info!(user_id = "alice", password = "hunter2", "login attempt");
         });
         assert_eq!(lines.len(), 1);
@@ -509,6 +510,7 @@ mod tests {
         }
 
         let lines = capture(format, || {
+            // lint:redaction-ok FMT-layer test must emit raw value to verify deny-list redaction
             tracing::info!(email = "user@example.com", "signup");
         });
         let attrs = lines[0]["attributes"]
@@ -555,6 +557,7 @@ mod tests {
             build_fmt_layer::<Registry>(FmtTarget::File(path.clone())).expect("build layer");
         let subscriber = Registry::default().with(layer);
         with_default(subscriber, || {
+            // lint:redaction-ok FMT-layer test must emit raw value to verify deny-list redaction
             tracing::info!(password = "hunter2", user = "alice", "login");
         });
         // Drop the guard so the worker thread drains its queue to the file.

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -27,6 +27,9 @@ see *why* something was wired the way it is.
 - [Egress classification](egress-classification-notes.md) — Phase 2 / T4.
   `// trace-egress: <class>` comments at HTTP call sites and which calls
   do or don't get `inject_w3c` wrapping.
+- [Redaction lint](redaction-lint.md) — Phase 5 / T1. CI guard that fails
+  if a `tracing` macro emits a sensitive field as a raw value instead of
+  through `redact!()` / `redact_id!()`.
 
 ## Source-of-truth pointers
 

--- a/docs/observability/redaction-lint.md
+++ b/docs/observability/redaction-lint.md
@@ -1,0 +1,102 @@
+# Redaction lint (Phase 5 / T1)
+
+Static guard that fails CI if a `tracing` macro emits a sensitive field as a
+raw value instead of routing it through the redaction macros.
+
+This is the second of two layers of defence:
+
+1. **Format-time deny-list** in the `RedactingFormat` JSON formatter
+   (`crates/observability/src/layers/fmt.rs`) — replaces values for the
+   denied keys with `<redacted>` even if a call site forgets.
+2. **CI lint** (this doc) — catches the mistake at PR time so the deny-list
+   never has to fire in production.
+
+## Guarded fields
+
+The lint pattern matches the literal field name on the left of `=` inside a
+`tracing::{info,warn,debug,error,trace}!(...)` invocation:
+
+```
+password
+token
+api_key
+secret
+auth_token
+email
+phone
+ssn
+```
+
+These mirror the static deny-list inside `RedactingFormat`. To extend the
+list, edit the `PATTERN` regex in `scripts/lint-redaction.sh` **and** the
+deny-list in `crates/observability/src/layers/fmt.rs` together so the two
+layers stay in sync.
+
+## What "redacted" means
+
+A value is considered redacted if the right-hand side of the `=` (up to the
+next `,`) goes through one of:
+
+- `observability::redact!(...)` — opaque, returns the literal `<redacted>`.
+  Use for values you never want back: passwords, raw API keys, encrypted
+  blob contents.
+- `observability::redact_id!(...)` — correlatable, returns
+  `<id:HHHHHHHH>` (low 32 bits of xxhash64, lowercase hex). Use for
+  identifiers you need to follow across log lines without exposing the
+  underlying string.
+
+Either is recognised whether prefixed with `%` (the `tracing` `Display` form)
+or used bare. Example:
+
+```rust
+tracing::info!(
+    api_key = %observability::redact!(&api_key),
+    user.hash = %observability::redact_id!(&user_hash),
+    "request received",
+);
+```
+
+## Override
+
+For an intentional exception — for example, a unit test that has to feed a
+raw value to the FMT layer to verify the deny-list redacts it — add a
+comment containing the literal `lint:redaction-ok <reason>` either on the
+violating line itself or on the line directly above it:
+
+```rust
+// lint:redaction-ok FMT-layer test must emit raw value to verify deny-list redaction
+tracing::info!(password = "hunter2", "login");
+```
+
+The two-line window exists so the override survives `rustfmt`, which will
+lift a long trailing `//` comment onto its own line. The script honours
+any comment style (`//`, `/* */`, `#`); the only thing it grep's for is the
+marker substring. Always include a short reason after the marker so the
+next reviewer can tell at a glance whether the override is still
+load-bearing.
+
+Use the override sparingly. A single override per intentional case is
+fine; if you find yourself overriding in production code, it almost
+certainly should have been wrapped in `redact!()` or `redact_id!()`
+instead.
+
+## Running locally
+
+```sh
+sh scripts/lint-redaction.sh
+```
+
+The script walks `crates/*/src/` only — generated tests under
+`crates/*/tests/` are out of scope. Exit code is `0` if every match is
+wrapped or overridden, `1` otherwise. The CI job
+`Redaction Lint` in `.github/workflows/ci-tests.yml` runs the same
+invocation on every PR and `push` to `main`.
+
+## Out of scope
+
+- `crates/*/tests/` integration tests. Top-level integration tests run
+  against the public API; they should not be emitting raw secrets either,
+  but the lint scope deliberately mirrors `lint-tracing-egress.sh` for
+  consistency. Revisit if a violation slips through.
+- Sibling repos (`fold_db_node`, `schema_service`, `exemem-infra`). Each
+  ships its own copy of the same lint as a follow-up task.

--- a/scripts/lint-redaction.sh
+++ b/scripts/lint-redaction.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+# lint-redaction.sh
+#
+# Fail the build if a `tracing` macro emits a sensitive field as a raw value
+# instead of through `observability::redact!()` / `observability::redact_id!()`.
+#
+# Sensitive fields (Phase 5 / T1):
+#   password, token, api_key, secret, auth_token, email, phone, ssn
+#
+# Scope: `crates/*/src/` — the same scope as `lint-tracing-egress.sh`.
+# Tests under `crates/*/tests/` and the FMT-layer self-tests are out of scope
+# at the directory level; intentional raw-value test fixtures inside
+# `crates/*/src/` use the inline override below.
+#
+# Override: add a comment containing the literal `lint:redaction-ok <reason>`
+# on the violating line OR on the line immediately above it. The two-line
+# window is so the override survives `rustfmt`, which will lift a long
+# trailing comment onto its own line. Example:
+#
+#     // lint:redaction-ok FMT-layer test must emit raw value to verify deny-list
+#     tracing::info!(password = "hunter2", "login");
+#
+# Use overrides sparingly — typically only for unit tests that need to feed
+# the raw value to verify the FMT layer's deny-list.
+#
+# Usage: sh scripts/lint-redaction.sh
+# Exit code: 0 if every match is wrapped or overridden, 1 otherwise.
+
+set -eu
+
+PATTERN='tracing::(info|warn|debug|error|trace)!.*?(password|token|api_key|secret|auth_token|email|phone|ssn)\s*=\s*[^,]'
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/.." && pwd)
+cd "$REPO_ROOT"
+
+if ! command -v rg >/dev/null 2>&1; then
+    echo "lint-redaction: ripgrep (rg) not found in PATH" >&2
+    exit 1
+fi
+
+# Confirm at least one crate src dir exists, mirroring lint-tracing-egress.sh.
+found_any=0
+for d in crates/*/src; do
+    [ -d "$d" ] && found_any=1
+done
+if [ "$found_any" -eq 0 ]; then
+    echo "lint-redaction: no crates/*/src directories found at $REPO_ROOT" >&2
+    exit 1
+fi
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT INT HUP TERM
+
+# rg --pcre2 -n: numbered lines; `|| true` because rg exits 1 when no matches.
+rg --pcre2 -n "$PATTERN" crates/*/src > "$tmp" 2>/dev/null || true
+
+failed=0
+hits=0
+
+while IFS= read -r match; do
+    [ -z "$match" ] && continue
+
+    file=${match%%:*}
+    rest=${match#*:}
+    lineno=${rest%%:*}
+    content=${rest#*:}
+
+    # Override on the violating line itself.
+    if printf '%s\n' "$content" | grep -q 'lint:redaction-ok'; then
+        continue
+    fi
+
+    # Override on the line directly above (so rustfmt is free to lift a
+    # trailing comment onto its own line without breaking the override).
+    if [ "$lineno" -gt 1 ] && [ -r "$file" ]; then
+        prev_lineno=$((lineno - 1))
+        prev=$(sed -n "${prev_lineno}p" "$file" 2>/dev/null || true)
+        if printf '%s\n' "$prev" | grep -q 'lint:redaction-ok'; then
+            continue
+        fi
+    fi
+
+    # Extract the right-hand side starting at the sensitive field name and
+    # check whether it routes through redact!() / redact_id!() before the
+    # next field separator. We accept either `field = %redact!(x)` (the
+    # `tracing` `%`-display form) or a bare `redact!(...)` / `redact_id!(...)`.
+    rhs=$(printf '%s\n' "$content" | grep -oE '(password|token|api_key|secret|auth_token|email|phone|ssn)[[:space:]]*=[^,]*' | head -1)
+    if printf '%s\n' "$rhs" | grep -qE 'redact(_id)?!\('; then
+        continue
+    fi
+
+    hits=$((hits + 1))
+    echo "ERROR: $file:$lineno — sensitive field emitted without redact!() / redact_id!()"
+    echo "    $content"
+    failed=1
+done < "$tmp"
+
+if [ "$failed" -ne 0 ]; then
+    cat >&2 <<EOF
+
+Found $hits unredacted sensitive-field site(s) in tracing macros.
+
+Wrap the value in observability::redact!(...) (opaque "<redacted>") or
+observability::redact_id!(...) (correlatable hash). Example:
+
+    tracing::info!(
+        api_key = %observability::redact!(&api_key),
+        user.hash = %observability::redact_id!(&user_hash),
+        "request received",
+    );
+
+For an intentional exception (e.g. a test feeding the FMT layer a raw value
+to verify deny-list redaction), add an inline comment containing
+\`lint:redaction-ok <reason>\` on the same line.
+
+See docs/observability/redaction-lint.md for guidance.
+EOF
+    exit 1
+fi
+
+echo "lint-redaction: ok — no unredacted sensitive-field tracing call sites in crates/*/src/."


### PR DESCRIPTION
## Summary

- Adds `scripts/lint-redaction.sh`: scans `crates/*/src/` for `tracing::{info,warn,debug,error,trace}!` macros that emit one of `password|token|api_key|secret|auth_token|email|phone|ssn` as a raw value instead of routing it through `observability::redact!()` / `observability::redact_id!()`. POSIX `sh`, uses `rg --pcre2`.
- Wires it into `.github/workflows/ci-tests.yml` as a fast standalone `Redaction Lint` job that runs in parallel with the existing `Rust Tests` job (no cargo, just `apt-get install -y ripgrep`).
- Calibration: only the FMT-layer self-tests in `crates/observability/src/layers/fmt.rs` triggered the lint — they intentionally emit raw values to verify the deny-list redacts them. Each gets a `// lint:redaction-ok <reason>` override comment on the preceding line so the override survives `rustfmt`'s trailing-comment lift.
- Documentation: `docs/observability/redaction-lint.md` covers guarded fields, override mechanism, and how to extend the deny-list in lockstep with the FMT layer; cross-linked from the observability README index.

This is the second of two layers of defence — the format-time deny-list in `RedactingFormat` (Phase 1 / T3) is the runtime safety net, and this lint catches the mistake at PR time so the deny-list never has to fire in production.

## Test plan
- [x] `sh scripts/lint-redaction.sh` exits 0 on the cleaned tree
- [x] Self-tested: synthetic violation correctly fails, `redact_id!()`-wrapped value passes, `lint:redaction-ok` override honored
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p observability --lib` — 78 passed, including the FMT-layer redaction tests on overridden lines
- [ ] CI green on this PR

## Out of scope
- Same lint for `fold_db_node`, `schema_service`, `exemem-infra` — separate per-repo follow-ups.
- Format-time deny-list extension in the FMT layer — that safety net is already in place; this is the pre-merge guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)