### PR TITLE
feat(observability): CI lint for tokio::spawn instrumentation (Phase 5 / T2)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -34,6 +34,11 @@ jobs:
         continue-on-error: true
         run: bash scripts/lint-tracing-egress.sh
 
+      - name: Lint tokio::spawn instrumentation
+        id: spawn-instrument
+        continue-on-error: true
+        run: bash scripts/lint-spawn-instrument.sh
+
       - name: Check formatting
         id: fmt
         continue-on-error: true
@@ -54,18 +59,20 @@ jobs:
       - name: Rust test summary
         if: always()
         run: |
-          for step_name in trace-egress fmt clippy cargo-test; do
+          for step_name in trace-egress spawn-instrument fmt clippy cargo-test; do
             case "$step_name" in
-              trace-egress)   label="Trace Egress Lint" ;;
-              fmt)            label="Rust Format" ;;
-              clippy)         label="Rust Clippy" ;;
-              cargo-test)     label="Rust Tests" ;;
+              trace-egress)     label="Trace Egress Lint" ;;
+              spawn-instrument) label="Spawn Instrument Lint" ;;
+              fmt)              label="Rust Format" ;;
+              clippy)           label="Rust Clippy" ;;
+              cargo-test)       label="Rust Tests" ;;
             esac
             case "$step_name" in
-              trace-egress)   status="${{ steps.trace-egress.outcome }}" ;;
-              fmt)            status="${{ steps.fmt.outcome }}" ;;
-              clippy)         status="${{ steps.clippy.outcome }}" ;;
-              cargo-test)     status="${{ steps.cargo-test.outcome }}" ;;
+              trace-egress)     status="${{ steps.trace-egress.outcome }}" ;;
+              spawn-instrument) status="${{ steps.spawn-instrument.outcome }}" ;;
+              fmt)              status="${{ steps.fmt.outcome }}" ;;
+              clippy)           status="${{ steps.clippy.outcome }}" ;;
+              cargo-test)       status="${{ steps.cargo-test.outcome }}" ;;
             esac
             case "$status" in
               success) echo "✅ **$label** — passed" >> $GITHUB_STEP_SUMMARY ;;
@@ -77,6 +84,7 @@ jobs:
       - name: Fail if any check failed
         if: |
           steps.trace-egress.outcome == 'failure' ||
+          steps.spawn-instrument.outcome == 'failure' ||
           steps.fmt.outcome == 'failure' ||
           steps.clippy.outcome == 'failure' ||
           steps.cargo-test.outcome == 'failure'

--- a/crates/core/src/fold_db_core/event_monitor.rs
+++ b/crates/core/src/fold_db_core/event_monitor.rs
@@ -33,6 +33,7 @@ impl EventMonitor {
         // FieldValueSet
         let stats = statistics.clone();
         let mut rx = message_bus.subscribe("FieldValueSet").await;
+        // lint:spawn-bare-ok boot-time event subscriber loop — perpetual worker, no per-request parent.
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
                 if let Event::FieldValueSet(_) = event {
@@ -47,6 +48,7 @@ impl EventMonitor {
         // AtomCreated
         let stats = statistics.clone();
         let mut rx = message_bus.subscribe("AtomCreated").await;
+        // lint:spawn-bare-ok boot-time event subscriber loop — perpetual worker, no per-request parent.
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
                 if let Event::AtomCreated(_) = event {
@@ -61,6 +63,7 @@ impl EventMonitor {
         // MoleculeCreated
         let stats = statistics.clone();
         let mut rx = message_bus.subscribe("MoleculeCreated").await;
+        // lint:spawn-bare-ok boot-time event subscriber loop — perpetual worker, no per-request parent.
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
                 if let Event::MoleculeCreated(_) = event {
@@ -75,6 +78,7 @@ impl EventMonitor {
         // QueryExecuted
         let stats = statistics.clone();
         let mut rx = message_bus.subscribe("QueryExecuted").await;
+        // lint:spawn-bare-ok boot-time event subscriber loop — perpetual worker, no per-request parent.
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
                 if let Event::QueryExecuted(e) = event {
@@ -94,6 +98,7 @@ impl EventMonitor {
         // MutationExecuted
         let stats = statistics.clone();
         let mut rx = message_bus.subscribe("MutationExecuted").await;
+        // lint:spawn-bare-ok boot-time event subscriber loop — perpetual worker, no per-request parent.
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
                 if let Event::MutationExecuted(e) = event {

--- a/crates/core/src/fold_db_core/fold_db.rs
+++ b/crates/core/src/fold_db_core/fold_db.rs
@@ -530,6 +530,7 @@ impl FoldDB {
         {
             let runner = Arc::clone(&trigger_runner);
             let shutdown = Arc::clone(&trigger_shutdown);
+            // lint:spawn-bare-ok boot-time scheduler loop — perpetual worker, no per-request parent span.
             tokio::spawn(async move {
                 runner.run_scheduler_loop(shutdown).await;
             });

--- a/crates/core/src/fold_db_core/mutation_manager.rs
+++ b/crates/core/src/fold_db_core/mutation_manager.rs
@@ -1000,6 +1000,7 @@ impl MutationManager {
         is_listening.store(true, std::sync::atomic::Ordering::Release);
 
         // Use tokio::spawn for async background task
+        // lint:spawn-bare-ok boot-time MutationRequest listener — perpetual worker; per-event spans created downstream.
         tokio::spawn(async move {
             crate::user_context::run_with_user(&user_id, async move {
                 // Subscribe to MutationRequest events

--- a/crates/core/src/fold_db_core/process_results_subscriber.rs
+++ b/crates/core/src/fold_db_core/process_results_subscriber.rs
@@ -35,6 +35,7 @@ impl ProcessResultsSubscriber {
         let db_ops = Arc::clone(&self.db_ops);
         let mut consumer = message_bus.subscribe("MutationExecuted").await;
 
+        // lint:spawn-bare-ok boot-time MutationExecuted listener — perpetual worker; per-event spans created downstream.
         tokio::spawn(async move {
             crate::user_context::run_with_user(&user_id, async move {
                 while let Some(event) = consumer.recv().await {

--- a/crates/core/src/fold_db_core/sync_coordinator.rs
+++ b/crates/core/src/fold_db_core/sync_coordinator.rs
@@ -85,6 +85,7 @@ impl SyncCoordinator {
 
         let wake = engine.wake_handle();
 
+        // lint:spawn-bare-ok boot-time sync poll loop — perpetual worker, no per-request parent span.
         let handle = tokio::spawn(async move {
             let base_interval = tokio::time::Duration::from_millis(interval_ms);
             let max_delay = MAX_OFFLINE_BACKOFF;

--- a/crates/core/src/fold_db_core/trigger_runner.rs
+++ b/crates/core/src/fold_db_core/trigger_runner.rs
@@ -1928,6 +1928,7 @@ mod tests {
         // sleep between attempts.
         let runner2 = Arc::clone(&runner);
         let clock2 = Arc::clone(&clock);
+        // lint:spawn-bare-ok cfg(test) scaffolding — quarantine test driver, no parent request span.
         let handle = tokio::spawn(async move {
             for _ in 0..20 {
                 clock2.advance(1_000);
@@ -2017,6 +2018,7 @@ mod tests {
         // a task (it blocks on the gate) and issue the second mutation
         // from the main task while the first fire is held.
         let r1 = Arc::clone(&runner);
+        // lint:spawn-bare-ok cfg(test) scaffolding — coalesce-refire test driver, no parent request span.
         let first = tokio::spawn(async move {
             r1.on_mutation_notified("S1").await.unwrap();
         });
@@ -3054,6 +3056,7 @@ mod tests {
             // Driver task: advance the mock clock past each exp_backoff
             // so the spawned retry loop's `clock.sleep(...)` wakes up.
             let clock_drive = Arc::clone(&clock);
+            // lint:spawn-bare-ok cfg(test) scaffolding — backoff/quarantine restart test driver.
             let driver = tokio::spawn(async move {
                 for _ in 0..50 {
                     clock_drive.advance(1_000);

--- a/crates/core/src/storage/sled_pool.rs
+++ b/crates/core/src/storage/sled_pool.rs
@@ -136,6 +136,7 @@ impl SledPool {
     /// Call this once after creating the pool.
     pub fn start_idle_reaper(self: &Arc<Self>, idle_timeout: Duration) {
         let pool = Arc::clone(self);
+        // lint:spawn-bare-ok boot-time idle reaper — perpetual worker, no per-request parent span.
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(1)).await;

--- a/crates/core/src/triggers/clock.rs
+++ b/crates/core/src/triggers/clock.rs
@@ -189,6 +189,7 @@ mod tests {
     async fn mock_clock_advance_wakes_sleeper() {
         let clock = Arc::new(MockClock::new(0));
         let c = Arc::clone(&clock);
+        // lint:spawn-bare-ok cfg(test) scaffolding — no parent request span to propagate.
         let handle = tokio::spawn(async move {
             c.sleep(100).await;
             c.now_ms()

--- a/docs/observability/spawn-instrument-lint.md
+++ b/docs/observability/spawn-instrument-lint.md
@@ -1,0 +1,156 @@
+# `tokio::spawn` instrument lint (Phase 5 / T2)
+
+Static guard that fails CI if a `tokio::spawn(async ... { ... })` site in
+`crates/*/src/` does not chain `.instrument(...)` / `.in_current_span()`
+on the spawned future, and is not explicitly marked as an intentional
+bare spawn.
+
+This pairs with the runtime test in
+`crates/observability/src/layers/ring.rs::instrument_propagates_trace_id_across_tokio_spawn`,
+which proves that *with* `.instrument(Span::current())` the spawned task's
+events join the parent's trace. The lint enforces the call-site
+discipline so the runtime invariant doesn't silently regress.
+
+## Why it matters
+
+`tokio::spawn` runs the future on a worker thread that has no thread-local
+default subscriber state — the spawned task starts with an **empty span
+stack**. Concretely, this means:
+
+- The parent's `trace_id` does not propagate. Logs emitted from the
+  spawned task get no `trace_id` (or, worse, a fresh one), so they cannot
+  be stitched back to the originating request in Honeycomb / Sentry.
+- Span fields the parent carried (`user.hash`, `schema.name`,
+  `request.id`, etc.) vanish.
+- Sampling decisions made at the parent are ignored — a child task may
+  emit on a request the operator chose not to sample.
+
+`fut.instrument(tracing::Span::current())` (or the `.in_current_span()`
+shorthand) attaches the caller's current span to the future *as data*,
+so when the worker polls the future it re-enters that span before
+running the body. Trace stitching survives the spawn boundary.
+
+`Span::current()` is always safe: when there is no enclosing span it
+resolves to a disabled root that the OTel layer simply skips. The
+choice to leave a site bare is documentation, not correctness.
+
+## The pattern the lint enforces
+
+The lint walks every `tokio::spawn(` occurrence in `crates/*/src/`. For
+each one whose body is an `async` block (single-line or multi-line, with
+or without `move`), it scans the call's full parenthesised body —
+balancing parentheses character-by-character through the awk scanner so
+strings, char literals, line comments, and block comments don't poison
+the depth count — and looks for one of:
+
+- `.instrument(`           — the canonical form, usually
+  `.instrument(tracing::Span::current())`.
+- `.in_current_span()`     — the no-arg shorthand from `tracing` for the
+  same thing.
+- `// lint:spawn-bare-ok <reason>` — the explicit override marker. May
+  live on the spawn line itself, the line immediately preceding it, or
+  anywhere inside the spawn call's body.
+
+If none of those is present anywhere in the spawn's parenthesised body
+(or in the line immediately preceding it, for the override case), the
+lint fails the build and points at the spawn line.
+
+### Canonical good shapes
+
+Single-line:
+
+```rust
+tokio::spawn(async move { do_work().await }.in_current_span());
+```
+
+Multi-line — closing brace then `.instrument(...)` before the matching
+`)`, the form rustfmt prefers when the body is more than a few lines:
+
+```rust
+tokio::spawn(
+    async move {
+        runner
+            .run_fire_with_refire_loop(&view_name, trigger_index, &rt)
+            .await;
+        rt.dispatch_in_flight.store(false, Ordering::SeqCst);
+    }
+    .instrument(tracing::Span::current()),
+);
+```
+
+Both forms pass the lint because `.instrument(...)` lives inside the
+`tokio::spawn(...)` call's parens.
+
+`use tracing::Instrument;` (or `use tracing::instrument::Instrument;`)
+must be in scope at the file level for `.instrument(...)` to resolve.
+
+## The override marker
+
+Use `// lint:spawn-bare-ok <reason>` for spawns that genuinely have no
+parent context to propagate. Two categories qualify, both pre-classified
+in `docs/observability/tokio-spawn-instrument-notes.md`:
+
+1. **Boot-time perpetual workers.** Spawned once at process startup
+   from `init_*` / constructors. The current span at boot is either the
+   binary's startup span or no span at all — tagging every event with it
+   would be misleading on dashboards. Per-event spans are created by
+   downstream code as work flows through. Examples:
+   - `SledPool::start_idle_reaper` — the idle reaper.
+   - `EventMonitor::new` — five subscriber loops.
+   - `MutationManager::start_event_listener`.
+   - `ProcessResultsSubscriber::start_event_listener`.
+   - `FoldDB::new` — the `TriggerRunner` scheduler loop.
+   - `SyncCoordinator::start_background_sync`.
+
+2. **`#[cfg(test)]` scaffolding.** Test driver tasks that advance a
+   `MockClock` or block on a gate so the test can exercise concurrent
+   behaviour. There is no parent request span; tagging would be
+   misleading.
+
+Always include a short reason after the marker:
+
+```rust
+// lint:spawn-bare-ok boot-time idle reaper — perpetual worker, no per-request parent span.
+tokio::spawn(async move { /* ... */ });
+```
+
+The marker may live on the spawn line, the preceding line, or anywhere
+inside the spawn call's body. The two-line window survives `rustfmt`
+lifting a long trailing comment onto its own line.
+
+If you find yourself reaching for the override in code that runs on the
+request path (anything reachable from a handler, ingestion pipeline, or
+mutation), step back: the right fix is almost always
+`.instrument(tracing::Span::current())`. The override is for code that
+runs *outside* any request context, not for code that runs inside one
+and finds propagation inconvenient.
+
+## Running locally
+
+```sh
+bash scripts/lint-spawn-instrument.sh
+```
+
+Exit code is `0` when every spawn site is instrumented or marked, `1`
+otherwise. The CI step `Spawn Instrument Lint` inside the `Rust Tests`
+job (`.github/workflows/ci-tests.yml`) runs the same invocation on
+every PR and `push` to `main`.
+
+## Scope and limits
+
+- `crates/*/src/` only. Top-level integration tests under
+  `crates/*/tests/` are out of scope, mirroring `lint-tracing-egress.sh`.
+- `tokio::spawn(some_future)` (where the argument is a *named future*,
+  not an `async` block literal) is intentionally not flagged — the
+  caller of that helper is expected to have wrapped the future already.
+  If a future-returning helper grows callers that bypass instrumentation,
+  prefer fixing the helper signature over widening the lint.
+- `tokio::task::spawn_blocking(...)` takes a synchronous closure, so
+  `.instrument()` does not apply; that case needs a separate helper
+  (capture `Span::current()`, `let _e = span.enter()` inside the
+  closure) and is deferred.
+- `Span::current().context()` propagation across non-`spawn` task
+  boundaries (e.g. mpsc message hand-offs that re-enter on the receiver)
+  is deferred to a follow-up task.
+- Sibling repos (`fold_db_node`, `schema_service`, `exemem-infra`) each
+  ship their own copy of the same lint as a follow-up.

--- a/scripts/lint-spawn-instrument.sh
+++ b/scripts/lint-spawn-instrument.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# lint-spawn-instrument.sh
+#
+# Enforce that every `tokio::spawn(async ... { ... })` site inside
+# `crates/*/src/` either:
+#   - chains `.instrument(tracing::Span::current())`
+#   - chains `.in_current_span()`
+#   - carries an explicit `// lint:spawn-bare-ok <reason>` override on the
+#     spawn line, the line immediately preceding it, or anywhere inside
+#     the spawn call's parenthesised body.
+#
+# The "window" for the check is the spawn call's own parenthesised body —
+# from `tokio::spawn(` through its matching `)` — found by balancing
+# parens forward from the spawn line. This avoids fragile fixed-line
+# heuristics that miss `.instrument(...)` parked just past the body.
+#
+# Why this matters (Phase 5 / observability):
+#   Without `.instrument(...)`, the spawned future starts with an empty
+#   span stack — the parent's `trace_id` / `user.hash` / `schema.name`
+#   never propagate across the spawn boundary, so child logs can't be
+#   stitched back to the originating request in the trace.
+#
+# `Span::current()` is always safe: when there is no enclosing span it
+# resolves to a disabled root that the OTel layer skips. The override
+# comment exists for spawns that genuinely have no parent context
+# (perpetual workers started at `init_*`, `#[cfg(test)]` scaffolding).
+#
+# Usage:        bash scripts/lint-spawn-instrument.sh
+# Exit code:    0 if every match is instrumented or marked, 1 otherwise.
+#
+# See docs/observability/spawn-instrument-lint.md for the canonical
+# pattern and override syntax.
+
+set -euo pipefail
+
+# Maximum forward-line scan when balancing the spawn's parens. Large
+# enough to cover any sane body, small enough to avoid runaway scans on
+# malformed input.
+MAX_FORWARD_LINES=200
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
+cd "$REPO_ROOT"
+
+if ! compgen -G "crates/*/src" > /dev/null; then
+    echo "lint-spawn-instrument: no crates/*/src directories found at $REPO_ROOT" >&2
+    exit 1
+fi
+
+# Print the full text of the tokio::spawn(...) call, beginning at $2
+# (1-based line number) of $1, by balancing parentheses character-by-
+# character. Strings, char literals, line comments, and block comments
+# are skipped so their parens don't poison the depth count.
+spawn_call_text() {
+    local file="$1"
+    local start_line="$2"
+    awk -v start="$start_line" -v max="$MAX_FORWARD_LINES" '
+        BEGIN {
+            depth = 0
+            opened = 0
+            in_block_comment = 0
+            collected = ""
+        }
+        NR >= start {
+            line = $0
+            if (collected == "") {
+                collected = line
+            } else {
+                collected = collected "\n" line
+            }
+            i = 1
+            n = length(line)
+            in_string = 0
+            string_char = ""
+            in_line_comment = 0
+            while (i <= n) {
+                ch = substr(line, i, 1)
+                next_ch = (i < n) ? substr(line, i + 1, 1) : ""
+
+                if (in_line_comment) {
+                    i++
+                    continue
+                }
+                if (in_block_comment) {
+                    if (ch == "*" && next_ch == "/") {
+                        in_block_comment = 0
+                        i += 2
+                        continue
+                    }
+                    i++
+                    continue
+                }
+                if (in_string) {
+                    if (ch == "\\") {
+                        i += 2
+                        continue
+                    }
+                    if (ch == string_char) {
+                        in_string = 0
+                    }
+                    i++
+                    continue
+                }
+
+                if (ch == "/" && next_ch == "/") {
+                    in_line_comment = 1
+                    i += 2
+                    continue
+                }
+                if (ch == "/" && next_ch == "*") {
+                    in_block_comment = 1
+                    i += 2
+                    continue
+                }
+                if (ch == "\"" || ch == "\x27") {
+                    in_string = 1
+                    string_char = ch
+                    i++
+                    continue
+                }
+                if (ch == "(") {
+                    depth++
+                    opened = 1
+                } else if (ch == ")") {
+                    depth--
+                    if (opened && depth == 0) {
+                        print collected
+                        exit
+                    }
+                }
+                i++
+            }
+            if (NR - start + 1 >= max) {
+                print collected
+                exit
+            }
+        }
+    ' "$file"
+}
+
+failed=0
+total=0
+
+trim_left() {
+    local s="$1"
+    s="${s#"${s%%[![:space:]]*}"}"
+    printf '%s' "$s"
+}
+
+while IFS= read -r match; do
+    [[ -z "$match" ]] && continue
+
+    file="${match%%:*}"
+    rest="${match#*:}"
+    lineno="${rest%%:*}"
+
+    spawn_line=$(sed -n "${lineno}p" "$file")
+
+    # Skip doc comments and comment-block lines (the rg target is real
+    # spawn calls, not occurrences of `tokio::spawn(` inside docstrings).
+    trimmed=$(trim_left "$spawn_line")
+    case "$trimmed" in
+        //*|\**|/\**)
+            continue
+            ;;
+    esac
+
+    # Confirm this is a spawn of an async block, not `tokio::spawn(some_future)`.
+    # The `async` keyword may sit on the spawn line itself or the next 1-2
+    # lines (we have both styles in-tree).
+    async_end=$((lineno + 2))
+    async_window=$(sed -n "${lineno},${async_end}p" "$file")
+    if ! printf '%s\n' "$async_window" | grep -qE 'tokio::spawn\(\s*async|^[[:space:]]*async[[:space:]]+(move[[:space:]]+)?\{|^[[:space:]]*async[[:space:]]*\{'; then
+        continue
+    fi
+
+    total=$((total + 1))
+
+    body=$(spawn_call_text "$file" "$lineno")
+
+    # Allow override on the line just preceding the spawn too — a common
+    # place reviewers expect the rationale to live.
+    prev_line=""
+    if [[ $lineno -gt 1 ]]; then
+        prev_line=$(sed -n "$((lineno - 1))p" "$file")
+    fi
+
+    if printf '%s\n' "$body" | grep -qE '\.instrument\(|\.in_current_span\(\)|// lint:spawn-bare-ok'; then
+        continue
+    fi
+    if printf '%s\n' "$prev_line" | grep -qE '// lint:spawn-bare-ok'; then
+        continue
+    fi
+
+    echo "ERROR: $file:$lineno — tokio::spawn(async ...) without .instrument() / .in_current_span() / override inside the spawn call"
+    failed=1
+done < <(grep -rnE 'tokio::spawn\(' crates/*/src/ 2>/dev/null || true)
+
+if [[ $failed -ne 0 ]]; then
+    cat >&2 <<'EOF'
+
+Each tokio::spawn(async ...) must either:
+  - chain .instrument(tracing::Span::current()) on the future, or
+  - chain .in_current_span() on the future, or
+  - carry a `// lint:spawn-bare-ok <reason>` comment on the spawn line,
+    the line immediately preceding it, or anywhere inside the spawn body.
+
+See docs/observability/spawn-instrument-lint.md for guidance and the
+list of pre-approved bare-spawn rationales.
+EOF
+    exit 1
+fi
+
+echo "lint-spawn-instrument: ok — all $total tokio::spawn(async) sites in crates/*/src/ are instrumented or explicitly marked."


### PR DESCRIPTION
## Summary
- New `scripts/lint-spawn-instrument.sh`: balanced-paren bash scanner walks every `tokio::spawn(async ... { ... })` site in `crates/*/src/` and fails CI when the spawn body contains neither `.instrument(...)` / `.in_current_span()` nor an explicit `// lint:spawn-bare-ok <reason>` override marker. Strings, char literals, and `// … *` comments are masked while balancing.
- Calibrates on the current tree: PR #643 (Phase 3 / T6) instrumented the two `dispatch_*` spawns in `trigger_runner.rs` plus the ring-layer regression test — verified all three still chain `.instrument(tracing::Span::current())`. The 14 pre-existing bare spawns (boot-time perpetual workers + `#[cfg(test)]` test drivers, all classified in `docs/observability/tokio-spawn-instrument-notes.md`) get a `// lint:spawn-bare-ok <reason>` override with a short rationale so the lint is a no-op on this tree (17 sites total).
- Wires into the existing `Rust Tests` CI job in `.github/workflows/ci-tests.yml` next to the trace-egress lint, with a `Spawn Instrument Lint` row in the step summary and a matching entry in the final pass/fail gate. New doc `docs/observability/spawn-instrument-lint.md` covers canonical good shapes (single-line and multi-line), override syntax, and which classes of spawn are legitimately bare.

## Why a paren-balanced window
The brief asked for `~6` lines. fold_db has spawns where rustfmt parks the trailing `.instrument(...)` 7 lines (`trigger_runner.rs:544 → :551`) or 10 lines (`:600 → :610`) past the opener — fixed lookahead would either miss them or burn arbitrary headroom. Balancing parens forward from `tokio::spawn(` to its matching `)` (with string / char / comment masking in the `awk` scanner) gives a precise window without a fragile magic constant.

## Test plan
- [x] `bash scripts/lint-spawn-instrument.sh` — exits 0 on clean tree (17 sites: 3 instrumented, 14 marked).
- [x] Verified the lint catches regressions: temporarily removed one override marker → script exits 1 and points at the right line.
- [x] `bash scripts/lint-tracing-egress.sh` — still green (no interaction).
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (one flaky `test_purge_org_data` retry passed in isolation; my changes are comment-only additions to spawn call sites and cannot affect that path).

## Out of scope
- Same lint in sibling repos (`fold_db_node`, `schema_service`, `exemem-infra`) — per-repo follow-ups.
- `Span::current().context()` propagation across non-`spawn` task boundaries (e.g. mpsc hand-offs that re-enter on the receiver).
- `tokio::task::spawn_blocking(...)` — takes a synchronous closure, so `.instrument()` does not apply; needs a separate helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)