### PR TITLE
ci: pass --squash to auto-merge so the queue accepts the request

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,13 +12,16 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      # No strategy flag: the org's merge-queue ruleset enforces SQUASH.
-      # Passing `--squash` makes `gh` warn "merge strategy is set by the merge
-      # queue" and store an inconsistent autoMergeRequest.mergeMethod, which
-      # the queue silently refuses — stranding the PR until manually queued.
+      # The merge-queue ruleset enforces SQUASH. `gh pr merge --auto` with
+      # no strategy flag stores `autoMergeRequest.mergeMethod = MERGE`
+      # (the repo's UI default merge button), which the queue silently
+      # refuses — stranding the PR until someone re-enables auto-merge
+      # with `--squash`. Passing `--squash` here just produces a benign
+      # "merge strategy is set by the merge queue" warning from gh while
+      # correctly aligning the auto-merge request with the queue.
       - name: Enable auto-merge on PR
         if: github.event_name == 'pull_request'
-        run: gh pr merge ${{ github.event.pull_request.number }} --auto --repo ${{ github.repository }}
+        run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -27,7 +30,7 @@ jobs:
         run: |
           prs=$(gh pr list --base main --state open --json number --jq '.[].number' --repo ${{ github.repository }})
           for pr in $prs; do
-            gh pr merge "$pr" --auto --repo ${{ github.repository }} 2>&1 || true
+            gh pr merge "$pr" --auto --squash --repo ${{ github.repository }} 2>&1 || true
           done
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,10 @@ cargo test --workspace --all-targets
 
 After creating the PR, enable auto-merge:
 ```bash
-gh pr merge --auto <PR_URL>
+gh pr merge --auto --squash <PR_URL>
 ```
 
-Do NOT pass `--squash`, `--merge`, or `--rebase`. The org-wide merge queue ruleset enforces SQUASH; passing a strategy flag here makes `gh` store an inconsistent `autoMergeRequest.mergeMethod` that the queue silently refuses, stranding the PR. The merge queue rebases the PR onto current main inside its merge group, so "Update branch" never needs to be clicked manually.
+Pass `--squash` explicitly. The org-wide merge queue ruleset enforces SQUASH; without `--squash`, `gh` stores `autoMergeRequest.mergeMethod = MERGE` (the repo's UI default merge button), and the queue silently refuses the mismatched method — stranding the PR until someone re-enables auto-merge with the right flag. The benign "merge strategy is set by the merge queue" warning gh prints is fine; what matters is that the auto-merge request and queue agree on SQUASH. The merge queue rebases the PR onto current main inside its merge group, so "Update branch" never needs to be clicked manually.
 
 **Monitor the PR until it merges — your task is NOT done until the PR is merged.**
 Poll CI status (`gh pr view <PR_URL> --json state,statusCheckRollup,mergeStateStatus`) every 30-60 seconds.


### PR DESCRIPTION
## Summary

`gh pr merge --auto` with no strategy flag stores `autoMergeRequest.mergeMethod = MERGE` (the repo's UI default merge button). The merge-queue ruleset enforces SQUASH, so the mismatched method is silently refused and the PR is stranded — auto-merge enabled, but the PR never enters the queue.

`gh pr merge --auto --squash` produces a benign "merge strategy is set by the merge queue" warning while correctly setting mergeMethod to SQUASH; the queue then accepts the auto-merge request.

## Verification

I hit this exact bug today on [exemem-infra#140](https://github.com/EdgeVector/exemem-infra/pull/140): the workflow ran \`gh pr merge --auto\` (no flag) → \`autoMergeRequest.mergeMethod\` was stored as MERGE → \`isInMergeQueue: false\` → PR sat there indefinitely with CI green. Manually re-running \`gh pr merge 140 --auto --squash\` immediately put it at queue position 1.

The pre-existing comment in this workflow (and in CLAUDE.md) claimed the opposite. Both updated to match the empirical behavior.

## Test plan

- [ ] CI green on this PR (the workflow runs \`gh pr merge --auto --squash\` on this very PR — if it strands itself, the bug is back)
- [ ] After merge: subsequent PRs auto-enter the queue once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)