### PR TITLE
docs(auto-merge): correct misleading guidance about merge-queue strategy flags

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,13 +12,16 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      # The merge-queue ruleset enforces SQUASH. `gh pr merge --auto` with
-      # no strategy flag stores `autoMergeRequest.mergeMethod = MERGE`
-      # (the repo's UI default merge button), which the queue silently
-      # refuses — stranding the PR until someone re-enables auto-merge
-      # with `--squash`. Passing `--squash` here just produces a benign
-      # "merge strategy is set by the merge queue" warning from gh while
-      # correctly aligning the auto-merge request with the queue.
+      # The merge-queue ruleset enforces SQUASH at land time. GitHub's
+      # API silently overrides `autoMergeRequest.mergeMethod = MERGE` on
+      # merge-queue branches regardless of what the client requests
+      # (verified: even `enablePullRequestAutoMerge(mergeMethod: SQUASH)`
+      # via GraphQL returns MERGE). So passing `--squash` here triggers
+      # a benign "merge strategy is set by the merge queue" warning but
+      # has no effect — the queue uses its own SQUASH method when it
+      # lands the PR (commits land as 1-parent squash). Note: there is
+      # a `min_entries_to_merge_wait_minutes: 5` delay between CI green
+      # and queue admission; that wait is normal, not a strand.
       - name: Enable auto-merge on PR
         if: github.event_name == 'pull_request'
         run: gh pr merge ${{ github.event.pull_request.number }} --auto --squash --repo ${{ github.repository }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,12 @@ cargo test --workspace --all-targets
 
 After creating the PR, enable auto-merge:
 ```bash
-gh pr merge --auto --squash <PR_URL>
+gh pr merge --auto <PR_URL>
 ```
 
-Pass `--squash` explicitly. The org-wide merge queue ruleset enforces SQUASH; without `--squash`, `gh` stores `autoMergeRequest.mergeMethod = MERGE` (the repo's UI default merge button), and the queue silently refuses the mismatched method — stranding the PR until someone re-enables auto-merge with the right flag. The benign "merge strategy is set by the merge queue" warning gh prints is fine; what matters is that the auto-merge request and queue agree on SQUASH. The merge queue rebases the PR onto current main inside its merge group, so "Update branch" never needs to be clicked manually.
+Don't bother passing a strategy flag. The org-wide merge queue ruleset enforces SQUASH at land time, but GitHub's API silently overrides `autoMergeRequest.mergeMethod = MERGE` on any merge-queue branch — verified that even `enablePullRequestAutoMerge(mergeMethod: SQUASH)` via GraphQL returns `MERGE`. There's no client-side way to set anything else. The queue still squashes when it actually lands the PR (commits arrive as 1-parent squash), so this discrepancy is cosmetic. The "merge strategy is set by the merge queue" warning gh prints if you do pass a flag is honest — gh is telling you it ignored your flag.
+
+After CI goes green there's a `min_entries_to_merge_wait_minutes: 5` delay before the queue admits the PR — that wait is normal, not a strand. The queue also rebases the PR onto current main inside its merge group, so "Update branch" never needs to be clicked manually.
 
 **Monitor the PR until it merges — your task is NOT done until the PR is merged.**
 Poll CI status (`gh pr view <PR_URL> --json state,statusCheckRollup,mergeStateStatus`) every 30-60 seconds.


### PR DESCRIPTION
## Summary

My earlier [#664](https://github.com/EdgeVector/fold_db/pull/664) / [#188](https://github.com/EdgeVector/exemem-workspace/pull/188) PR claimed `--squash` was needed to avoid stranding PRs in the merge queue. After actually testing it, that claim is wrong:

- GitHub's API silently overrides `autoMergeRequest.mergeMethod` to `MERGE` on any merge-queue-protected branch, regardless of what the client requests. Verified by calling `enablePullRequestAutoMerge(mergeMethod: SQUASH)` directly via the GraphQL API — the response still returns `mergeMethod: MERGE`.
- The queue still uses its own configured `SQUASH` method at land time, so PRs land as 1-parent squash commits regardless. The stored-vs-applied discrepancy is cosmetic.
- The "stranding" pattern I was diagnosing was actually the queue's `min_entries_to_merge_wait_minutes: 5` window between CI green and queue admission — normal behavior, not a bug.

## What changes

- Workflow comment in `.github/workflows/auto-merge.yml` rewritten to describe the actual behavior.
- CLAUDE.md guidance flipped from "Pass `--squash` explicitly" back to "Don't bother passing a strategy flag" with the real reason.
- The workflow code itself (`gh pr merge --auto --squash …`) is unchanged. The flag is silently ignored, so it's harmless to leave it; pulling it would just be churn.

## Test plan

- [ ] CI green on this PR (it's a docs/comment change; should be trivial)
- Once merged: future readers of CLAUDE.md / the workflow comment get accurate guidance about how the merge queue actually treats the auto-merge `mergeMethod` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)