### PR TITLE
refactor(storage): drop dead DatabaseConfig::from_env() (post-#685)

### DIFF
--- a/crates/core/src/storage/config.rs
+++ b/crates/core/src/storage/config.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::env;
 use std::path::PathBuf;
 
 /// Error type for configuration parsing
@@ -135,43 +134,6 @@ impl DatabaseConfig {
     /// Check if cloud sync is enabled
     pub fn has_cloud_sync(&self) -> bool {
         self.cloud_sync.is_some()
-    }
-
-    /// Creates DatabaseConfig from environment variables:
-    /// - FOLD_STORAGE_PATH: path for local storage (default: "data")
-    /// - FOLD_STORAGE_MODE: "local" (default) or "exemem"
-    /// - For exemem mode: EXEMEM_API_URL, EXEMEM_API_KEY
-    pub fn from_env() -> Result<Self, ConfigError> {
-        let path = env::var("FOLD_STORAGE_PATH")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from("data"));
-
-        let mode = env::var("FOLD_STORAGE_MODE").unwrap_or_else(|_| "local".to_string());
-
-        let cloud_sync = match mode.to_lowercase().as_str() {
-            "local" => None,
-            "exemem" => {
-                let api_url = env::var("EXEMEM_API_URL")
-                    .map_err(|_| ConfigError::MissingVariable("EXEMEM_API_URL".to_string()))?;
-                let api_key = env::var("EXEMEM_API_KEY")
-                    .map_err(|_| ConfigError::MissingVariable("EXEMEM_API_KEY".to_string()))?;
-                Some(CloudSyncConfig {
-                    api_url,
-                    api_key,
-                    session_token: env::var("EXEMEM_SESSION_TOKEN").ok(),
-                    user_hash: env::var("EXEMEM_USER_HASH").ok(),
-                    p2p_sync: None,
-                })
-            }
-            _ => {
-                return Err(ConfigError::InvalidValue(format!(
-                    "Invalid FOLD_STORAGE_MODE: '{}'. Must be 'local' or 'exemem'",
-                    mode
-                )))
-            }
-        };
-
-        Ok(DatabaseConfig { path, cloud_sync })
     }
 }
 


### PR DESCRIPTION
## Summary

[#685](https://github.com/EdgeVector/fold_db/pull/685) removed the only caller of `DatabaseConfig::from_env()` (the factory, which now consumes `config.path` directly). After that landed, the constructor was unreachable from any caller across **fold_db**, **fold_db_node**, **fold_dev_node**, or **schema_service** — verified via `git grep` locally and `gh search code` against the EdgeVector org.

This PR deletes it.

### Removed

- `DatabaseConfig::from_env()` and its doc comment (`crates/core/src/storage/config.rs:140-175`).
- The env-var reads that lived only inside that function:
  - `FOLD_STORAGE_PATH`
  - `FOLD_STORAGE_MODE`
  - `EXEMEM_API_URL`
  - `EXEMEM_API_KEY`
  - `EXEMEM_SESSION_TOKEN`
  - `EXEMEM_USER_HASH`
- `use std::env;` — now unused. (The legacy deserializer branch uses `std::env::var` fully-qualified, so the bare import isn't needed anymore.)

### Left intact (out of scope)

- The legacy `{"type":"exemem"}` deserializer branch in the same file still reads `FOLD_STORAGE_PATH` as a path fallback. Per its own `TODO(storage-path)`, downstream consumers (`fold_db_node`'s `run.sh`, `org-test.sh`, `smoke-test-dmg.sh`, `src/bin/folddb/main.rs`, `src-tauri/src/lib.rs`) still emit that JSON shape — dropping it needs a coordinated migration.
- `ConfigError` stays. It's `pub`-reachable via `storage::config::ConfigError` and renaming/restructuring it is explicitly out of scope.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --all-targets` — green
- [x] `git grep -n 'DatabaseConfig::from_env\|DatabaseConfig\.from_env'` — zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)