### PR TITLE
fix(field): make refresh_from_db fail loud on molecule deserialize errors

### DIFF
--- a/crates/core/src/fold_db_core/mutation_manager.rs
+++ b/crates/core/src/fold_db_core/mutation_manager.rs
@@ -316,7 +316,7 @@ impl MutationManager {
                 .or_insert(std::time::Duration::ZERO) += phase1_start.elapsed();
 
             // Phase 3: Restore molecules missing from memory
-            self.restore_missing_molecules(&mut schema).await;
+            self.restore_missing_molecules(&mut schema).await?;
 
             // Phase 4: Apply mutations to molecules in memory
             let phase2_start = std::time::Instant::now();
@@ -636,7 +636,12 @@ impl MutationManager {
 
     /// Ensures molecules are loaded from DB for fields that have molecule_uuid
     /// but no molecule in memory (e.g. after server restart or schema reload).
-    async fn restore_missing_molecules(&self, schema: &mut Schema) {
+    ///
+    /// Returns `Err(SchemaError::InvalidData)` when any field's stored
+    /// molecule ref fails to deserialize — fail loud rather than silently
+    /// continuing with a `None` molecule slot, which would make subsequent
+    /// reads return empty results and mask data corruption.
+    async fn restore_missing_molecules(&self, schema: &mut Schema) -> Result<(), SchemaError> {
         let fields_needing_refresh: Vec<String> = schema
             .runtime_fields
             .iter()
@@ -646,9 +651,10 @@ impl MutationManager {
 
         for field_name in fields_needing_refresh {
             if let Some(field) = schema.runtime_fields.get_mut(&field_name) {
-                field.refresh_from_db(&self.db_ops).await;
+                field.refresh_from_db(&self.db_ops).await?;
             }
         }
+        Ok(())
     }
 
     /// Applies atom writes to in-memory molecules, collecting mutation events

--- a/crates/core/src/schema/types/field/base.rs
+++ b/crates/core/src/schema/types/field/base.rs
@@ -1,5 +1,6 @@
 use super::common::FieldCommon;
 use crate::db_operations::DbOperations;
+use crate::schema::types::SchemaError;
 use serde::de::DeserializeOwned;
 
 /// Refresh a field's molecule state from the database.
@@ -10,52 +11,66 @@ use serde::de::DeserializeOwned;
 /// with an `org_hash` remain resolvable. See
 /// `docs/designs/org_shared_sync.md` — `set-org-hash` does not rewrite
 /// pre-existing keys.
+///
+/// A successful read populates `molecule_slot`. A read miss leaves the
+/// slot untouched and is not an error. A deserialize failure is fatal —
+/// it means the bytes at the ref key don't match `M`'s shape, which
+/// historically meant a cross-`schema_type` field_mapper carry-over had
+/// corrupted molecule storage (see fold_db_node PR #923). Returning
+/// `Err` makes the corruption surface immediately at the read/write
+/// boundary instead of silently returning empty results from
+/// `resolve_value`.
 pub async fn refresh_field_from_db<M>(
     inner: &mut FieldCommon,
     molecule_slot: &mut Option<M>,
     db_ops: &DbOperations,
-) where
+) -> Result<(), SchemaError>
+where
     M: DeserializeOwned + Send + Sync + Clone,
 {
-    if let Some(molecule_uuid) = inner.molecule_uuid() {
-        let base_key = format!("ref:{}", molecule_uuid);
-        let ref_key = inner.storage_key(&base_key);
-        use crate::storage::traits::TypedStore;
-        let store = db_ops.atoms().raw();
-        match store.get_item::<M>(&ref_key).await {
+    let Some(molecule_uuid) = inner.molecule_uuid().cloned() else {
+        return Ok(());
+    };
+    let base_key = format!("ref:{}", molecule_uuid);
+    let ref_key = inner.storage_key(&base_key);
+    use crate::storage::traits::TypedStore;
+    let store = db_ops.atoms().raw();
+    match store.get_item::<M>(&ref_key).await {
+        Ok(Some(molecule)) => {
+            *molecule_slot = Some(molecule);
+            return Ok(());
+        }
+        Ok(None) => {}
+        Err(e) => {
+            return Err(SchemaError::InvalidData(format!(
+                "refresh_field_from_db: failed to deserialize molecule ref \
+                 key={} target_type={} error={}",
+                ref_key,
+                std::any::type_name::<M>(),
+                e
+            )));
+        }
+    }
+
+    if inner.org_hash().is_some() {
+        match store.get_item::<M>(&base_key).await {
             Ok(Some(molecule)) => {
+                tracing::debug!(
+                    "refresh_field_from_db: resolved molecule via pre-tag (unprefixed) key"
+                );
                 *molecule_slot = Some(molecule);
-                return;
             }
             Ok(None) => {}
             Err(e) => {
-                // Non-fatal: molecule ref may be in an old serialization format.
-                // The field still works — data is read from atoms directly.
-                tracing::warn!(
-                    "refresh_field_from_db: skipping molecule ref for {}: {}",
-                    molecule_uuid,
+                return Err(SchemaError::InvalidData(format!(
+                    "refresh_field_from_db: failed to deserialize pre-tag molecule ref \
+                     key={} target_type={} error={}",
+                    base_key,
+                    std::any::type_name::<M>(),
                     e
-                );
-                return;
-            }
-        }
-
-        if inner.org_hash().is_some() {
-            match store.get_item::<M>(&base_key).await {
-                Ok(Some(molecule)) => {
-                    tracing::debug!(
-                        "refresh_field_from_db: resolved molecule via pre-tag (unprefixed) key"
-                    );
-                    *molecule_slot = Some(molecule);
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        "refresh_field_from_db: pre-tag fallback for molecule ref failed: {}",
-                        e
-                    );
-                }
+                )));
             }
         }
     }
+    Ok(())
 }

--- a/crates/core/src/schema/types/field/common.rs
+++ b/crates/core/src/schema/types/field/common.rs
@@ -52,7 +52,16 @@ pub trait Field: Send + Sync {
     fn common_mut(&mut self) -> &mut FieldCommon;
 
     /// Refreshes the field's data from the database using the provided key configuration.
-    async fn refresh_from_db(&mut self, db_ops: &crate::db_operations::DbOperations);
+    ///
+    /// Returns `Err(SchemaError::InvalidData)` when the on-disk molecule ref
+    /// fails to deserialize into the field's molecule type — that is fatal,
+    /// not a "skip and continue" case (a `None` molecule slot makes
+    /// `resolve_value` return empty results, which silently masks data
+    /// corruption). Read misses (no value at the ref key) are still `Ok(())`.
+    async fn refresh_from_db(
+        &mut self,
+        db_ops: &crate::db_operations::DbOperations,
+    ) -> Result<(), SchemaError>;
 
     /// Writes a mutation to the field
     fn write_mutation(&mut self, key_value: &KeyValue, ctx: WriteContext);
@@ -172,8 +181,16 @@ macro_rules! impl_field {
                 &mut self.inner
             }
 
-            async fn refresh_from_db(&mut self, db_ops: &$crate::db_operations::DbOperations) {
+            async fn refresh_from_db(
+                &mut self,
+                db_ops: &$crate::db_operations::DbOperations,
+            ) -> Result<(), $crate::schema::types::SchemaError> {
+                let _ = db_ops;
                 tracing::error!("refresh_from_db not implemented for {}", stringify!($t));
+                Err($crate::schema::types::SchemaError::InvalidField(format!(
+                    "refresh_from_db not implemented for {}",
+                    stringify!($t)
+                )))
             }
 
             fn write_mutation(

--- a/crates/core/src/schema/types/field/hash_field.rs
+++ b/crates/core/src/schema/types/field/hash_field.rs
@@ -50,8 +50,11 @@ impl crate::schema::types::field::Field for HashField {
         &mut self.inner
     }
 
-    async fn refresh_from_db(&mut self, db_ops: &crate::db_operations::DbOperations) {
-        refresh_field_from_db(&mut self.inner, &mut self.molecule, db_ops).await;
+    async fn refresh_from_db(
+        &mut self,
+        db_ops: &crate::db_operations::DbOperations,
+    ) -> Result<(), SchemaError> {
+        refresh_field_from_db(&mut self.inner, &mut self.molecule, db_ops).await
     }
 
     fn write_mutation(
@@ -113,7 +116,7 @@ impl crate::schema::types::field::Field for HashField {
         filter: Option<HashRangeFilter>,
         _as_of: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
-        self.refresh_from_db(db_ops).await;
+        self.refresh_from_db(db_ops).await?;
         let result = self.apply_filter(filter);
         // Attach per-key metadata + per-AtomEntry writer_pubkey from the
         // molecule to each match. The writer_pubkey is the only way Hash

--- a/crates/core/src/schema/types/field/hash_range_field.rs
+++ b/crates/core/src/schema/types/field/hash_range_field.rs
@@ -53,8 +53,11 @@ impl crate::schema::types::field::Field for HashRangeField {
         &mut self.inner
     }
 
-    async fn refresh_from_db(&mut self, db_ops: &crate::db_operations::DbOperations) {
-        refresh_field_from_db(&mut self.inner, &mut self.molecule, db_ops).await;
+    async fn refresh_from_db(
+        &mut self,
+        db_ops: &crate::db_operations::DbOperations,
+    ) -> Result<(), SchemaError> {
+        refresh_field_from_db(&mut self.inner, &mut self.molecule, db_ops).await
     }
 
     fn write_mutation(
@@ -132,7 +135,7 @@ impl crate::schema::types::field::Field for HashRangeField {
         filter: Option<HashRangeFilter>,
         _as_of: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
-        self.refresh_from_db(db_ops).await;
+        self.refresh_from_db(db_ops).await?;
         let result = self.apply_filter(filter);
         if result.matches.is_empty() {
             // No matches found

--- a/crates/core/src/schema/types/field/range_field.rs
+++ b/crates/core/src/schema/types/field/range_field.rs
@@ -74,8 +74,11 @@ impl crate::schema::types::field::Field for RangeField {
         &mut self.inner
     }
 
-    async fn refresh_from_db(&mut self, db_ops: &crate::db_operations::DbOperations) {
-        refresh_field_from_db(&mut self.inner, &mut self.molecule, db_ops).await;
+    async fn refresh_from_db(
+        &mut self,
+        db_ops: &crate::db_operations::DbOperations,
+    ) -> Result<(), SchemaError> {
+        refresh_field_from_db(&mut self.inner, &mut self.molecule, db_ops).await
     }
 
     fn write_mutation(
@@ -138,7 +141,7 @@ impl crate::schema::types::field::Field for RangeField {
         filter: Option<HashRangeFilter>,
         _as_of: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
-        self.refresh_from_db(db_ops).await;
+        self.refresh_from_db(db_ops).await?;
 
         // Fetch actual atom content from database using shared helper.
         // Attach per-key metadata + per-AtomEntry writer_pubkey from the

--- a/crates/core/src/schema/types/field/single_field.rs
+++ b/crates/core/src/schema/types/field/single_field.rs
@@ -41,8 +41,11 @@ impl crate::schema::types::field::Field for SingleField {
         &mut self.inner
     }
 
-    async fn refresh_from_db(&mut self, db_ops: &crate::db_operations::DbOperations) {
-        refresh_field_from_db(&mut self.inner, &mut self.molecule, db_ops).await;
+    async fn refresh_from_db(
+        &mut self,
+        db_ops: &crate::db_operations::DbOperations,
+    ) -> Result<(), SchemaError> {
+        refresh_field_from_db(&mut self.inner, &mut self.molecule, db_ops).await
     }
 
     fn write_mutation(
@@ -98,7 +101,7 @@ impl crate::schema::types::field::Field for SingleField {
         _filter: Option<HashRangeFilter>,
         _as_of: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
-        self.refresh_from_db(db_ops).await;
+        self.refresh_from_db(db_ops).await?;
         if let Some(molecule) = &self.molecule {
             let uuid = molecule.get_atom_uuid().clone();
             let key_meta = molecule.get_key_metadata().cloned();

--- a/crates/core/src/schema/types/field/variant.rs
+++ b/crates/core/src/schema/types/field/variant.rs
@@ -79,7 +79,7 @@ impl Field for FieldVariant {
         delegate_field_method!(self, common_mut)
     }
 
-    async fn refresh_from_db(&mut self, db_ops: &DbOperations) {
+    async fn refresh_from_db(&mut self, db_ops: &DbOperations) -> Result<(), SchemaError> {
         match self {
             Self::Single(f) => f.refresh_from_db(db_ops).await,
             Self::Hash(f) => f.refresh_from_db(db_ops).await,
@@ -103,7 +103,7 @@ impl Field for FieldVariant {
         as_of: Option<DateTime<Utc>>,
     ) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
         // Refresh field data from database first
-        self.refresh_from_db(db_ops).await;
+        self.refresh_from_db(db_ops).await?;
 
         // If as_of is requested, rewind molecule to that point in time
         if let Some(as_of) = as_of {


### PR DESCRIPTION
## Summary

`refresh_field_from_db` swallowed deserialize failures with a `tracing::warn!` and returned success, leaving `molecule_slot` as `None`. PR #470's comment claimed "the field still works, data is read from atoms directly" — but a `None` molecule makes `resolve_value` return `Ok(HashMap::new())` (empty), so the field silently drops every read.

This is the safety net behind fold_db_node PR [#923](https://github.com/EdgeVector/fold_db_node/pull/923) (cross-`schema_type` field_mapper carry-over corrupting molecule storage). #923 closed the known trigger at the ingestion boundary; this PR turns the safety net itself into a hard error so any future shape mismatch surfaces as `SchemaError::InvalidData` instead of silently returning empty.

Honors fold_db's Iron Law: "No silent failures — throw errors if anything goes wrong."

## Changes

- `refresh_field_from_db` returns `Result<(), SchemaError>`. Deserialize failure → `SchemaError::InvalidData` carrying ref key, target type (via `std::any::type_name::<M>()`), and underlying serde error. Read miss is still `Ok(())`.
- `Field::refresh_from_db` trait method, `impl_field!` default, all four impls (`SingleField`, `HashField`, `RangeField`, `HashRangeField`), and `FieldVariant` now return `Result<(), SchemaError>`.
- Each `Field::resolve_value` `?`-propagates the result.
- `MutationManager::restore_missing_molecules` propagates the error; the sole caller (`write_mutations_batch_async`) `?`s through (it already returns `Result<_, SchemaError>`).

On-disk format is unchanged. Only error propagation changes.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` green (664 lib + integration)
- [ ] Downstream fold_db_node bumps the rev; dogfood confirms zero `skipping molecule ref` WARNs and any future cross-type bug surfaces as `SchemaError::InvalidData`