### PR TITLE
feat(atom): derive utoipa::ToSchema on AtomEntry, KeyMetadata, Provenance, MoleculeRef

### DIFF
--- a/crates/core/src/atom/mod.rs
+++ b/crates/core/src/atom/mod.rs
@@ -71,7 +71,9 @@ pub struct MergeConflict {
 /// Write-time metadata stored per-key on the molecule.
 /// Survives atom deduplication because it lives on the key-to-atom
 /// association, not on the content-addressed atom itself.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq, utoipa::ToSchema)]
+#[derive(
+    Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq, utoipa::ToSchema,
+)]
 pub struct KeyMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_file_name: Option<String>,

--- a/crates/core/src/atom/mod.rs
+++ b/crates/core/src/atom/mod.rs
@@ -18,7 +18,7 @@ pub use mutation_event::{FieldKey, MutationEvent};
 pub use provenance::{MoleculeRef, Provenance};
 
 /// An atom reference with per-key write timestamp for merge resolution.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, utoipa::ToSchema)]
 pub struct AtomEntry {
     pub atom_uuid: String,
     #[serde(default)]
@@ -71,7 +71,7 @@ pub struct MergeConflict {
 /// Write-time metadata stored per-key on the molecule.
 /// Survives atom deduplication because it lives on the key-to-atom
 /// association, not on the content-addressed atom itself.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq, utoipa::ToSchema)]
 pub struct KeyMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_file_name: Option<String>,

--- a/crates/core/src/atom/provenance.rs
+++ b/crates/core/src/atom/provenance.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// `Derived` — produced by a deterministic WASM transform; unsigned.
 /// Authority is by recomputation: given `wasm_hash` + `input_snapshot_hash`,
 /// any node can re-run the transform and check the output matches.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Provenance {
     /// User-originated write. Signed by the user's Ed25519 keypair.
@@ -82,7 +82,7 @@ impl Provenance {
 /// as the payload for the forward/reverse lineage indexes (PR 6). The
 /// `written_at` pins recomputation to the exact source version even if the
 /// molecule has moved on.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct MoleculeRef {
     pub molecule_uuid: String,
     pub atom_uuid: String,


### PR DESCRIPTION
## Summary

First slice of cross-repo Phase 3 from gbrain \`projects/api-typegen-unification\` (driven by fold_db_node). Adds \`utoipa::ToSchema\` derives to four atom-module types so utoipa can generate JSON Schema for them when referenced by registered consumers.

## Why

fold_db_node registers \`Molecule\`, \`MoleculeHash\`, \`MoleculeRange\`, and \`MoleculeHashRange\` as OpenAPI components. Those types' fields reference \`AtomEntry\`, \`KeyMetadata\`, \`Provenance\`, and \`MoleculeRef\` — none of which had \`ToSchema\` derives, so \`openapi-typescript\` failed with unresolved \`\$ref\`s and fold_db_node had to drop the Molecule registrations entirely (https://github.com/EdgeVector/fold_db_node/pull/790).

Once this PR cascades through the bump bot to schema_service and fold_db_node, the four Molecule types can be safely re-registered and \`/api/schema/{name}\` etc. can return typed responses in \`openapi.ts\` instead of \`serde_json::Value\`.

## Test plan

- [x] \`cargo check -p fold_db\` passes
- [x] \`cargo test -p fold_db --lib atom\` — 88 tests pass
- [ ] CI green
- [ ] Bump cascade lands the rev in fold_db_node within ~10–15 min after merge

## Out of scope (separate follow-ups)

- \`Query\` + sub-types (\`HashRangeFilter\`, \`SortOrder\`, \`ValueFilter\`) used in \`QueryPlan.query\` on the fold_db_node side
- \`Schema\`, \`FieldCommon\`, \`DeclarativeSchemaDefinition\` if more gaps surface after this cascades

🤖 Generated with [Claude Code](https://claude.com/claude-code)