### PR TITLE
chore(schema): scrub stale FieldBase log strings post-#684 inline

### DIFF
--- a/crates/core/src/schema/types/field/base.rs
+++ b/crates/core/src/schema/types/field/base.rs
@@ -32,7 +32,7 @@ pub async fn refresh_field_from_db<M>(
                 // Non-fatal: molecule ref may be in an old serialization format.
                 // The field still works — data is read from atoms directly.
                 tracing::warn!(
-                    "FieldBase: skipping molecule ref for {}: {}",
+                    "refresh_field_from_db: skipping molecule ref for {}: {}",
                     molecule_uuid,
                     e
                 );
@@ -43,12 +43,17 @@ pub async fn refresh_field_from_db<M>(
         if inner.org_hash().is_some() {
             match store.get_item::<M>(&base_key).await {
                 Ok(Some(molecule)) => {
-                    tracing::debug!("FieldBase: resolved molecule via pre-tag (unprefixed) key");
+                    tracing::debug!(
+                        "refresh_field_from_db: resolved molecule via pre-tag (unprefixed) key"
+                    );
                     *molecule_slot = Some(molecule);
                 }
                 Ok(None) => {}
                 Err(e) => {
-                    tracing::warn!("FieldBase: pre-tag fallback for molecule ref failed: {}", e);
+                    tracing::warn!(
+                        "refresh_field_from_db: pre-tag fallback for molecule ref failed: {}",
+                        e
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary
- The \`FieldBase<M>\` generic was inlined into the four field variants and deleted in #684 (refactor: inline FieldBase<M> into the four Field variants), but three \`tracing\` log messages in \`crates/core/src/schema/types/field/base.rs\` still carried the old \`FieldBase:\` prefix.
- These logs now live inside the free function \`refresh_field_from_db<M>\` shared across the four variants, so retag the prefix to match the actual call site.
- Levels and fields preserved; no behavior change. \`git grep -n FieldBase\` returns zero hits in this repo.

## Affected lines
\`crates/core/src/schema/types/field/base.rs\`:
- L34 \`tracing::warn!(\"FieldBase: skipping molecule ref ...\")\` → \`refresh_field_from_db: skipping molecule ref ...\`
- L46 \`tracing::debug!(\"FieldBase: resolved molecule via pre-tag (unprefixed) key\")\` → \`refresh_field_from_db: resolved molecule via pre-tag (unprefixed) key\`
- L51 \`tracing::warn!(\"FieldBase: pre-tag fallback for molecule ref failed: ...\")\` → \`refresh_field_from_db: pre-tag fallback for molecule ref failed: ...\`

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace --all-targets\` clean
- [x] \`git grep -n FieldBase\` returns 0 hits