### PR TITLE
feat(schema): derive ToSchema on SchemaState + SchemaWithState

### DIFF
--- a/crates/core/src/schema/schema_types.rs
+++ b/crates/core/src/schema/schema_types.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::schema::types::schema::Schema;
 
 /// State of a schema within the system
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, utoipa::ToSchema)]
 pub enum SchemaState {
     /// Schema discovered from files but not yet approved by user
     #[default]
@@ -15,7 +15,7 @@ pub enum SchemaState {
 }
 
 /// Schema definition bundled with its current state for UI/API responses
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct SchemaWithState {
     /// All schema fields serialized at the top level
     #[serde(flatten)]


### PR DESCRIPTION
## Summary

Tiny follow-on to #681. \`fold_db_node\`'s \`/api/schema/{name}\` returns \`SchemaWithState\` (Schema + state enum), not \`Schema\` directly. To re-tighten the route's \`body =\` declaration in fold_db_node Phase 4d', \`SchemaWithState\` and \`SchemaState\` need ToSchema upstream.

Two derive additions in \`crates/core/src/schema/schema_types.rs\`:

- \`SchemaState\` (enum)
- \`SchemaWithState\` (struct)

## Why

#681 unblocked registering the Schema/Field family in fold_db_node's \`openapi.rs\`. The recipe-suggested route retighten (\`body = serde_json::Value\` → \`body = SchemaResponse\`) requires \`SchemaWithState\` to have ToSchema since \`SchemaResponse.schema\` will be retyped to \`SchemaWithState\` in the same fold_db_node PR. This shipped separately from #681 because that PR was already in the merge queue when the SchemaWithState dependency surfaced.

Parent: gbrain \`projects/api-typegen-unification\`. Sibling: gbrain \`projects/register-schema-field-bodies\`.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo check\` clean
- [ ] CI green
- [ ] Bump cascade picks up alongside #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)