### PR TITLE
refactor(storage): collapse 29 boilerplate map_err sites in sled_backend via From impls

### DIFF
--- a/crates/core/src/storage/error.rs
+++ b/crates/core/src/storage/error.rs
@@ -31,4 +31,16 @@ pub enum StorageError {
     EncryptionError(String),
 }
 
+impl From<sled::Error> for StorageError {
+    fn from(e: sled::Error) -> Self {
+        Self::SledError(e.to_string())
+    }
+}
+
+impl From<tokio::task::JoinError> for StorageError {
+    fn from(e: tokio::task::JoinError) -> Self {
+        Self::BackendError(e.to_string())
+    }
+}
+
 pub type StorageResult<T> = Result<T, StorageError>;

--- a/crates/core/src/storage/sled_backend.rs
+++ b/crates/core/src/storage/sled_backend.rs
@@ -29,17 +29,10 @@ impl KvStore for SledKvStore {
 
         tokio::task::spawn_blocking(move || {
             let guard = pool.acquire_arc()?;
-            let tree = guard
-                .db()
-                .open_tree(&tree_name)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
-            tree.get(&key)
-                .map_err(|e| StorageError::SledError(e.to_string()))?
-                .map(|ivec| Ok(ivec.to_vec()))
-                .transpose()
+            let tree = guard.db().open_tree(&tree_name)?;
+            tree.get(&key)?.map(|ivec| Ok(ivec.to_vec())).transpose()
         })
-        .await
-        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .await?
     }
 
     async fn put(&self, key: &[u8], value: Vec<u8>) -> StorageResult<()> {
@@ -49,18 +42,12 @@ impl KvStore for SledKvStore {
 
         tokio::task::spawn_blocking(move || -> Result<(), StorageError> {
             let guard = pool.acquire_arc()?;
-            let tree = guard
-                .db()
-                .open_tree(&tree_name)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
-            tree.insert(&key, value)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
-            tree.flush()
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
+            let tree = guard.db().open_tree(&tree_name)?;
+            tree.insert(&key, value)?;
+            tree.flush()?;
             Ok(())
         })
-        .await
-        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .await?
     }
 
     async fn delete(&self, key: &[u8]) -> StorageResult<bool> {
@@ -70,18 +57,11 @@ impl KvStore for SledKvStore {
 
         tokio::task::spawn_blocking(move || {
             let guard = pool.acquire_arc()?;
-            let tree = guard
-                .db()
-                .open_tree(&tree_name)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
-            let existed = tree
-                .remove(&key)
-                .map_err(|e| StorageError::SledError(e.to_string()))?
-                .is_some();
+            let tree = guard.db().open_tree(&tree_name)?;
+            let existed = tree.remove(&key)?.is_some();
             Ok(existed)
         })
-        .await
-        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .await?
     }
 
     async fn exists(&self, key: &[u8]) -> StorageResult<bool> {
@@ -89,17 +69,12 @@ impl KvStore for SledKvStore {
         let tree_name = self.tree_name.clone();
         let key = key.to_vec();
 
-        tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || -> StorageResult<bool> {
             let guard = pool.acquire_arc()?;
-            let tree = guard
-                .db()
-                .open_tree(&tree_name)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
-            tree.contains_key(&key)
-                .map_err(|e| StorageError::SledError(e.to_string()))
+            let tree = guard.db().open_tree(&tree_name)?;
+            Ok(tree.contains_key(&key)?)
         })
-        .await
-        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .await?
     }
 
     async fn scan_prefix(&self, prefix: &[u8]) -> StorageResult<Vec<(Vec<u8>, Vec<u8>)>> {
@@ -109,20 +84,15 @@ impl KvStore for SledKvStore {
 
         tokio::task::spawn_blocking(move || {
             let guard = pool.acquire_arc()?;
-            let tree = guard
-                .db()
-                .open_tree(&tree_name)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
+            let tree = guard.db().open_tree(&tree_name)?;
             tree.scan_prefix(&prefix)
-                .map(|result| {
-                    result
-                        .map(|(k, v)| (k.to_vec(), v.to_vec()))
-                        .map_err(|e| StorageError::SledError(e.to_string()))
+                .map(|result| -> StorageResult<(Vec<u8>, Vec<u8>)> {
+                    let (k, v) = result?;
+                    Ok((k.to_vec(), v.to_vec()))
                 })
                 .collect()
         })
-        .await
-        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .await?
     }
 
     async fn batch_put(&self, items: Vec<(Vec<u8>, Vec<u8>)>) -> StorageResult<()> {
@@ -131,22 +101,16 @@ impl KvStore for SledKvStore {
 
         tokio::task::spawn_blocking(move || -> Result<(), StorageError> {
             let guard = pool.acquire_arc()?;
-            let tree = guard
-                .db()
-                .open_tree(&tree_name)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
+            let tree = guard.db().open_tree(&tree_name)?;
             let mut batch = sled::Batch::default();
             for (key, value) in items {
                 batch.insert(key, value);
             }
-            tree.apply_batch(batch)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
-            tree.flush()
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
+            tree.apply_batch(batch)?;
+            tree.flush()?;
             Ok(())
         })
-        .await
-        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .await?
     }
 
     async fn batch_delete(&self, keys: Vec<Vec<u8>>) -> StorageResult<()> {
@@ -155,20 +119,15 @@ impl KvStore for SledKvStore {
 
         tokio::task::spawn_blocking(move || {
             let guard = pool.acquire_arc()?;
-            let tree = guard
-                .db()
-                .open_tree(&tree_name)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
+            let tree = guard.db().open_tree(&tree_name)?;
             let mut batch = sled::Batch::default();
             for key in keys {
                 batch.remove(key);
             }
-            tree.apply_batch(batch)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
+            tree.apply_batch(batch)?;
             Ok(())
         })
-        .await
-        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .await?
     }
 
     async fn flush(&self) -> StorageResult<()> {
@@ -177,16 +136,11 @@ impl KvStore for SledKvStore {
 
         tokio::task::spawn_blocking(move || -> Result<(), StorageError> {
             let guard = pool.acquire_arc()?;
-            let tree = guard
-                .db()
-                .open_tree(&tree_name)
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
-            tree.flush()
-                .map_err(|e| StorageError::SledError(e.to_string()))?;
+            let tree = guard.db().open_tree(&tree_name)?;
+            tree.flush()?;
             Ok(())
         })
-        .await
-        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .await?
     }
 
     fn backend_name(&self) -> &'static str {
@@ -248,22 +202,17 @@ impl NamespacedStore for SledNamespacedStore {
                 .collect();
             Ok(tree_names)
         })
-        .await
-        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .await?
     }
 
     async fn delete_namespace(&self, name: &str) -> StorageResult<bool> {
         let pool = Arc::clone(&self.pool);
         let name = name.to_string();
 
-        tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || -> StorageResult<bool> {
             let guard = pool.acquire_arc()?;
-            guard
-                .db()
-                .drop_tree(&name)
-                .map_err(|e| StorageError::SledError(e.to_string()))
+            Ok(guard.db().drop_tree(&name)?)
         })
-        .await
-        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .await?
     }
 }


### PR DESCRIPTION
## Summary

Add two `From` impls on `StorageError` so the `?` operator handles sled and `tokio::task::JoinError` conversions directly, then drop the 29 boilerplate `.map_err(|e| StorageError::SledError(e.to_string()))` / `.map_err(|e| StorageError::BackendError(e.to_string()))` sites in `crates/core/src/storage/sled_backend.rs`.

```rust
impl From<sled::Error> for StorageError {
    fn from(e: sled::Error) -> Self {
        Self::SledError(e.to_string())
    }
}

impl From<tokio::task::JoinError> for StorageError {
    fn from(e: tokio::task::JoinError) -> Self {
        Self::BackendError(e.to_string())
    }
}
```

- 19 `.map_err(|e| StorageError::SledError(e.to_string()))` sites → 0
- 10 `.map_err(|e| StorageError::BackendError(e.to_string()))` sites → 0
- Net: `+45 / −84`, two files touched.

## API contract

Error-message text is preserved **byte-for-byte**: both the original manual `map_err` and the new `From` impls call `e.to_string()`. Tests asserting on these messages should still pass.

`StorageError` variant payloads are intentionally **left as `String`** — not switched to `#[from] sled::Error` / `#[from] tokio::task::JoinError`. Keeping them as `String` preserves the public enum signature so other call sites that build these variants from format strings (e.g. `inmemory_backend.rs` `format!("Lock poisoned: {}", e)`, `exemem_api_store.rs` rich-context HTTP errors) keep compiling.

## Out of scope

- `inmemory_backend.rs`, `exemem_api_store.rs`, `fold_db.rs` — their `BackendError` sites carry context strings worth preserving. Untouched.
- `sled` / `tokio` version bumps. Untouched.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --all-targets` — all suites green (800+ tests, zero failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)