### PR TITLE
chore(deps): drop unused fold_db_core zip dependency flagged by cargo-machete

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,7 +10,7 @@ ts-bindings = ["ts-rs"]  # Generate TypeScript bindings when enabled
 cli = ["dep:clap", "dep:clap_complete"]  # CLI tooling (clap derives)
 transform-wasm = ["dep:wasmtime"]  # Enable WASM transform execution for views
 test-utils = []  # Expose test helpers (MockEmbeddingModel, etc.) for integration tests
-face-detection = ["dep:ort", "dep:image", "dep:zip"]  # Face detection and embedding via ONNX Runtime
+face-detection = ["dep:ort", "dep:image"]  # Face detection and embedding via ONNX Runtime
 
 [dependencies]
 # Cryptography
@@ -72,7 +72,6 @@ wasmtime = { version = "29", optional = true }
 # Face detection (ONNX runtime + image processing)
 ort = { version = "2.0.0-rc.9", optional = true, default-features = false }
 image = { version = "0.25", optional = true, default-features = false, features = ["png", "jpeg"] }
-zip = { version = "2", optional = true, default-features = false, features = ["deflate"] }
 
 ed25519-compact = "2.2.0"
 


### PR DESCRIPTION
## Summary

Follows PR #691 cleanup pattern. The original cargo-machete sweep flagged 9 deps in `crates/core/Cargo.toml`; #691 removed the 6 Tier-A items (`colored`, `futures-util`, `regex`, `ring`, `tokio-stream`, `toml`). This PR closes out the Tier-B analysis.

## Tier B (feature-gate analysis)

- **`zip` — REMOVED.** Only `zip::ZipArchive` use site is `crates/core/build.rs`, served by a separate `[build-dependencies] zip` line. The `[dependencies] zip` (optional, gated on `face-detection`) had **no runtime use site** under `crates/core/src` or `crates/core/tests` (`grep -rE '\bzip::' --include='*.rs' crates/core/src crates/core/tests` → 0 hits). Removed both `dep:zip` from the `face-detection` feature list and the `[dependencies] zip` line. `[build-dependencies] zip` left untouched.
- **`clap_complete` — KEPT.** Grep evidence: `~/code/edgevector/fold_db_node/Cargo.toml` and the Tauri-side `src/server/static-react/src-tauri/Cargo.toml` both enable `features = ["cli"]` on the `fold_db` git dep — public feature contract is live. The `cli` feature also enables `dep:clap`, which is the active consumer (`clap::ValueEnum` derive on `SortOrder` at `crates/core/src/schema/types/operations.rs:136`).

## Tier C (kept by design)

- **`ureq`** — transitive version pin for fastembed (per the existing pin comment); not directly used in our source. Leaving alone.

## Verification

- `cargo machete --skip-target-dir`: `zip` no longer flagged. (Remaining flags: `clap_complete` — kept by Tier B; `ureq` — kept by Tier C.)
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo build --workspace`: pass.
- `cargo build -p fold_db --features cli`: pass.
- `cargo build -p fold_db --features face-detection`: pass (the operative test — feature still builds with `dep:zip` removed from its list).
- `cargo build -p fold_db --features ts-bindings`: pass.

## Test plan
- [x] `cargo build --features face-detection` still succeeds end-to-end after removing `dep:zip` from the feature list.
- [x] `cargo build --features cli` still succeeds (clap_complete kept).
- [x] `cargo machete` no longer flags `zip`.