### PR TITLE
chore(deps): drop unused clap_complete and ureq from fold_db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,15 +687,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_complete"
-version = "4.5.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
-dependencies = [
- "clap",
-]
-
-[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,7 +1509,6 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
- "clap_complete",
  "croner",
  "ed25519-compact",
  "ed25519-dalek",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [features]
 default = []
 ts-bindings = ["ts-rs"]  # Generate TypeScript bindings when enabled
-cli = ["dep:clap", "dep:clap_complete"]  # CLI tooling (clap derives)
+cli = ["dep:clap"]  # CLI tooling (clap derives)
 transform-wasm = ["dep:wasmtime"]  # Enable WASM transform execution for views
 test-utils = []  # Expose test helpers (MockEmbeddingModel, etc.) for integration tests
 face-detection = ["dep:ort", "dep:image"]  # Face detection and embedding via ONNX Runtime
@@ -50,7 +50,6 @@ thiserror = "1.0"
 
 # Optional CLI support
 clap = { version = "4.4", features = ["derive", "string"], optional = true }
-clap_complete = { version = "4.4", optional = true }
 
 # OpenAPI schema derives (used by core types)
 utoipa = { version = "4", features = ["actix_extras"] }
@@ -63,8 +62,6 @@ observability = { path = "../observability" }
 
 # Vector embedding model for semantic search
 fastembed = "4"
-# Pin ureq to 2.x — fastembed uses ureq internally and ureq 3.x broke the TLS API
-ureq = "2"
 
 # WASM runtime for transform views
 wasmtime = { version = "29", optional = true }


### PR DESCRIPTION
## Summary

`cargo machete` flagged these two as unused in `crates/core/Cargo.toml`, on top of the seven deps already removed in #691 and #692. Both are real removals after grepping the workspace:

- `clap_complete` — never imported. Also dropped `dep:clap_complete` from the `cli` feature list. The `clap` derive is still used in `schema/types/operations.rs` under `cfg(feature = "cli")`.
- `ureq` — only used in `build.rs`, and already declared in `[build-dependencies]`. The Cargo.toml comment claimed it pinned fastembed's transitive ureq to 2.x, but fastembed pulls ureq via `hf-hub`, which already locks `ureq 2.12.1` itself — so the direct runtime dep was redundant.

`cargo machete` exits clean after this PR. No false-positive ignores were needed; `crates/observability/Cargo.toml` was clean both before and after.

## Test plan

- [x] `cargo machete` — clean
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — green
- [x] `cargo build --workspace --all-targets --all-features` — exercises `cli` (covers the `clap_complete` removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)