### PR TITLE
ci: add notify-downstream sender for bump cascade

### DIFF
--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -1,0 +1,37 @@
+name: Notify downstream of fold_db main bump
+
+# Fires once per merge to main. Sends a repository_dispatch to
+# schema_service so its bump-fold-db.yml listener opens (or force-
+# updates) a PR pinning this fold_db sha. After that PR lands,
+# schema_service's notify-downstream.yml cascades the bump into
+# fold_db_node.
+#
+# Replaces the manual 3-PR lockstep (fold_db -> schema_service ->
+# fold_db_node) that gbrain shows as a recurring pattern. End-to-end
+# bot run is ~10-15 min from this dispatch to fold_db_node merge.
+
+on:
+  push:
+    branches: [main]
+
+# A merge burst (rare but possible) will queue multiple notifications.
+# We only need the latest sha to land downstream — coalesce.
+concurrency:
+  group: notify-downstream
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Send repository_dispatch to schema_service
+        env:
+          # GH_PAT (admin PAT) is required for cross-repo dispatch:
+          # GITHUB_TOKEN is scoped to this repo only. Same token the
+          # auto-merge / release workflows use across the org.
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh api -X POST /repos/EdgeVector/schema_service/dispatches \
+            -f event_type=fold_db-main-bump \
+            -F client_payload[fold_db_sha]=${{ github.sha }}


### PR DESCRIPTION
## Summary

First hop of the cross-repo bump-cascade. Fires a `fold_db-main-bump` `repository_dispatch` to schema_service on every merge to fold_db's main. schema_service's `bump-fold-db.yml` listener (already landed in EdgeVector/schema_service#81) opens a PR pinning the new fold_db sha; on its merge, the next hop fires into fold_db_node.

## Why

Replaces the manual 3-PR lockstep cascade (fold_db → schema_service → fold_db_node) that gbrain shows as a recurring pattern. End-to-end ~10–15 min from this fold_db merge to fold_db_node land.

## Test plan

The chain has been verified piecewise:
- ✅ schema_service listener: `gh workflow run bump-fold-db.yml` no-op test (output: `no-op: Cargo.toml already pins fold_db at 3ea472f3...`)
- ✅ fold_db_node listener: `gh workflow run bump-schema-service.yml` real-bump test → opened EdgeVector/fold_db_node#746 with both shas applied correctly
- ⏳ This sender + companion in schema_service: smoke-tested by their own merges (a sender's PR merge IS a push event to main, exercising the workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)