### PR TITLE
chore(deps): drop 6 unused fold_db workspace deps flagged by cargo-machete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,15 +744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "colored"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,13 +1519,11 @@ dependencies = [
  "chrono-tz",
  "clap",
  "clap_complete",
- "colored",
  "croner",
  "ed25519-compact",
  "ed25519-dalek",
  "fastembed",
  "futures",
- "futures-util",
  "hkdf",
  "hmac",
  "image",
@@ -1542,9 +1531,7 @@ dependencies = [
  "once_cell",
  "ort",
  "rand 0.8.5",
- "regex",
  "reqwest 0.11.27",
- "ring",
  "seahash",
  "serde",
  "serde_json",
@@ -1555,8 +1542,6 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tokio-stream",
- "toml",
  "tracing",
  "tracing-subscriber",
  "ts-rs",
@@ -5049,18 +5034,6 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,7 +14,6 @@ face-detection = ["dep:ort", "dep:image", "dep:zip"]  # Face detection and embed
 
 [dependencies]
 # Cryptography
-ring = "0.17.14"
 base64 = "0.21.0"
 ed25519-dalek = { version = "2.0", features = ["rand_core", "serde"] }
 aes-gcm = "0.10"
@@ -25,7 +24,6 @@ sha2 = "0.10"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-toml = "0.8"
 ts-rs = { version = "10", optional = true, features = ["serde-compat", "serde-json-impl"] }
 
 # Storage
@@ -36,18 +34,14 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.9"
 croner = "2"
-regex = "1"
 rand = "0.8"
 tempfile = "3.8"
 seahash = "4.1"
 once_cell = "1"
-colored = "3.1.1"
 tracing = "0.1"
 
 # Async runtime
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "sync", "time", "fs", "signal", "io-util"] }
-tokio-stream = { version = "0.1", features = ["sync"] }
-futures-util = "0.3"
 futures = "0.3"
 async-trait = "0.1"
 


### PR DESCRIPTION
## Summary

Removes six unused workspace deps from `crates/core/Cargo.toml` `[dependencies]`:

- `ring`
- `toml`
- `regex`
- `colored`
- `tokio-stream`
- `futures-util`

All six were flagged by `cargo machete` and verified zero `use`/`::` references in `crates/core/src/**/*.rs`. No source or feature changes — only the auto-generated `Cargo.lock` diff.

Same shape as fold_dev_node [#20](https://github.com/EdgeVector/fold_dev_node/pull/20).

## Out of scope (intentionally retained)

`cargo machete` also flags three more, all false positives that must stay:

- `ureq` — load-bearing 2.x pin so fastembed's transitive resolution doesn't pick up 3.x (which broke the TLS API). Comment in `Cargo.toml` documents this.
- `zip` — optional, gated on `face-detection`; machete doesn't enable optional features.
- `clap_complete` — optional, gated on `cli`; same reason.

## Test plan

- [x] `cargo machete` now reports only `ureq` / `zip` / `clap_complete`
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets --features cli -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets --features face-detection -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets --features ts-bindings -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` clean