### PR TITLE
feat(observability): add init_node_with_web that composes the WEB layer

### DIFF
--- a/crates/observability/src/init.rs
+++ b/crates/observability/src/init.rs
@@ -12,12 +12,13 @@
 //!
 //! ## Per-target shape
 //!
-//! | helper        | FMT target               | RELOAD | RING | Sentry |
-//! |---------------|--------------------------|--------|------|--------|
-//! | [`init_node`]   | `OBS_FILE_PATH` ▸ `$FOLDDB_HOME/observability.jsonl` ▸ `~/.folddb/observability.jsonl` | yes | yes | env-gated |
-//! | [`init_lambda`] | stdout                   | yes    | no   | env-gated |
-//! | [`init_tauri`]  | inherits from embedded server, else delegates to [`init_node`] | conditional | conditional | inherits |
-//! | [`init_cli`]    | stderr                   | no     | no   | no    |
+//! | helper                  | FMT target               | RELOAD | RING | WEB | Sentry |
+//! |-------------------------|--------------------------|--------|------|-----|--------|
+//! | [`init_node`]           | `OBS_FILE_PATH` ▸ `$FOLDDB_HOME/observability.jsonl` ▸ `~/.folddb/observability.jsonl` | yes | yes | no  | env-gated |
+//! | [`init_node_with_web`]  | same as [`init_node`]    | yes    | yes  | yes | env-gated |
+//! | [`init_lambda`]         | stdout                   | yes    | no   | no  | env-gated |
+//! | [`init_tauri`]          | inherits from embedded server, else delegates to [`init_node`] | conditional | conditional | no | inherits |
+//! | [`init_cli`]            | stderr                   | no     | no   | no  | no     |
 //!
 //! ## CLI is intentionally bare
 //!
@@ -77,6 +78,7 @@ use crate::layers::error::{build_error_layer, SentryGuard};
 use crate::layers::fmt::{build_fmt_writer, FmtGuard, FmtTarget, RedactingFormat};
 use crate::layers::reload::{build_reload_layer, ReloadHandle};
 use crate::layers::ring::{build_ring_layer, RingHandle, OBS_RING_CAPACITY};
+use crate::layers::web::{build_web_layer, WebHandle, OBS_WEB_CAPACITY};
 use crate::ObsError;
 
 /// Override for the node log file path. Read once per `init_node` call.
@@ -252,6 +254,150 @@ pub fn init_node(service_name: &'static str, _version: &str) -> Result<ObsGuard,
         fmt_guard: Some(fmt_guard),
         ring: Some(ring),
         reload: Some(reload),
+        cloud_shutdown: Some(CloudShutdown { sentry_guard }),
+    })
+}
+
+/// RAII guard returned by [`init_node_with_web`].
+///
+/// Same lifetime contract as [`ObsGuard`] — must be held for the lifetime of
+/// the binary. Differs in two ways:
+/// - Every handle is non-optional. Node binaries always wire FMT + RING +
+///   RELOAD + WEB, so `Option<…>` accessors only push the unwrap onto every
+///   caller.
+/// - Adds a [`WebHandle`] for the dashboard's `/api/logs/stream` SSE
+///   endpoint. `ReloadHandle` is wrapped in [`Arc`] because it is not
+///   `Clone` upstream and `/api/logs/level` needs to share it across Actix
+///   workers via `web::Data`.
+#[must_use = "NodeObsGuardWithWeb must be held for the lifetime of the binary or log lines may be dropped"]
+pub struct NodeObsGuardWithWeb {
+    fmt_guard: Option<FmtGuard>,
+    ring: RingHandle,
+    reload: Arc<ReloadHandle>,
+    web: WebHandle,
+    cloud_shutdown: Option<CloudShutdown>,
+}
+
+impl NodeObsGuardWithWeb {
+    /// Handle for in-process `/api/logs` queries.
+    pub fn ring(&self) -> &RingHandle {
+        &self.ring
+    }
+
+    /// Shared handle for runtime `EnvFilter` swaps via `/api/logs/level`.
+    pub fn reload(&self) -> Arc<ReloadHandle> {
+        Arc::clone(&self.reload)
+    }
+
+    /// Handle that the dashboard's `/api/logs/stream` SSE endpoint subscribes
+    /// to for live event fan-out.
+    pub fn web(&self) -> &WebHandle {
+        &self.web
+    }
+
+    /// Cheap clones of every handle, ready to wrap in Actix `web::Data`.
+    pub fn handles(&self) -> ObsHandles {
+        ObsHandles {
+            ring: self.ring.clone(),
+            web: self.web.clone(),
+            reload: Arc::clone(&self.reload),
+        }
+    }
+}
+
+impl std::fmt::Debug for NodeObsGuardWithWeb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NodeObsGuardWithWeb")
+            .field("fmt_guard", &self.fmt_guard.is_some())
+            .field("ring_capacity", &self.ring.capacity())
+            .field(
+                "cloud_shutdown",
+                &self.cloud_shutdown.as_ref().map(|s| s.is_engaged()),
+            )
+            .finish()
+    }
+}
+
+impl Drop for NodeObsGuardWithWeb {
+    fn drop(&mut self) {
+        let _ = self.cloud_shutdown.take();
+    }
+}
+
+/// Bundle of handles consumed by the HTTP server's `/api/logs*` endpoints.
+///
+/// Cheap to clone: [`RingHandle`] and [`WebHandle`] are `Arc`-backed,
+/// [`ReloadHandle`] is shared through [`Arc`] because it is not `Clone`
+/// upstream.
+#[derive(Clone)]
+pub struct ObsHandles {
+    pub ring: RingHandle,
+    pub web: WebHandle,
+    pub reload: Arc<ReloadHandle>,
+}
+
+/// Initialize observability for a node binary that ALSO needs a WEB
+/// broadcast layer (i.e. anything serving `/api/logs/stream` SSE).
+///
+/// Composition matches [`init_node`] exactly — redacting JSON FMT to the
+/// resolved node log file + RELOAD + RING + a no-op-traces OTel layer
+/// stamping W3C `trace_id` / `span_id` + the env-gated Sentry sink — and
+/// adds a [`crate::layers::web::WebLayer`] whose [`WebHandle`] the returned
+/// guard exposes via [`NodeObsGuardWithWeb::web`].
+///
+/// The `service_name` validation, `INIT_ONCE` claim, log-file path
+/// resolution, and `LogTracer` / W3C-propagator install are identical to
+/// [`init_node`] — both helpers route through the same private plumbing so
+/// they cannot drift.
+///
+/// OTLP / Sentry defaults are unchanged from [`init_node`]: no OTLP
+/// exporter is wired, and the Sentry layer is composed only when
+/// `OBS_SENTRY_DSN` is set at startup.
+pub fn init_node_with_web(service_name: &'static str) -> Result<NodeObsGuardWithWeb, ObsError> {
+    assert_service_name(service_name);
+    try_claim_init(&INIT_ONCE)?;
+    install_log_tracer();
+
+    let path = default_node_log_path()?;
+    let (writer, fmt_guard) = build_fmt_writer(FmtTarget::File(path))?;
+    let (reload_layer, reload) = build_reload_layer::<Registry>(default_env_filter());
+    let (ring_layer, ring) = build_ring_layer(OBS_RING_CAPACITY);
+    let (web_layer, web) = build_web_layer(OBS_WEB_CAPACITY);
+
+    let otel_layer = build_noop_traces_layer(service_name);
+
+    let (error_layer, sentry_guard) = match build_error_layer() {
+        Some((layer, guard)) => (Some(layer), Some(guard)),
+        None => (None, None),
+    };
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .event_format(RedactingFormat::from_env_with_service(service_name))
+        .with_writer(writer);
+
+    // Layer order mirrors `init_node` — RELOAD innermost so its `S = Registry`
+    // binding pins the type; OTel before FMT/RING/WEB so its `on_new_span`
+    // attaches `OtelData` before the downstream layers' `on_event` runs and
+    // their lookups for trace/span ids succeed; WEB after RING because both
+    // independently lift trace/span ids off the same `OtelData` extension and
+    // their relative order is irrelevant for correctness; ERROR last so its
+    // `event_span` lookup sees `OtelData` already attached.
+    let subscriber = Registry::default()
+        .with(reload_layer)
+        .with(otel_layer)
+        .with(fmt_layer)
+        .with(ring_layer)
+        .with(web_layer)
+        .with(error_layer);
+    install_subscriber(subscriber)?;
+    install_globals();
+    record_service_name(service_name);
+
+    Ok(NodeObsGuardWithWeb {
+        fmt_guard: Some(fmt_guard),
+        ring,
+        reload: Arc::new(reload),
+        web,
         cloud_shutdown: Some(CloudShutdown { sentry_guard }),
     })
 }
@@ -789,10 +935,86 @@ mod tests {
     #[test]
     fn public_exports_resolve() {
         let _: fn(&'static str, &str) -> Result<ObsGuard, ObsError> = init_node;
+        let _: fn(&'static str) -> Result<NodeObsGuardWithWeb, ObsError> = init_node_with_web;
         let _: fn(&'static str, &str) -> Result<ObsGuard, ObsError> = init_lambda;
         let _: fn(&'static str, &str) -> Result<ObsGuard, ObsError> = init_cli;
         // init_tauri is generic over H; bind it to () for the type-check.
         let _: fn(&'static str, &str, &()) -> Result<ObsGuard, ObsError> = init_tauri::<()>;
+    }
+
+    /// `NodeObsGuardWithWeb`'s public accessors return the inner handles.
+    /// Constructed directly (rather than via `init_node_with_web`) so the
+    /// test does not contend with the process-global subscriber slot.
+    #[test]
+    fn node_obs_guard_with_web_accessors_match_inner_state() {
+        use crate::layers::ring::build_ring_layer;
+        use crate::layers::web::build_web_layer;
+
+        let (_reload_layer, reload_handle) = build_reload_layer::<Registry>(EnvFilter::new("info"));
+        let (_ring_layer, ring) = build_ring_layer(8);
+        let (_web_layer, web) = build_web_layer(8);
+
+        let guard = NodeObsGuardWithWeb {
+            fmt_guard: None,
+            ring: ring.clone(),
+            reload: Arc::new(reload_handle),
+            web: web.clone(),
+            cloud_shutdown: Some(CloudShutdown::empty()),
+        };
+
+        assert_eq!(guard.ring().capacity(), ring.capacity());
+        // `Arc::clone` on the reload handle yields a second strong ref.
+        let _r = guard.reload();
+        // Subscribing through the guard's WebHandle increments the count
+        // observed by the originally-built handle.
+        let _rx = guard.web().subscribe();
+        assert_eq!(web.receiver_count(), 1);
+
+        let handles = guard.handles();
+        assert_eq!(handles.ring.capacity(), ring.capacity());
+        assert_eq!(handles.web.receiver_count(), 1);
+
+        let _ = format!("{guard:?}");
+    }
+
+    /// The composition `init_node_with_web` performs must drive
+    /// `tracing::info!` events through the WEB broadcast channel. We
+    /// rebuild the same layer stack the function does (minus globals /
+    /// subscriber install, which are process-shared) and verify the
+    /// `WebHandle` sees the event.
+    #[test]
+    fn init_node_with_web_composition_emits_to_web_handle() {
+        use crate::layers::ring::build_ring_layer;
+        use crate::layers::web::build_web_layer;
+        use serde_json::Value;
+        use tracing::subscriber::with_default;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let (reload_layer, _reload) = build_reload_layer::<Registry>(EnvFilter::new("info"));
+        let (ring_layer, _ring) = build_ring_layer(OBS_RING_CAPACITY);
+        let (web_layer, web_handle) = build_web_layer(OBS_WEB_CAPACITY);
+        let otel_layer = build_noop_traces_layer("init-node-with-web-test");
+
+        let mut rx = web_handle.subscribe();
+        assert_eq!(web_handle.receiver_count(), 1);
+
+        let subscriber = Registry::default()
+            .with(reload_layer)
+            .with(otel_layer)
+            .with(ring_layer)
+            .with(web_layer);
+
+        with_default(subscriber, || {
+            tracing::info!(target: "init_node_with_web_test", "broadcast probe");
+        });
+
+        let json = rx
+            .try_recv()
+            .expect("event must reach the broadcast channel");
+        let value: Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(value["level"], "INFO");
+        assert_eq!(value["event_type"], "init_node_with_web_test");
+        assert_eq!(value["message"], "broadcast probe");
     }
 
     /// Phase 3 / T7: `LogTracer::init` is wired so third-party `log::*` calls

--- a/crates/observability/src/lib.rs
+++ b/crates/observability/src/lib.rs
@@ -15,16 +15,20 @@
 //! - [`layers`] — FMT (redacting JSON formatter), RELOAD (runtime
 //!   `EnvFilter` swap), RING (bounded in-memory log buffer), WEB (SSE
 //!   broadcast), and the ERROR-only Sentry sink.
-//! - [`init`] — `init_node` / `init_lambda` / `init_tauri` / `init_cli`
-//!   helpers that compose the layers per binary type and return an
-//!   [`ObsGuard`] for the lifetime of the process.
+//! - [`init`] — `init_node` / `init_node_with_web` / `init_lambda` /
+//!   `init_tauri` / `init_cli` helpers that compose the layers per binary
+//!   type and return an [`ObsGuard`] (or [`NodeObsGuardWithWeb`] for the
+//!   web-streaming variant) for the lifetime of the process.
 
 pub mod attrs;
 pub mod init;
 pub mod layers;
 pub mod propagation;
 
-pub use init::{init_cli, init_lambda, init_node, init_tauri, installed_service_name, ObsGuard};
+pub use init::{
+    init_cli, init_lambda, init_node, init_node_with_web, init_tauri, installed_service_name,
+    NodeObsGuardWithWeb, ObsGuard, ObsHandles,
+};
 
 /// Errors raised by `init_*` helpers and other crate-level operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/observability/tests/init_node_with_web.rs
+++ b/crates/observability/tests/init_node_with_web.rs
@@ -1,0 +1,144 @@
+//! End-to-end integration test for [`observability::init_node_with_web`].
+//!
+//! Mirrors `tests/integration.rs` (which exercises [`init_node`]) but covers
+//! the WEB-broadcast variant. Each `tests/<name>.rs` runs in its own binary,
+//! so this file owns the `INIT_ONCE` slot and the global tracing subscriber
+//! for the duration of its test process.
+//!
+//! Asserts:
+//! 1. `init_node_with_web` returns a guard exposing `RingHandle`,
+//!    `Arc<ReloadHandle>`, and `WebHandle` accessors that match the existing
+//!    `NodeObsGuard` API in `fold_db_node`.
+//! 2. Subscribing to the `WebHandle` BEFORE emitting an event delivers the
+//!    serialized `LogEntry` JSON to the receiver.
+//! 3. The captured event carries a real W3C `trace_id` in `metadata`,
+//!    proving the OTel layer is composed and the subscriber is installed.
+//! 4. A second `init_node_with_web` call surfaces as `AlreadyInitialized`.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use observability::{init_node_with_web, ObsError};
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// Pin a `TempDir` for the lifetime of the test process so the FMT log path
+/// the global subscriber holds open does not get unlinked while the worker
+/// thread is still draining its queue.
+fn shared_tempdir() -> &'static TempDir {
+    static DIR: OnceLock<TempDir> = OnceLock::new();
+    DIR.get_or_init(|| tempfile::tempdir().expect("create tempdir"))
+}
+
+#[test]
+fn init_compose_emit_then_already_initialized() {
+    let dir = shared_tempdir();
+    let log_path = dir.path().join("observability.jsonl");
+    // SAFETY: this binary's only test owns these env vars for the duration
+    // of the process. Cargo runs each `tests/<name>.rs` in its own binary.
+    std::env::set_var("OBS_FILE_PATH", &log_path);
+    std::env::set_var("RUST_LOG", "info");
+
+    let guard =
+        init_node_with_web("init_node_with_web_it").expect("init_node_with_web should succeed");
+
+    // Subscribe BEFORE emitting — `broadcast::Sender::send` returns Err with
+    // no receivers, and the WEB layer deliberately swallows that error.
+    let mut rx = guard.web().subscribe();
+    assert_eq!(
+        guard.web().receiver_count(),
+        1,
+        "subscribe() must be observable through the guard's WebHandle",
+    );
+    assert!(
+        guard.ring().capacity() > 0,
+        "RingHandle exposed via guard must have capacity",
+    );
+
+    {
+        let span = tracing::info_span!("init_node_with_web_test");
+        let _enter = span.enter();
+        tracing::info!(
+            user.hash = %"abc123",
+            schema.name = %"PhotoMetadata",
+            "schema registered",
+        );
+    }
+
+    // The broadcast send is synchronous on the emitter side, so the receiver
+    // sees the JSON string immediately after the macro returns. A small
+    // backstop timeout keeps a regression from hanging the test runner.
+    let json_str = recv_with_timeout(&mut rx, Duration::from_secs(2))
+        .expect("event must reach the WEB broadcast channel");
+    let value: Value = serde_json::from_str(&json_str).expect("WEB payload must be JSON");
+
+    assert_eq!(value["level"], "INFO");
+    assert_eq!(value["message"], "schema registered");
+    let metadata = value["metadata"]
+        .as_object()
+        .expect("metadata object on WEB payload");
+    assert_eq!(
+        metadata.get("user.hash").and_then(Value::as_str),
+        Some("abc123"),
+    );
+    assert_eq!(
+        metadata.get("schema.name").and_then(Value::as_str),
+        Some("PhotoMetadata"),
+    );
+    let trace_id = metadata
+        .get("trace_id")
+        .and_then(Value::as_str)
+        .expect("OTel layer must populate trace_id on WEB payload");
+    assert_eq!(trace_id.len(), 32, "trace_id should be 32-char hex");
+    assert!(
+        trace_id.chars().all(|c| c.is_ascii_hexdigit()),
+        "trace_id should be hex, got {trace_id:?}",
+    );
+    assert_ne!(
+        trace_id,
+        &"0".repeat(32),
+        "trace_id should not be the all-zero invalid context",
+    );
+
+    // RING captured the same event — both layers run on every emission
+    // regardless of `with()` order.
+    let ring_entries = guard.ring().query(None, None);
+    assert_eq!(
+        ring_entries.len(),
+        1,
+        "RING handle exposed via guard must capture the same event",
+    );
+
+    // Second init must surface as AlreadyInitialized — same single-init
+    // contract as `init_node`.
+    let err = init_node_with_web("init_node_with_web_it").expect_err("second init must fail");
+    assert!(
+        matches!(err, ObsError::AlreadyInitialized),
+        "expected AlreadyInitialized, got {err:?}",
+    );
+
+    drop(guard);
+}
+
+/// Block-receiving from a `tokio::sync::broadcast::Receiver` without dragging
+/// in a tokio runtime — `try_recv` plus a small sleep loop bounded by
+/// `deadline`. The WEB layer's `send` is synchronous on the producing
+/// thread, so in practice this returns on the very first `try_recv`.
+fn recv_with_timeout(
+    rx: &mut tokio::sync::broadcast::Receiver<String>,
+    deadline: Duration,
+) -> Option<String> {
+    let started = std::time::Instant::now();
+    loop {
+        match rx.try_recv() {
+            Ok(s) => return Some(s),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => {
+                if started.elapsed() >= deadline {
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(_) => return None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Hoist fold_db_node's hand-typed `init_node_with_web` mirror upstream into the `observability` crate so the local mirror can collapse to a re-export.
- New public `observability::init_node_with_web(service_name)` matches `init_node`'s FMT + RELOAD + RING + OTel + LogTracer composition and adds the `WebLayer` whose `WebHandle` powers `/api/logs/stream` SSE.
- New `NodeObsGuardWithWeb` (with `ring()` / `reload()` / `web()` / `handles()`) exposes the broadcast handle. `ReloadHandle` is wrapped in `Arc` to match the existing `fold_db_node::observability_setup::NodeObsGuard` API.

## Why

The mirror's existence already cost a correctness bug — its stale snapshot of `default_node_log_path()` silently diverged from upstream until the FOLDDB_HOME isolation fix in #668 caught it. After this lands, `fold_db_node/src/observability_setup.rs` collapses to a 5-line re-export wrapper (filed as a follow-up). OTLP / Sentry defaults are unchanged — no exporter is wired and the Sentry layer is composed only when `OBS_SENTRY_DSN` is set.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (clean run; an earlier transient failure in `db_operations::org_operations::tests::test_purge_org_data` is unrelated and reproduces neither in isolation nor on a re-run of the workspace)
- [x] New unit tests in `init.rs`:
  - `node_obs_guard_with_web_accessors_match_inner_state` — accessor wiring
  - `init_node_with_web_composition_emits_to_web_handle` — emitted events reach the WEB broadcast channel under a layer stack mirroring `init_node_with_web`
- [x] New integration test `tests/init_node_with_web.rs` — drives the full init → emit → broadcast → `AlreadyInitialized` path through the process-global subscriber

## Follow-ups (filed separately, not in this PR)

- Bump `fold_db` rev in `fold_db_node` and `schema_service` to consume `init_node_with_web`.
- Collapse `fold_db_node/src/observability_setup.rs` to a re-export of `observability::init_node_with_web` and the new guard type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)