### PR TITLE
feat(observability): warn-only CI lint for structured tracing fields (Phase 5 / T4)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -29,6 +29,44 @@ jobs:
       - name: Run redaction lint
         run: sh scripts/lint-redaction.sh
 
+  lint-structured-fields:
+    name: Structured Fields Lint (warn-only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install ripgrep
+        run: |
+          if ! command -v rg >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends ripgrep
+          fi
+
+      - name: Run structured-fields lint
+        id: structured-fields
+        run: |
+          # The script always exits 0. Tee output to a file so we can
+          # surface it as a job summary regardless of hit count.
+          sh scripts/lint-structured-fields.sh | tee structured-fields-lint.log
+
+      - name: Publish suggestions to job summary
+        if: always()
+        run: |
+          {
+            echo "## Structured fields lint (warn-only, educational)"
+            echo
+            echo "This lint never blocks a PR. It surfaces \`tracing\` call sites that"
+            echo "use positional message args instead of structured fields, so reviewers"
+            echo "can prefer the structured form on new code. See"
+            echo "\`docs/observability/structured-fields-lint.md\`."
+            echo
+            echo '```'
+            cat structured-fields-lint.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   rust-tests:
     name: Rust Tests
     runs-on: ubuntu-latest

--- a/docs/observability/structured-fields-lint.md
+++ b/docs/observability/structured-fields-lint.md
@@ -1,0 +1,145 @@
+# Structured fields lint (Phase 5 / T4)
+
+Educational, **warn-only** CI lint that highlights `tracing` call sites
+whose message string carries positional `{}` / `{:?}` / `{name}`
+placeholders instead of emitting structured fields. The script always
+exits 0; the CI job always passes. The point is to nudge new code
+toward the structured form, not to block PRs.
+
+## Why it matters
+
+`tracing` events have two kinds of payload:
+
+1. **The message string** — a flat, formatted line like
+   `"upload to 'edgevector-prod' failed: connection reset"`.
+2. **Structured fields** — typed key/value pairs attached to the event
+   (`target = "edgevector-prod"`, `error = "connection reset"`).
+
+In Honeycomb, Sentry, and our local query tooling, you can pivot, group,
+and filter on **fields**. You cannot pivot on the contents of the message
+string. So this:
+
+```rust
+tracing::warn!("upload to '{}' failed: {}", target.label, err);
+```
+
+produces a log line where `target.label` is unrecoverable as a field —
+you can grep for it, but you cannot ask "show me the upload error rate
+broken down by target". This:
+
+```rust
+tracing::warn!(
+    target = %target.label,
+    error = %err,
+    "upload failed",
+);
+```
+
+emits the same human-readable text plus two queryable fields. Same
+ergonomics for the author, dramatically more useful in the dashboard.
+
+## What the lint flags
+
+The script greps `crates/*/src/` for the regex
+
+```
+tracing::(info|warn|debug|error|trace)!(...,"...{...}...", ...)
+```
+
+i.e. a `tracing` macro whose message string contains a `{...}`
+placeholder and is followed by a comma (so at least one positional arg
+trails it). Both the legacy `"...{}", x` form and the Rust-2021
+`"...{x}", x = thing` form are flagged.
+
+Pure-message calls without placeholders (`tracing::info!("started")`)
+and already-structured calls (`tracing::info!(field = %x, "msg")`) are
+ignored. Calls that mix structured fields *and* a positional message
+arg (`tracing::info!(field = %x, "msg {}", y)`) **are** flagged — the
+positional `y` is still unqueryable even though `field` is fine.
+
+## Output and CI surface
+
+Run locally:
+
+```sh
+sh scripts/lint-structured-fields.sh
+```
+
+The script exits 0 always. When there are hits, it prints a short
+explainer, a before/after example, and the list of flagged sites with
+file path, line number, and the source line. Sample:
+
+```
+lint-structured-fields: 39 site(s) use positional/inline message args
+instead of structured fields. This is warn-only — no PR is blocked.
+
+...
+
+Sites flagged:
+  crates/core/src/sync/engine.rs:732
+      tracing::warn!("upload to '{}' failed (auth): {e}", target.label);
+  ...
+```
+
+In CI (`.github/workflows/ci-tests.yml`), the
+`Structured Fields Lint (warn-only)` job runs the same invocation and
+republishes the output as a **job summary** on the PR's Checks tab.
+Because the script exits 0 the check is always green; the summary is
+where reviewers see the suggestions.
+
+## Why warn-only (and not block)
+
+Two reasons.
+
+1. **There is a backlog.** At time of landing, the lint flags ~39
+   pre-existing sites in `crates/core/src/`. Migrating them is a
+   separate ergonomics PR; we did not want to gate that work on every
+   downstream change.
+2. **The structured form is a preference, not a correctness invariant.**
+   Unlike redaction (which protects PII) or `tokio::spawn` instrumentation
+   (which preserves trace stitching), a positional log arg is *worse for
+   query ergonomics* but doesn't break anything. A nudge is the right
+   shape of feedback.
+
+If the structured-fields rate stops improving — or if the lint is being
+ignored — we can revisit and promote it to blocking with an inline
+override marker, mirroring `lint:redaction-ok` and
+`lint:spawn-bare-ok`.
+
+## Migrating a flagged site
+
+Replace each `{}` / `{name}` in the message with a structured field on
+the macro argument list, and shorten the message to the human-readable
+event name:
+
+```rust
+// Before
+tracing::info!("Loaded {} embeddings from store", entries.len());
+
+// After
+tracing::info!(count = entries.len(), "loaded embeddings from store");
+```
+
+For errors, prefer `error = %err` (the `%` is `tracing`'s `Display`
+form) over `error = ?err` (Debug) unless you specifically want the
+debug rendering:
+
+```rust
+// Before
+tracing::warn!("Failed to embed face: {}", err);
+
+// After
+tracing::warn!(error = %err, "failed to embed face");
+```
+
+## Scope and limits
+
+- `crates/*/src/` only, mirroring `lint-redaction.sh` and
+  `lint-spawn-instrument.sh`. Top-level integration tests under
+  `crates/*/tests/` are out of scope.
+- `println!`, `eprintln!`, `log::*!`, and other non-`tracing` macros are
+  not in scope. The lint is specifically about events that flow into
+  Honeycomb / OTel.
+- Sibling repos (`fold_db_node`, `schema_service`, `exemem-infra`) each
+  own their own copy of this lint as a follow-up — same as the rest of
+  the Phase 5 lint set.

--- a/scripts/lint-structured-fields.sh
+++ b/scripts/lint-structured-fields.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# lint-structured-fields.sh
+#
+# Educational, warn-only lint that highlights `tracing` call sites whose
+# message string carries positional `{}` / `{:?}` / `{name}` placeholders
+# instead of emitting structured fields.
+#
+# Why: a positional arg becomes part of the flat message string. Honeycomb,
+# Sentry, and our local query tools index *fields*, not message bodies, so
+# `tracing::warn!("upload to '{}' failed: {}", target, err)` produces a log
+# line you cannot pivot on by `target` or `err`. The structured form
+#
+#     tracing::warn!(target = %target, error = %err, "upload failed");
+#
+# emits the same human-readable text plus two queryable fields.
+#
+# This is intentionally non-blocking. The script always exits 0 — CI prints
+# the suggestions to the job summary so reviewers see them, but no PR is
+# blocked. Migrating existing sites is out of scope here; the goal is to
+# stop the bleed at the call-site level.
+#
+# Scope: `crates/*/src/` only — same scope as `lint-redaction.sh` and
+# `lint-spawn-instrument.sh`.
+#
+# Usage:    sh scripts/lint-structured-fields.sh
+# Exit:     0, always.
+#
+# See docs/observability/structured-fields-lint.md for guidance.
+
+set -eu
+
+# Match `tracing::{info,warn,debug,error,trace}!(...,"...{...}...", ...)` —
+# the message string contains a `{...}` placeholder and is followed by a
+# comma, which means at least one positional/inline arg trails it. We keep
+# the leading-arg slop (`[^"]*`) so the match also fires when a structured
+# field precedes the message (mixed-style call) — that is still a candidate
+# for full conversion.
+PATTERN='tracing::(info|warn|debug|error|trace)!\([^"]*"[^"]*\{[^"]*\}[^"]*",'
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/.." && pwd)
+cd "$REPO_ROOT"
+
+if ! command -v rg >/dev/null 2>&1; then
+    # Mirror lint-redaction.sh: ripgrep is a hard requirement on dev
+    # machines and CI installs it explicitly. Stay quiet otherwise.
+    echo "lint-structured-fields: ripgrep (rg) not found in PATH — skipping" >&2
+    exit 0
+fi
+
+found_any=0
+for d in crates/*/src; do
+    [ -d "$d" ] && found_any=1
+done
+if [ "$found_any" -eq 0 ]; then
+    echo "lint-structured-fields: no crates/*/src directories found at $REPO_ROOT" >&2
+    exit 0
+fi
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT INT HUP TERM
+
+rg --pcre2 -n "$PATTERN" crates/*/src > "$tmp" 2>/dev/null || true
+
+hits=0
+while IFS= read -r match; do
+    [ -z "$match" ] && continue
+    hits=$((hits + 1))
+done < "$tmp"
+
+if [ "$hits" -eq 0 ]; then
+    echo "lint-structured-fields: ok — no positional-arg tracing call sites in crates/*/src/."
+    exit 0
+fi
+
+cat <<EOF
+lint-structured-fields: $hits site(s) use positional/inline message args
+instead of structured fields. This is warn-only — no PR is blocked.
+
+Why prefer structured fields: positional args are baked into the flat
+message string and cannot be queried as fields in Honeycomb / Sentry /
+local log tools. Structured fields can.
+
+Before:
+    tracing::warn!("upload to '{}' failed: {}", target, err);
+
+After:
+    tracing::warn!(target = %target, error = %err, "upload failed");
+
+Sites flagged:
+EOF
+
+while IFS= read -r match; do
+    [ -z "$match" ] && continue
+    file=${match%%:*}
+    rest=${match#*:}
+    lineno=${rest%%:*}
+    content=${rest#*:}
+    # Trim leading whitespace from the source line for legible output.
+    trimmed=$(printf '%s' "$content" | sed 's/^[[:space:]]*//')
+    printf '  %s:%s\n      %s\n' "$file" "$lineno" "$trimmed"
+done < "$tmp"
+
+cat <<'EOF'
+
+See docs/observability/structured-fields-lint.md for the full rationale.
+EOF
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/lint-structured-fields.sh` — an educational lint that flags `tracing::*!("...{}", x)` style call sites and suggests the structured `tracing::*!(field = %x, "msg")` form.
- Wires it into CI as a new `Structured Fields Lint (warn-only)` job that **always passes** — the suggestions land in the job summary so reviewers see them, but no PR is blocked.
- Documents the rationale at `docs/observability/structured-fields-lint.md`.

Why warn-only: positional args are *worse for query ergonomics* (Honeycomb / Sentry index fields, not message bodies) but don't break correctness, so a nudge is the right shape of feedback. The lint flags ~39 pre-existing sites in `crates/core/src/`; migrating them is intentionally deferred to a separate ergonomics PR.

## Test plan

- [x] `bash scripts/lint-structured-fields.sh` exits 0 locally with hits printed
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green; `Structured Fields Lint (warn-only)` job passes and surfaces the 39 hits in its job summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)