### PR TITLE
ci: switch auto-merge to org-wide reusable workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,22 +8,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  auto-merge:
-    runs-on: ubuntu-latest
-    steps:
-      # Authenticate with GH_PAT (admin PAT) instead of GITHUB_TOKEN.
-      # Auto-merge requests authored by github-actions[bot] (the
-      # GITHUB_TOKEN identity) are silently refused by the merge queue
-      # under the org's bypass-actor config — only the admin role
-      # (id=5) is in `bypass_actors`, the bot is not. Empirically
-      # verified 2026-04-28 across this and 4 sibling repos: bot-
-      # enabled auto-merge strands until manually kicked, while user-
-      # enabled auto-merge admits to the queue within 2–12 minutes.
-      # With a PAT belonging to an admin (in the bypass list), the
-      # auto-merge request is owned by an in-bypass actor and admits
-      # normally. No --squash flag: the queue's `merge_method: SQUASH`
-      # enforces strategy at land time regardless.
-      - name: Enable auto-merge
-        run: gh pr merge ${{ github.event.pull_request.number }} --auto --repo ${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+  call:
+    uses: EdgeVector/.github/.github/workflows/auto-merge.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Replaces the per-repo `auto-merge.yml` body with a 6-line stub that calls `EdgeVector/.github/.github/workflows/auto-merge.yml@main`.
- `secrets: inherit` carries the org-level `GH_PAT` through, so the admin-PAT-vs-bot bypass-actor reasoning still applies; behavior is identical.
- Part of an org-wide rollout. Canary repo (`fold_dev_node` PR #16) verified the reusable workflow works.

## Test plan

- [ ] Auto-merge workflow on this PR turns green
- [ ] PR enters merge queue and lands without manual intervention