### PR TITLE
feat(fold_db): inject Clock into FoldDB so consumers can drive TriggerRunner with MockClock

### DIFF
--- a/crates/core/src/fold_db_core/factory.rs
+++ b/crates/core/src/fold_db_core/factory.rs
@@ -7,6 +7,7 @@ use crate::storage::config::DatabaseConfig;
 use crate::storage::node_config_store::NodeConfigStore;
 use crate::storage::SledPool;
 use crate::sync::SyncSetup;
+use crate::triggers::clock::{Clock, SystemClock};
 use std::sync::Arc;
 
 /// Creates a fully initialized FoldDB instance based on the database configuration.
@@ -24,6 +25,35 @@ pub async fn create_fold_db(
     signer: Arc<Ed25519KeyPair>,
 ) -> FoldDbResult<Arc<FoldDB>> {
     create_fold_db_with_auth_refresh(config, e2e_keys, signer, None).await
+}
+
+/// Creates a `FoldDB` instance whose embedded `TriggerRunner` is driven by
+/// the supplied [`Clock`].
+///
+/// This is the test-injection seam for fold_db consumers (notably
+/// fold_dev_node) that want to drive `Scheduled` / `ScheduledIfDirty`
+/// triggers deterministically with `MockClock::advance` — no real
+/// `tokio::time::sleep`, no flaky timing-based assertions.
+///
+/// Cloud-sync paths are intentionally excluded here: the test factory
+/// configures only the local Sled stack so callers can wire a `MockClock`
+/// without spinning up the sync engine. Production wiring with cloud sync
+/// stays on [`create_fold_db`] / [`create_fold_db_with_auth_refresh`],
+/// which inject `SystemClock`.
+pub async fn create_fold_db_with_clock<C: Clock>(
+    config: &DatabaseConfig,
+    e2e_keys: &E2eKeys,
+    signer: Arc<Ed25519KeyPair>,
+    clock: Arc<C>,
+) -> FoldDbResult<Arc<FoldDB<C>>> {
+    if config.cloud_sync.is_some() {
+        return Err(FoldDbError::Config(
+            "create_fold_db_with_clock does not support cloud_sync; \
+             cloud-sync paths use SystemClock through create_fold_db"
+                .to_string(),
+        ));
+    }
+    create_local_fold_db(&config.path, e2e_keys, signer, None, None, clock).await
 }
 
 /// Creates a FoldDB instance with an optional auth-refresh callback for the sync engine.
@@ -69,7 +99,15 @@ pub async fn create_fold_db_with_pool_and_auth_refresh(
         None
     };
 
-    let db = create_local_fold_db(&config.path, e2e_keys, signer, sync_setup, pool).await?;
+    let db = create_local_fold_db(
+        &config.path,
+        e2e_keys,
+        signer,
+        sync_setup,
+        pool,
+        Arc::new(SystemClock::new()),
+    )
+    .await?;
 
     // If cloud sync is configured, persist ONLY api_url and user_hash to Sled.
     // API keys and session tokens are per-device secrets stored in credentials.json
@@ -103,13 +141,14 @@ pub async fn create_fold_db_with_pool_and_auth_refresh(
 ///       |
 /// SledNamespacedStore        (local persistence)
 /// ```
-async fn create_local_fold_db(
+async fn create_local_fold_db<C: Clock>(
     path: &std::path::Path,
     e2e_keys: &E2eKeys,
     signer: Arc<Ed25519KeyPair>,
     sync_setup: Option<SyncSetup>,
     injected_pool: Option<Arc<SledPool>>,
-) -> FoldDbResult<Arc<FoldDB>> {
+    clock: Arc<C>,
+) -> FoldDbResult<Arc<FoldDB<C>>> {
     let path_str = path
         .to_str()
         .ok_or_else(|| FoldDbError::Config("Invalid storage path".to_string()))?;
@@ -252,7 +291,7 @@ async fn create_local_fold_db(
 
     let job_store = crate::progress::create_tracker_with_sled(Arc::clone(&pool));
 
-    let fold_db = FoldDB::initialize_from_db_ops_with_sled(
+    let fold_db = FoldDB::<C>::initialize_from_db_ops_with_sled_and_clock(
         Arc::new(db_ops),
         path_str,
         Some(job_store),
@@ -260,6 +299,7 @@ async fn create_local_fold_db(
         Some(pool),
         enc_store_ref,
         signer,
+        clock,
     )
     .await
     .map_err(|e| FoldDbError::Config(e.to_string()))?;

--- a/crates/core/src/fold_db_core/fold_db.rs
+++ b/crates/core/src/fold_db_core/fold_db.rs
@@ -27,10 +27,15 @@ use super::trigger_runner::{
 use crate::messaging::AsyncMessageBus;
 use crate::progress::ProgressStore as JobStore;
 use crate::progress::ProgressTracker;
-use crate::triggers::clock::SystemClock;
+use crate::triggers::clock::{Clock, SystemClock};
 
 /// The main database coordinator that manages schemas, permissions, and data storage.
-pub struct FoldDB {
+///
+/// Generic over a `Clock` so consumers can swap in `MockClock` to drive the
+/// embedded `TriggerRunner` deterministically in tests. The default
+/// `SystemClock` keeps existing `Arc<FoldDB>` callers (factory, downstream
+/// crates) source-compatible.
+pub struct FoldDB<C: Clock = SystemClock> {
     pub(crate) schema_manager: Arc<SchemaCore>,
     /// Shared database operations with storage abstraction
     pub(crate) db_ops: Arc<DbOperations>,
@@ -51,7 +56,7 @@ pub struct FoldDB {
     /// Trigger runner — the single source of truth for firing views.
     /// Held as `dyn TriggerShutdown` so callers can `clear_dispatcher`
     /// during shutdown to break the Arc cycle with MutationManager.
-    trigger_runner: Arc<TriggerRunner<SystemClock>>,
+    trigger_runner: Arc<TriggerRunner<C>>,
     /// Shutdown notifier for the trigger runner's scheduler loop.
     trigger_shutdown: Arc<tokio::sync::Notify>,
     /// Tracker for pending background tasks
@@ -74,7 +79,7 @@ pub struct FoldDB {
     pub(crate) signer: Arc<crate::security::Ed25519KeyPair>,
 }
 
-impl FoldDB {
+impl<C: Clock> FoldDB<C> {
     /// Retrieves or generates and persists the node identifier.
     pub async fn get_node_id(&self) -> Result<String, crate::storage::StorageError> {
         self.db_ops
@@ -279,7 +284,13 @@ impl FoldDB {
                 .await;
         }
     }
+}
 
+/// Constructors that hardcode the production `SystemClock`. Tests that
+/// need `MockClock` go through
+/// [`super::factory::create_fold_db_with_clock`] (which calls
+/// [`FoldDB::initialize_from_db_ops_with_sled_and_clock`] directly).
+impl FoldDB<SystemClock> {
     /// Creates a new FoldDB instance with the specified storage path.
     ///
     /// This is a convenience path for tests and other in-process callers
@@ -400,6 +411,36 @@ impl FoldDB {
         .await
     }
 
+    /// Backwards-compatible thin wrapper around
+    /// [`FoldDB::initialize_from_db_ops_with_sled_and_clock`] that injects
+    /// the production `SystemClock`. Existing in-process callers (the
+    /// factory, `FoldDB::new`) reach the runner through this entry point;
+    /// tests that need a `MockClock` call `_and_clock` directly via
+    /// [`super::factory::create_fold_db_with_clock`].
+    pub async fn initialize_from_db_ops_with_sled(
+        db_ops: Arc<DbOperations>,
+        db_path: &str,
+        job_store: Option<Arc<dyn JobStore>>,
+        user_id: String,
+        sled_pool: Option<Arc<SledPool>>,
+        encrypting_store: Option<Arc<crate::storage::EncryptingNamespacedStore>>,
+        signer: Arc<crate::security::Ed25519KeyPair>,
+    ) -> Result<Self, StorageError> {
+        Self::initialize_from_db_ops_with_sled_and_clock(
+            db_ops,
+            db_path,
+            job_store,
+            user_id,
+            sled_pool,
+            encrypting_store,
+            signer,
+            Arc::new(SystemClock::new()),
+        )
+        .await
+    }
+}
+
+impl<C: Clock> FoldDB<C> {
     /// Internal initializer that optionally retains the SledPool handle.
     /// The pool is needed by org operations and org sync configuration.
     ///
@@ -409,7 +450,13 @@ impl FoldDB {
     /// `MutationManager`. Production callers (via the factory) must load
     /// this from the node's persistent identity so signatures match the
     /// node's public key — see the module docs on [`FoldDB::new`] for why.
-    pub async fn initialize_from_db_ops_with_sled(
+    ///
+    /// `clock` is the wall-clock service injected into the embedded
+    /// `TriggerRunner`. Production paths pass an `Arc<SystemClock>`; tests
+    /// pass an `Arc<MockClock>` so `MockClock::advance` can drive the
+    /// scheduler deterministically. See [`super::factory::create_fold_db_with_clock`].
+    #[allow(clippy::too_many_arguments)]
+    pub async fn initialize_from_db_ops_with_sled_and_clock(
         db_ops: Arc<DbOperations>,
         _db_path: &str,
         job_store: Option<Arc<dyn JobStore>>,
@@ -417,6 +464,7 @@ impl FoldDB {
         sled_pool: Option<Arc<SledPool>>,
         encrypting_store: Option<Arc<crate::storage::EncryptingNamespacedStore>>,
         signer: Arc<crate::security::Ed25519KeyPair>,
+        clock: Arc<C>,
     ) -> Result<Self, StorageError> {
         // Initialize message bus
         let message_bus = Arc::new(AsyncMessageBus::new());
@@ -491,7 +539,7 @@ impl FoldDB {
             Arc::clone(&schema_manager),
             Arc::clone(&view_orchestrator),
             sled_pool.clone(),
-            Arc::new(SystemClock::new()),
+            clock,
             firing_writer,
             signer.public_key_base64(),
         ));
@@ -683,7 +731,7 @@ impl FoldDB {
 
     /// Get the trigger runner — primarily used by integration tests and
     /// admin endpoints that want to inspect pending/quarantined state.
-    pub fn trigger_runner(&self) -> &Arc<TriggerRunner<SystemClock>> {
+    pub fn trigger_runner(&self) -> &Arc<TriggerRunner<C>> {
         &self.trigger_runner
     }
 
@@ -693,7 +741,7 @@ impl FoldDB {
     }
 }
 
-impl Drop for FoldDB {
+impl<C: Clock> Drop for FoldDB<C> {
     fn drop(&mut self) {
         // Abort the background sync task to prevent tokio panic:
         // "Cannot drop a runtime in a context where blocking is not allowed"

--- a/crates/core/tests/clock_injection_test.rs
+++ b/crates/core/tests/clock_injection_test.rs
@@ -1,0 +1,222 @@
+//! Integration test: drive `TriggerRunner` deterministically with a
+//! `MockClock` injected via [`fold_db::fold_db_core::factory::create_fold_db_with_clock`].
+//!
+//! Guards against regressing the clock-injection seam that consumers
+//! (notably fold_dev_node) rely on for testing `Trigger::Scheduled`
+//! behavior without `tokio::time::sleep`. A break here means a downstream
+//! test that does `MockClock::advance(60_000)` to step a 60-second cron
+//! tick will silently hang or flake.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use fold_db::crypto::E2eKeys;
+use fold_db::fold_db_core::factory::create_fold_db_with_clock;
+use fold_db::fold_db_core::FoldDB;
+use fold_db::schema::types::field_value_type::FieldValueType;
+use fold_db::schema::types::key_config::KeyConfig;
+use fold_db::schema::types::operations::Query;
+use fold_db::schema::types::schema::DeclarativeSchemaType as SchemaType;
+use fold_db::schema::SchemaState;
+use fold_db::security::Ed25519KeyPair;
+use fold_db::storage::config::DatabaseConfig;
+use fold_db::test_helpers::TestSchemaBuilder;
+use fold_db::triggers::clock::{Clock, MockClock};
+use fold_db::triggers::types::Trigger;
+use fold_db::triggers::{fields, TRIGGER_FIRING_SCHEMA_NAME};
+use fold_db::view::types::TransformView;
+
+fn source_schema_json(name: &str) -> String {
+    TestSchemaBuilder::new(name)
+        .fields(&["f1"])
+        .range_key("f_key")
+        .build_json()
+}
+
+fn scheduled_view(name: &str, source: &str, cron: &str) -> TransformView {
+    let mut view = TransformView::new(
+        name,
+        SchemaType::Range,
+        Some(KeyConfig::new(None, Some("f_key".to_string()))),
+        vec![Query::new(source.to_string(), vec!["f1".to_string()])],
+        None,
+        HashMap::from([("f1".to_string(), FieldValueType::Any)]),
+    );
+    view.triggers = vec![Trigger::Scheduled {
+        cron: cron.to_string(),
+        timezone: "UTC".to_string(),
+        max_catch_up_age: None,
+        skip_if_idle: false,
+        schemas: vec![source.to_string()],
+    }];
+    view
+}
+
+async fn scan_trigger_firings(
+    db: &FoldDB<MockClock>,
+    view_name: &str,
+) -> Vec<HashMap<String, serde_json::Value>> {
+    let q = Query::new(
+        TRIGGER_FIRING_SCHEMA_NAME.to_string(),
+        vec![
+            fields::TRIGGER_ID.to_string(),
+            fields::VIEW_NAME.to_string(),
+            fields::FIRED_AT.to_string(),
+            fields::STATUS.to_string(),
+        ],
+    );
+    let results = db
+        .query_executor()
+        .query(q)
+        .await
+        .expect("query TriggerFiring");
+
+    let mut rows: HashMap<(Option<String>, Option<String>), HashMap<String, serde_json::Value>> =
+        HashMap::new();
+    for (field_name, entries) in results {
+        for (kv, fv) in entries {
+            let key = (kv.hash.clone(), kv.range.clone());
+            rows.entry(key)
+                .or_default()
+                .insert(field_name.clone(), fv.value.clone());
+        }
+    }
+    rows.into_values()
+        .filter(|row| {
+            row.get(fields::VIEW_NAME)
+                .and_then(|v| v.as_str())
+                .map(|s| s == view_name)
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// Poll `pred` every 5 ms up to `timeout`. Useful while waiting for the
+/// scheduler task to react to a `MockClock::advance` — we can't tie into
+/// the scheduler's wakeup cycle directly, so we observe its side
+/// effects (parked sleepers, persisted firing rows).
+async fn wait_until<F: Fn() -> bool>(pred: F, label: &str, timeout: Duration) {
+    let start = std::time::Instant::now();
+    while !pred() {
+        if start.elapsed() > timeout {
+            panic!("timeout waiting for: {label}");
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+/// Async-predicate variant of [`wait_until`] for cases where the
+/// observation requires hitting an async API (e.g. querying TriggerFiring
+/// rows through the executor).
+async fn wait_for<F, Fut>(pred: F, label: &str, timeout: Duration)
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let start = std::time::Instant::now();
+    loop {
+        if pred().await {
+            return;
+        }
+        if start.elapsed() > timeout {
+            panic!("timeout waiting for: {label}");
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_clock_advance_fires_scheduled_trigger() {
+    let tmp = tempfile::tempdir().unwrap();
+    let secret = [42u8; 32];
+    let e2e_keys = E2eKeys::from_secret(&secret);
+    let signer = Arc::new(Ed25519KeyPair::generate().unwrap());
+    let config = DatabaseConfig::local(tmp.path().to_path_buf());
+
+    // MockClock starts at the unix epoch. With cron `* * * * *` the
+    // first fire lands at 60_000 ms; after the runner discovers the view
+    // (idle 60s wake), the next fire computes to 120_000 ms.
+    let clock = Arc::new(MockClock::new(0));
+    let db = create_fold_db_with_clock(&config, &e2e_keys, signer, Arc::clone(&clock))
+        .await
+        .expect("create_fold_db_with_clock");
+
+    // Production fold_db loads the TriggerFiring schema via fold_db_node's
+    // schema-fetch path. Tests that boot a bare FoldDB seed it directly so
+    // the audit-row writer has a target schema.
+    fold_db::triggers::register_trigger_firing_schema(&db.schema_manager())
+        .await
+        .unwrap();
+
+    db.load_schema_from_json(&source_schema_json("S1"))
+        .await
+        .unwrap();
+    db.schema_manager()
+        .set_schema_state("S1", SchemaState::Approved)
+        .await
+        .unwrap();
+
+    db.schema_manager()
+        .register_view(scheduled_view("V1", "S1", "* * * * *"))
+        .await
+        .unwrap();
+
+    // Wait for the scheduler's idle 60s sleeper to register so we know
+    // it's parked before we advance.
+    wait_until(
+        || clock.pending_sleeps() == 1,
+        "scheduler parked on initial idle sleep",
+        Duration::from_secs(2),
+    )
+    .await;
+
+    // No firings yet — clock has not advanced.
+    assert!(
+        scan_trigger_firings(&db, "V1").await.is_empty(),
+        "expected no firings before advance"
+    );
+
+    // Wake 1: the runner's idle 60s poll fires, the populate pass
+    // discovers V1 and queues the next fire at 120_000 ms.
+    clock.advance(60_000);
+    wait_until(
+        || clock.now_ms() == 60_000 && clock.pending_sleeps() == 1,
+        "scheduler re-parked after registry populate",
+        Duration::from_secs(2),
+    )
+    .await;
+
+    // Wake 2: now == fire deadline, dispatch_nonblocking fires the view
+    // and writes a TriggerFiring audit row through MutationManager.
+    clock.advance(60_000);
+
+    // Poll for the firing row — the dispatch path is async (spawned)
+    // and the audit-row write goes through MutationManager.
+    wait_for(
+        || async { !scan_trigger_firings(&db, "V1").await.is_empty() },
+        "TriggerFiring row for V1",
+        Duration::from_secs(5),
+    )
+    .await;
+    let rows = scan_trigger_firings(&db, "V1").await;
+
+    assert_eq!(
+        rows.len(),
+        1,
+        "expected exactly one TriggerFiring row for V1, got {:?}",
+        rows
+    );
+
+    let row = &rows[0];
+    assert_eq!(
+        row.get(fields::VIEW_NAME),
+        Some(&serde_json::json!("V1")),
+        "view_name"
+    );
+    assert_eq!(
+        row.get(fields::TRIGGER_ID),
+        Some(&serde_json::json!("V1:0")),
+        "trigger_id"
+    );
+}


### PR DESCRIPTION
## Summary

Make \`FoldDB<C: Clock = SystemClock>\` generic over a \`Clock\` so consumers (notably **fold_dev_node**) can inject \`MockClock\` and drive scheduled triggers deterministically with \`MockClock::advance\` instead of real \`tokio::time::sleep\`. The default type parameter keeps every existing \`Arc<FoldDB>\` caller source-compatible — \`FoldDB\` without type args resolves to \`FoldDB<SystemClock>\`, so the factory, downstream crates, and the existing 30+ tests using \`FoldDB::new\` all compile unchanged.

* Threads \`clock: Arc<C>\` through \`FoldDB::initialize_from_db_ops_with_sled_and_clock\`. The existing \`_with_sled\` entry point becomes a thin wrapper on \`impl FoldDB<SystemClock>\` that injects \`Arc::new(SystemClock::new())\`.
* Adds \`factory::create_fold_db_with_clock<C: Clock>\` returning \`Arc<FoldDB<C>>\`. Cloud-sync paths stay on \`create_fold_db\` / \`create_fold_db_with_auth_refresh\` (SystemClock); the new entry rejects configs with \`cloud_sync\` set so the test seam can't accidentally spin up the sync engine.
* Adds \`crates/core/tests/clock_injection_test.rs\` proving the seam end-to-end: boots FoldDB with \`MockClock::new(0)\`, registers a view with \`Trigger::Scheduled\` (cron \`* * * * *\`), advances the clock through the runner's two-phase wake cycle (idle 60s poll discovers the view, second tick fires it), and asserts exactly one TriggerFiring audit row lands.

This is fold_dev_node Phase 2 follow-up #1.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo build --workspace --all-targets\`
- [x] \`cargo test --workspace --all-targets\` (864 tests pass, including new clock_injection test)
- [x] \`cargo test --test clock_injection_test\`
- [x] \`bash scripts/lint-tracing-egress.sh --strict\`
- [x] \`bash scripts/lint-spawn-instrument.sh\`
- [x] \`bash scripts/lint-redaction.sh\`
- [ ] CI green
- [ ] Auto-merge enabled, PR lands on main

## Out of scope

- fold_dev_node consumer migration (separate kanban task)
- \`create_fold_db_with_auth_refresh\` / \`with_pool_and_auth_refresh\` clock variants (no consumer needs them yet — the new clock-aware entry covers fold_dev_node's test usage)