### PR TITLE
refactor(fold_db_core): dedupe 4 SystemTime now() blocks via now_secs() helper

### DIFF
--- a/crates/core/src/fold_db_core/event_monitor.rs
+++ b/crates/core/src/fold_db_core/event_monitor.rs
@@ -5,10 +5,10 @@
 //! with a single component that can see all system activity.
 
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use tracing::info;
 
+use super::event_statistics::now_secs;
 pub use super::event_statistics::{EventStatistics, MutationStats, QueryStats};
 use crate::messaging::{AsyncMessageBus, Event};
 
@@ -21,10 +21,7 @@ impl EventMonitor {
     /// Create a new EventMonitor that subscribes to all event types
     pub async fn new(message_bus: Arc<AsyncMessageBus>) -> Self {
         let statistics = Arc::new(Mutex::new(EventStatistics {
-            monitoring_start_time: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
+            monitoring_start_time: now_secs(),
             ..Default::default()
         }));
 
@@ -124,11 +121,7 @@ impl EventMonitor {
     /// Log a summary of all activity since monitoring started
     pub fn log_summary(&self) {
         let stats = self.get_statistics();
-        let runtime = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-            - stats.monitoring_start_time;
+        let runtime = now_secs() - stats.monitoring_start_time;
 
         info!("📊 EventMonitor Summary ({}s runtime):", runtime);
         info!("  📝 Field Value Sets: {}", stats.field_value_sets);

--- a/crates/core/src/fold_db_core/event_statistics.rs
+++ b/crates/core/src/fold_db_core/event_statistics.rs
@@ -4,6 +4,13 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
+pub(super) fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
 /// Statistics about system activity tracked by the event monitor
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct EventStatistics {
@@ -77,10 +84,7 @@ impl EventStatistics {
             stats.total_execution_time_ms as f64 / stats.executions as f64;
         stats.total_results += result_count;
         stats.avg_result_count = stats.total_results as f64 / stats.executions as f64;
-        stats.last_execution_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        stats.last_execution_time = now_secs();
     }
 
     pub fn increment_mutation_executions(
@@ -102,9 +106,6 @@ impl EventStatistics {
             stats.total_execution_time_ms as f64 / stats.executions as f64;
         stats.total_fields_affected += fields_affected;
         stats.avg_fields_affected = stats.total_fields_affected as f64 / stats.executions as f64;
-        stats.last_execution_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        stats.last_execution_time = now_secs();
     }
 }


### PR DESCRIPTION
## Summary

Four identical `SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()` chains lived across `fold_db_core/event_monitor.rs` (2 sites) and `fold_db_core/event_statistics.rs` (2 sites). Collapsed into a single shared `pub(super) fn now_secs() -> u64` helper in `event_statistics.rs`, reused from `event_monitor.rs`.

Same dedupe pattern as #705 for `progress.rs`. **Behavior-preserving**: the helper uses `.unwrap()` (not `.unwrap_or_default()`), so panic-on-clock-before-epoch semantics are unchanged at all four call sites. Different choice from #705 because these files already used `.unwrap()` — matching what was there.

`event_monitor.rs` no longer needs `std::time::{SystemTime, UNIX_EPOCH}` and that import was dropped.

Net diff: −18 +12 = **−6 lines**.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — all tests pass (including `fold_db_core::event_monitor::tests::test_event_monitor_observability`)
- [x] `git grep 'SystemTime::now'` in the two touched files returns only the new helper definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)