### PR TITLE
docs: replace stale OpenRouter references with Anthropic / Settings UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,11 @@ npm run lint                             # ESLint
 npm run generate:api                     # Generate TypeScript types from OpenAPI spec
 ```
 
-## Environment Variables
+## AI Provider Configuration
 
-Required for AI-powered ingestion:
-```bash
-export FOLD_OPENROUTER_API_KEY=your_key  # Or OPENROUTER_API_KEY
-```
+AI ingestion runs against either **Ollama** (local, default — auto-detected at `http://127.0.0.1:11434`) or **Anthropic** (cloud, direct calls to `https://api.anthropic.com` per [`llm_registry/models.rs`](crates/core/src/llm_registry/models.rs)).
+
+The provider choice and Anthropic API key live in the node config store (`crates/core/src/storage/node_config_store.rs`) and are configured via the **Settings → AI Provider** tab in the web UI — **not** via environment variables. There is no `FOLD_*_API_KEY` env var for AI providers.
 
 ## Key Architecture Concepts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,8 +120,8 @@ src/
 │   └── ingestion.rs     # Ingestion-specific handlers
 ├── ingestion/           # AI-powered data ingestion pipeline
 │   ├── ingestion_service/  # Main service (schema recommendation, mutation generation)
-│   ├── openrouter_service.rs
-│   ├── ollama_service.rs
+│   ├── anthropic_service.rs # Cloud LLM client (https://api.anthropic.com)
+│   ├── ollama_service.rs    # Local LLM client (http://127.0.0.1:11434)
 │   ├── error.rs         # IngestionError with LLM error classifiers
 │   └── routes.rs        # HTTP routes (Actix-web)
 ├── server/
@@ -199,7 +199,7 @@ FOLD_LOG_LEVEL=debug ./run.sh --local 2>&1 | grep '\[Ingestion\]'
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
 | "Schema not found" on mutation | Schema not approved | Call `schema_manager.approve("name")` |
-| "OpenRouter service not initialized" | Missing API key | Set `FOLD_OPENROUTER_API_KEY` or configure in Settings |
+| "Anthropic service not initialized" | Missing API key | Configure your Anthropic API key in **Settings → AI Provider** (or switch the provider to Ollama) |
 | Frontend embed error at build | Missing `dist/` | `cd src/server/static-react && npm ci && npm run build` |
 | Test fixture is 130 bytes | Git LFS pointer | `git lfs pull` |
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Visit [http://localhost:5173](http://localhost:5173) — that's it. No API key r
                     |
                     v
           +------------------+
-          |   AI Ingestion   |  ← Ollama (local) or OpenRouter (cloud)
+          |   AI Ingestion   |  ← Ollama (local) or Anthropic (cloud)
           +------------------+
                     |
         +-----------+-----------+
@@ -121,7 +121,7 @@ FoldDB works with two AI backends. Pick one (or both):
 | Provider | Cost | Runs Where | Setup |
 |----------|------|-----------|-------|
 | **[Ollama](https://ollama.com)** | Free | Your machine | Install Ollama, pull a model, done |
-| **[OpenRouter](https://openrouter.ai)** | Pay-per-use | Cloud API | `export FOLD_OPENROUTER_API_KEY="sk-..."` |
+| **[Anthropic](https://www.anthropic.com)** | Pay-per-use | Cloud API | Paste your API key in **Settings → AI Provider** |
 
 Ollama is the default — no API key needed. FoldDB will use it automatically if it's running.
 
@@ -209,10 +209,11 @@ cargo install --git https://github.com/EdgeVector/fold_db.git --bin folddb
 
 | Variable | Purpose |
 |----------|---------|
-| `FOLD_OPENROUTER_API_KEY` | API key for OpenRouter AI (or `OPENROUTER_API_KEY`). Not needed with Ollama. |
 | `FOLD_SCHEMA_SERVICE_URL` | Schema service URL (default: `https://schema.folddb.com`) |
 | `FOLD_CONFIG` | Path to configuration file |
 | `FOLD_LOG_LEVEL` | Logging level (`trace`, `debug`, `info`, `warn`, `error`) |
+
+> AI provider credentials (Anthropic API key, Ollama host) are configured in **Settings → AI Provider** in the web UI, not via environment variables.
 
 <details>
 <summary><h2>Advanced: AWS Deployment</h2></summary>
@@ -284,13 +285,13 @@ FoldDB auto-detects Ollama at `http://127.0.0.1:11434`. If it's not found:
 </details>
 
 <details>
-<summary><strong>OpenRouter API key errors</strong></summary>
+<summary><strong>Anthropic API key errors</strong></summary>
 
-- **"API key invalid or expired"** — Check your key at [openrouter.ai/keys](https://openrouter.ai/keys)
-- **"insufficient credits"** — Add funds at [openrouter.ai/credits](https://openrouter.ai/credits)
-- **"model not found"** — The configured model may have been removed; switch to a different one in Settings
+- **"API key invalid or expired"** — Check or rotate your key at [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys)
+- **"insufficient credit"** / 429 rate limits — Top up or raise limits at [console.anthropic.com/settings/billing](https://console.anthropic.com/settings/billing)
+- **"model not found"** — The configured model may have been deprecated; pick a different one in Settings
 
-Set your key: `export FOLD_OPENROUTER_API_KEY="sk-or-v1-..."` or configure in the Settings tab.
+Configure your key in the **Settings → AI Provider** tab. FoldDB stores it locally in the node config; it never leaves your machine except to authenticate calls to Anthropic.
 
 </details>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,7 @@ When reporting, please include:
 
 ### Security Best Practices for Users
 
-1. **API Keys**: Never commit API keys (e.g., `FOLD_OPENROUTER_API_KEY`) to version control
+1. **API Keys**: Never commit API keys (Anthropic, AWS, etc.) to version control. AI provider keys are stored in the local node config and should never appear in git history.
 2. **AWS Credentials**: Use IAM roles or environment variables, never hardcode credentials
 3. **Network**: Use TLS in production environments
 4. **Updates**: Keep your FoldDB installation up to date


### PR DESCRIPTION
## Summary

OpenRouter is no longer a runtime AI provider — there is no `openrouter_service.rs`, no `openrouter::` imports, and [`crates/core/src/llm_registry/models.rs:49`](crates/core/src/llm_registry/models.rs#L49) points directly at `https://api.anthropic.com`. User-facing options are **Anthropic** (cloud, direct) and **Ollama** (local). The Anthropic API key lives in `node_config_store` and is configured via **Settings → AI Provider** in the web UI — there is no `FOLD_*_API_KEY` env var for it.

## Touched

| File | What changed |
|---|---|
| `README.md` | Architecture diagram, AI Providers table, env-var table, troubleshooting section |
| `CLAUDE.md` | Replaced the `FOLD_OPENROUTER_API_KEY` env-var block with a description of the actual config flow |
| `CONTRIBUTING.md` | Fixed `src/ingestion/` listing (`anthropic_service.rs`, not `openrouter_service.rs`) and the common-issues table |
| `SECURITY.md` | Removed the stale env-var example |

## Out of scope (deferred)

- `docs/LAUNCH_PLAN.md` — multi-model marketing matrix listing non-Anthropic models (Gemini, GPT-4.1, DeepSeek). Will revisit once we know the cloud-provider plans.
- `.github/README.md` — CI secrets bootstrap, will revisit once we know what CI actually expects.
- `docs/observability/*` — the `skip-3p` mentions of OpenRouter are still accurate for tracing-egress classification.

## Test plan

- [x] No `.rs` files touched — pure docs change, can't break compile or tests
- [x] No remaining `OpenRouter` / `FOLD_OPENROUTER` references in the four touched files
- [ ] CI green
- [ ] Reviewer sanity-checks the new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)