### PR TITLE
feat(schema): derive utoipa::ToSchema on Field/Schema family + alias FieldBase<M>

### DIFF
--- a/crates/core/src/access/capability.rs
+++ b/crates/core/src/access/capability.rs
@@ -4,7 +4,7 @@ use super::types::{AccessContext, AccessDecision, AccessDenialReason};
 
 /// The kind of access a capability token grants.
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub enum CapabilityKind {
     /// RX_k(pk): grants read access; counter decrements with each read
     Read,
@@ -15,7 +15,7 @@ pub enum CapabilityKind {
 /// A cryptographic capability constraint on a field.
 /// Binds a public key to a quota-limited access grant.
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct CapabilityConstraint {
     /// Base64-encoded public key of the capability holder
     pub public_key: String,

--- a/crates/core/src/access/types.rs
+++ b/crates/core/src/access/types.rs
@@ -24,7 +24,19 @@ use std::fmt;
 /// trust-invite + org membership mechanisms, which are distinct from this).
 /// See `docs/designs/platform_manifesto.md` for the full naming rationale.
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    utoipa::ToSchema,
+)]
 #[repr(u8)]
 pub enum AccessTier {
     Public = 0,
@@ -228,7 +240,7 @@ impl fmt::Display for AccessDenialReason {
 /// Per-field access policy combining trust tier and capability checks.
 /// Attached to `FieldCommon`. If `None`, field uses default (owner-only).
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct FieldAccessPolicy {
     /// Which trust domain governs this field's access.
     /// Default: "personal".

--- a/crates/core/src/schema/types/data_classification.rs
+++ b/crates/core/src/schema/types/data_classification.rs
@@ -37,7 +37,7 @@ pub const MAX_SENSITIVITY_LEVEL: u8 = 4;
 /// └───────┴───────────────────┴──────────────────────────────────────────────┘
 /// ```
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, utoipa::ToSchema)]
 pub struct DataClassification {
     /// Sensitivity level: 0 (Public) through 4 (Highly Restricted).
     pub sensitivity_level: u8,

--- a/crates/core/src/schema/types/declarative_schemas.rs
+++ b/crates/core/src/schema/types/declarative_schemas.rs
@@ -1,7 +1,7 @@
 use crate::schema::types::data_classification::DataClassification;
 use crate::schema::types::field::Field;
 use crate::schema::types::key_config::KeyConfig;
-use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
+use crate::schema::types::schema::DeclarativeSchemaType;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -108,7 +108,7 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
             #[serde(skip_serializing_if = "Option::is_none")]
             descriptive_name: Option<String>,
             // Allow schema_type to be omitted; we will derive from key if missing
-            schema_type: Option<SchemaType>,
+            schema_type: Option<DeclarativeSchemaType>,
             #[serde(skip_serializing_if = "Option::is_none")]
             key: Option<KeyConfig>,
             // Accept either an array of strings or an object map and normalize later
@@ -184,16 +184,16 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
                 let has_hash = k.hash_field.is_some();
                 let has_range = k.range_field.is_some();
                 if has_hash && has_range {
-                    SchemaType::HashRange
+                    DeclarativeSchemaType::HashRange
                 } else if has_hash {
-                    SchemaType::Hash
+                    DeclarativeSchemaType::Hash
                 } else if has_range {
-                    SchemaType::Range
+                    DeclarativeSchemaType::Range
                 } else {
-                    SchemaType::Single
+                    DeclarativeSchemaType::Single
                 }
             }
-            (None, None) => SchemaType::Single,
+            (None, None) => DeclarativeSchemaType::Single,
         };
 
         // Use the constructor to create the actual struct with generated mappings
@@ -285,7 +285,7 @@ pub struct DeclarativeSchemaDefinition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub descriptive_name: Option<String>,
     /// Schema type ("Single" | "Hash" | "Range" | "HashRange")
-    pub schema_type: SchemaType,
+    pub schema_type: DeclarativeSchemaType,
     /// Key configuration (required when schema_type == "Hash", "Range", or "HashRange")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<KeyConfig>,
@@ -430,19 +430,19 @@ impl DeclarativeSchemaDefinition {
         let mut add_field = |field_name: String| {
             let schema_type = self.schema_type.clone();
             match &schema_type {
-                SchemaType::HashRange => {
+                DeclarativeSchemaType::HashRange => {
                     let hashrange_field = HashRangeField::new(default_field_mappers.clone(), None);
                     runtime_fields.insert(field_name, FieldVariant::HashRange(hashrange_field));
                 }
-                SchemaType::Hash => {
+                DeclarativeSchemaType::Hash => {
                     let hash_field = HashField::new(default_field_mappers.clone(), None);
                     runtime_fields.insert(field_name, FieldVariant::Hash(hash_field));
                 }
-                SchemaType::Range => {
+                DeclarativeSchemaType::Range => {
                     let range_field = RangeField::new(default_field_mappers.clone(), None);
                     runtime_fields.insert(field_name, FieldVariant::Range(range_field));
                 }
-                SchemaType::Single => {
+                DeclarativeSchemaType::Single => {
                     let single_field = SingleField::new(default_field_mappers.clone(), None);
                     runtime_fields.insert(field_name, FieldVariant::Single(single_field));
                 }
@@ -549,7 +549,7 @@ impl DeclarativeSchemaDefinition {
     /// A new DeclarativeSchemaDefinition with all hash mappings populated
     pub fn new(
         name: String,
-        schema_type: SchemaType,
+        schema_type: DeclarativeSchemaType,
         key: Option<KeyConfig>,
         fields: Option<Vec<String>>,
         transform_fields: Option<HashMap<String, String>>,
@@ -767,8 +767,6 @@ mod tests {
 
     #[test]
     fn test_schema_metadata_after_serialize_deserialize() {
-        use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
-
         // Create a transform schema like BlogPostWordIndex
         let mut transform_fields = HashMap::new();
         transform_fields.insert(
@@ -782,7 +780,7 @@ mod tests {
 
         let schema = DeclarativeSchemaDefinition::new(
             "BlogPostWordIndex".to_string(),
-            SchemaType::Single,
+            DeclarativeSchemaType::Single,
             None,
             None,
             Some(transform_fields),
@@ -846,12 +844,10 @@ mod tests {
 
     #[test]
     fn test_descriptive_name_serialization() {
-        use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
-
         // Create a schema with descriptive_name
         let mut schema = DeclarativeSchemaDefinition::new(
             "UserProfile".to_string(),
-            SchemaType::Single,
+            DeclarativeSchemaType::Single,
             None,
             Some(vec!["name".to_string(), "email".to_string()]),
             None,
@@ -885,11 +881,10 @@ mod tests {
         // so tagging a schema with `set-org-hash` sent `trust_domain=None`
         // to peers even though the serialized form carried it. Regression
         // guard for alpha papercut d2f07.
-        use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
 
         let mut schema = DeclarativeSchemaDefinition::new(
             "OrgNotes".to_string(),
-            SchemaType::Single,
+            DeclarativeSchemaType::Single,
             None,
             Some(vec!["body".to_string()]),
             None,
@@ -915,12 +910,10 @@ mod tests {
 
     #[test]
     fn test_descriptive_name_optional() {
-        use crate::schema::types::schema::DeclarativeSchemaType as SchemaType;
-
         // Create a schema without descriptive_name
         let schema = DeclarativeSchemaDefinition::new(
             "UserProfile".to_string(),
-            SchemaType::Single,
+            DeclarativeSchemaType::Single,
             None,
             Some(vec!["name".to_string(), "email".to_string()]),
             None,
@@ -1016,7 +1009,7 @@ mod tests {
     fn test_partial_eq_includes_field_descriptions() {
         let mut s1 = DeclarativeSchemaDefinition::new(
             "Test".to_string(),
-            SchemaType::Single,
+            DeclarativeSchemaType::Single,
             None,
             Some(vec!["name".to_string()]),
             None,
@@ -1096,7 +1089,7 @@ mod tests {
     fn schema_preserves_source_through_round_trip() {
         let mut schema = DeclarativeSchemaDefinition::new(
             "test".to_string(),
-            SchemaType::Single,
+            DeclarativeSchemaType::Single,
             None,
             Some(vec![]),
             None,
@@ -1113,7 +1106,7 @@ mod tests {
     fn schema_partial_eq_considers_source() {
         let mut s1 = DeclarativeSchemaDefinition::new(
             "test".to_string(),
-            SchemaType::Single,
+            DeclarativeSchemaType::Single,
             None,
             Some(vec![]),
             None,

--- a/crates/core/src/schema/types/field/base.rs
+++ b/crates/core/src/schema/types/field/base.rs
@@ -9,7 +9,13 @@ use std::collections::HashMap;
 /// Encapsulates common state and logic:
 /// - `inner`: FieldCommon metadata
 /// - `molecule`: Optional type-specific molecule (state)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[aliases(
+    FieldBaseSingle = FieldBase<crate::atom::Molecule>,
+    FieldBaseHash = FieldBase<crate::atom::MoleculeHash>,
+    FieldBaseRange = FieldBase<crate::atom::MoleculeRange>,
+    FieldBaseHashRange = FieldBase<crate::atom::MoleculeHashRange>,
+)]
 pub struct FieldBase<M> {
     pub inner: FieldCommon,
     pub molecule: Option<M>,

--- a/crates/core/src/schema/types/field/common.rs
+++ b/crates/core/src/schema/types/field/common.rs
@@ -56,7 +56,7 @@ pub trait Field: Send + Sync {
     ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError>;
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 pub enum FieldType {
     Single,
     Range,

--- a/crates/core/src/schema/types/field_value_type.rs
+++ b/crates/core/src/schema/types/field_value_type.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 /// enforced at mutation time. Every field in every schema has a concrete
 /// type — `Any` is reserved for backward compatibility only.
 #[cfg_attr(feature = "ts-bindings", derive(ts_rs::TS))]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, utoipa::ToSchema)]
 pub enum FieldValueType {
     // ── Primitives ──────────────────────────────────────
     String,


### PR DESCRIPTION
## Summary

Phase 3 slice 3 of cross-repo API typegen unification. Closes the upstream half of fold_db_node Phase 4d'.

Adds \`utoipa::ToSchema\` to the transitive types referenced by the Schema/Field family that fold_db_node wants to register in its \`openapi.rs\`:

- \`FieldType\` (\`schema/types/field/common.rs\`)
- \`FieldAccessPolicy\` + \`AccessTier\` (\`access/types.rs\`)
- \`CapabilityKind\` + \`CapabilityConstraint\` (\`access/capability.rs\`) — transitive deps of \`FieldAccessPolicy\`
- \`DataClassification\` (\`schema/types/data_classification.rs\`)
- \`FieldValueType\` (\`schema/types/field_value_type.rs\`) — transitive dep of \`DeclarativeSchemaDefinition.field_types\`

Adds \`#[aliases(...)]\` on \`FieldBase<M>\` for the four molecule variants:

- \`FieldBaseSingle = FieldBase<Molecule>\`
- \`FieldBaseHash = FieldBase<MoleculeHash>\`
- \`FieldBaseRange = FieldBase<MoleculeRange>\`
- \`FieldBaseHashRange = FieldBase<MoleculeHashRange>\`

Resolves the \`DeclarativeSchemaType as SchemaType\` alias quirk in \`declarative_schemas.rs\` (same class as #679's \`super::KeyMetadata\` fix). The file-level alias is removed; usages collapse to the canonical \`DeclarativeSchemaType\` in struct fields, constructor params, match arms, and tests. The unrelated utoipa-internal \`SchemaType\` at line 92 is preserved.

\`FieldMapper\` is intentionally not touched — it already has a hand-written \`ToSchema\` impl that emits \`type: string\` per its \`serde(into = \"String\")\` contract.

## Why

After this lands and bump-cascades to fold_db_node, the following \$refs go from unresolved to resolved during \`npm run generate:api\`:

- \`DeclarativeSchemaDefinition.{schema_type, source, field_access_policies, field_data_classifications, field_mappers, field_types}\`
- \`FieldCommon.{access_policy, field_mappers, transform}\`
- \`{Single,Hash,Range,HashRange}Field/allOf/0\`

This closes the loop fold_db_node Phase 1.5 (#790) had to leave dangling and that Phase 4d (#801, atom-module family) couldn't reach because of these transitive ToSchema gaps.

Parent: gbrain \`projects/api-typegen-unification\`. Recipe: gbrain \`projects/register-schema-field-bodies\`.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace --all-targets\` — 662 core tests + observability/etc. green, no regressions
- [ ] CI green
- [ ] Bump cascade picks this up automatically (schema_service hop ~10 min, fold_db_node hop within 2h cron)

🤖 Generated with [Claude Code](https://claude.com/claude-code)