### PR TITLE
refactor(storage): drop orphaned ConfigError enum (post-#689)

### DIFF
--- a/crates/core/src/storage/config.rs
+++ b/crates/core/src/storage/config.rs
@@ -1,24 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-/// Error type for configuration parsing
-#[derive(Debug)]
-pub enum ConfigError {
-    MissingVariable(String),
-    InvalidValue(String),
-}
-
-impl std::fmt::Display for ConfigError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ConfigError::MissingVariable(var) => write!(f, "Missing environment variable: {}", var),
-            ConfigError::InvalidValue(msg) => write!(f, "Invalid configuration value: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for ConfigError {}
-
 /// Configuration for cloud sync (Exemem encrypted S3 backup).
 ///
 /// **Field persistence model:** only `api_url` and `p2p_sync` are serialized


### PR DESCRIPTION
## Summary

PR #689 deleted `DatabaseConfig::from_env()`, the only consumer of the `ConfigError` enum in `crates/core/src/storage/config.rs`. The type, its `Display` impl, and its `std::error::Error` impl are now defined but referenced by nothing.

This PR deletes the orphan: the enum, both impls, and the `/// Error type for configuration parsing` doc comment.

## Verification

- `git grep -n "ConfigError"` returns zero hits across the fold_db repo (and zero across `fold_db_node`, `fold_dev_node`, `schema_service`).
- `ConfigError` is not re-exported from `crates/core/src/storage/mod.rs` (only `CloudSyncConfig`, `DatabaseConfig`, `P2pSyncConfig` are), so removing it does not change the public API surface.
- The legacy `{"type":"exemem"}` `Deserialize` branch later in `config.rs` uses `serde::de::Error::custom`, not `ConfigError` — unaffected.

## Local checks

- `cargo fmt --all` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)