### PR TITLE
refactor(core): drop 3 dead filter_utils wrappers with zero callers

### DIFF
--- a/crates/core/src/schema/types/field/filter_utils.rs
+++ b/crates/core/src/schema/types/field/filter_utils.rs
@@ -36,45 +36,6 @@ impl FilterUtils {
     }
 }
 
-/// Resolve atom UUID matches into concrete FieldValue map by fetching atoms (async version)
-pub async fn fetch_atoms_for_matches_async(
-    db_ops: &Arc<DbOperations>,
-    matches: impl IntoIterator<Item = (KeyValue, String)>,
-) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
-    fetch_atoms_for_matches_async_with_org(db_ops, matches, None).await
-}
-
-/// Resolve atom UUID matches with org_hash prefix support.
-pub async fn fetch_atoms_for_matches_async_with_org(
-    db_ops: &Arc<DbOperations>,
-    matches: impl IntoIterator<Item = (KeyValue, String)>,
-    org_hash: Option<&str>,
-) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
-    fetch_atoms_with_key_metadata_async_with_org(
-        db_ops,
-        matches.into_iter().map(|(kv, uuid)| (kv, uuid, None, None)),
-        org_hash,
-    )
-    .await
-}
-
-/// Resolve atom UUID matches into concrete FieldValue map, preferring molecule
-/// per-key metadata over atom metadata for source_file_name and metadata fields.
-/// Falls back to atom metadata for backward compatibility with pre-existing data.
-pub async fn fetch_atoms_with_key_metadata_async(
-    db_ops: &Arc<DbOperations>,
-    matches: impl IntoIterator<
-        Item = (
-            KeyValue,
-            String,
-            Option<crate::atom::KeyMetadata>,
-            Option<String>,
-        ),
-    >,
-) -> Result<HashMap<KeyValue, FieldValue>, SchemaError> {
-    fetch_atoms_with_key_metadata_async_with_org(db_ops, matches, None).await
-}
-
 /// Resolve atom UUID matches into concrete FieldValue map with org_hash prefix support.
 ///
 /// When `org_hash` is `Some` and an atom is missing at the org-prefixed key,

--- a/crates/core/src/schema/types/field/mod.rs
+++ b/crates/core/src/schema/types/field/mod.rs
@@ -9,8 +9,7 @@ pub mod variant;
 
 pub use common::{build_storage_key, Field, FieldCommon, FieldType, WriteContext};
 pub use filter_utils::{
-    apply_hash_filter, apply_hash_range_filter, apply_range_filter, fetch_atoms_for_matches_async,
-    fetch_atoms_for_matches_async_with_org, fetch_atoms_with_key_metadata_async,
+    apply_hash_filter, apply_hash_range_filter, apply_range_filter,
     fetch_atoms_with_key_metadata_async_with_org, FilterApplicator, FilterUtils, HashOperations,
     HashRangeOperations, RangeOperations,
 };


### PR DESCRIPTION
## Summary

Three `pub async fn` wrappers in `crates/core/src/schema/types/field/filter_utils.rs` originally added as `org_hash: None` convenience overloads have **zero callers** anywhere in the workspace. Every real call site (single_field, range_field, hash_range_field, hash_field, variant) already calls `fetch_atoms_with_key_metadata_async_with_org` directly.

Removed:
- `fetch_atoms_for_matches_async`
- `fetch_atoms_for_matches_async_with_org`
- `fetch_atoms_with_key_metadata_async`

Kept untouched: the workhorse `fetch_atoms_with_key_metadata_async_with_org` plus its load-bearing org-prefix/fallback/SKIP-on-org-miss doc comment.

Pure removal. Zero behavior change. ~40 LOC out, 2 files touched (`filter_utils.rs`, `mod.rs`).

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` green
- [x] `cargo fmt --check` clean
- [x] Re-confirmed no callers across workspace before deleting
- [x] No cross-crate consumers in `fold_db_node` or `schema_service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)