### PR TITLE
feat(mutation): preserve imported writer_pubkey on cross-node share replay

### DIFF
--- a/crates/core/src/atom/molecule.rs
+++ b/crates/core/src/atom/molecule.rs
@@ -127,6 +127,38 @@ impl Molecule {
         self.key_metadata.as_ref()
     }
 
+    /// Updates the atom reference using a writer identity supplied by the
+    /// caller rather than produced by a local keypair. Used by the
+    /// replay/import path (e.g. inbound `data_share` from another node).
+    /// See `MoleculeHashRange::set_atom_uuid_from_values_imported` for full
+    /// rationale on `signature_version` / `verify` semantics.
+    pub fn set_atom_uuid_imported(
+        &mut self,
+        atom_uuid: String,
+        writer_pubkey: String,
+        signature: String,
+        signature_version: u8,
+    ) {
+        if self.atom_uuid != atom_uuid {
+            self.version += 1;
+        }
+        self.atom_uuid = atom_uuid;
+        self.written_at = now_nanos();
+        self.updated_at = Utc::now();
+        self.writer_pubkey = writer_pubkey.clone();
+        self.signature = signature.clone();
+        self.signature_version = signature_version;
+        self.provenance = if signature_version > 0 {
+            Some(Provenance::User {
+                pubkey: writer_pubkey,
+                signature,
+                signature_version,
+            })
+        } else {
+            None
+        };
+    }
+
     /// Updates the atom reference WITHOUT signing.
     /// Only for ephemeral in-memory operations (e.g., rewind for time-travel queries).
     /// The resulting molecule will not pass `verify()`.

--- a/crates/core/src/atom/molecule_hash.rs
+++ b/crates/core/src/atom/molecule_hash.rs
@@ -116,6 +116,50 @@ impl MoleculeHash {
         self.key_metadata.get(key)
     }
 
+    /// Inserts an entry whose writer identity was supplied by the caller
+    /// rather than produced by a local keypair. Used by the replay/import
+    /// path (e.g. inbound `data_share` from another node). See
+    /// `MoleculeHashRange::set_atom_uuid_from_values_imported` for full
+    /// rationale on `signature_version` / `verify_key` semantics.
+    pub fn set_atom_uuid_imported(
+        &mut self,
+        key: String,
+        atom_uuid: String,
+        writer_pubkey: String,
+        signature: String,
+        signature_version: u8,
+    ) {
+        let changed = self
+            .atom_uuids
+            .get(&key)
+            .is_none_or(|e| e.atom_uuid != atom_uuid);
+        if changed {
+            self.version += 1;
+        }
+        let written_at = now_nanos();
+        let provenance = if signature_version > 0 {
+            Some(super::Provenance::User {
+                pubkey: writer_pubkey.clone(),
+                signature: signature.clone(),
+                signature_version,
+            })
+        } else {
+            None
+        };
+        self.atom_uuids.insert(
+            key,
+            AtomEntry {
+                atom_uuid,
+                written_at,
+                writer_pubkey,
+                signature,
+                signature_version,
+                provenance,
+            },
+        );
+        self.updated_at = Utc::now();
+    }
+
     /// Updates a key WITHOUT signing. Only for ephemeral in-memory operations (rewind).
     pub(crate) fn set_atom_uuid_unsigned(&mut self, key: String, atom_uuid: String) {
         let changed = self

--- a/crates/core/src/atom/molecule_hash_range.rs
+++ b/crates/core/src/atom/molecule_hash_range.rs
@@ -316,6 +316,57 @@ impl MoleculeHashRange {
             .and_then(|range_map| range_map.get(range))
     }
 
+    /// Inserts an entry whose writer identity was supplied by the caller
+    /// rather than produced by a local keypair. Used by the replay/import
+    /// path (e.g. inbound `data_share` from another node): the original
+    /// author's `writer_pubkey` is preserved on the AtomEntry so downstream
+    /// queries can attribute the record to its sender.
+    ///
+    /// The caller is responsible for the meaning of `signature` /
+    /// `signature_version`. Pass `signature_version = 0` and an empty
+    /// `signature` when no verifiable signature is available — `verify_key`
+    /// will then return false for this entry, which is the correct semantics
+    /// for an imported record whose canonical bytes (built from the local
+    /// `written_at`) differ from whatever the original author signed.
+    pub fn set_atom_uuid_from_values_imported(
+        &mut self,
+        hash_value: String,
+        range_value: String,
+        atom_uuid: String,
+        writer_pubkey: String,
+        signature: String,
+        signature_version: u8,
+    ) {
+        let changed = self.get_atom_uuid(&hash_value, &range_value) != Some(&atom_uuid);
+        if changed {
+            self.version += 1;
+            let key_value = KeyValue::new(Some(hash_value.clone()), Some(range_value.clone()));
+            self.update_order.push(key_value);
+        }
+        let written_at = now_nanos();
+        let provenance = if signature_version > 0 {
+            Some(super::Provenance::User {
+                pubkey: writer_pubkey.clone(),
+                signature: signature.clone(),
+                signature_version,
+            })
+        } else {
+            None
+        };
+        self.atom_uuids.entry(hash_value).or_default().insert(
+            range_value,
+            AtomEntry {
+                atom_uuid,
+                written_at,
+                writer_pubkey,
+                signature,
+                signature_version,
+                provenance,
+            },
+        );
+        self.updated_at = Utc::now();
+    }
+
     /// Updates a key WITHOUT signing. Only for ephemeral in-memory operations (rewind).
     pub(crate) fn set_atom_uuid_from_values_unsigned(
         &mut self,
@@ -559,6 +610,62 @@ mod tests {
         assert!(conflicts.is_empty());
         assert_eq!(mol1.get_atom_uuid("h1", "r1"), Some(&"atom-1".to_string()));
         assert_eq!(mol1.get_atom_uuid("h2", "r2"), Some(&"atom-2".to_string()));
+    }
+
+    /// Imported entries preserve the supplied `writer_pubkey` verbatim
+    /// rather than overwriting it with a locally-derived signer pubkey.
+    /// This is the load-bearing property for cross-node share replay
+    /// (face-discovery-3node `bob.shared_record_count[Photography]`).
+    #[test]
+    fn test_set_atom_uuid_from_values_imported_preserves_external_pubkey() {
+        let mut mol = MoleculeHashRange::new("schema", "field");
+        mol.set_atom_uuid_from_values_imported(
+            "h1".to_string(),
+            "r1".to_string(),
+            "atom-1".to_string(),
+            "alice-pubkey-base64".to_string(),
+            String::new(),
+            0,
+        );
+        let entry = mol.get_atom_entry("h1", "r1").expect("entry present");
+        assert_eq!(entry.writer_pubkey, "alice-pubkey-base64");
+        assert_eq!(entry.signature_version, 0);
+        // signature_version=0 means "unverifiable replay"; verify_key
+        // must therefore return false rather than claiming verification.
+        assert!(!mol.verify_key("h1", "r1"));
+        // No User provenance is attached when there's no verifiable
+        // signature — anything else would lie about authenticity.
+        assert!(entry.provenance.is_none());
+    }
+
+    /// Sibling test: when `signature_version > 0`, the imported entry
+    /// stamps a `Provenance::User` whose pubkey/signature mirror the
+    /// supplied values. This is the path a future "replay with original
+    /// signature" feature would take.
+    #[test]
+    fn test_set_atom_uuid_from_values_imported_with_signature_records_provenance() {
+        let mut mol = MoleculeHashRange::new("schema", "field");
+        mol.set_atom_uuid_from_values_imported(
+            "h1".to_string(),
+            "r1".to_string(),
+            "atom-1".to_string(),
+            "pk".to_string(),
+            "sig".to_string(),
+            1,
+        );
+        let entry = mol.get_atom_entry("h1", "r1").expect("entry present");
+        match entry.provenance.as_ref() {
+            Some(crate::atom::Provenance::User {
+                pubkey,
+                signature,
+                signature_version,
+            }) => {
+                assert_eq!(pubkey, "pk");
+                assert_eq!(signature, "sig");
+                assert_eq!(*signature_version, 1);
+            }
+            other => panic!("expected User variant, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/core/src/atom/molecule_range.rs
+++ b/crates/core/src/atom/molecule_range.rs
@@ -117,6 +117,50 @@ impl MoleculeRange {
         self.key_metadata.get(key)
     }
 
+    /// Inserts an entry whose writer identity was supplied by the caller
+    /// rather than produced by a local keypair. Used by the replay/import
+    /// path (e.g. inbound `data_share` from another node). See
+    /// `MoleculeHashRange::set_atom_uuid_from_values_imported` for full
+    /// rationale on `signature_version` / `verify_key` semantics.
+    pub fn set_atom_uuid_imported(
+        &mut self,
+        key: String,
+        atom_uuid: String,
+        writer_pubkey: String,
+        signature: String,
+        signature_version: u8,
+    ) {
+        let changed = self
+            .atom_uuids
+            .get(&key)
+            .is_none_or(|e| e.atom_uuid != atom_uuid);
+        if changed {
+            self.version += 1;
+        }
+        let written_at = now_nanos();
+        let provenance = if signature_version > 0 {
+            Some(super::Provenance::User {
+                pubkey: writer_pubkey.clone(),
+                signature: signature.clone(),
+                signature_version,
+            })
+        } else {
+            None
+        };
+        self.atom_uuids.insert(
+            key,
+            AtomEntry {
+                atom_uuid,
+                written_at,
+                writer_pubkey,
+                signature,
+                signature_version,
+                provenance,
+            },
+        );
+        self.updated_at = Utc::now();
+    }
+
     /// Updates a key WITHOUT signing. Only for ephemeral in-memory operations (rewind).
     pub(crate) fn set_atom_uuid_unsigned(&mut self, key: String, atom_uuid: String) {
         let changed = self

--- a/crates/core/src/fold_db_core/mutation_manager.rs
+++ b/crates/core/src/fold_db_core/mutation_manager.rs
@@ -700,7 +700,11 @@ impl MutationManager {
                     }),
             };
 
-            // Write mutation to memory
+            // Write mutation to memory. When the mutation carries a
+            // `Provenance::User` (e.g. inbound `data_share` replay), pass it
+            // through as `writer_override` so the per-key signing layer
+            // preserves the original author's `writer_pubkey` on the
+            // `AtomEntry` instead of overwriting via the local signer.
             schema_field.write_mutation(
                 key_value,
                 crate::schema::types::field::WriteContext {
@@ -711,6 +715,7 @@ impl MutationManager {
                     schema_name: mutation.schema_name.clone(),
                     field_name: field_name.clone(),
                     signer: Arc::clone(&self.signer),
+                    writer_override: mutation.provenance.clone(),
                 },
             );
 

--- a/crates/core/src/schema/types/field/common.rs
+++ b/crates/core/src/schema/types/field/common.rs
@@ -23,8 +23,19 @@ pub struct WriteContext {
     pub metadata: Option<std::collections::HashMap<String, String>>,
     pub schema_name: String,
     pub field_name: String,
-    /// The signing keypair for molecule signatures.
+    /// The signing keypair for molecule signatures. Used when
+    /// `writer_override` is `None`.
     pub signer: std::sync::Arc<crate::security::Ed25519KeyPair>,
+    /// Replay/import override. When `Some(Provenance::User { .. })`, the
+    /// molecule's per-key write path stamps the caller-supplied
+    /// `(pubkey, signature, signature_version)` directly onto the
+    /// `AtomEntry` instead of re-signing locally with `signer`. This is
+    /// how an inbound `data_share` from another node preserves the
+    /// original sender's `writer_pubkey` on the receiver's AtomEntry,
+    /// so the assertion `record.author_pub_key == sender.pub_key` can
+    /// pass on HashRange schemas. `None` (the default) keeps the local
+    /// signing path used by every first-party mutation.
+    pub writer_override: Option<crate::atom::provenance::Provenance>,
 }
 
 /// Common interface for all schema fields.

--- a/crates/core/src/schema/types/field/filter_utils.rs
+++ b/crates/core/src/schema/types/field/filter_utils.rs
@@ -52,7 +52,7 @@ pub async fn fetch_atoms_for_matches_async_with_org(
 ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
     fetch_atoms_with_key_metadata_async_with_org(
         db_ops,
-        matches.into_iter().map(|(kv, uuid)| (kv, uuid, None)),
+        matches.into_iter().map(|(kv, uuid)| (kv, uuid, None, None)),
         org_hash,
     )
     .await
@@ -63,7 +63,14 @@ pub async fn fetch_atoms_for_matches_async_with_org(
 /// Falls back to atom metadata for backward compatibility with pre-existing data.
 pub async fn fetch_atoms_with_key_metadata_async(
     db_ops: &Arc<DbOperations>,
-    matches: impl IntoIterator<Item = (KeyValue, String, Option<crate::atom::KeyMetadata>)>,
+    matches: impl IntoIterator<
+        Item = (
+            KeyValue,
+            String,
+            Option<crate::atom::KeyMetadata>,
+            Option<String>,
+        ),
+    >,
 ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
     fetch_atoms_with_key_metadata_async_with_org(db_ops, matches, None).await
 }
@@ -84,13 +91,20 @@ pub async fn fetch_atoms_with_key_metadata_async(
 /// strict error so genuine data integrity bugs still surface.
 pub async fn fetch_atoms_with_key_metadata_async_with_org(
     db_ops: &Arc<DbOperations>,
-    matches: impl IntoIterator<Item = (KeyValue, String, Option<crate::atom::KeyMetadata>)>,
+    matches: impl IntoIterator<
+        Item = (
+            KeyValue,
+            String,
+            Option<crate::atom::KeyMetadata>,
+            Option<String>,
+        ),
+    >,
     org_hash: Option<&str>,
 ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
     let mut resolved_values: HashMap<KeyValue, FieldValue> = HashMap::new();
 
     use crate::storage::traits::TypedStore;
-    for (key, atom_uuid, key_meta) in matches.into_iter() {
+    for (key, atom_uuid, key_meta, writer_pubkey) in matches.into_iter() {
         let base_key = format!("atom:{}", atom_uuid);
         let storage_key = super::build_storage_key(org_hash, &base_key);
         let store = db_ops.atoms().raw();
@@ -131,7 +145,14 @@ pub async fn fetch_atoms_with_key_metadata_async_with_org(
                         metadata,
                         molecule_uuid: None,
                         molecule_version: None,
-                        writer_pubkey: None,
+                        // Per-key writer_pubkey looked up from the molecule's
+                        // AtomEntry. For Hash/Range/HashRange variants this is
+                        // the only place writer_pubkey gets surfaced (the
+                        // molecule has no molecule-level signing key); for
+                        // Single this path will be `None` here and overwritten
+                        // by `FieldVariant::resolve_value` with the
+                        // molecule-level pubkey.
+                        writer_pubkey: writer_pubkey.filter(|s| !s.is_empty()),
                         written_at,
                     },
                 );

--- a/crates/core/src/schema/types/field/hash_field.rs
+++ b/crates/core/src/schema/types/field/hash_field.rs
@@ -67,10 +67,34 @@ impl crate::schema::types::field::Field for HashField {
             self.molecule = Some(new_molecule);
         }
 
-        // For HashField, we use the hash key to store the atom
+        // For HashField, we use the hash key to store the atom. If the
+        // caller supplied a `writer_override` (replay/import path), stamp
+        // the supplied identity onto the AtomEntry directly instead of
+        // signing with the local keypair.
         if let Some(hash_key) = &key_value.hash {
             if let Some(molecule) = &mut self.molecule {
-                molecule.set_atom_uuid(hash_key.clone(), ctx.atom.uuid().to_string(), &ctx.signer);
+                match ctx.writer_override {
+                    Some(crate::atom::provenance::Provenance::User {
+                        pubkey,
+                        signature,
+                        signature_version,
+                    }) => {
+                        molecule.set_atom_uuid_imported(
+                            hash_key.clone(),
+                            ctx.atom.uuid().to_string(),
+                            pubkey,
+                            signature,
+                            signature_version,
+                        );
+                    }
+                    _ => {
+                        molecule.set_atom_uuid(
+                            hash_key.clone(),
+                            ctx.atom.uuid().to_string(),
+                            &ctx.signer,
+                        );
+                    }
+                }
                 // Store per-key metadata on the molecule
                 molecule.set_key_metadata(
                     hash_key.clone(),
@@ -91,17 +115,30 @@ impl crate::schema::types::field::Field for HashField {
     ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
         self.refresh_from_db(db_ops).await;
         let result = self.apply_filter(filter);
-        // Attach per-key metadata from molecule to each match
-        let matches_with_meta: Vec<(KeyValue, String, Option<crate::atom::KeyMetadata>)> = result
+        // Attach per-key metadata + per-AtomEntry writer_pubkey from the
+        // molecule to each match. The writer_pubkey is the only way Hash
+        // variants surface authorship into the query response — there is
+        // no molecule-level signing key for Hash molecules.
+        let matches_with_meta: Vec<(
+            KeyValue,
+            String,
+            Option<crate::atom::KeyMetadata>,
+            Option<String>,
+        )> = result
             .matches
             .into_iter()
             .map(|(kv, atom_uuid)| {
-                let key_meta = kv.hash.as_ref().and_then(|h| {
-                    self.molecule
-                        .as_ref()
-                        .and_then(|m| m.get_key_metadata(h).cloned())
-                });
-                (kv, atom_uuid, key_meta)
+                let (key_meta, writer_pubkey) = match kv.hash.as_ref() {
+                    Some(h) => match self.molecule.as_ref() {
+                        Some(m) => (
+                            m.get_key_metadata(h).cloned(),
+                            m.get_atom_entry(h).map(|e| e.writer_pubkey.clone()),
+                        ),
+                        None => (None, None),
+                    },
+                    None => (None, None),
+                };
+                (kv, atom_uuid, key_meta, writer_pubkey)
             })
             .collect();
         super::fetch_atoms_with_key_metadata_async_with_org(

--- a/crates/core/src/schema/types/field/hash_range_field.rs
+++ b/crates/core/src/schema/types/field/hash_range_field.rs
@@ -72,16 +72,37 @@ impl crate::schema::types::field::Field for HashRangeField {
             self.molecule = Some(new_molecule);
         }
 
-        // For HashRangeField, we use both hash and range keys to store the atom
+        // For HashRangeField, we use both hash and range keys to store the
+        // atom. If the caller supplied a `writer_override` (replay/import
+        // path), stamp the supplied identity onto the AtomEntry directly
+        // instead of signing with the local keypair.
         match (&key_value.hash, &key_value.range) {
             (Some(hash_key), Some(range_key)) => {
                 if let Some(molecule) = &mut self.molecule {
-                    molecule.set_atom_uuid_from_values(
-                        hash_key.clone(),
-                        range_key.clone(),
-                        ctx.atom.uuid().to_string(),
-                        &ctx.signer,
-                    );
+                    match ctx.writer_override {
+                        Some(crate::atom::provenance::Provenance::User {
+                            pubkey,
+                            signature,
+                            signature_version,
+                        }) => {
+                            molecule.set_atom_uuid_from_values_imported(
+                                hash_key.clone(),
+                                range_key.clone(),
+                                ctx.atom.uuid().to_string(),
+                                pubkey,
+                                signature,
+                                signature_version,
+                            );
+                        }
+                        _ => {
+                            molecule.set_atom_uuid_from_values(
+                                hash_key.clone(),
+                                range_key.clone(),
+                                ctx.atom.uuid().to_string(),
+                                &ctx.signer,
+                            );
+                        }
+                    }
                     // Store per-key metadata on the molecule
                     molecule.set_key_metadata(
                         hash_key.clone(),
@@ -116,19 +137,30 @@ impl crate::schema::types::field::Field for HashRangeField {
         if result.matches.is_empty() {
             // No matches found
         }
-        // Attach per-key metadata from molecule to each match
-        let matches_with_meta: Vec<(KeyValue, String, Option<crate::atom::KeyMetadata>)> = result
+        // Attach per-key metadata + per-AtomEntry writer_pubkey from the
+        // molecule to each match. HashRange has no molecule-level signing
+        // key, so the per-AtomEntry pubkey is the only way authorship
+        // (e.g. a shared record's original author) reaches the response.
+        let matches_with_meta: Vec<(
+            KeyValue,
+            String,
+            Option<crate::atom::KeyMetadata>,
+            Option<String>,
+        )> = result
             .matches
             .into_iter()
             .map(|(kv, atom_uuid)| {
-                let key_meta = match (&kv.hash, &kv.range) {
-                    (Some(h), Some(r)) => self
-                        .molecule
-                        .as_ref()
-                        .and_then(|m| m.get_key_metadata(h, r).cloned()),
-                    _ => None,
+                let (key_meta, writer_pubkey) = match (&kv.hash, &kv.range) {
+                    (Some(h), Some(r)) => match self.molecule.as_ref() {
+                        Some(m) => (
+                            m.get_key_metadata(h, r).cloned(),
+                            m.get_atom_entry(h, r).map(|e| e.writer_pubkey.clone()),
+                        ),
+                        None => (None, None),
+                    },
+                    _ => (None, None),
                 };
-                (kv, atom_uuid, key_meta)
+                (kv, atom_uuid, key_meta, writer_pubkey)
             })
             .collect();
         super::fetch_atoms_with_key_metadata_async_with_org(

--- a/crates/core/src/schema/types/field/range_field.rs
+++ b/crates/core/src/schema/types/field/range_field.rs
@@ -92,10 +92,34 @@ impl crate::schema::types::field::Field for RangeField {
             }
         }
 
-        // For RangeField, we use the range key to store the atom
+        // For RangeField, we use the range key to store the atom. If the
+        // caller supplied a `writer_override` (replay/import path), stamp
+        // the supplied identity onto the AtomEntry directly instead of
+        // signing with the local keypair.
         if let Some(range_key) = &key_value.range {
             if let Some(molecule) = &mut self.molecule {
-                molecule.set_atom_uuid(range_key.clone(), ctx.atom.uuid().to_string(), &ctx.signer);
+                match ctx.writer_override {
+                    Some(crate::atom::provenance::Provenance::User {
+                        pubkey,
+                        signature,
+                        signature_version,
+                    }) => {
+                        molecule.set_atom_uuid_imported(
+                            range_key.clone(),
+                            ctx.atom.uuid().to_string(),
+                            pubkey,
+                            signature,
+                            signature_version,
+                        );
+                    }
+                    _ => {
+                        molecule.set_atom_uuid(
+                            range_key.clone(),
+                            ctx.atom.uuid().to_string(),
+                            &ctx.signer,
+                        );
+                    }
+                }
                 // Store per-key metadata on the molecule
                 molecule.set_key_metadata(
                     range_key.clone(),
@@ -116,19 +140,31 @@ impl crate::schema::types::field::Field for RangeField {
     ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
         self.refresh_from_db(db_ops).await;
 
-        // Fetch actual atom content from database using shared helper
+        // Fetch actual atom content from database using shared helper.
+        // Attach per-key metadata + per-AtomEntry writer_pubkey from the
+        // molecule to each match (see HashField::resolve_value for why
+        // writer_pubkey lives on the entry, not the molecule).
         let result = self.apply_filter(filter);
-        // Attach per-key metadata from molecule to each match
-        let matches_with_meta: Vec<(KeyValue, String, Option<crate::atom::KeyMetadata>)> = result
+        let matches_with_meta: Vec<(
+            KeyValue,
+            String,
+            Option<crate::atom::KeyMetadata>,
+            Option<String>,
+        )> = result
             .matches
             .into_iter()
             .map(|(kv, atom_uuid)| {
-                let key_meta = kv.range.as_ref().and_then(|r| {
-                    self.molecule
-                        .as_ref()
-                        .and_then(|m| m.get_key_metadata(r).cloned())
-                });
-                (kv, atom_uuid, key_meta)
+                let (key_meta, writer_pubkey) = match kv.range.as_ref() {
+                    Some(r) => match self.molecule.as_ref() {
+                        Some(m) => (
+                            m.get_key_metadata(r).cloned(),
+                            m.get_atom_entry(r).map(|e| e.writer_pubkey.clone()),
+                        ),
+                        None => (None, None),
+                    },
+                    None => (None, None),
+                };
+                (kv, atom_uuid, key_meta, writer_pubkey)
             })
             .collect();
         super::fetch_atoms_with_key_metadata_async_with_org(

--- a/crates/core/src/schema/types/field/single_field.rs
+++ b/crates/core/src/schema/types/field/single_field.rs
@@ -63,9 +63,27 @@ impl crate::schema::types::field::Field for SingleField {
             self.molecule = Some(new_molecule);
         }
 
-        // For SingleField, we store the atom and sign
+        // For SingleField, we store the atom and sign — unless the caller
+        // provided a `writer_override` (replay/import path), in which case
+        // we stamp the supplied identity onto the molecule directly.
         if let Some(molecule) = &mut self.molecule {
-            molecule.set_atom_uuid(ctx.atom.uuid().to_string(), &ctx.signer);
+            match ctx.writer_override {
+                Some(crate::atom::provenance::Provenance::User {
+                    pubkey,
+                    signature,
+                    signature_version,
+                }) => {
+                    molecule.set_atom_uuid_imported(
+                        ctx.atom.uuid().to_string(),
+                        pubkey,
+                        signature,
+                        signature_version,
+                    );
+                }
+                _ => {
+                    molecule.set_atom_uuid(ctx.atom.uuid().to_string(), &ctx.signer);
+                }
+            }
             // Store per-key metadata on the molecule
             molecule.set_key_metadata(crate::atom::KeyMetadata {
                 source_file_name: ctx.source_file_name,
@@ -84,9 +102,17 @@ impl crate::schema::types::field::Field for SingleField {
         if let Some(molecule) = &self.molecule {
             let uuid = molecule.get_atom_uuid().clone();
             let key_meta = molecule.get_key_metadata().cloned();
+            let writer_pubkey = {
+                let pk = molecule.writer_pubkey();
+                if pk.is_empty() {
+                    None
+                } else {
+                    Some(pk.to_string())
+                }
+            };
             let result = super::fetch_atoms_with_key_metadata_async_with_org(
                 db_ops,
-                vec![(KeyValue::new(None, None), uuid, key_meta)],
+                vec![(KeyValue::new(None, None), uuid, key_meta, writer_pubkey)],
                 self.inner.org_hash(),
             )
             .await?;

--- a/crates/core/src/schema/types/field/variant.rs
+++ b/crates/core/src/schema/types/field/variant.rs
@@ -121,34 +121,64 @@ impl Field for FieldVariant {
             FieldVariant::Range(f) => f.apply_filter(filter),
             FieldVariant::HashRange(f) => f.apply_filter(filter),
         };
-        let matches_with_meta: Vec<(KeyValue, String, Option<crate::atom::KeyMetadata>)> = results
+        let matches_with_meta: Vec<(
+            KeyValue,
+            String,
+            Option<crate::atom::KeyMetadata>,
+            Option<String>,
+        )> = results
             .matches
             .into_iter()
             .map(|(kv, atom_uuid)| {
-                let key_meta = match self {
-                    FieldVariant::Single(f) => f
-                        .molecule
-                        .as_ref()
-                        .and_then(|m| m.get_key_metadata().cloned()),
-                    FieldVariant::Hash(f) => kv.hash.as_ref().and_then(|h| {
-                        f.molecule
-                            .as_ref()
-                            .and_then(|m| m.get_key_metadata(h).cloned())
-                    }),
-                    FieldVariant::Range(f) => kv.range.as_ref().and_then(|r| {
-                        f.molecule
-                            .as_ref()
-                            .and_then(|m| m.get_key_metadata(r).cloned())
-                    }),
-                    FieldVariant::HashRange(f) => {
-                        kv.hash.as_ref().zip(kv.range.as_ref()).and_then(|(h, r)| {
+                // Extract per-key metadata AND per-AtomEntry writer_pubkey
+                // from the molecule. Hash/Range/HashRange molecules carry
+                // writer identity per-entry rather than per-molecule, so
+                // this is the only place the original author's pubkey
+                // reaches the query response for those variants. Single
+                // molecules don't expose a per-key writer_pubkey at the
+                // entry level (only the molecule-level field), so
+                // `writer_pubkey` is `None` here for Single — the
+                // molecule-level value is stamped on below.
+                let (key_meta, writer_pubkey): (Option<crate::atom::KeyMetadata>, Option<String>) =
+                    match self {
+                        FieldVariant::Single(f) => (
                             f.molecule
                                 .as_ref()
-                                .and_then(|m| m.get_key_metadata(h, r).cloned())
-                        })
-                    }
-                };
-                (kv, atom_uuid, key_meta)
+                                .and_then(|m| m.get_key_metadata().cloned()),
+                            None,
+                        ),
+                        FieldVariant::Hash(f) => match kv.hash.as_ref() {
+                            Some(h) => match f.molecule.as_ref() {
+                                Some(m) => (
+                                    m.get_key_metadata(h).cloned(),
+                                    m.get_atom_entry(h).map(|e| e.writer_pubkey.clone()),
+                                ),
+                                None => (None, None),
+                            },
+                            None => (None, None),
+                        },
+                        FieldVariant::Range(f) => match kv.range.as_ref() {
+                            Some(r) => match f.molecule.as_ref() {
+                                Some(m) => (
+                                    m.get_key_metadata(r).cloned(),
+                                    m.get_atom_entry(r).map(|e| e.writer_pubkey.clone()),
+                                ),
+                                None => (None, None),
+                            },
+                            None => (None, None),
+                        },
+                        FieldVariant::HashRange(f) => match (&kv.hash, &kv.range) {
+                            (Some(h), Some(r)) => match f.molecule.as_ref() {
+                                Some(m) => (
+                                    m.get_key_metadata(h, r).cloned(),
+                                    m.get_atom_entry(h, r).map(|e| e.writer_pubkey.clone()),
+                                ),
+                                None => (None, None),
+                            },
+                            _ => (None, None),
+                        },
+                    };
+                (kv, atom_uuid, key_meta, writer_pubkey)
             })
             .collect();
         let mut resolved = fetch_atoms_with_key_metadata_async_with_org(
@@ -158,14 +188,21 @@ impl Field for FieldVariant {
         )
         .await?;
 
-        // Stamp molecule info on each resolved FieldValue
+        // Stamp molecule info on each resolved FieldValue. molecule_uuid /
+        // version always apply. `molecule_writer_pubkey` only returns
+        // `Some` for Single variants — when it does, it's authoritative;
+        // when it's `None` we leave the per-AtomEntry `writer_pubkey`
+        // already set by `fetch_atoms_with_key_metadata_async_with_org`
+        // alone (Hash/Range/HashRange).
         let mol_uuid = self.common().molecule_uuid().cloned();
         let mol_version = self.molecule_version();
         let mol_writer_pubkey = self.molecule_writer_pubkey();
         for fv in resolved.values_mut() {
             fv.molecule_uuid = mol_uuid.clone();
             fv.molecule_version = mol_version;
-            fv.writer_pubkey = mol_writer_pubkey.clone();
+            if let Some(pk) = mol_writer_pubkey.clone() {
+                fv.writer_pubkey = Some(pk);
+            }
         }
 
         Ok(resolved)

--- a/crates/core/tests/mutation_provenance_test.rs
+++ b/crates/core/tests/mutation_provenance_test.rs
@@ -3,9 +3,15 @@
 //!
 //! PR 4 added the field on `Mutation`. PR 5 wires it through the write
 //! path so that `MutationEvent` records propagate the originating
-//! mutation's provenance. The underlying `Molecule` / `AtomEntry` also
-//! carry `Some(Provenance::User{..})` after signing (populated from the
-//! local signer, not the submitter's claimed provenance).
+//! mutation's provenance.
+//!
+//! As of the cross-node share-replay fix (face-discovery-3node), a
+//! mutation that arrives with `Some(Provenance::User { pubkey, .. })`
+//! also propagates that pubkey onto the `AtomEntry.writer_pubkey` of the
+//! per-key molecule entry — so a query response on the receiving node can
+//! attribute the record to its original author rather than to the local
+//! signer. See `mutation_provenance_user_propagates_to_atom_entry_writer_pubkey`
+//! below for the load-bearing assertion.
 
 use fold_db::atom::deterministic_molecule_uuid;
 use fold_db::atom::provenance::Provenance;
@@ -166,5 +172,133 @@ async fn mutation_provenance_propagates_to_mutation_event() {
         "every MutationEvent for Person.name must carry the submitter's \
          provenance; got {:?}",
         events.iter().map(|e| &e.provenance).collect::<Vec<_>>()
+    );
+}
+
+/// Cross-node share replay: a mutation submitted with
+/// `Provenance::User { pubkey, .. }` MUST land on the per-key AtomEntry
+/// with `writer_pubkey == pubkey` (the original author), not with the
+/// receiving node's local signer pubkey. The query response surfaces this
+/// via `FieldValue.writer_pubkey`. This is the load-bearing property for
+/// `bob.shared_record_count[Photography] >= 1` in the e2e
+/// face-discovery-3node scenario.
+#[tokio::test]
+async fn mutation_provenance_user_propagates_to_atom_entry_writer_pubkey() {
+    let db = setup_db().await;
+    db.load_schema_from_json(&person_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager()
+        .set_schema_state("Person", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let alice_pubkey = "alice-pubkey-base64".to_string();
+    let mut fields = HashMap::new();
+    fields.insert("name".to_string(), json!("Dave"));
+    fields.insert("created_at".to_string(), json!("2026-01-04"));
+
+    // signature_version=0 means "imported without a verifiable signature"
+    // — the path inbound `data_share` takes when the receiving node has
+    // the sender's pubkey but not a signature over the receiver's local
+    // canonical bytes.
+    let provenance = Provenance::User {
+        pubkey: alice_pubkey.clone(),
+        signature: String::new(),
+        signature_version: 0,
+    };
+    let mutation = Mutation::new(
+        "Person".to_string(),
+        fields,
+        KeyValue::new(None, Some("2026-01-04".to_string())),
+        alice_pubkey.clone(),
+        MutationType::Create,
+    )
+    .with_provenance(provenance);
+
+    db.mutation_manager()
+        .write_mutations_batch_async(vec![mutation])
+        .await
+        .expect("write should succeed");
+
+    let results = db
+        .query_executor()
+        .query(Query::new("Person".to_string(), vec!["name".to_string()]))
+        .await
+        .unwrap();
+    let name_values = results
+        .get("name")
+        .expect("Person.name should be queryable");
+    let dave = name_values
+        .iter()
+        .find(|(_, fv)| fv.value == json!("Dave"))
+        .expect("Dave should appear in result set");
+    assert_eq!(
+        dave.1.writer_pubkey.as_deref(),
+        Some(alice_pubkey.as_str()),
+        "FieldValue.writer_pubkey must be Alice's pubkey (the submitter), \
+         not the local signer; got {:?}",
+        dave.1.writer_pubkey
+    );
+}
+
+/// Sibling negative control: a mutation with `provenance = None` (the
+/// normal first-party write path) must NOT pick up the local signer's
+/// pubkey as `writer_pubkey` for Range fields. The local signer is
+/// recorded on the AtomEntry, but it bubbles up to `FieldValue.writer_pubkey`
+/// on Hash/Range/HashRange variants — confirming Gap 2 wiring works for
+/// the locally-signed path too.
+#[tokio::test]
+async fn local_mutation_surfaces_local_signer_writer_pubkey_on_range_field() {
+    let db = setup_db().await;
+    db.load_schema_from_json(&person_schema_json())
+        .await
+        .unwrap();
+    db.schema_manager()
+        .set_schema_state("Person", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    let mut fields = HashMap::new();
+    fields.insert("name".to_string(), json!("Eve"));
+    fields.insert("created_at".to_string(), json!("2026-01-05"));
+
+    // No provenance — local sign path.
+    let mutation = Mutation::new(
+        "Person".to_string(),
+        fields,
+        KeyValue::new(None, Some("2026-01-05".to_string())),
+        "ignored-pub-key".to_string(),
+        MutationType::Create,
+    );
+
+    db.mutation_manager()
+        .write_mutations_batch_async(vec![mutation])
+        .await
+        .expect("write should succeed");
+
+    let results = db
+        .query_executor()
+        .query(Query::new("Person".to_string(), vec!["name".to_string()]))
+        .await
+        .unwrap();
+    let name_values = results
+        .get("name")
+        .expect("Person.name should be queryable");
+    let eve = name_values
+        .iter()
+        .find(|(_, fv)| fv.value == json!("Eve"))
+        .expect("Eve should appear in result set");
+    let pk = eve
+        .1
+        .writer_pubkey
+        .as_deref()
+        .expect("locally-signed Range entry must surface a writer_pubkey");
+    assert!(!pk.is_empty(), "local signer pubkey must be non-empty");
+    // Must NOT be the unrelated `mutation.pub_key` — that's just an
+    // identity hint, not the signer.
+    assert_ne!(
+        pk, "ignored-pub-key",
+        "writer_pubkey must reflect the local signing keypair, not mutation.pub_key"
     );
 }


### PR DESCRIPTION
## Summary

- Closes the two structural plumbing gaps that block the
  `bob.shared_record_count[Photography] >= 1` assertion in
  fold_db_node's `face-discovery-3node` e2e scenario. Live BLOCKED
  diagnosis: [`fold_db_node/.task-blocked.md`](https://github.com/EdgeVector/fold_db_node/blob/fix/e2e-bob-shared-photography-blocked/.task-blocked.md) and
  [`docs/e2e/face-discovery-3node-debug.md`](https://github.com/EdgeVector/fold_db_node/blob/fix/e2e-bob-shared-photography-blocked/docs/e2e/face-discovery-3node-debug.md).
- **Write path**: `MutationManager` always re-signed each `AtomEntry`
  with `self.signer`, so a mutation submitted with
  `Provenance::User { pubkey: alice, .. }` landed on disk with
  `AtomEntry.writer_pubkey = bob.pubkey`. Adds
  `WriteContext.writer_override: Option<Provenance>` plus
  `set_atom_uuid_*_imported` siblings on each molecule type — when
  the mutation carries `Some(Provenance::User { .. })`, the supplied
  identity is stamped onto `AtomEntry` verbatim instead of being
  re-signed locally. `signature_version = 0` is the
  "imported, no verifiable signature" mode the inbound `data_share`
  path uses (the receiver doesn't have the sender's signature over
  its own local canonical bytes). `provenance: None` falls through
  to the existing local-sign path — every first-party write is
  unchanged.
- **Read path**: `fetch_atoms_with_key_metadata_async_with_org`
  hardcoded `FieldValue.writer_pubkey: None`, and
  `FieldVariant::resolve_value` then unconditionally overwrote it
  with `molecule_writer_pubkey()` — which returns `None` for
  Hash/Range/HashRange (those carry per-AtomEntry pubkeys, not a
  molecule-level key). Helper now accepts an optional per-entry
  `writer_pubkey`; each per-field `resolve_value` looks it up from
  the molecule's `AtomEntry`. `variant.rs` no longer clobbers the
  per-entry pubkey for non-Single variants — only overwrites when
  `molecule_writer_pubkey()` actually returns `Some(..)`.
- Each gap was structural since fold_db PR #544 (Ed25519 signatures,
  2026-04-15). Every nightly since then either failed at build or
  before reaching the assertion, so the regression went unobserved
  until the 2026-05-04 run.

## Follow-up (downstream, not in this PR)

- fold_db_node's `process_data_share` needs to set
  `mutation.provenance = Some(Provenance::User { pubkey: sender_pubkey, signature: String::new(), signature_version: 0 })`
  after constructing the `Mutation`. The bump-cascade bot will pick
  up this rev automatically (~2h); the fold_db_node-side code change
  is a one-liner that can land alongside the bump.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` — full suite green;
      `mutation_provenance_test` runs all 5 cases including the new
      `mutation_provenance_user_propagates_to_atom_entry_writer_pubkey`
      and the negative-control
      `local_mutation_surfaces_local_signer_writer_pubkey_on_range_field`.
- [x] Unit tests on `MoleculeHashRange::set_atom_uuid_from_values_imported`
      cover both the `signature_version = 0` (no provenance attached)
      and `signature_version > 0` (Provenance::User mirrored) branches.
- [ ] Cascade verification: once merged + rev bumped on fold_db_node,
      the next nightly should turn `bob.shared_record_count[Photography]`
      green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)