### PR TITLE
refactor(factory): drop FOLD_STORAGE_PATH env read; consume config.path

### DIFF
--- a/crates/core/src/fold_db_core/factory.rs
+++ b/crates/core/src/fold_db_core/factory.rs
@@ -58,8 +58,11 @@ pub async fn create_fold_db_with_pool_and_auth_refresh(
     pool: Option<Arc<SledPool>>,
 ) -> FoldDbResult<Arc<FoldDB>> {
     let sync_setup = if let Some(cloud) = &config.cloud_sync {
-        let path = std::env::var("FOLD_STORAGE_PATH").unwrap_or_else(|_| "data".to_string());
-        let mut setup = SyncSetup::from_exemem(&cloud.api_url, &cloud.api_key, &path);
+        let path_str = config
+            .path
+            .to_str()
+            .ok_or_else(|| FoldDbError::Config("Invalid storage path".to_string()))?;
+        let mut setup = SyncSetup::from_exemem(&cloud.api_url, &cloud.api_key, path_str);
         setup.auth_refresh = auth_refresh;
         Some(setup)
     } else {

--- a/crates/core/src/storage/config.rs
+++ b/crates/core/src/storage/config.rs
@@ -236,6 +236,13 @@ impl<'de> Deserialize<'de> for DatabaseConfig {
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string());
 
+                    // TODO(storage-path): the legacy `{"type":"exemem"}` JSON has no
+                    // `path` field, so the path is recovered from FOLD_STORAGE_PATH.
+                    // Downstream consumers (fold_db_node's run.sh, org-test.sh,
+                    // smoke-test-dmg.sh, src/bin/folddb/main.rs, and
+                    // src-tauri/src/lib.rs) still emit this shape; once they are
+                    // migrated to the new `{path, cloud_sync}` format, drop this
+                    // legacy branch entirely.
                     let path = std::env::var("FOLD_STORAGE_PATH")
                         .map(PathBuf::from)
                         .unwrap_or_else(|_| PathBuf::from("data"));


### PR DESCRIPTION
## Summary

- `create_fold_db_with_pool_and_auth_refresh` already takes `config: &DatabaseConfig`, which carries `config.path` — the `std::env::var(\"FOLD_STORAGE_PATH\")` read at `factory.rs:61` was redundant. Replace it with a `config.path.to_str()` (matching the existing pattern at `factory.rs:110-112`).
- The legacy `{\"type\":\"exemem\"}` deserializer at `storage/config.rs:239` still reads `FOLD_STORAGE_PATH` because the legacy JSON shape carries no `path` field. fold_db_node's `run.sh`, `org-test.sh`, `smoke-test-dmg.sh`, `src/bin/folddb/main.rs`, and `src-tauri/src/lib.rs` still emit that shape, so the branch stays for now — added a TODO with the migration path.
- `DatabaseConfig::from_env()` (`storage/config.rs:144`) is a separate constructor with its own callers, out of scope.

## Why

This unblocks an fold_db_node follow-up that removes the last process-global env mutation in its boot path: with this change in, `fold_db_node` can drop `std::env::set_var(\"FOLD_STORAGE_PATH\", ...)` from `node_manager.rs:108` and `folddb_server.rs:140`, and thread `storage_path` explicitly through `StartupCtx` instead. Original task: PR #821 follow-up in fold_db_node.

The downstream PR is staged behind the standard bump cascade — schema_service auto-bump → fold_db_node auto-bump (every 2h cron) — and will land once this merges.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo test --workspace --all-targets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)