### PR TITLE
refactor(atom): use simple `KeyMetadata` name in Molecule field types

### DIFF
--- a/crates/core/src/atom/molecule.rs
+++ b/crates/core/src/atom/molecule.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use super::{deterministic_molecule_uuid, now_nanos, MergeConflict};
+use super::{deterministic_molecule_uuid, now_nanos, KeyMetadata, MergeConflict};
 use crate::atom::provenance::Provenance;
 use crate::security::Ed25519KeyPair;
 
@@ -20,7 +20,7 @@ pub struct Molecule {
     #[serde(default)]
     version: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    key_metadata: Option<super::KeyMetadata>,
+    key_metadata: Option<KeyMetadata>,
     /// Base64-encoded public key of the writer who last signed this molecule.
     #[serde(default)]
     writer_pubkey: String,
@@ -117,13 +117,13 @@ impl Molecule {
     }
 
     /// Sets per-key metadata on the molecule.
-    pub fn set_key_metadata(&mut self, meta: super::KeyMetadata) {
+    pub fn set_key_metadata(&mut self, meta: KeyMetadata) {
         self.key_metadata = Some(meta);
     }
 
     /// Returns the per-key metadata, if any.
     #[must_use]
-    pub fn get_key_metadata(&self) -> Option<&super::KeyMetadata> {
+    pub fn get_key_metadata(&self) -> Option<&KeyMetadata> {
         self.key_metadata.as_ref()
     }
 

--- a/crates/core/src/atom/molecule_hash.rs
+++ b/crates/core/src/atom/molecule_hash.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use super::{deterministic_molecule_uuid, now_nanos, AtomEntry, MergeConflict};
+use super::{deterministic_molecule_uuid, now_nanos, AtomEntry, KeyMetadata, MergeConflict};
 use crate::security::Ed25519KeyPair;
 
 /// A hash-based collection of atom references stored in a HashMap.
@@ -16,7 +16,7 @@ pub struct MoleculeHash {
     #[serde(default)]
     version: u64,
     #[serde(default)]
-    key_metadata: HashMap<String, super::KeyMetadata>,
+    key_metadata: HashMap<String, KeyMetadata>,
 }
 
 impl MoleculeHash {

--- a/crates/core/src/atom/molecule_hash_range.rs
+++ b/crates/core/src/atom/molecule_hash_range.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
-use super::{deterministic_molecule_uuid, now_nanos, AtomEntry, MergeConflict};
+use super::{deterministic_molecule_uuid, now_nanos, AtomEntry, KeyMetadata, MergeConflict};
 
 /// A hash-range-based collection of atom references stored in a nested HashMap<BTreeMap> structure.
 ///
@@ -38,7 +38,7 @@ pub struct MoleculeHashRange {
     /// Per-key metadata organized by hash and range values
     /// Structure: HashMap<hash_value, BTreeMap<range_value, KeyMetadata>>
     #[serde(default)]
-    key_metadata: HashMap<String, BTreeMap<String, crate::atom::KeyMetadata>>,
+    key_metadata: HashMap<String, BTreeMap<String, KeyMetadata>>,
 }
 
 impl MoleculeHashRange {

--- a/crates/core/src/atom/molecule_range.rs
+++ b/crates/core/src/atom/molecule_range.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-use super::{deterministic_molecule_uuid, now_nanos, AtomEntry, MergeConflict};
+use super::{deterministic_molecule_uuid, now_nanos, AtomEntry, KeyMetadata, MergeConflict};
 use crate::security::Ed25519KeyPair;
 
 /// A range-based collection of atom references stored in a BTreeMap.
@@ -15,7 +15,7 @@ pub struct MoleculeRange {
     #[serde(default)]
     version: u64,
     #[serde(default)]
-    key_metadata: BTreeMap<String, super::KeyMetadata>,
+    key_metadata: BTreeMap<String, KeyMetadata>,
 }
 
 impl MoleculeRange {


### PR DESCRIPTION
## Summary

\`utoipa::ToSchema\` derives the \`\$ref\` from the path expression at the field site, not the type's effective name. So \`super::KeyMetadata\` produces \`#/components/schemas/super.KeyMetadata\` and \`crate::atom::KeyMetadata\` produces \`#/components/schemas/crate.atom.KeyMetadata\` — neither matches the registered component name (\`KeyMetadata\`).

Downstream, fold_db_node's drift check (\`npm run generate:api\`) fails:

\`\`\`
✘ Can't resolve \$ref at #/components/schemas/MoleculeRange/properties/key_metadata/additionalProperties
✘ Can't resolve \$ref at #/components/schemas/Molecule/properties/key_metadata/allOf/0
✘ Can't resolve \$ref at #/components/schemas/MoleculeHash/properties/key_metadata/additionalProperties
✘ Can't resolve \$ref at #/components/schemas/MoleculeHashRange/properties/key_metadata/additionalProperties/additionalProperties
\`\`\`

Fix: add \`KeyMetadata\` to each file's \`super::{...}\` (or \`crate::atom::{...}\`) imports and reference it bare at the field site. utoipa then emits the canonical \`#/components/schemas/KeyMetadata\` ref.

Follow-up to #678 (which added \`ToSchema\` derives to these types but missed the simple-name issue).

## Test plan

- [x] \`cargo check -p fold_db\` clean
- [x] 88 atom-module tests pass
- [x] \`cargo fmt --all\` clean
- [ ] CI green
- [ ] After cascade lands in fold_db_node, \`npm run generate:api\` succeeds with Molecule family in \`components(schemas(...))\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)