### PR TITLE
ci: align with merge queue + add ci-required umbrella

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,9 +12,13 @@ jobs:
       pull-requests: write
       contents: write
     steps:
+      # No strategy flag: the org's merge-queue ruleset enforces SQUASH.
+      # Passing `--squash` makes `gh` warn "merge strategy is set by the merge
+      # queue" and store an inconsistent autoMergeRequest.mergeMethod, which
+      # the queue silently refuses — stranding the PR until manually queued.
       - name: Enable auto-merge on PR
         if: github.event_name == 'pull_request'
-        run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash --repo ${{ github.repository }}
+        run: gh pr merge ${{ github.event.pull_request.number }} --auto --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -23,7 +27,7 @@ jobs:
         run: |
           prs=$(gh pr list --base main --state open --json number --jq '.[].number' --repo ${{ github.repository }})
           for pr in $prs; do
-            gh pr merge "$pr" --auto --squash --repo ${{ github.repository }} 2>&1 || true
+            gh pr merge "$pr" --auto --repo ${{ github.repository }} 2>&1 || true
           done
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -145,3 +145,25 @@ jobs:
           steps.clippy.outcome == 'failure' ||
           steps.cargo-test.outcome == 'failure'
         run: exit 1
+
+  # Org-wide convention: every EdgeVector repo exposes a check named
+  # `ci-required` so the org ruleset can require a single uniform check
+  # across all repos.
+  ci-required:
+    name: ci-required
+    needs: [lint-redaction, rust-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: All required jobs must succeed
+        env:
+          RESULTS: ${{ join(needs.*.result, ',') }}
+        run: |
+          echo "Required job results: $RESULTS"
+          for r in ${RESULTS//,/ }; do
+            if [ "$r" != "success" ]; then
+              echo "::error::A required job did not succeed (result: $r)"
+              exit 1
+            fi
+          done
+          echo "All required jobs passed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,10 @@ cargo test --workspace --all-targets
 
 After creating the PR, enable auto-merge:
 ```bash
-gh pr merge --auto --squash <PR_URL>
+gh pr merge --auto <PR_URL>
 ```
+
+Do NOT pass `--squash`, `--merge`, or `--rebase`. The org-wide merge queue ruleset enforces SQUASH; passing a strategy flag here makes `gh` store an inconsistent `autoMergeRequest.mergeMethod` that the queue silently refuses, stranding the PR. The merge queue rebases the PR onto current main inside its merge group, so "Update branch" never needs to be clicked manually.
 
 **Monitor the PR until it merges — your task is NOT done until the PR is merged.**
 Poll CI status (`gh pr view <PR_URL> --json state,statusCheckRollup,mergeStateStatus`) every 30-60 seconds.


### PR DESCRIPTION
Drops `--squash` from auto-merge.yml + CLAUDE.md (org merge queue dictates strategy) and adds a `ci-required` umbrella job to ci-tests.yml depending on the 2 existing jobs (lint-redaction, rust-tests). Part of org-wide rollout.