### PR TITLE
chore(schema): scrub stale FieldBase log strings post-#684 inline

### DIFF
--- a/crates/core/src/schema/types/field/base.rs
+++ b/crates/core/src/schema/types/field/base.rs
@@ -32,7 +32,7 @@ pub async fn refresh_field_from_db<M>(
                 // Non-fatal: molecule ref may be in an old serialization format.
                 // The field still works — data is read from atoms directly.
                 tracing::warn!(
-                    "FieldBase: skipping molecule ref for {}: {}",
+                    "refresh_field_from_db: skipping molecule ref for {}: {}",
                     molecule_uuid,
                     e
                 );
@@ -43,12 +43,17 @@ pub async fn refresh_field_from_db<M>(
         if inner.org_hash().is_some() {
             match store.get_item::<M>(&base_key).await {
                 Ok(Some(molecule)) => {
-                    tracing::debug!("FieldBase: resolved molecule via pre-tag (unprefixed) key");
+                    tracing::debug!(
+                        "refresh_field_from_db: resolved molecule via pre-tag (unprefixed) key"
+                    );
                     *molecule_slot = Some(molecule);
                 }
                 Ok(None) => {}
                 Err(e) => {
-                    tracing::warn!("FieldBase: pre-tag fallback for molecule ref failed: {}", e);
+                    tracing::warn!(
+                        "refresh_field_from_db: pre-tag fallback for molecule ref failed: {}",
+                        e
+                    );
                 }
             }
         }


### PR DESCRIPTION
Scrubs the three stale `"FieldBase: ..."` log strings in `crates/core/src/schema/types/field/base.rs` that were left over after #684 inlined `FieldBase<M>` into the four field variants. These logs now live in the free function `refresh_field_from_db<M>`, so the prefix is retagged to match.

- `tracing::warn!("FieldBase: skipping molecule ref ...` → `refresh_field_from_db: ...`
- `tracing::debug!("FieldBase: resolved molecule via pre-tag ...` → `refresh_field_from_db: ...`
- `tracing::warn!("FieldBase: pre-tag fallback ...` → `refresh_field_from_db: ...`

No behavior change. Levels, fields, and message structure preserved. `git grep -n FieldBase` is now clean across `crates/core/src/schema/types/field/`.

Reconciled by /kanban babysit — the originating task agent committed locally but stalled before pushing.