### PR TITLE
fix(core): convert warn-and-skip silent failures to fail-loud Err

### DIFF
--- a/crates/core/src/db_operations/core.rs
+++ b/crates/core/src/db_operations/core.rs
@@ -124,7 +124,11 @@ impl DbOperations {
             None
         } else {
             let mgr = NativeIndexManager::new(native_index_kv);
-            mgr.restore_from_store().await;
+            mgr.restore_from_store().await.map_err(|e| {
+                crate::storage::StorageError::BackendError(format!(
+                    "Failed to restore embedding index from store: {e}"
+                ))
+            })?;
             Some(mgr)
         };
 

--- a/crates/core/src/db_operations/native_index/embedding_index.rs
+++ b/crates/core/src/db_operations/native_index/embedding_index.rs
@@ -123,14 +123,25 @@ impl EmbeddingIndex {
 
     /// Load all persisted embeddings from the KV store into memory.
     /// Handles both old (per-record) and new (per-fragment) formats.
-    pub(super) async fn load_from_store(store: &dyn KvStore) -> Vec<EmbeddingEntry> {
-        let raw = match store.scan_prefix(EMB_PREFIX.as_bytes()).await {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!("Failed to scan embedding index from store: {}", e);
-                return Vec::new();
-            }
-        };
+    ///
+    /// Returns `Err` when the underlying store scan fails. Previously this
+    /// silently returned an empty vec on scan failure, which left the
+    /// in-memory index empty and made every subsequent semantic search
+    /// silently return zero results — indistinguishable from "no
+    /// embeddings indexed". Per-entry deserialize failures are still
+    /// tolerated (forward-compat for old StoredEmbedding shapes).
+    pub(super) async fn load_from_store(
+        store: &dyn KvStore,
+    ) -> Result<Vec<EmbeddingEntry>, SchemaError> {
+        let raw = store
+            .scan_prefix(EMB_PREFIX.as_bytes())
+            .await
+            .map_err(|e| {
+                SchemaError::InvalidData(format!(
+                    "Failed to scan embedding index from store: {}",
+                    e
+                ))
+            })?;
 
         let mut entries = Vec::with_capacity(raw.len());
         for (_key, value) in raw {
@@ -153,7 +164,7 @@ impl EmbeddingIndex {
         }
 
         tracing::info!("Loaded {} embeddings from store", entries.len());
-        entries
+        Ok(entries)
     }
 
     /// Persist and upsert a single fragment embedding.
@@ -223,8 +234,11 @@ impl EmbeddingIndex {
 
     /// Reload embeddings from the store, adding any entries not already in the in-memory index.
     /// Returns the number of newly added entries.
-    pub(super) async fn reload_from_store(&self, store: &dyn KvStore) -> usize {
-        let new_entries = Self::load_from_store(store).await;
+    pub(super) async fn reload_from_store(
+        &self,
+        store: &dyn KvStore,
+    ) -> Result<usize, SchemaError> {
+        let new_entries = Self::load_from_store(store).await?;
         let mut current = self.entries.write().unwrap();
         let before = current.len();
 
@@ -257,7 +271,7 @@ impl EmbeddingIndex {
         if added > 0 {
             tracing::info!("reload_from_store: added {} new embeddings to index", added);
         }
-        added
+        Ok(added)
     }
 
     /// Remove all entries belonging to a specific org from the in-memory index.

--- a/crates/core/src/db_operations/native_index/mod.rs
+++ b/crates/core/src/db_operations/native_index/mod.rs
@@ -50,9 +50,15 @@ impl NativeIndexManager {
     }
 
     /// Load persisted embeddings from the store. Call this once after `new()` during node startup.
-    pub async fn restore_from_store(&self) {
-        let entries = EmbeddingIndex::load_from_store(&*self.store).await;
+    ///
+    /// Returns `Err` when the store scan fails. Startup must surface the
+    /// failure rather than booting with a silently-empty index — every
+    /// subsequent semantic search would otherwise return zero results
+    /// indistinguishable from "no embeddings indexed".
+    pub async fn restore_from_store(&self) -> Result<(), SchemaError> {
+        let entries = EmbeddingIndex::load_from_store(&*self.store).await?;
         *self.embedding_index.entries.write().unwrap() = entries;
+        Ok(())
     }
 
     #[cfg(test)]
@@ -115,7 +121,7 @@ impl NativeIndexManager {
     /// Reload embeddings from the persistent store into the in-memory index.
     /// Called after sync replays new native_index entries. Returns the count of
     /// newly added embeddings.
-    pub async fn reload_embeddings(&self) -> usize {
+    pub async fn reload_embeddings(&self) -> Result<usize, SchemaError> {
         self.embedding_index.reload_from_store(&*self.store).await
     }
 

--- a/crates/core/src/db_operations/native_index/tests.rs
+++ b/crates/core/src/db_operations/native_index/tests.rs
@@ -166,7 +166,7 @@ async fn test_restore_from_store_loads_existing_embeddings() {
 
     // Create manager 2 with same store, restore from store
     let mgr2 = NativeIndexManager::with_model(kv, Arc::new(MockEmbeddingModel));
-    mgr2.restore_from_store().await;
+    mgr2.restore_from_store().await.unwrap();
 
     let entries = mgr2.embedding_index.entries.read().unwrap();
     assert_eq!(entries.len(), 1);
@@ -228,6 +228,98 @@ async fn test_detect_faces_errors_without_processor() {
     let msg = format!("{:?}", result.unwrap_err());
     assert!(
         msg.contains("No face processor configured"),
+        "unexpected error: {}",
+        msg
+    );
+}
+
+/// KvStore that always fails on `scan_prefix`. Used to exercise the
+/// fail-loud path in `EmbeddingIndex::load_from_store`: the previous
+/// behavior silently returned an empty Vec, leaving every subsequent
+/// semantic search returning zero results indistinguishable from
+/// "no embeddings indexed".
+struct FailingScanKvStore;
+
+#[async_trait::async_trait]
+impl crate::storage::traits::KvStore for FailingScanKvStore {
+    async fn get(&self, _key: &[u8]) -> crate::storage::error::StorageResult<Option<Vec<u8>>> {
+        Ok(None)
+    }
+    async fn put(&self, _key: &[u8], _value: Vec<u8>) -> crate::storage::error::StorageResult<()> {
+        Ok(())
+    }
+    async fn delete(&self, _key: &[u8]) -> crate::storage::error::StorageResult<bool> {
+        Ok(false)
+    }
+    async fn exists(&self, _key: &[u8]) -> crate::storage::error::StorageResult<bool> {
+        Ok(false)
+    }
+    async fn scan_prefix(
+        &self,
+        _prefix: &[u8],
+    ) -> crate::storage::error::StorageResult<Vec<(Vec<u8>, Vec<u8>)>> {
+        Err(crate::storage::error::StorageError::BackendError(
+            "simulated scan failure".to_string(),
+        ))
+    }
+    async fn batch_put(
+        &self,
+        _items: Vec<(Vec<u8>, Vec<u8>)>,
+    ) -> crate::storage::error::StorageResult<()> {
+        Ok(())
+    }
+    async fn batch_delete(&self, _keys: Vec<Vec<u8>>) -> crate::storage::error::StorageResult<()> {
+        Ok(())
+    }
+    async fn flush(&self) -> crate::storage::error::StorageResult<()> {
+        Ok(())
+    }
+    fn backend_name(&self) -> &'static str {
+        "FailingScanKvStore"
+    }
+    fn execution_model(&self) -> crate::storage::traits::ExecutionModel {
+        crate::storage::traits::ExecutionModel::SyncWrapped
+    }
+    fn flush_behavior(&self) -> crate::storage::traits::FlushBehavior {
+        crate::storage::traits::FlushBehavior::NoOp
+    }
+}
+
+#[tokio::test]
+async fn test_restore_from_store_propagates_scan_failure() {
+    // When the underlying KvStore fails to scan the embedding prefix,
+    // `restore_from_store` must surface the error so node startup can
+    // refuse to boot with a silently-empty in-memory index. Previously
+    // this site logged a warn and returned an empty Vec, which made
+    // every subsequent semantic search silently return zero results.
+    let store: Arc<dyn crate::storage::traits::KvStore> = Arc::new(FailingScanKvStore);
+    let mgr = NativeIndexManager::with_model(store, Arc::new(MockEmbeddingModel));
+    let err = mgr
+        .restore_from_store()
+        .await
+        .expect_err("scan failure must propagate");
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("Failed to scan embedding index from store")
+            && msg.contains("simulated scan failure"),
+        "unexpected error: {}",
+        msg
+    );
+}
+
+#[tokio::test]
+async fn test_reload_embeddings_propagates_scan_failure() {
+    // `reload_embeddings` is called after sync replays — it too must
+    // surface scan failures rather than silently returning 0.
+    let store: Arc<dyn crate::storage::traits::KvStore> = Arc::new(FailingScanKvStore);
+    let mgr = NativeIndexManager::with_model(store, Arc::new(MockEmbeddingModel));
+    let err = mgr
+        .reload_embeddings()
+        .await
+        .expect_err("reload scan failure must propagate");
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("Failed to scan embedding index from store"),
         "unexpected error: {}",
         msg
     );

--- a/crates/core/src/db_operations/org_operations.rs
+++ b/crates/core/src/db_operations/org_operations.rs
@@ -145,7 +145,7 @@ mod tests {
             .unwrap();
 
         // Reload in-memory index so it picks up the entries we just wrote
-        nim.reload_embeddings().await;
+        nim.reload_embeddings().await.unwrap();
 
         // Verify both exist
         let val_p: Option<String> = atoms_store.get_item(personal_key).await.unwrap();

--- a/crates/core/src/fold_db_core/fold_db.rs
+++ b/crates/core/src/fold_db_core/fold_db.rs
@@ -141,8 +141,9 @@ impl<C: Clock> FoldDB<C> {
                 .set_embedding_reloader(Arc::new(move || {
                     let idx = embedding_index.clone();
                     Box::pin(async move {
-                        let count = idx.reload_embeddings().await;
-                        Ok(count)
+                        idx.reload_embeddings()
+                            .await
+                            .map_err(|e| format!("EmbeddingIndex reload failed: {e}"))
                     })
                 }))
                 .await;

--- a/crates/core/src/fold_db_core/trigger_runner.rs
+++ b/crates/core/src/fold_db_core/trigger_runner.rs
@@ -42,7 +42,7 @@ use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
-use tracing::{debug, info, warn, Instrument};
+use tracing::{debug, error, info, warn, Instrument};
 
 use super::view_orchestrator::ViewOrchestrator;
 use crate::schema::types::{KeyValue, Mutation};
@@ -1144,8 +1144,17 @@ impl<C: Clock> TriggerRunner<C> {
                 _ => continue,
             };
             let Some(next_at) = next_fire_from_cron(cron_expr, tz_str, now_ms) else {
-                warn!(
-                    "trigger '{}:{}': failed to compute next fire from cron='{}' tz='{}'",
+                // TODO(kanban c95c5): graduate this to a permanent
+                // FiringStatus::Skipped(SkipReason::InvalidCron) audit row
+                // so the user sees in their trigger UI that the schedule is
+                // broken, plus tighten upstream validation in
+                // schema_service::validate_cron at PUT /v1/views register
+                // time. Until then this `error!` is the only signal that a
+                // trigger is silently un-scheduled — a `warn!` was too quiet
+                // for an "your trigger never fires again" failure mode.
+                error!(
+                    "trigger '{}:{}': failed to compute next fire from cron='{}' tz='{}' \
+                     — trigger will not fire until cron/timezone is fixed (kanban c95c5)",
                     view_name, idx, cron_expr, tz_str
                 );
                 continue;

--- a/crates/core/src/schema/field_mapper.rs
+++ b/crates/core/src/schema/field_mapper.rs
@@ -87,21 +87,19 @@ impl FieldMapperService {
         for (target_field, mapper) in field_mappers {
             let source_schema_name = mapper.source_schema().to_string();
 
-            let source_schema = match self
+            let source_schema = self
                 .resolve_source_schema(&source_schema_name, &mut source_cache)
-                .await
-            {
-                Some(s) => s,
-                None => continue,
-            };
+                .await?;
 
             let Some(source_field) = source_schema.runtime_fields.get(mapper.source_field()) else {
-                tracing::warn!(
-                    "apply_field_mappers: source field '{}.{}' not in runtime_fields, skipping",
+                return Err(SchemaError::InvalidData(format!(
+                    "apply_field_mappers: source field '{}.{}' missing from runtime_fields \
+                     for schema '{}' (mapper points at a field that doesn't exist in the \
+                     source schema — this is a malformed FieldMapper)",
                     source_schema_name,
-                    mapper.source_field()
-                );
-                continue;
+                    mapper.source_field(),
+                    schema_name,
+                )));
             };
 
             // If the source field doesn't have a molecule UUID yet (no data written),
@@ -111,11 +109,12 @@ impl FieldMapperService {
             };
 
             let Some(target_runtime_field) = schema.runtime_fields.get_mut(&target_field) else {
-                tracing::warn!(
-                    "apply_field_mappers: target field '{}' not in runtime_fields, skipping",
-                    target_field
-                );
-                continue;
+                return Err(SchemaError::InvalidData(format!(
+                    "apply_field_mappers: target field '{}' missing from runtime_fields \
+                     for schema '{}' (the schema's own field_mappers reference a field \
+                     that isn't in runtime_fields — schema is internally inconsistent)",
+                    target_field, schema_name,
+                )));
             };
 
             target_runtime_field
@@ -149,34 +148,43 @@ impl FieldMapperService {
     /// Following that redirect would produce a circular lookup. We need the raw
     /// source schema with its original molecule UUIDs.
     ///
-    /// Returns `None` (with a warning log) if the source schema can't be loaded;
-    /// the caller should skip that mapper entry.
+    /// Returns `Err(SchemaError::InvalidData)` if the source schema is missing
+    /// (dangling mapper) or cannot be loaded — silently skipping a missing
+    /// source would leave the target schema's runtime fields without their
+    /// molecule UUIDs, making every read against the new schema return nothing
+    /// (data corruption surfaced as empty results).
     async fn resolve_source_schema<'a>(
         &self,
         source_schema_name: &str,
         source_cache: &'a mut HashMap<String, Schema>,
-    ) -> Option<&'a Schema> {
+    ) -> Result<&'a Schema, SchemaError> {
         if !source_cache.contains_key(source_schema_name) {
-            let fetched = match self.db_ops.get_schema(source_schema_name).await {
-                Ok(Some(s)) => s,
-                Ok(None) => {
-                    tracing::warn!(
-                        "apply_field_mappers: source schema '{}' not found, skipping its mappers",
-                        source_schema_name
-                    );
-                    return None;
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "apply_field_mappers: error loading source schema '{}': {}, skipping",
+            let fetched = self
+                .db_ops
+                .get_schema(source_schema_name)
+                .await
+                .map_err(|e| {
+                    SchemaError::InvalidData(format!(
+                        "apply_field_mappers: failed to load source schema '{}': {}",
+                        source_schema_name, e,
+                    ))
+                })?
+                .ok_or_else(|| {
+                    SchemaError::InvalidData(format!(
+                        "apply_field_mappers: source schema '{}' referenced by a FieldMapper \
+                     does not exist (dangling mapper — the source schema was deleted or \
+                     never installed)",
                         source_schema_name,
-                        e
-                    );
-                    return None;
-                }
-            };
+                    ))
+                })?;
             source_cache.insert(source_schema_name.to_string(), fetched);
         }
-        source_cache.get(source_schema_name)
+        source_cache.get(source_schema_name).ok_or_else(|| {
+            SchemaError::InvalidData(format!(
+                "apply_field_mappers: source schema '{}' missing from cache after insert \
+                 (unreachable)",
+                source_schema_name,
+            ))
+        })
     }
 }

--- a/crates/core/src/schema/types/field/filter_utils.rs
+++ b/crates/core/src/schema/types/field/filter_utils.rs
@@ -160,9 +160,17 @@ pub async fn fetch_atoms_with_key_metadata_async_with_org(
             Ok(None) => {
                 let key_str = key.to_string();
                 if org_hash.is_some() {
+                    // Intentional filter (not a bug-skip): the function-level
+                    // doc comment above explains that org-scoped reads must
+                    // tolerate orphan molecule refs whose pre-tag atoms never
+                    // replayed through the org log, otherwise every
+                    // unfiltered query on a shared schema is unusable. Personal
+                    // reads (the `else` branches below) still error-out, so
+                    // genuine integrity bugs surface there.
                     tracing::warn!(
-                        "Skipping unresolvable atom ref — pre-tag molecule ref leaked \
-                         without atom data (alpha BLOCKER 4b171)"
+                        "Filtering orphan atom ref from org-scoped read — pre-tag \
+                         molecule ref has no atom data, intentionally skipped per \
+                         alpha BLOCKER 4b171 design (see fetch_atoms_with_key_metadata_async_with_org docs)"
                     );
                     continue;
                 }

--- a/crates/core/src/sync/engine.rs
+++ b/crates/core/src/sync/engine.rs
@@ -2088,11 +2088,17 @@ impl SyncEngine {
             // keys come back as `snapshots/{name}` — we want the bare
             // `{name}` for the delete request.
             let Some(name) = obj.key.strip_prefix("snapshots/") else {
-                tracing::warn!(
-                    "purge_personal_log: skipping snapshot key '{}' that doesn't start with 'snapshots/'",
-                    obj.key
-                );
-                continue;
+                // The Lambda's list_snapshot_objects contract is that every
+                // returned key starts with `snapshots/`. A non-`snapshots/`
+                // key here means the contract was violated upstream — fail
+                // loud rather than silently skipping (and possibly leaving
+                // stale snapshots behind on a "purge" call). Mirrors the
+                // defense-in-depth check on `targets[0]` above.
+                return Err(SyncError::Auth(format!(
+                    "purge_personal_log: snapshot key '{}' did not start with 'snapshots/' \
+                     (Lambda list_snapshot_objects contract violation)",
+                    obj.key,
+                )));
             };
             let url = self.auth.presign_snapshot_delete(name).await?;
             self.s3.delete(&url).await?;

--- a/crates/core/tests/field_mapper_approval_test.rs
+++ b/crates/core/tests/field_mapper_approval_test.rs
@@ -1,5 +1,6 @@
 use fold_db::atom::deterministic_molecule_uuid;
 use fold_db::schema::types::field::Field;
+use fold_db::schema::types::SchemaError;
 use fold_db::schema::{SchemaCore, SchemaState};
 use fold_db::test_helpers::TestSchemaBuilder;
 
@@ -83,4 +84,82 @@ async fn approving_schema_applies_field_mappers() {
         deterministic_molecule_uuid("User", "name"),
         "display_name should map to User.name's molecule"
     );
+}
+
+#[tokio::test]
+async fn approving_schema_with_dangling_source_schema_errors() {
+    // A FieldMapper that points at a source schema that does not exist
+    // must surface as a hard error at approval time. Silently skipping
+    // would leave the target field without its molecule UUID and turn
+    // every read against the new schema into an empty result.
+    let core = SchemaCore::new_for_testing().await.expect("init core");
+
+    // Note: we never load a "User" source schema — the mapper is dangling.
+    let target = TestSchemaBuilder::new("UserPublic")
+        .fields(&["id", "display_name"])
+        .range_key("created_at")
+        .field_mapper("id", "User.id")
+        .build_json();
+    core.load_schema_from_json(&target)
+        .await
+        .expect("load target schema");
+
+    let err = core
+        .set_schema_state("UserPublic", SchemaState::Approved)
+        .await
+        .expect_err("approval should reject dangling source schema");
+
+    match err {
+        SchemaError::InvalidData(msg) => {
+            assert!(
+                msg.contains("source schema 'User'") && msg.contains("does not exist"),
+                "expected dangling-source-schema error, got: {msg}",
+            );
+        }
+        other => panic!("expected SchemaError::InvalidData, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn approving_schema_with_missing_source_field_errors() {
+    // FieldMapper's source_field references a field that doesn't exist in
+    // the source schema's runtime_fields. A malformed mapper like this
+    // means the schema is internally inconsistent — fail loud at approval
+    // rather than silently dropping the mapping.
+    let core = SchemaCore::new_for_testing().await.expect("init core");
+
+    // Source schema 'User' exists but does NOT have a 'phantom' field.
+    let source = TestSchemaBuilder::new("User")
+        .fields(&["id", "name"])
+        .range_key("created_at")
+        .build_json();
+    core.load_schema_from_json(&source)
+        .await
+        .expect("load source");
+
+    // Target schema points at User.phantom — the field is missing.
+    let target = TestSchemaBuilder::new("UserPublic")
+        .fields(&["display_name"])
+        .range_key("created_at")
+        .field_mapper("display_name", "User.phantom")
+        .build_json();
+    core.load_schema_from_json(&target)
+        .await
+        .expect("load target");
+
+    let err = core
+        .set_schema_state("UserPublic", SchemaState::Approved)
+        .await
+        .expect_err("approval should reject missing source field");
+
+    match err {
+        SchemaError::InvalidData(msg) => {
+            assert!(
+                msg.contains("source field 'User.phantom'")
+                    && msg.contains("missing from runtime_fields"),
+                "expected missing-source-field error, got: {msg}",
+            );
+        }
+        other => panic!("expected SchemaError::InvalidData, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary

Audit pass over `crates/core/src` mirroring [#696](https://github.com/EdgeVector/fold_db/pull/696) (`refresh_from_db` molecule deserialize errors) and the cross-`schema_type` rejection PR. Eight `tracing::warn!` + `continue|return None|Vec::new` sites were classified; five (a)-class genuine fail-silent paths are converted to hard errors so corrupt input shapes surface immediately instead of returning empty/default results.

## Classification table

| # | File:Line | Class | Action |
|---|-----------|-------|--------|
| 1 | `schema/field_mapper.rs:99` source field not in runtime_fields | (a) | Return `Err(SchemaError::InvalidData)` — malformed FieldMapper |
| 2 | `schema/field_mapper.rs:114` target field not in runtime_fields | (a) | Return `Err` — schema internally inconsistent |
| 3 | `schema/field_mapper.rs:163` source schema not found | (a) | Threaded `Result` through `resolve_source_schema` — dangling mapper |
| 4 | `schema/field_mapper.rs:170` source schema load error | (a) | Propagate via `?` instead of swallowing |
| 5 | `db_operations/native_index/embedding_index.rs:130` scan failure | (a) | `Result<Vec, SchemaError>`, propagated through `restore_from_store` and `reload_embeddings` to `DbOperations::new` and the `SyncEngine` embedding reloader callback |
| 6 | `fold_db_core/trigger_runner.rs:1147` cron parse fail | (c) | Escalated `warn!` → `error!`, added TODO referencing follow-up kanban `c95c5`. Full fix needs a new `SkipReason::InvalidCron` audit-row variant + upstream `validate_cron` at `PUT /v1/views` register time in schema_service |
| 7 | `schema/types/field/filter_utils.rs:163` org-scoped pre-tag molecule ref | (b) | The function-level doc comment already documents this as an intentional alpha-blocker filter (4b171). Rewrote the warn message to read as a filter ("Filtering orphan atom ref…") rather than a bug-skip ("Skipping unresolvable…") so future readers don't confuse it with (a). I disagree with the prompt's "graduate to error" suggestion — see review note below |
| 8 | `sync/engine.rs:2091` snapshot key prefix violation | (a) | `Err(SyncError::Auth)` — Lambda `list_snapshot_objects` contract violation; mirrors the `targets[0]` defense-in-depth pattern just above |

### Reviewer note on (b) site #7

The task brief said "graduate to error". I kept the skip and only retagged the message because the function-level doc comment at `fetch_atoms_with_key_metadata_async_with_org` (lines 86-91) explicitly says: *"For org-scoped reads, if BOTH lookups miss we log a warning and SKIP the ref rather than returning an error (alpha BLOCKER 4b171). Rationale: when Alice tags a schema post-ingest, only post-tag atoms ship through the org log; a receiver (Bob) may hold a molecule ref whose pre-tag atom never replayed. Failing the whole query on one orphan ref would make every unfiltered query on a shared schema unusable."* If the alpha BLOCKER was lifted upstream and this is now safe to fail loud, happy to flip in a follow-up — but I didn't see evidence and didn't want to silently make alpha shared schemas unusable.

## Tests

Added integration tests for the (a) sites I could exercise without standing up new mock infrastructure:

- `crates/core/tests/field_mapper_approval_test.rs::approving_schema_with_dangling_source_schema_errors` — covers site #3
- `crates/core/tests/field_mapper_approval_test.rs::approving_schema_with_missing_source_field_errors` — covers site #1
- `crates/core/src/db_operations/native_index/tests.rs::test_restore_from_store_propagates_scan_failure` — covers site #5 (startup path)
- `crates/core/src/db_operations/native_index/tests.rs::test_reload_embeddings_propagates_scan_failure` — covers site #5 (post-sync reload path)

Sites #2 (target field missing in own runtime_fields) and #4 (DB error loading source schema) are defensive-only paths not reachable without bypassing the schema interpreter or injecting a failing Sled — left untested and called out here so a future author knows.

Site #8 has no test in this PR. Mocking `purge_personal_log` requires AuthClient + S3Client mocks that don't exist yet (`AuthClient` is a concrete type, not a trait). The change is a 5-line `let-else` mirroring the `targets[0]` defense-in-depth check just above which is also untested for the same reason — adding test scaffolding here is its own task.

## Follow-ups filed

- Kanban `c95c5` (in `EdgeVector/fold_db`): graduate `trigger_runner.rs` cron-parse failure from `error!` log to permanent `SkipReason::InvalidCron` audit row, plus tighten upstream `validate_cron` in schema_service. Referenced from a TODO in `populate_scheduled_from_registry`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo build` in `fold_db_node` and `schema_service` against this rev via `[patch]` override (not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)