### PR TITLE
feat(atom-store): public iter-atoms-by-schema for snapshot enumeration (H1-prep)

### DIFF
--- a/crates/core/src/db_operations/atom_operations.rs
+++ b/crates/core/src/db_operations/atom_operations.rs
@@ -87,4 +87,14 @@ impl DbOperations {
             .get_mutation_events(molecule_uuid, org_hash)
             .await
     }
+
+    pub async fn list_atoms_by_schema(
+        &self,
+        schema_name: &str,
+        org_hash: Option<&str>,
+    ) -> Result<Vec<Atom>, SchemaError> {
+        self.atoms()
+            .list_atoms_by_schema(schema_name, org_hash)
+            .await
+    }
 }

--- a/crates/core/src/db_operations/atom_store.rs
+++ b/crates/core/src/db_operations/atom_store.rs
@@ -275,6 +275,48 @@ impl AtomStore {
         })
     }
 
+    /// Enumerate every atom whose `source_schema_name` matches `schema_name`.
+    ///
+    /// Scans the entire `atom:` namespace, deserializes each value, and filters
+    /// by schema in memory. Output is sorted by atom UUID for deterministic
+    /// ordering — required for snapshot reproducibility (e.g. fold_dev_node's
+    /// snapshot enumeration).
+    ///
+    /// When `org_hash` is `Some`, the scan prefix is `{org_hash}:atom:`. If the
+    /// org-prefixed scan returns nothing, falls back to the unprefixed
+    /// (personal) prefix so atoms written before a schema was tagged remain
+    /// readable. Same dual-read pattern as `get_atom_by_uuid` and
+    /// `get_mutation_events`.
+    pub async fn list_atoms_by_schema(
+        &self,
+        schema_name: &str,
+        org_hash: Option<&str>,
+    ) -> Result<Vec<Atom>, SchemaError> {
+        let base_prefix = "atom:";
+        let prefix = build_storage_key(org_hash, base_prefix);
+        let items: Vec<(String, Atom)> = self
+            .main_store
+            .scan_items_with_prefix(&prefix)
+            .await
+            .map_err(|e| SchemaError::InvalidData(format!("Failed to scan atoms: {}", e)))?;
+
+        let items = if items.is_empty() && org_hash.is_some() {
+            self.main_store
+                .scan_items_with_prefix(base_prefix)
+                .await
+                .map_err(|e| SchemaError::InvalidData(format!("Failed to scan atoms: {}", e)))?
+        } else {
+            items
+        };
+
+        let mut atoms: Vec<Atom> = items
+            .into_iter()
+            .filter_map(|(_, atom)| (atom.source_schema_name() == schema_name).then_some(atom))
+            .collect();
+        atoms.sort_by(|a, b| a.uuid().cmp(b.uuid()));
+        Ok(atoms)
+    }
+
     /// Load all mutation events for a molecule, sorted chronologically.
     ///
     /// When `org_hash` is `Some`, the scan prefix is `{org_hash}:history:{mol}:`.

--- a/crates/core/tests/list_atoms_by_schema_test.rs
+++ b/crates/core/tests/list_atoms_by_schema_test.rs
@@ -1,0 +1,90 @@
+use fold_db::atom::Atom;
+use fold_db::testing_utils::TestDatabaseFactory;
+use serde_json::json;
+
+#[tokio::test]
+async fn test_list_atoms_by_schema_returns_only_matching_schema() {
+    let db_ops = TestDatabaseFactory::create_temp_db_ops()
+        .await
+        .expect("Failed to create DB");
+
+    let blog_a = Atom::new("BlogPost".into(), json!({"title": "A"}));
+    let blog_b = Atom::new("BlogPost".into(), json!({"title": "B"}));
+    let blog_c = Atom::new("BlogPost".into(), json!({"title": "C"}));
+    let other = Atom::new("OtherSchema".into(), json!({"x": 1}));
+
+    db_ops
+        .batch_store_atoms(
+            vec![
+                blog_a.clone(),
+                blog_b.clone(),
+                blog_c.clone(),
+                other.clone(),
+            ],
+            None,
+        )
+        .await
+        .expect("batch store failed");
+
+    let atoms = db_ops
+        .list_atoms_by_schema("BlogPost", None)
+        .await
+        .expect("list_atoms_by_schema failed");
+
+    assert_eq!(atoms.len(), 3, "should only return BlogPost atoms");
+    for a in &atoms {
+        assert_eq!(a.source_schema_name(), "BlogPost");
+    }
+
+    let mut expected_uuids = vec![
+        blog_a.uuid().to_string(),
+        blog_b.uuid().to_string(),
+        blog_c.uuid().to_string(),
+    ];
+    expected_uuids.sort();
+    let actual_uuids: Vec<String> = atoms.iter().map(|a| a.uuid().to_string()).collect();
+    assert_eq!(
+        actual_uuids, expected_uuids,
+        "results should be sorted by uuid for deterministic snapshots"
+    );
+}
+
+#[tokio::test]
+async fn test_list_atoms_by_schema_empty_when_no_match() {
+    let db_ops = TestDatabaseFactory::create_temp_db_ops()
+        .await
+        .expect("Failed to create DB");
+
+    db_ops
+        .batch_store_atoms(vec![Atom::new("SchemaA".into(), json!({"v": 1}))], None)
+        .await
+        .expect("batch store failed");
+
+    let atoms = db_ops
+        .list_atoms_by_schema("SchemaB", None)
+        .await
+        .expect("list_atoms_by_schema failed");
+
+    assert!(atoms.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_atoms_by_schema_org_falls_back_to_personal() {
+    let db_ops = TestDatabaseFactory::create_temp_db_ops()
+        .await
+        .expect("Failed to create DB");
+
+    let atom = Atom::new("SchemaX".into(), json!({"v": 1}));
+    db_ops
+        .batch_store_atoms(vec![atom.clone()], None)
+        .await
+        .expect("batch store failed");
+
+    let atoms = db_ops
+        .list_atoms_by_schema("SchemaX", Some("orghash"))
+        .await
+        .expect("list_atoms_by_schema failed");
+
+    assert_eq!(atoms.len(), 1, "should fall back to personal namespace");
+    assert_eq!(atoms[0].uuid(), atom.uuid());
+}


### PR DESCRIPTION
## Summary
- Adds `AtomStore::list_atoms_by_schema(schema_name, org_hash)` plus a `DbOperations` delegator that enumerates every atom whose `source_schema_name` matches and returns them sorted by UUID for deterministic snapshot output.
- Matches the org-prefix dual-read pattern from `get_atom_by_uuid` / `get_mutation_events`: scans `{org_hash}:atom:` first, falls back to bare `atom:` when org-prefixed scan is empty.
- Read-only, additive — no existing API touched, no fallbacks, no write paths.

## Why
Unblocks fold_dev_node Phase 2 H2 (D2 fill snapshot collections). Task D's blocker file flagged that walking every atom for a schema otherwise required either making `AtomStore::raw()` public or bypassing the storage abstraction with a sled-direct read. This is the surgical addition that keeps the abstraction clean.

## Test plan
- [x] New `crates/core/tests/list_atoms_by_schema_test.rs` covers: matching-schema-only filter, empty-when-no-match, and personal-namespace fallback when the caller passes an `org_hash`.
- [x] `cargo fmt --all` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --all-targets` passes (transient parallel-test flake in `org_operations::tests::test_purge_org_data` cleared on re-run; unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)