### PR TITLE
refactor(core): audit and tighten #[allow(dead_code)] sites in crates/core/src

### DIFF
--- a/crates/core/src/db_operations/native_index/embedding_index.rs
+++ b/crates/core/src/db_operations/native_index/embedding_index.rs
@@ -80,13 +80,6 @@ impl EmbeddingEntry {
         )
     }
 
-    /// Legacy storage key: emb:{schema}:{key_hash}
-    #[allow(dead_code)] // Used when migrating old-format entries
-    pub(super) fn legacy_storage_key(schema: &str, key: &KeyValue) -> String {
-        let key_hash = Self::key_hash(key);
-        format!("{}{}:{}", EMB_PREFIX, schema, key_hash)
-    }
-
     fn key_hash(key: &KeyValue) -> String {
         match (&key.hash, &key.range) {
             (Some(h), Some(r)) => format!("{}_{}", h, r),

--- a/crates/core/src/db_operations/native_index/embedding_index.rs
+++ b/crates/core/src/db_operations/native_index/embedding_index.rs
@@ -45,12 +45,16 @@ pub(super) struct StoredEmbedding {
 }
 
 /// Entry held in the in-memory index.
-#[allow(dead_code)] // fragment_text read by discovery publisher
 pub(super) struct EmbeddingEntry {
     pub schema: String,
     pub key: KeyValue,
     pub field_name: String,
     pub fragment_idx: usize,
+    /// Mirrors `StoredEmbedding::fragment_text`. The Sled-persisted copy is
+    /// consumed by `fold_db_node::discovery::publisher` (which deserializes
+    /// its own `StoredEmbedding`); the in-memory copy is read only by
+    /// `native_index::tests` (cfg(test)), hence the allow on non-test builds.
+    #[allow(dead_code)]
     pub fragment_text: Option<String>,
     pub embedding: Vec<f32>,
     /// Legacy field names from old-format entries (for backward-compat search expansion).

--- a/crates/core/src/db_operations/native_index/face/detector.rs
+++ b/crates/core/src/db_operations/native_index/face/detector.rs
@@ -8,9 +8,6 @@ use crate::schema::SchemaError;
 pub struct FaceDetection {
     pub bbox: [f32; 4], // x1, y1, x2, y2 in original image pixels
     pub confidence: f32,
-    /// 5 facial landmarks (used for face alignment).
-    #[allow(dead_code)]
-    pub landmarks: Option<[[f32; 2]; 5]>,
 }
 
 pub struct ScrfdDetector {
@@ -114,10 +111,12 @@ impl ScrfdDetector {
             .run(inputs)
             .map_err(|e| SchemaError::InvalidData(format!("SCRFD inference failed: {e}")))?;
 
-        // SCRFD det_500m outputs 9 tensors (3 strides × 3 types):
-        //   [0] scores_8  [N8, 1]    [3] bboxes_8  [N8, 4]    [6] kps_8  [N8, 10]
-        //   [1] scores_16 [N16, 1]   [4] bboxes_16 [N16, 4]   [7] kps_16 [N16, 10]
-        //   [2] scores_32 [N32, 1]   [5] bboxes_32 [N32, 4]   [8] kps_32 [N32, 10]
+        // SCRFD det_500m outputs 9 tensors (3 strides × 3 types). We consume
+        // scores and bboxes; the kps tensors (indices 6, 7, 8) carry facial
+        // landmarks but no downstream consumer reads them, so we skip extraction.
+        //   [0] scores_8  [N8, 1]    [3] bboxes_8  [N8, 4]
+        //   [1] scores_16 [N16, 1]   [4] bboxes_16 [N16, 4]
+        //   [2] scores_32 [N32, 1]   [5] bboxes_32 [N32, 4]
         // where N_s = (640/s)^2 * 2 anchors
         let mut detections = Vec::new();
         let strides = [8u32, 16, 32];
@@ -125,7 +124,6 @@ impl ScrfdDetector {
         for (stride_idx, &stride) in strides.iter().enumerate() {
             let score_idx = stride_idx; // 0, 1, 2
             let bbox_idx = stride_idx + 3; // 3, 4, 5
-            let kps_idx = stride_idx + 6; // 6, 7, 8
 
             if bbox_idx >= outputs.len() {
                 continue;
@@ -170,32 +168,9 @@ impl ScrfdDetector {
                         let x2 = (cx + r).min(input_w as f32) / input_w as f32 * orig_w as f32;
                         let y2 = (cy + b).min(input_h as f32) / input_h as f32 * orig_h as f32;
 
-                        let landmarks = if kps_idx < outputs.len() {
-                            outputs[kps_idx].try_extract_tensor::<f32>().ok().map(|k| {
-                                let k_view = k.view();
-                                let mut pts = [[0.0f32; 2]; 5];
-                                for (i, pt) in pts.iter_mut().enumerate() {
-                                    let kx = i * 2;
-                                    let ky = i * 2 + 1;
-                                    if ky < k_view.shape()[1] {
-                                        pt[0] = (cx + k_view[[idx, kx]] * stride as f32)
-                                            / input_w as f32
-                                            * orig_w as f32;
-                                        pt[1] = (cy + k_view[[idx, ky]] * stride as f32)
-                                            / input_h as f32
-                                            * orig_h as f32;
-                                    }
-                                }
-                                pts
-                            })
-                        } else {
-                            None
-                        };
-
                         detections.push(FaceDetection {
                             bbox: [x1, y1, x2, y2],
                             confidence: score,
-                            landmarks,
                         });
                     }
                 }

--- a/crates/core/src/db_operations/native_index/mod.rs
+++ b/crates/core/src/db_operations/native_index/mod.rs
@@ -55,8 +55,7 @@ impl NativeIndexManager {
         *self.embedding_index.entries.write().unwrap() = entries;
     }
 
-    #[allow(dead_code)]
-    #[cfg(any(test, feature = "test-utils"))]
+    #[cfg(test)]
     pub(crate) fn with_model(store: Arc<dyn KvStore>, model: Arc<dyn Embedder>) -> Self {
         Self {
             store,

--- a/crates/core/src/fold_db_core/fold_db.rs
+++ b/crates/core/src/fold_db_core/fold_db.rs
@@ -67,10 +67,10 @@ pub struct FoldDB {
     /// Optional Sled-backed configuration store for runtime node config.
     /// Uses RwLock for interior mutability so FoldDB doesn't need &mut self.
     config_store: std::sync::RwLock<Option<crate::storage::NodeConfigStore>>,
-    /// Signing keypair for molecule signatures. Plumbed to MutationManager.
-    /// Kept on FoldDB so the node layer can access it for future use cases
-    /// (e.g., signing sync uploads, signing query responses).
-    #[allow(dead_code)]
+    /// Signing keypair for molecule signatures. Cloned at construction into
+    /// `MutationManager` (for atom signatures) and `TriggerRunner` (for
+    /// TriggerFiring audit rows). Held on `FoldDB` so `start_sync_engine_runtime`
+    /// can pass it to `SyncEngine::new` when sync activates after boot.
     pub(crate) signer: Arc<crate::security::Ed25519KeyPair>,
 }
 


### PR DESCRIPTION
## Summary

Mirrors the cleanup pattern of #689 / #690. Audits every non-test, non-cfg-gated `#[allow(dead_code)]` annotation in `crates/core/src` and either deletes the dead code or replaces a misleading suppression with an honest pointer to the real consumer.

## Per-site verdicts

| Site | Verdict | What changed |
|---|---|---|
| `db_operations/native_index/mod.rs:58` `with_model` | DROP allow | The fn is `pub(crate)` and only ever called by `tests.rs` (cfg(test)). The `cfg(any(test, feature = "test-utils"))` gate didn't expose anything across crates anyway — `pub(crate)` blocks that. Tightened to `cfg(test)`; the allow becomes unnecessary. |
| `db_operations/native_index/face/detector.rs:12` `landmarks` field | DROP field | `grep -rEn '\.landmarks' --include='*.rs' ~/code/edgevector` returns only the field definition, its initializer, and a stale "used for face alignment" comment. No alignment exists. Dropped the field, the kps tensor extraction that only existed to populate it, and the comment. |
| `db_operations/native_index/embedding_index.rs:48` `EmbeddingEntry` (struct-level) | TIGHTEN allow | The struct-level allow was overbroad — every other field (`schema`, `key`, `field_name`, `fragment_idx`, `embedding`, `legacy_field_names`, `face_bbox`, `face_confidence`) is read in non-test code. Only `fragment_text` is read solely by `cfg(test)` tests. The accompanying comment also lied: it claimed "fragment_text read by discovery publisher", but `fold_db_node::discovery::publisher` reads its own `StoredEmbedding` deserialized from Sled bytes, **not** the in-memory `EmbeddingEntry`. Moved the allow to the field and rewrote the comment. |
| `db_operations/native_index/embedding_index.rs:80` `legacy_storage_key` fn | DROP fn | Zero callers anywhere (`grep -rEn 'legacy_storage_key' ~/code/edgevector`). The "Used when migrating old-format entries" comment described intent that never landed — `load_from_store` already handles both old and new formats during deserialization. |
| `fold_db_core/fold_db.rs:73` `FoldDB::signer` field | DROP allow | Stale annotation. `self.signer` is read at fold_db.rs:253 inside `start_sync_engine_runtime`, where it's cloned into `SyncEngine::new`. The "future use cases" comment was wrong — the consumer exists. Rewrote the doc to name the actual readers (MutationManager + TriggerRunner at construction; SyncEngine via runtime sync activation). |

## Pre-PR checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets` (all green)
- [x] `cargo build -p fold_db --features cli`
- [x] `cargo build -p fold_db --features face-detection`
- [x] `cargo build -p fold_db --features ts-bindings`
- [x] `cargo build -p fold_db --features test-utils`
- [x] `cargo build -p fold_db --features transform-wasm`

(Note: `aws-backend` feature listed in the kanban prompt does not exist in the workspace — only the 5 features above are defined.)

## After

Five `#[allow(dead_code)]` sites collapsed to one — a tightened field-level allow on `EmbeddingEntry::fragment_text` (load-bearing for cfg(test) tests; intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)