### PR TITLE
chore(observability): drop Phase 6 / opentelemetry-aws references

### DIFF
--- a/crates/observability/src/init.rs
+++ b/crates/observability/src/init.rs
@@ -563,7 +563,7 @@ where
 /// Build the OTel `Resource` carrying the canonical `service.name`
 /// attribute. Centralised so both branches of [`build_traces_layer_or_noop`]
 /// — and any future expansion to `service.version` / `deployment.environment`
-/// (Phase 6) — agree on the exact key.
+/// — agree on the exact key.
 fn build_service_resource(service_name: &str) -> Resource {
     Resource::new(vec![KeyValue::new(
         "service.name",

--- a/crates/observability/src/propagation.rs
+++ b/crates/observability/src/propagation.rs
@@ -16,8 +16,10 @@
 //! module install one ad-hoc.
 //!
 //! AWS SDK egress is **not** covered — Lambdas talk to AWS services, which
-//! use a different propagation format. Phase 6 closes that gap via
-//! `opentelemetry-aws`.
+//! use a different propagation format. This is intentionally out of scope:
+//! AWS SDK calls are auth/billing/sync metadata, not on the user-facing
+//! critical path. A lightweight `#[tracing::instrument]` on the Lambda
+//! wrapper functions is the fallback if span coverage is needed.
 
 use opentelemetry::global;
 #[cfg(test)]

--- a/docs/observability/loggingsystem-retirement-notes.md
+++ b/docs/observability/loggingsystem-retirement-notes.md
@@ -89,6 +89,8 @@ transitive `log::*` calls coming from `reqwest` / `hyper` / `sled` / etc.
 ## Out of scope (filed as follow-ups)
 
 - CI lint enforcing `tracing::*` over `log::*` (Phase 5).
-- Frontend dashboard rewrite (Phase 6).
-- AWS SDK propagation (Phase 6).
+- Trace context propagation into AWS SDK egress — intentionally out of
+  scope. Those calls are auth/billing/sync metadata, not on the user-facing
+  critical path; a lightweight `#[tracing::instrument]` on Lambda wrapper
+  functions is the fallback if span coverage is needed.
 - `fold_db_node` consumer migration (separate PR in `fold_db_node` repo).


### PR DESCRIPTION
## Summary

Phase 6 (frontend dashboard rebuild + AWS SDK trace propagation via `opentelemetry-aws`) was dropped on 2026-04-28. This PR strips the aspirational forward-pointing doc comments that still referenced it.

- `crates/observability/src/propagation.rs` — replace "Phase 6 closes that gap via `opentelemetry-aws`" with the actual rationale: AWS SDK egress is intentionally out of scope (auth/billing/sync metadata, not user-facing critical path) and `#[tracing::instrument]` on Lambda wrappers is the fallback if span coverage is ever needed.
- `crates/observability/src/init.rs` — drop the dangling "(Phase 6)" parenthetical from the `service.version` / `deployment.environment` doc comment.
- `docs/observability/loggingsystem-retirement-notes.md` — remove the "Frontend dashboard rewrite (Phase 6)" follow-up and reword the AWS SDK propagation entry to document it as intentionally out of scope rather than deferred.

`rg "opentelemetry-aws|Phase 6|AWS SDK propagation"` returns zero remaining observability hits (the lone surviving "Phase 6" hit is `mutation_manager.rs:346`, an unrelated internal mutation pipeline phase number).

## Test plan
- [x] `rg "opentelemetry-aws|Phase 6|AWS SDK propagation"` — zero observability hits
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p observability --all-targets -- -D warnings`
- [x] `cargo build -p observability`
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)