### PR TITLE
chore(deps): drop unused crates/core deps flagged by cargo-machete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,6 @@ dependencies = [
  "seahash",
  "serde",
  "serde_json",
- "serial_test",
  "sha2",
  "sled",
  "temp-env",
@@ -4229,15 +4228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4251,12 +4241,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -4459,32 +4443,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
-dependencies = [
- "futures-executor",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot 0.12.5",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -90,7 +90,12 @@ reqwest = { version = "0.11", features = ["json"] }
 tracing-subscriber = "0.3"
 wat = "1"
 temp-env = "0.3"
-serial_test = "3"
+
+# `ureq` and `zip` are real build-dependencies used by `build.rs`, but only
+# inside the `#[cfg(feature = "face-detection")]` module. cargo-machete doesn't
+# trace cfg-gated build-script imports, so it flags them as unused.
+[package.metadata.cargo-machete]
+ignored = ["ureq", "zip"]
 
 [lib]
 name = "fold_db"


### PR DESCRIPTION
## Summary

Mirror the [fold_db_node #862](https://github.com/EdgeVector/fold_db_node/pull/862) precedent for `crates/core/Cargo.toml`. Drops one truly-unused dep and ignores two false-positives so `cargo machete` lands silent on this crate.

`cargo machete --with-metadata` from the repo root flagged 3 entries on `crates/core/Cargo.toml`:

| Dep | Disposition | Why |
| --- | --- | --- |
| `serial_test` (dev-dep) | **Removed** | Genuinely unused — no `#[serial]` attribute or `serial_test` import anywhere in the workspace; only reference was Cargo.toml itself. |
| `ureq` (build-dep) | **Ignored** | Real use in `build.rs`, but only inside `#[cfg(feature = "face-detection")]`. cargo-machete doesn't trace cfg-gated build-script imports. |
| `zip` (build-dep) | **Ignored** | Same as `ureq` — used in the same cfg-gated build.rs module to extract the InsightFace model pack. |

`[package.metadata.cargo-machete]` block added with a one-line comment so future cleanups don't waste a round-trip relitigating these two.

## Verification

- `cargo machete --with-metadata` — silent
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo check --workspace --all-targets --all-features` — ureq/zip compile when face-detection is on
- `cargo test --workspace --lib` — all suites green
- `cargo fmt --check` — clean

## Out of scope

`crates/observability/Cargo.toml` is silent under both default and `--with-metadata` machete, so no changes there. The original task spec mentioned a 9-dep set; the other 6 (clap_complete, colored, futures-util, regex, ring, tokio-stream, toml) are no longer present in `crates/core/Cargo.toml` — earlier PRs (#691, #692, #694) already cleaned them up.

## Test plan

- [x] `cargo machete --with-metadata` silent on this branch
- [x] CI green (clippy, test, fmt)
- [x] auto-merge enabled with `--squash`