### PR TITLE
feat(schema): unblock fold_db_node openapi.rs registration ( path-prefix + FieldBase inline)

### DIFF
--- a/crates/core/src/access/types.rs
+++ b/crates/core/src/access/types.rs
@@ -1,3 +1,4 @@
+use super::capability::{CapabilityConstraint, CapabilityKind};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -193,10 +194,10 @@ pub enum AccessDenialReason {
         domain: String,
     },
     CapabilityMissing {
-        kind: super::capability::CapabilityKind,
+        kind: CapabilityKind,
     },
     CapabilityExhausted {
-        kind: super::capability::CapabilityKind,
+        kind: CapabilityKind,
     },
     PaymentRequired {
         cost: f64,
@@ -255,7 +256,7 @@ pub struct FieldAccessPolicy {
     #[serde(default = "default_tier")]
     pub min_write_tier: AccessTier,
     /// Capability tokens required for access
-    pub capabilities: Vec<super::capability::CapabilityConstraint>,
+    pub capabilities: Vec<CapabilityConstraint>,
 }
 
 fn default_trust_domain() -> String {

--- a/crates/core/src/schema/schema_types.rs
+++ b/crates/core/src/schema/schema_types.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::schema::types::schema::Schema;
+use crate::schema::types::declarative_schemas::DeclarativeSchemaDefinition;
 
 /// State of a schema within the system
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, utoipa::ToSchema)]
@@ -19,14 +19,14 @@ pub enum SchemaState {
 pub struct SchemaWithState {
     /// All schema fields serialized at the top level
     #[serde(flatten)]
-    pub schema: Schema,
+    pub schema: DeclarativeSchemaDefinition,
     /// Current state of the schema
     pub state: SchemaState,
 }
 
 impl SchemaWithState {
     /// Create a new [`SchemaWithState`] from components
-    pub fn new(schema: Schema, state: SchemaState) -> Self {
+    pub fn new(schema: DeclarativeSchemaDefinition, state: SchemaState) -> Self {
         Self { schema, state }
     }
 

--- a/crates/core/src/schema/types/declarative_schemas.rs
+++ b/crates/core/src/schema/types/declarative_schemas.rs
@@ -1,5 +1,7 @@
+use crate::access::types::FieldAccessPolicy;
 use crate::schema::types::data_classification::DataClassification;
 use crate::schema::types::field::Field;
+use crate::schema::types::field_value_type::FieldValueType;
 use crate::schema::types::key_config::KeyConfig;
 use crate::schema::types::schema::DeclarativeSchemaType;
 use serde::{Deserialize, Serialize};
@@ -131,7 +133,7 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
             #[serde(default)]
             ref_fields: HashMap<String, String>,
             #[serde(default)]
-            field_types: HashMap<String, crate::schema::types::field_value_type::FieldValueType>,
+            field_types: HashMap<String, FieldValueType>,
             #[serde(skip_serializing_if = "Option::is_none")]
             identity_hash: Option<String>,
             #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -139,7 +141,7 @@ impl<'de> serde::Deserialize<'de> for DeclarativeSchemaDefinition {
             #[serde(skip_serializing_if = "Option::is_none", default)]
             trust_domain: Option<String>,
             #[serde(default)]
-            field_access_policies: HashMap<String, crate::access::types::FieldAccessPolicy>,
+            field_access_policies: HashMap<String, FieldAccessPolicy>,
             #[serde(default)]
             source: SchemaSource,
         }
@@ -328,7 +330,7 @@ pub struct DeclarativeSchemaDefinition {
     /// Strongly typed field value types from the canonical field registry.
     /// Maps field_name -> FieldValueType. Fields not in this map default to Any.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub field_types: HashMap<String, crate::schema::types::field_value_type::FieldValueType>,
+    pub field_types: HashMap<String, FieldValueType>,
     /// SHA256 hash of sorted field names — unique fingerprint of schema structure
     #[serde(skip_serializing_if = "Option::is_none")]
     pub identity_hash: Option<String>,
@@ -351,7 +353,7 @@ pub struct DeclarativeSchemaDefinition {
     /// Persisted per-field access policies. Survives serialization (unlike runtime_fields).
     /// When set, these are copied onto runtime fields during populate_runtime_fields().
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub field_access_policies: HashMap<String, crate::access::types::FieldAccessPolicy>,
+    pub field_access_policies: HashMap<String, FieldAccessPolicy>,
 
     /// Origin of this schema in the service. See [`SchemaSource`] for variants.
     /// Existing stored schemas without this field deserialize as `User`.
@@ -589,12 +591,8 @@ impl DeclarativeSchemaDefinition {
     }
 
     /// Get the declared type for a field. Returns `Any` if no type is declared.
-    pub fn get_field_type(
-        &self,
-        field_name: &str,
-    ) -> &crate::schema::types::field_value_type::FieldValueType {
-        static ANY: crate::schema::types::field_value_type::FieldValueType =
-            crate::schema::types::field_value_type::FieldValueType::Any;
+    pub fn get_field_type(&self, field_name: &str) -> &FieldValueType {
+        static ANY: FieldValueType = FieldValueType::Any;
         self.field_types.get(field_name).unwrap_or(&ANY)
     }
 
@@ -942,8 +940,6 @@ mod tests {
 
     #[test]
     fn test_field_access_policies_deserialization() {
-        use crate::access::types::FieldAccessPolicy;
-
         // Build JSON with field_access_policies
         let json = serde_json::json!({
             "name": "SecureNotes",

--- a/crates/core/src/schema/types/field/base.rs
+++ b/crates/core/src/schema/types/field/base.rs
@@ -1,4 +1,5 @@
 use super::common::FieldCommon;
+use crate::atom::{Molecule, MoleculeHash, MoleculeHashRange, MoleculeRange};
 use crate::db_operations::DbOperations;
 use crate::schema::types::declarative_schemas::FieldMapper;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -11,10 +12,10 @@ use std::collections::HashMap;
 /// - `molecule`: Optional type-specific molecule (state)
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[aliases(
-    FieldBaseSingle = FieldBase<crate::atom::Molecule>,
-    FieldBaseHash = FieldBase<crate::atom::MoleculeHash>,
-    FieldBaseRange = FieldBase<crate::atom::MoleculeRange>,
-    FieldBaseHashRange = FieldBase<crate::atom::MoleculeHashRange>,
+    FieldBaseSingle = FieldBase<Molecule>,
+    FieldBaseHash = FieldBase<MoleculeHash>,
+    FieldBaseRange = FieldBase<MoleculeRange>,
+    FieldBaseHashRange = FieldBase<MoleculeHashRange>,
 )]
 pub struct FieldBase<M> {
     pub inner: FieldCommon,

--- a/crates/core/src/schema/types/field/hash_field.rs
+++ b/crates/core/src/schema/types/field/hash_field.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct HashField {
     #[serde(flatten)]
+    #[schema(inline)]
     pub base: FieldBase<MoleculeHash>,
 }
 

--- a/crates/core/src/schema/types/field/hash_range_field.rs
+++ b/crates/core/src/schema/types/field/hash_range_field.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct HashRangeField {
     #[serde(flatten)]
+    #[schema(inline)]
     pub base: FieldBase<MoleculeHashRange>,
 }
 

--- a/crates/core/src/schema/types/field/range_field.rs
+++ b/crates/core/src/schema/types/field/range_field.rs
@@ -20,6 +20,7 @@ use crate::schema::types::SchemaError;
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct RangeField {
     #[serde(flatten)]
+    #[schema(inline)]
     pub base: FieldBase<MoleculeRange>,
 }
 

--- a/crates/core/src/schema/types/field/single_field.rs
+++ b/crates/core/src/schema/types/field/single_field.rs
@@ -18,6 +18,7 @@ use crate::schema::types::SchemaError;
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct SingleField {
     #[serde(flatten)]
+    #[schema(inline)]
     pub base: FieldBase<Molecule>,
 }
 


### PR DESCRIPTION
## Summary

Phase 4 follow-on to slice 3 (#681) and slice 3-extension (#682). The slice-3 family registration in fold_db_node hit four classes of utoipa \$ref resolution issues post-cascade:

### 1. \$ref path-prefix quirks

utoipa renders fully-qualified type paths with dots:

\`\`\`
"crate::schema::types::field_value_type::FieldValueType"
  → "crate.schema.types.field_value_type.FieldValueType"
\`\`\`

which don't match the registered component names. Fixed via module-scope \`use\` statements in:

- \`access/types.rs\` — \`super::capability::{CapabilityConstraint, CapabilityKind}\`
- \`schema/types/declarative_schemas.rs\` — \`FieldAccessPolicy\` + \`FieldValueType\`
- \`schema/types/field/base.rs\` — \`atom::{Molecule, MoleculeHash, MoleculeRange, MoleculeHashRange}\`

so the bare type names appear in field declarations / alias macros.

### 2. \`#[aliases]\` doesn't substitute into bare \`FieldBase\` references

utoipa's \`#[aliases(...)]\` on \`FieldBase<M>\` registers aliases (\`FieldBaseSingle\`, \`FieldBaseHash\`, etc.) as separate components but does NOT substitute alias names into bare \`FieldBase\` references in dependents (\`SingleField\`/\`HashField\`/etc. via \`#[serde(flatten)]\`).

Fixed by adding \`#[schema(inline)]\` to each variant's \`base\` field so the FieldBase shape is inlined directly into the variant schema rather than \$ref'd. Avoids the larger inline-FieldBase refactor that would have required moving 60+ \`.base.X\` accessors across the field/ module and \`variant.rs\`.

### 3. \`SchemaWithState.schema\` referenced the \`Schema\` alias

\`SchemaWithState\` had \`pub schema: Schema\` where \`Schema\` is a \`pub use crate::schema::types::declarative_schemas::DeclarativeSchemaDefinition as Schema;\` re-export. utoipa emits \`\$ref: Schema\` (alias name), but the canonical component is named \`DeclarativeSchemaDefinition\`.

Fixed by changing the field type to \`DeclarativeSchemaDefinition\` directly. Drops the alias usage in this load-bearing wire shape.

## Why

Without these fixes, fold_db_node's Phase 4d' regen produces 14 unresolved \$refs even though all the underlying types have ToSchema. After this lands + the bump cascade, fold_db_node's openapi.rs registration resolves cleanly with zero unresolved \$refs.

Parent: gbrain \`projects/api-typegen-unification\`. Recipe: gbrain \`projects/register-schema-field-bodies\`.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace --all-targets\` — 662 core tests + observability all green
- [ ] CI green
- [ ] Bump cascade picks this up

🤖 Generated with [Claude Code](https://claude.com/claude-code)